### PR TITLE
Making lac tensor module public

### DIFF
--- a/crates/cubecl-lac/src/lib.rs
+++ b/crates/cubecl-lac/src/lib.rs
@@ -1,4 +1,4 @@
 /// Matrix multiplication components.
 pub mod matmul;
-mod tensor;
+pub mod tensor;
 mod tests;


### PR DESCRIPTION
Making lac tensor module public as per stated in the issue
closes #8