### PR TITLE
Fix a doc for CubeMode

### DIFF
--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -22,7 +22,7 @@ enum CubeMode {
     /// Generates the expanded version of the function
     Default,
     /// Panics and prints the generated code, useful when debugging
-    /// Use by writing #[cube(panic)]
+    /// Use by writing #[cube(debug)]
     Debug,
 }
 


### PR DESCRIPTION
The doc for `#[cude]` proc macro seems wrong.

According to https://github.com/tracel-ai/cubecl/blob/89af40f86bc634e228d3c9fe044ebf3f680c5e08/crates/cubecl-macros/src/lib.rs#L87 and some experiment on my side, `#[cube(debug)]` should be correct.