### PR TITLE
fix wgpu compiler visibility

### DIFF
--- a/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
@@ -228,7 +228,7 @@ impl Display for Location {
 impl Display for Visibility {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Visibility::Read => f.write_str("read_write"),
+            Visibility::Read => f.write_str("read"),
             Visibility::ReadWrite => f.write_str("read_write"),
         }
     }


### PR DESCRIPTION
```rust
impl Display for Visibility {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        match self {
            Visibility::Read => f.write_str("read_write"),
            Visibility::ReadWrite => f.write_str("read_write"),
        }
    }
}
```
should be
```rust
impl Display for Visibility {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        match self {
            Visibility::Read => f.write_str("read"),
            Visibility::ReadWrite => f.write_str("read_write"),
        }
    }
}
```