### PR TITLE
Add tuple expression in cube derive macro

### DIFF
--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -175,8 +175,19 @@ macro_rules! tuple_init {
     }
 }
 
-all_tuples!(tuple_cube_type, 1, 16, P);
-all_tuples!(tuple_init, 1, 16, P);
+tuple_cube_type!(P1);
+tuple_cube_type!(P1, P2);
+tuple_cube_type!(P1, P2, P3);
+tuple_cube_type!(P1, P2, P3, P4);
+tuple_cube_type!(P1, P2, P3, P4, P5);
+tuple_cube_type!(P1, P2, P3, P4, P5, P6);
+
+tuple_init!(P1);
+tuple_init!(P1, P2);
+tuple_init!(P1, P2, P3);
+tuple_init!(P1, P2, P3, P4);
+tuple_init!(P1, P2, P3, P4, P5);
+tuple_init!(P1, P2, P3, P4, P5, P6);
 
 pub trait ExpandElementBaseInit: CubeType {
     fn init_elem(context: &mut CubeContext, elem: ExpandElement) -> ExpandElement;

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -5,8 +5,8 @@ use crate::{
     KernelSettings, Runtime,
 };
 use alloc::rc::Rc;
-use std::marker::PhantomData;
 use cubecl_macros::all_tuples;
+use std::marker::PhantomData;
 
 /// Types used in a cube function must implement this trait
 ///

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -5,7 +5,6 @@ use crate::{
     KernelSettings, Runtime,
 };
 use alloc::rc::Rc;
-use cubecl_macros::all_tuples;
 use std::marker::PhantomData;
 
 /// Types used in a cube function must implement this trait

--- a/crates/cubecl-core/src/frontend/element/mod.rs
+++ b/crates/cubecl-core/src/frontend/element/mod.rs
@@ -11,7 +11,6 @@ mod slice;
 mod tensor;
 mod uint;
 mod vectorized;
-
 pub use array::*;
 pub use base::*;
 pub use bool::*;

--- a/crates/cubecl-core/tests/frontend/mod.rs
+++ b/crates/cubecl-core/tests/frontend/mod.rs
@@ -20,4 +20,6 @@ mod r#struct;
 mod tensor;
 mod topology;
 mod r#trait;
+
+mod tuple;
 mod vectorization;

--- a/crates/cubecl-core/tests/frontend/tuple.rs
+++ b/crates/cubecl-core/tests/frontend/tuple.rs
@@ -8,7 +8,6 @@ pub fn tuple_const() -> (UInt, UInt) {
     (x, y)
 }
 
-
 mod tests {
     use super::*;
     use cubecl_core::{
@@ -25,7 +24,6 @@ mod tests {
 
         assert_eq!(scope.operations, inline_macro_ref_tuple_const());
     }
-
 
     fn inline_macro_ref_tuple_const() -> Vec<Operation> {
         let context = CubeContext::root();

--- a/crates/cubecl-core/tests/frontend/tuple.rs
+++ b/crates/cubecl-core/tests/frontend/tuple.rs
@@ -1,0 +1,45 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+#[cube]
+pub fn tuple_const() -> (UInt, UInt) {
+    let x = UInt::new(0);
+    let y = UInt::new(1);
+    (x, y)
+}
+
+
+mod tests {
+    use super::*;
+    use cubecl_core::{
+        cpa,
+        ir::{Elem, Item, Operation, Variable},
+    };
+
+    #[test]
+    fn cube_tuple_const_test() {
+        let mut context = CubeContext::root();
+
+        tuple_const::__expand(&mut context);
+        let scope = context.into_scope();
+
+        assert_eq!(scope.operations, inline_macro_ref_tuple_const());
+    }
+
+
+    fn inline_macro_ref_tuple_const() -> Vec<Operation> {
+        let context = CubeContext::root();
+
+        let mut scope = context.into_scope();
+        let x = scope.create_local(Item::new(Elem::UInt));
+        let y = scope.create_local(Item::new(Elem::UInt));
+
+        let zero: Variable = 0u32.into();
+        let one: Variable = 1u32.into();
+
+        cpa!(scope, x = zero);
+        cpa!(scope, y = one);
+
+        scope.operations
+    }
+}

--- a/crates/cubecl-linalg/README.md
+++ b/crates/cubecl-linalg/README.md
@@ -8,7 +8,6 @@ The crate contains common linear algebra algorithms.
 - [X] Tiling 2D Matrix Multiplication.
 
   The kernel is very flexible and can be used on pretty much any hardware.
-  
 - [X] Cooperative Matrix Multiplication.
 
   The kernel is using Automatic Mixed Precision (AMP) to leverage cooperative matrix-multiply and accumulate instructions.

--- a/crates/cubecl-linalg/README.md
+++ b/crates/cubecl-linalg/README.md
@@ -8,6 +8,7 @@ The crate contains common linear algebra algorithms.
 - [X] Tiling 2D Matrix Multiplication.
 
   The kernel is very flexible and can be used on pretty much any hardware.
+  
 - [X] Cooperative Matrix Multiplication.
 
   The kernel is using Automatic Mixed Precision (AMP) to leverage cooperative matrix-multiply and accumulate instructions.

--- a/crates/cubecl-macros/src/codegen_function/expr.rs
+++ b/crates/cubecl-macros/src/codegen_function/expr.rs
@@ -103,7 +103,6 @@ pub(crate) fn codegen_tuple(
             #res
             let #var = #expr_tokens;
         };
-        // vars.push(quote::quote! { #var});
         vars.push(var);
     }
     quote::quote! {
@@ -113,7 +112,6 @@ pub(crate) fn codegen_tuple(
         }
     }
 }
-
 
 /// Codegen for an expression containing a block
 pub(crate) fn codegen_expr_block(

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -15,7 +15,6 @@ use codegen_function::{codegen_launch, codegen_statement};
 use codegen_trait::{expand_trait_def, expand_trait_impl};
 use codegen_type::generate_cube_type;
 use proc_macro::TokenStream;
-use syn::parse::{Parse};
 use syn::{parse_macro_input, punctuated::Punctuated, token::Comma, Meta};
 use tracker::VariableTracker;
 

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -17,8 +17,8 @@ use codegen_type::generate_cube_type;
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, punctuated::Punctuated, token::Comma, Meta, LitInt};
 use syn::parse::{Parse, ParseStream};
+use syn::{parse_macro_input, punctuated::Punctuated, token::Comma, LitInt, Meta};
 use tracker::VariableTracker;
 
 enum CubeMode {
@@ -179,11 +179,9 @@ fn codegen_cube(
             #signature {
                 #body
             }
-
         }
     })
 }
