### PR TITLE
Upgrade wgpu to 22.0.0

### DIFF
--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -27,7 +27,7 @@ cubecl-common = { path = "../cubecl-common", version = "0.1.1" }
 cubecl-core = { path = "../cubecl-core", version = "0.1.1" }
 
 bytemuck = { workspace = true }
-wgpu = { version = "0.20.1", features = ["fragile-send-sync-non-atomic-wasm"] }
+wgpu = { version = "22.0.0", features = ["fragile-send-sync-non-atomic-wasm"] }
 pollster = { workspace = true }
 
 log = { workspace = true }

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -124,6 +124,7 @@ where
                     module: &module,
                     entry_point: "main",
                     compilation_options: Default::default(),
+                    cache: None,
                 }),
         )
     }

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -155,6 +155,10 @@ pub async fn select_device<G: GraphicsApi>(
                 label: None,
                 required_features: adapter.features(),
                 required_limits: limits,
+                // The default is MemoryHints::Performance, which tries to do some bigger
+                // block allocations. However, we already batch allocations, so we
+                // can use MemoryHints::MemoryUsage to lower memory usage.
+                memory_hints: wgpu::MemoryHints::MemoryUsage,
             },
             None,
         )


### PR DESCRIPTION
**Changes**

Upgrade wgpu to 22.0.0. There's two breaking things:

Have to specifiy a MemoryHint, choosing between performance and lower memory usage. GIven wgpu has it's own block allocator now, MemoryUsage seems better. I did a quick test on the train sample and see no clear performance difference between either.

Need to specify a pipeline cache. This allows to cache compiled shader outputs. As per the comment in the wgpu code this is usually done automatically though not on Android seemingly. Could be nice someday.