### PR TITLE
Add comment about autotuning

### DIFF
--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -54,6 +54,8 @@ impl<AK: AutotuneKey, ID: Hash + PartialEq + Eq + Clone + Display> LocalTuner<AK
         C: ComputeChannel<S>,
     {
         // We avoid locking in write mode when possible.
+        // (this makes us potentially check the cache twice, but allows to avoid
+        // locking the state if the cache is hit)
         if let Some(state) = self.state.read().as_ref() {
             if let Some(tuner) = state.get(id) {
                 let key = autotune_operation_set.key();


### PR DESCRIPTION
On reading the code it wasn't clear to me at first glance that we were checking the cache twice to avoid the lock (even with the existing comment)