-
 
 struct AllTuples {
     macro_ident: Ident,

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -15,10 +15,8 @@ use codegen_function::{codegen_launch, codegen_statement};
 use codegen_trait::{expand_trait_def, expand_trait_impl};
 use codegen_type::generate_cube_type;
 use proc_macro::TokenStream;
-use proc_macro2::Ident;
-use quote::{format_ident, quote};
-use syn::parse::{Parse, ParseStream};
-use syn::{parse_macro_input, punctuated::Punctuated, token::Comma, LitInt, Meta};
+use syn::parse::{Parse};
+use syn::{parse_macro_input, punctuated::Punctuated, token::Comma, Meta};
 use tracker::VariableTracker;
 
 enum CubeMode {
@@ -180,69 +178,5 @@ fn codegen_cube(
                 #body
             }
         }
-    })
-}
-
-struct AllTuples {
-    macro_ident: Ident,
-    start: usize,
-    end: usize,
-    idents: Vec<Ident>,
-}
-
-impl Parse for AllTuples {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let macro_ident = input.parse::<Ident>()?;
-        input.parse::<Comma>()?;
-        let start = input.parse::<LitInt>()?.base10_parse()?;
-        input.parse::<Comma>()?;
-        let end = input.parse::<LitInt>()?.base10_parse()?;
-        input.parse::<Comma>()?;
-        let mut idents = vec![input.parse::<Ident>()?];
-        while input.parse::<Comma>().is_ok() {
-            idents.push(input.parse::<Ident>()?);
-        }
-
-        Ok(AllTuples {
-            macro_ident,
-            start,
-            end,
-            idents,
-        })
-    }
-}
-
-#[proc_macro]
-pub fn all_tuples(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as AllTuples);
-    let len = 1 + input.end - input.start;
-    let mut ident_tuples = Vec::with_capacity(len);
-    for i in 0..=len {
-        let idents = input
-            .idents
-            .iter()
-            .map(|ident| format_ident!("{}{}", ident, i));
-        if input.idents.len() < 2 {
-            ident_tuples.push(quote! {
-                #(#idents)*
-            });
-        } else {
-            ident_tuples.push(quote! {
-                (#(#idents),*)
-            });
-        }
-    }
-
-    let macro_ident = &input.macro_ident;
-    let invocations = (input.start..=input.end).map(|i| {
-        let ident_tuples = &ident_tuples[..i];
-        quote! {
-            #macro_ident!(#(#ident_tuples),*);
-        }
-    });
-    TokenStream::from(quote! {
-        #(
-            #invocations
-        )*
     })
 }


### PR DESCRIPTION
- Fixes https://github.com/tracel-ai/cubecl/issues/48
- Adds handling for a tuple expression in the derive macro
- Implements `CubeType` for a tuple of `CubeType`s

- [x] ran `pull-request-checks`

Honestly I don't fully understand the code base (especially the part where the `CubeTypes` call `Init` or `Expand` to generate the `Scope` IR), so i'm not sure if this is correct.

Added a simple test