### PR TITLE
Fix comptime::runtime(value) for float and int types

### DIFF
--- a/crates/cubecl-core/src/frontend/comptime.rs
+++ b/crates/cubecl-core/src/frontend/comptime.rs
@@ -14,7 +14,7 @@ pub struct Comptime<T> {
 }
 
 /// Type that can be used within [Comptime].
-pub trait ComptimeType: CubeType {
+pub trait ComptimeType: CubeType + Into<ExpandElement> {
     /// Create the expand type from the normal type.
     fn into_expand(self) -> Self::ExpandType;
 }

--- a/crates/cubecl-core/src/frontend/element/float.rs
+++ b/crates/cubecl-core/src/frontend/element/float.rs
@@ -96,6 +96,13 @@ macro_rules! impl_float {
             }
         }
 
+        impl From<$type> for ExpandElement {
+            fn from(value: $type) -> Self {
+                let constant = $type::as_elem().from_constant(value.val.into());
+                ExpandElement::Plain(constant)
+            }
+        }
+
         impl Numeric for $type {
             type Primitive = $primitive;
         }

--- a/crates/cubecl-core/src/frontend/element/int.rs
+++ b/crates/cubecl-core/src/frontend/element/int.rs
@@ -93,6 +93,13 @@ macro_rules! impl_int {
             }
         }
 
+        impl From<$type> for ExpandElement {
+            fn from(value: $type) -> Self {
+                let constant = $type::as_elem().from_constant(value.val.into());
+                ExpandElement::Plain(constant)
+            }
+        }
+
         impl Numeric for $type {
             type Primitive = $primitive;
         }

--- a/crates/cubecl-core/tests/frontend/comptime.rs
+++ b/crates/cubecl-core/tests/frontend/comptime.rs
@@ -37,6 +37,12 @@ pub fn comptime_else_then_if<T: Numeric>(lhs: T, cond1: Comptime<bool>, cond2: C
 }
 
 #[cube]
+pub fn comptime_float() {
+    let comptime_float = Comptime::new(F32::new(0.0));
+    let _runtime_float = Comptime::runtime(comptime_float);
+}
+
+#[cube]
 pub fn comptime_elsif<T: Numeric>(lhs: T, cond1: Comptime<bool>, cond2: Comptime<bool>) {
     if Comptime::get(cond1) {
         let _ = lhs + T::from_int(4);


### PR DESCRIPTION
You sould be able to transfer float and int type from compile-time to runtime using `Comptime::runtime(value)`