### PR TITLE
Speed up wgpu passes/allocations

### DIFF
--- a/crates/cubecl-cuda/src/compute/storage.rs
+++ b/crates/cubecl-cuda/src/compute/storage.rs
@@ -158,18 +158,4 @@ impl ComputeStorage for CudaStorage {
     fn dealloc(&mut self, id: StorageId) {
         self.deallocations.push(id);
     }
-
-    fn copy(&mut self, from: &StorageHandle, to: &StorageHandle) {
-        let num_bytes = from.size();
-
-        unsafe {
-            cudarc::driver::result::memcpy_dtod_async(
-                self.get(to).ptr,
-                self.get(from).ptr,
-                num_bytes,
-                self.stream,
-            )
-            .unwrap();
-        }
-    }
 }

--- a/crates/cubecl-cuda/src/compute/storage.rs
+++ b/crates/cubecl-cuda/src/compute/storage.rs
@@ -151,7 +151,7 @@ impl ComputeStorage for CudaStorage {
     fn alloc(&mut self, size: usize) -> StorageHandle {
         let id = StorageId::new();
         let ptr = unsafe { cudarc::driver::result::malloc_async(self.stream, size).unwrap() };
-        self.memory.insert(id.clone(), ptr);
+        self.memory.insert(id, ptr);
         StorageHandle::new(id, StorageUtilization::Full(size))
     }
 

--- a/crates/cubecl-runtime/benches/dynamic.rs
+++ b/crates/cubecl-runtime/benches/dynamic.rs
@@ -22,7 +22,7 @@ fn main() {
         if handles.len() >= 4000 {
             handles.pop_front();
         }
-        let handle = mm.reserve(MB, || {});
+        let handle = mm.reserve(MB, &[]);
         handles.push_back(handle);
     }
     println!("{:?}", start.elapsed());

--- a/crates/cubecl-runtime/src/id.rs
+++ b/crates/cubecl-runtime/src/id.rs
@@ -5,7 +5,7 @@ use alloc::sync::Arc;
 macro_rules! storage_id_type {
     ($name:ident) => {
         /// Storage ID.
-        #[derive(Clone, Hash, PartialEq, Eq, Debug)]
+        #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
         pub struct $name {
             value: usize,
         }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/handle.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/handle.rs
@@ -1,8 +1,6 @@
 use crate::memory_id_type;
 use crate::memory_management::{MemoryBinding, MemoryHandle};
 
-// The ChunkId allows to keep track of how many references there are to a specific chunk.
-memory_id_type!(ChunkId, ChunkHandle);
 // The SliceId allows to keep track of how many references there are to a specific slice.
 memory_id_type!(SliceId, SliceHandle, SliceBinding);
 

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/ring.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/ring.rs
@@ -31,20 +31,6 @@ impl RingBuffer {
             .insert(storage_id, self.queue.len() - 1);
     }
 
-    pub fn remove_chunk(&mut self, storage_id: StorageId) {
-        if let Some(position) = self.chunk_positions.remove(&storage_id) {
-            self.queue.remove(position);
-        }
-
-        self.chunk_positions.clear();
-
-        for (pos, id) in self.queue.iter().enumerate() {
-            self.chunk_positions.insert(*id, pos);
-        }
-        self.cursor_chunk = 0;
-        self.cursor_slice = 0;
-    }
-
     pub fn find_free_slice(
         &mut self,
         size: usize,

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/ring.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/ring.rs
@@ -1,55 +1,38 @@
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 use hashbrown::HashMap;
 
-use super::{ChunkId, SliceId};
+use crate::storage::StorageId;
+
+use super::{Chunk, Slice, SliceId};
 
 #[derive(Debug)]
-pub struct RingBuffer<C: MemoryChunk<S>, S: MemorySlice> {
-    queue: Vec<ChunkId>,
-    chunk_positions: HashMap<ChunkId, usize>,
+pub struct RingBuffer {
+    queue: Vec<StorageId>,
+    chunk_positions: HashMap<StorageId, usize>,
     cursor_slice: usize,
     cursor_chunk: usize,
-    _s: PhantomData<S>,
-    _c: PhantomData<C>,
     buffer_alignment: usize,
 }
 
-pub trait MemoryChunk<S: MemorySlice> {
-    fn merge_next_slice(&mut self, slice_position: usize, slices: &mut HashMap<SliceId, S>)
-        -> bool;
-    fn slice(&self, index: usize) -> Option<SliceId>;
-    fn insert_slice(&mut self, position: usize, slice: S, slices: &mut HashMap<SliceId, S>);
-}
-
-pub trait MemorySlice: Sized {
-    fn is_free(&self) -> bool;
-    fn size(&self) -> usize;
-    fn split(&mut self, offset: usize, buffer_alignment: usize) -> Option<Self>;
-    fn id(&self) -> SliceId;
-    fn next_slice_position(&self) -> usize;
-}
-
-impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
+impl RingBuffer {
     pub fn new(buffer_alignment: usize) -> Self {
         Self {
             queue: Vec::new(),
             chunk_positions: HashMap::new(),
             cursor_slice: 0,
             cursor_chunk: 0,
-            _s: PhantomData,
-            _c: PhantomData,
             buffer_alignment,
         }
     }
 
-    pub fn push_chunk(&mut self, chunk_id: ChunkId) {
-        self.queue.push(chunk_id);
-        self.chunk_positions.insert(chunk_id, self.queue.len() - 1);
+    pub fn push_chunk(&mut self, storage_id: StorageId) {
+        self.queue.push(storage_id);
+        self.chunk_positions
+            .insert(storage_id, self.queue.len() - 1);
     }
 
-    pub fn remove_chunk(&mut self, chunk_id: ChunkId) {
-        if let Some(position) = self.chunk_positions.remove(&chunk_id) {
+    pub fn remove_chunk(&mut self, storage_id: StorageId) {
+        if let Some(position) = self.chunk_positions.remove(&storage_id) {
             self.queue.remove(position);
         }
 
@@ -65,11 +48,13 @@ impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
     pub fn find_free_slice(
         &mut self,
         size: usize,
-        chunks: &mut HashMap<ChunkId, C>,
-        slices: &mut HashMap<SliceId, S>,
+        chunks: &mut HashMap<StorageId, Chunk>,
+        slices: &mut HashMap<SliceId, Slice>,
+        exclude: &[StorageId],
     ) -> Option<SliceId> {
         let max_second = self.cursor_chunk;
-        let result = self.find_free_slice_in_all_chunks(size, chunks, slices, self.queue.len());
+        let result =
+            self.find_free_slice_in_all_chunks(size, chunks, slices, self.queue.len(), exclude);
 
         if result.is_some() {
             return result;
@@ -77,14 +62,14 @@ impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
 
         self.cursor_chunk = 0;
         self.cursor_slice = 0;
-        self.find_free_slice_in_all_chunks(size, chunks, slices, max_second)
+        self.find_free_slice_in_all_chunks(size, chunks, slices, max_second, exclude)
     }
 
     fn find_free_slice_in_chunk(
         &mut self,
         size: usize,
-        chunk: &mut C,
-        slices: &mut HashMap<SliceId, S>,
+        chunk: &mut Chunk,
+        slices: &mut HashMap<SliceId, Slice>,
         mut slice_index: usize,
     ) -> Option<(usize, SliceId)> {
         while let Some(slice_id) = chunk.slice(slice_index) {
@@ -127,9 +112,10 @@ impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
     fn find_free_slice_in_all_chunks(
         &mut self,
         size: usize,
-        chunks: &mut HashMap<ChunkId, C>,
-        slices: &mut HashMap<SliceId, S>,
+        chunks: &mut HashMap<StorageId, Chunk>,
+        slices: &mut HashMap<SliceId, Slice>,
         max_cursor_position: usize,
+        exclude: &[StorageId],
     ) -> Option<SliceId> {
         let start = self.cursor_chunk;
         let end = usize::min(self.queue.len(), max_cursor_position);
@@ -141,6 +127,10 @@ impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
             }
 
             if let Some(id) = self.queue.get(chunk_index) {
+                if exclude.contains(id) {
+                    continue;
+                }
+
                 let chunk = chunks.get_mut(id).unwrap();
                 let result = self.find_free_slice_in_chunk(size, chunk, slices, slice_index);
 
@@ -161,294 +151,221 @@ impl<C: MemoryChunk<S>, S: MemorySlice> RingBuffer<C, S> {
 
 #[cfg(test)]
 mod tests {
-    use super::stub::*;
+    use crate::{
+        memory_management::memory_pool::{MemoryPage, SliceHandle},
+        storage::StorageHandle,
+    };
+
     use super::*;
-    use alloc::vec;
 
     #[test]
     fn simple_1() {
-        let mut ring = RingBuffer::<TestChunk, TestSlice>::new(0);
+        let mut ring = RingBuffer::new(1);
 
-        let slice_1 = new_slice(0, 100, 0);
-        let slice_2 = new_slice(1, 200, 1);
-        let chunk_1 = new_chunk(0, vec![0, 1]);
+        let (storage_id, slice_ids, mut slices, chunk) = new_chunk(&[100, 200]);
 
-        let mut slices = HashMap::from([(slice_1.id, slice_1), (slice_2.id, slice_2)]);
-        let mut chunks = HashMap::from([(chunk_1.id, chunk_1)]);
+        ring.push_chunk(storage_id);
+        let mut chunks = HashMap::from([(storage_id, chunk)]);
 
-        ring.push_chunk(ChunkId { value: 0 });
+        let slice = ring
+            .find_free_slice(50, &mut chunks, &mut slices, &[])
+            .unwrap();
 
-        let slice = ring.find_free_slice(50, &mut chunks, &mut slices).unwrap();
-
-        assert_eq!(slice, SliceId { value: 0 });
-        assert_eq!(slices.get(&slice).unwrap().size, 50);
+        assert_eq!(slice, slice_ids[0]);
+        assert_eq!(slices.get(&slice).unwrap().size(), 50);
         assert_eq!(slices.len(), 3);
-        assert_eq!(chunks.values().last().unwrap().slices.len(), 3);
+        assert_eq!(chunks.values().last().unwrap().slices.slices.len(), 3);
     }
 
     #[test]
     fn simple_2() {
-        let mut ring = RingBuffer::<TestChunk, TestSlice>::new(0);
+        let mut ring = RingBuffer::new(1);
 
-        let slice_1 = new_slice(0, 100, 0);
-        let slice_2 = new_slice(1, 200, 1);
-        let chunk_1 = new_chunk(0, vec![0, 1]);
+        let (storage_id, slice_ids, mut slices, chunk) = new_chunk(&[100, 200]);
 
-        let mut slices = HashMap::from([(slice_1.id, slice_1), (slice_2.id, slice_2)]);
-        let mut chunks = HashMap::from([(chunk_1.id, chunk_1)]);
+        ring.push_chunk(storage_id);
+        let mut chunks = HashMap::from([(storage_id, chunk)]);
 
-        ring.push_chunk(ChunkId { value: 0 });
+        let slice = ring
+            .find_free_slice(150, &mut chunks, &mut slices, &[])
+            .unwrap();
 
-        let slice = ring.find_free_slice(150, &mut chunks, &mut slices).unwrap();
-
-        assert_eq!(slice, SliceId { value: 0 });
-        assert_eq!(slices.get(&slice).unwrap().size, 150);
+        assert_eq!(slice, slice_ids[0]);
+        assert_eq!(slices.get(&slice).unwrap().size(), 150);
         assert_eq!(slices.len(), 2);
-        assert_eq!(chunks.values().last().unwrap().slices.len(), 2);
+        assert_eq!(chunks.values().last().unwrap().slices.slices.len(), 2);
     }
 
     #[test]
     fn multiple_chunks() {
-        let mut ring = RingBuffer::<TestChunk, TestSlice>::new(0);
+        let mut ring = RingBuffer::new(1);
 
-        let slice_1 = new_slice(0, 100, 0);
-        let slice_2 = new_slice(1, 200, 1);
-        let slice_3 = new_slice(2, 200, 0);
-        let slice_4 = new_slice(3, 200, 1);
-        let chunk_1 = new_chunk(0, vec![0, 1]);
-        let chunk_2 = new_chunk(1, vec![2, 3]);
+        let (storage_id_1, mut slice_ids, mut slices, chunk_1) = new_chunk(&[100, 200]);
+        let (storage_id_2, slice_ids_2, slices_2, chunk_2) = new_chunk(&[200, 200]);
 
-        let mut slices = HashMap::from([
-            (slice_1.id, slice_1),
-            (slice_2.id, slice_2),
-            (slice_3.id, slice_3),
-            (slice_4.id, slice_4),
-        ]);
-        let mut chunks = HashMap::from([(chunk_1.id, chunk_1), (chunk_2.id, chunk_2)]);
+        ring.push_chunk(storage_id_1);
+        ring.push_chunk(storage_id_2);
 
-        ring.push_chunk(ChunkId { value: 0 });
-        ring.push_chunk(ChunkId { value: 1 });
+        let mut chunks = HashMap::from([(storage_id_1, chunk_1), (storage_id_2, chunk_2)]);
 
-        slices.get_mut(&SliceId { value: 0 }).unwrap().is_free = true;
-        slices.get_mut(&SliceId { value: 1 }).unwrap().is_free = false;
-        slices.get_mut(&SliceId { value: 3 }).unwrap().is_free = false;
+        slice_ids.extend(slice_ids_2);
+        slices.extend(slices_2);
 
-        let slice = ring.find_free_slice(200, &mut chunks, &mut slices).unwrap();
+        // Clone references to control what slice is free:
+        let _slice_1 = slices.get(&slice_ids[1]).unwrap().handle.clone();
+        let _slice_3 = slices.get(&slice_ids[3]).unwrap().handle.clone();
 
-        assert_eq!(slice, SliceId { value: 2 });
+        let slice = ring
+            .find_free_slice(200, &mut chunks, &mut slices, &[])
+            .unwrap();
 
-        let slice = ring.find_free_slice(100, &mut chunks, &mut slices).unwrap();
+        assert_eq!(slice, slice_ids[2]);
 
-        assert_eq!(slice, SliceId { value: 0 });
+        let slice = ring
+            .find_free_slice(100, &mut chunks, &mut slices, &[])
+            .unwrap();
+
+        assert_eq!(slice, slice_ids[0]);
     }
 
     #[test]
     fn find_free_slice_with_exact_fit() {
-        let mut ring = RingBuffer::<TestChunk, TestSlice>::new(0);
+        let mut ring = RingBuffer::new(1);
 
-        let slice_1 = new_slice(0, 100, 0);
-        let slice_2 = new_slice(1, 200, 1);
-        let chunk_1 = new_chunk(0, vec![0, 1]);
+        let (storage_id, slice_ids, mut slices, chunk) = new_chunk(&[100, 200]);
 
-        let mut slices = HashMap::from([(slice_1.id, slice_1), (slice_2.id, slice_2)]);
-        let mut chunks = HashMap::from([(chunk_1.id, chunk_1)]);
+        ring.push_chunk(storage_id);
+        let mut chunks = HashMap::from([(storage_id, chunk)]);
 
-        ring.push_chunk(ChunkId { value: 0 });
+        // Clone reference to control what slice is free:
+        let _slice_1 = slices.get(&slice_ids[0]).unwrap().handle.clone();
 
-        slices.get_mut(&SliceId { value: 0 }).unwrap().is_free = false;
-        slices.get_mut(&SliceId { value: 1 }).unwrap().is_free = true;
+        let slice = ring
+            .find_free_slice(200, &mut chunks, &mut slices, &[])
+            .unwrap();
 
-        let slice = ring.find_free_slice(200, &mut chunks, &mut slices).unwrap();
-
-        assert_eq!(slice, SliceId { value: 1 });
-        assert_eq!(slices.get(&slice).unwrap().size, 200);
+        assert_eq!(slice, slice_ids[1]);
+        assert_eq!(slices.get(&slice).unwrap().size(), 200);
         assert_eq!(slices.len(), 2);
-        assert_eq!(chunks.values().last().unwrap().slices.len(), 2);
+        assert_eq!(chunks.values().last().unwrap().slices.slices.len(), 2);
     }
 
     #[test]
     fn find_free_slice_with_merging() {
-        let mut ring = RingBuffer::<TestChunk, TestSlice>::new(0);
+        let mut ring = RingBuffer::new(1);
 
-        let slice_1 = new_slice(0, 100, 0);
-        let slice_2 = new_slice(1, 50, 1);
-        let slice_3 = new_slice(2, 100, 2);
-        let chunk_1 = new_chunk(0, vec![0, 1, 2]);
+        let (storage_id, slice_ids, mut slices, chunk) = new_chunk(&[100, 50, 100]);
 
-        let mut slices = HashMap::from([
-            (slice_1.id, slice_1),
-            (slice_2.id, slice_2),
-            (slice_3.id, slice_3),
-        ]);
-        let mut chunks = HashMap::from([(chunk_1.id, chunk_1)]);
+        ring.push_chunk(storage_id);
+        let mut chunks = HashMap::from([(storage_id, chunk)]);
 
-        ring.push_chunk(ChunkId { value: 0 });
+        let slice = ring
+            .find_free_slice(250, &mut chunks, &mut slices, &[])
+            .unwrap();
 
-        slices.get_mut(&SliceId { value: 0 }).unwrap().is_free = true;
-        slices.get_mut(&SliceId { value: 1 }).unwrap().is_free = true;
-        slices.get_mut(&SliceId { value: 2 }).unwrap().is_free = true;
-
-        let slice = ring.find_free_slice(250, &mut chunks, &mut slices).unwrap();
-
-        assert_eq!(slice, SliceId { value: 0 });
-        assert_eq!(slices.get(&slice).unwrap().size, 250);
+        assert_eq!(slice, slice_ids[0]);
+        assert_eq!(slices.get(&slice).unwrap().size(), 250);
         assert_eq!(slices.len(), 1);
-        assert_eq!(chunks.values().last().unwrap().slices.len(), 1);
+        assert_eq!(chunks.values().last().unwrap().slices.slices.len(), 1);
     }
 
     #[test]
     fn find_free_slice_with_multiple_chunks_and_merging() {
-        let mut ring = RingBuffer::<TestChunk, TestSlice>::new(0);
+        let mut ring = RingBuffer::new(1);
 
-        let slice_1 = new_slice(0, 50, 0);
-        let slice_2 = new_slice(1, 50, 1);
-        let chunk_1 = new_chunk(0, vec![0, 1]);
+        let (storage_id_1, mut slice_ids, mut slices, chunk_1) = new_chunk(&[50, 50]);
+        let (storage_id_2, slice_ids_2, slices_2, chunk_2) = new_chunk(&[100, 50]);
+        slice_ids.extend(slice_ids_2);
+        slices.extend(slices_2);
 
-        let slice_3 = new_slice(2, 100, 0);
-        let slice_4 = new_slice(3, 50, 1);
-        let chunk_2 = new_chunk(1, vec![2, 3]);
+        ring.push_chunk(storage_id_1);
+        ring.push_chunk(storage_id_2);
 
-        let mut slices = HashMap::from([
-            (slice_1.id, slice_1),
-            (slice_2.id, slice_2),
-            (slice_3.id, slice_3),
-            (slice_4.id, slice_4),
-        ]);
-        let mut chunks = HashMap::from([(chunk_1.id, chunk_1), (chunk_2.id, chunk_2)]);
+        let mut chunks = HashMap::from([(storage_id_1, chunk_1), (storage_id_2, chunk_2)]);
 
-        ring.push_chunk(ChunkId { value: 0 });
-        ring.push_chunk(ChunkId { value: 1 });
+        let slice = ring
+            .find_free_slice(150, &mut chunks, &mut slices, &[])
+            .unwrap();
 
-        slices.get_mut(&SliceId { value: 0 }).unwrap().is_free = true;
-        slices.get_mut(&SliceId { value: 1 }).unwrap().is_free = true;
-        slices.get_mut(&SliceId { value: 2 }).unwrap().is_free = true;
-        slices.get_mut(&SliceId { value: 3 }).unwrap().is_free = true;
-
-        let slice = ring.find_free_slice(150, &mut chunks, &mut slices).unwrap();
-
-        assert_eq!(slices.get(&slice).unwrap().size, 150);
+        assert_eq!(slices.get(&slice).unwrap().size(), 150);
         assert_eq!(slices.len(), 2);
-        assert_eq!(chunks.values().last().unwrap().slices.len(), 1);
+        assert_eq!(chunks.values().last().unwrap().slices.slices.len(), 1);
     }
 
-    fn new_slice(id: usize, size: usize, position: usize) -> TestSlice {
-        TestSlice {
-            id: SliceId { value: id },
-            is_free: true,
-            size,
-            position,
-        }
+    #[test]
+    fn excludes_excluded_storage() {
+        let mut ring = RingBuffer::new(1);
+
+        let (storage_id_1, mut slice_ids, mut slices, chunk_1) = new_chunk(&[100, 100]);
+        let (storage_id_2, slice_ids_2, slices_2, chunk_2) = new_chunk(&[100, 100]);
+
+        ring.push_chunk(storage_id_1);
+        ring.push_chunk(storage_id_2);
+
+        let mut chunks = HashMap::from([(storage_id_1, chunk_1), (storage_id_2, chunk_2)]);
+
+        slice_ids.extend(slice_ids_2);
+        slices.extend(slices_2);
+
+        let slice = ring
+            .find_free_slice(100, &mut chunks, &mut slices, &[])
+            .unwrap();
+        assert_eq!(slice, slice_ids[0]);
+
+        let slice = ring
+            .find_free_slice(100, &mut chunks, &mut slices, &[storage_id_1])
+            .unwrap();
+        assert_eq!(slice, slice_ids[2]);
     }
 
-    fn new_chunk(id: usize, slices: Vec<usize>) -> TestChunk {
-        TestChunk {
-            id: ChunkId { value: id },
-            slices: slices.into_iter().map(|i| SliceId { value: i }).collect(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod stub {
-    use super::*;
-    use cubecl_common::*;
-
-    #[derive(Debug)]
-    pub struct TestChunk {
-        pub id: ChunkId,
-        pub slices: Vec<SliceId>,
-    }
-
-    #[derive(Debug)]
-    pub struct TestSlice {
-        pub id: SliceId,
-        pub is_free: bool,
-        pub size: usize,
-        pub position: usize,
-    }
-
-    impl MemorySlice for TestSlice {
-        fn is_free(&self) -> bool {
-            self.is_free
-        }
-
-        fn size(&self) -> usize {
-            self.size
-        }
-
-        fn split(&mut self, offset: usize, _buffer_alignment: usize) -> Option<Self> {
-            let size_remained = self.size - offset;
-            self.size = offset;
-
-            Some(Self {
-                id: SliceId {
-                    value: rand::gen_random(),
-                },
-                is_free: true,
-                size: size_remained,
-                position: self.position + 1,
+    fn new_chunk(
+        slice_sizes: &[usize],
+    ) -> (StorageId, Vec<SliceId>, HashMap<SliceId, Slice>, Chunk) {
+        let offsets: Vec<_> = slice_sizes
+            .iter()
+            .scan(0, |state, size| {
+                let offset = *state;
+                *state += *size;
+                Some(offset)
             })
-        }
+            .collect();
 
-        fn id(&self) -> SliceId {
-            self.id
-        }
+        let storage_id = StorageId::new();
 
-        fn next_slice_position(&self) -> usize {
-            self.position + 1
-        }
-    }
+        let slices: Vec<_> = offsets
+            .iter()
+            .zip(slice_sizes)
+            .map(|(&offset, &size)| Slice {
+                storage: StorageHandle {
+                    id: storage_id,
+                    utilization: crate::storage::StorageUtilization::Slice { offset, size },
+                },
+                handle: SliceHandle::new(),
+                padding: 0,
+            })
+            .collect();
 
-    impl MemoryChunk<TestSlice> for TestChunk {
-        fn merge_next_slice(
-            &mut self,
-            from_slice_index: usize,
-            slices: &mut HashMap<SliceId, TestSlice>,
-        ) -> bool {
-            let slice_id_current = self.slices.get(from_slice_index).unwrap();
-            let slice_id_next = self.slices.get(from_slice_index + 1);
-            let slice_id_next = match slice_id_next {
-                Some(val) => val,
-                None => return false,
-            };
+        let mem_page = MemoryPage {
+            slices: slices
+                .iter()
+                .zip(offsets)
+                .map(|(slice, offset)| (offset, slice.id()))
+                .collect(),
+        };
 
-            let slice_next = slices.get(slice_id_next).unwrap();
-            let is_free = slice_next.is_free;
-            let size = slice_next.size;
+        let chunk = Chunk {
+            alloc_size: 1024 * 1024, // Arbitrary, just pretend we have a big enough allocation.
+            slices: mem_page,
+        };
 
-            let slice_current = slices.get_mut(slice_id_current).unwrap();
-
-            if is_free {
-                slice_current.size += size;
-                slices.remove(slice_id_next);
-                self.slices.remove(from_slice_index + 1);
-
-                for (index, temp_slice_id) in self.slices.iter_mut().enumerate() {
-                    let slice = slices.get_mut(temp_slice_id).unwrap();
-                    slice.position = index;
-                }
-                return true;
-            }
-
-            false
-        }
-
-        fn slice(&self, index: usize) -> Option<SliceId> {
-            self.slices.get(index).copied()
-        }
-
-        fn insert_slice(
-            &mut self,
-            position: usize,
-            slice: TestSlice,
-            slices: &mut HashMap<SliceId, TestSlice>,
-        ) {
-            self.slices.insert(position, slice.id());
-            slices.insert(slice.id(), slice);
-            for (index, temp_slice_id) in self.slices.iter_mut().enumerate() {
-                let temp_slice = slices.get_mut(temp_slice_id).unwrap();
-                temp_slice.position = index;
-            }
-        }
+        (
+            storage_id,
+            slices.iter().map(|slice| slice.id()).collect(),
+            slices
+                .into_iter()
+                .map(|slice| (slice.id(), slice))
+                .collect(),
+            chunk,
+        )
     }
 }

--- a/crates/cubecl-runtime/src/storage/base.rs
+++ b/crates/cubecl-runtime/src/storage/base.rs
@@ -58,7 +58,4 @@ pub trait ComputeStorage: Send {
 
     /// Deallocates the memory pointed by the given storage id.
     fn dealloc(&mut self, id: StorageId);
-
-    /// Copy
-    fn copy(&mut self, from: &StorageHandle, to: &StorageHandle);
 }

--- a/crates/cubecl-runtime/src/storage/bytes_cpu.rs
+++ b/crates/cubecl-runtime/src/storage/bytes_cpu.rs
@@ -57,7 +57,7 @@ impl ComputeStorage for BytesStorage {
     type Resource = BytesResource;
 
     fn get(&mut self, handle: &StorageHandle) -> Self::Resource {
-        let allocated_bytes = self.memory.get_mut(&handle.id).unwrap();
+        let allocated_bytes = self.memory.get(&handle.id).unwrap();
 
         BytesResource {
             ptr: allocated_bytes.ptr,
@@ -68,7 +68,7 @@ impl ComputeStorage for BytesStorage {
     fn alloc(&mut self, size: usize) -> StorageHandle {
         let id = StorageId::new();
         let handle = StorageHandle {
-            id: id.clone(),
+            id,
             utilization: StorageUtilization::Full(size),
         };
 
@@ -127,7 +127,7 @@ mod tests {
         let mut storage = BytesStorage::default();
         let handle_1 = storage.alloc(64);
         let handle_2 = StorageHandle::new(
-            handle_1.id.clone(),
+            handle_1.id,
             StorageUtilization::Slice {
                 offset: 24,
                 size: 8,

--- a/crates/cubecl-runtime/src/storage/bytes_cpu.rs
+++ b/crates/cubecl-runtime/src/storage/bytes_cpu.rs
@@ -90,23 +90,6 @@ impl ComputeStorage for BytesStorage {
             }
         }
     }
-
-    fn copy(&mut self, from: &StorageHandle, to: &StorageHandle) {
-        assert_eq!(from.size(), to.size());
-
-        let input = self.get(from);
-        let output = self.get(to);
-
-        for i in 0..from.size() {
-            let offset = i + from.offset();
-            let ptr_out = output.ptr.wrapping_add(offset);
-
-            let offset = i + to.offset();
-            let ptr_in = input.ptr.wrapping_add(offset);
-
-            unsafe { *ptr_in = *ptr_out }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -152,8 +152,7 @@ where
         let read_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size,
-            usage: wgpu::BufferUsages::MAP_READ
-                | wgpu::BufferUsages::COPY_DST,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -153,7 +153,6 @@ where
             label: None,
             size,
             usage: wgpu::BufferUsages::MAP_READ
-                | wgpu::BufferUsages::MAP_WRITE
                 | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -32,6 +32,12 @@ pub struct WgpuServer<MM: MemoryManagement<WgpuStorage>> {
     logger: DebugLogger,
 }
 
+fn create_encoder(device: &wgpu::Device) -> CommandEncoder {
+    device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("CubeCL Command Encoder"),
+    })
+}
+
 impl<MM> WgpuServer<MM>
 where
     MM: MemoryManagement<WgpuStorage>,
@@ -47,9 +53,7 @@ where
             memory_management,
             device: device.clone(),
             queue: queue.clone(),
-            encoder: device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("Command Encoder"),
-            }),
+            encoder: create_encoder(&device),
             current_pass: None,
             tasks_count: 0,
             compute_storage_used: Vec::new(),
@@ -301,11 +305,7 @@ where
     fn sync(&mut self, sync_type: SyncType) {
         // End the current compute pass.
         self.clear_compute_pass();
-        let new_encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("Command Encoder"),
-            });
+        let new_encoder = create_encoder(&self.device);
         let encoder = std::mem::replace(&mut self.encoder, new_encoder);
         self.queue.submit([encoder.finish()]);
 

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -1,25 +1,18 @@
-use std::num::NonZeroU64;
+use std::num::NonZero;
 
 use super::WgpuStorage;
 use alloc::{borrow::Cow, sync::Arc};
 use cubecl_common::{reader::Reader, sync_type::SyncType};
-use cubecl_core::{compute::DebugInformation, prelude::*, FeatureSet, KernelId};
+use cubecl_core::{compute::DebugInformation, prelude::*, server::Handle, FeatureSet, KernelId};
 use cubecl_runtime::{
     debug::DebugLogger,
     memory_management::MemoryManagement,
     server::{self, ComputeServer},
+    storage::{ComputeStorage, StorageId},
     ExecutionMode,
 };
 use hashbrown::HashMap;
-use wgpu::{
-    util::{BufferInitDescriptor, DeviceExt, StagingBelt},
-    BindGroup, CommandEncoder, ComputePipeline, ShaderModuleDescriptor,
-};
-
-// Allocations with existing data smaller than this can use a staging belt
-// which speeds up the allocation. A higher number here will catch more
-// allocations, but can also increase memory usage.
-const SMALL_ALLOC_SIZE: usize = 512;
+use wgpu::{CommandEncoder, ComputePass, ComputePipeline, ShaderModuleDescriptor};
 
 /// Wgpu compute server.
 #[derive(Debug)]
@@ -27,11 +20,15 @@ pub struct WgpuServer<MM: MemoryManagement<WgpuStorage>> {
     memory_management: MM,
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,
+
     encoder: CommandEncoder,
-    staging_belt: StagingBelt,
+    current_pass: Option<ComputePass<'static>>,
+    tasks_count: usize,
+    // TODO: Is this better as a hashset?
+    compute_storage_used: Vec<StorageId>,
+
     pipelines: HashMap<KernelId, Arc<ComputePipeline>>,
     tasks_max: usize,
-    tasks_count: usize,
     logger: DebugLogger,
 }
 
@@ -46,57 +43,20 @@ where
         queue: Arc<wgpu::Queue>,
         tasks_max: usize,
     ) -> Self {
-        let encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("Command Encoder"),
-        });
-
         Self {
             memory_management,
-            device,
-            queue,
-            encoder,
-            staging_belt: StagingBelt::new(SMALL_ALLOC_SIZE as u64),
+            device: device.clone(),
+            queue: queue.clone(),
+            encoder: device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Command Encoder"),
+            }),
+            current_pass: None,
+            tasks_count: 0,
+            compute_storage_used: Vec::new(),
             pipelines: HashMap::new(),
             tasks_max,
-            tasks_count: 0,
             logger: DebugLogger::new(),
         }
-    }
-
-    fn register_compute(
-        &mut self,
-        pipeline: Arc<ComputePipeline>,
-        bind_group: BindGroup,
-        count: CubeCount<Self>,
-    ) {
-        // First resolve the dispatch buffer if needed. The weird ordering is because the lifetime of this
-        // needs to be longer than the compute pass, so we can't do this just before dispatching.
-        let dispatch_resource = match count.clone() {
-            CubeCount::Dynamic(binding) => Some(self.memory_management.get(binding.memory)),
-            _ => None,
-        };
-
-        let mut compute = self
-            .encoder
-            .begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: None,
-                timestamp_writes: None,
-            });
-
-        compute.set_pipeline(&pipeline);
-        compute.set_bind_group(0, &bind_group, &[]);
-
-        match count {
-            CubeCount::Static(x, y, z) => {
-                compute.dispatch_workgroups(x, y, z);
-            }
-            CubeCount::Dynamic(_) => {
-                let resource = dispatch_resource.as_ref().unwrap();
-                compute.dispatch_workgroups_indirect(&resource.buffer, resource.offset());
-            }
-        }
-
-        self.tasks_count += 1;
     }
 
     fn pipeline(
@@ -152,28 +112,26 @@ where
         )
     }
 
-    fn create_read_buffer(&mut self, handle: server::Binding<Self>) -> wgpu::Buffer {
-        let resource = self.memory_management.get(handle.memory);
-
-        let size = resource.size();
-        let buffer_dest = self.device.create_buffer(&wgpu::BufferDescriptor {
-            label: None,
-            size,
-            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
-        self.encoder.copy_buffer_to_buffer(
-            &resource.buffer,
-            resource.offset(),
-            &buffer_dest,
-            0,
-            size,
-        );
+    fn start_compute_pass(&mut self) -> &mut ComputePass<'static> {
         self.tasks_count += 1;
 
-        self.sync(SyncType::Flush);
-        buffer_dest
+        // Start a new compute pass if needed. The forget_lifetime allows
+        // to store this with a 'static lifetime, but in reality
+        // the compute pass must be dropped before the encoder.
+        // This isn't unsafe - it's checked at runtime - but panics
+        // otherwise.
+        self.current_pass.get_or_insert_with(|| {
+            self.encoder
+                .begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: None,
+                    timestamp_writes: None,
+                })
+                .forget_lifetime()
+        })
+    }
+
+    fn end_compute_pass(&mut self) {
+        self.current_pass = None;
     }
 }
 
@@ -188,36 +146,60 @@ where
     type FeatureSet = FeatureSet;
 
     fn read(&mut self, binding: server::Binding<Self>) -> Reader {
+        let resource = self.get_resource(binding);
+
+        let size = resource.size();
+        let read_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size,
+            usage: wgpu::BufferUsages::MAP_READ
+                | wgpu::BufferUsages::MAP_WRITE
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        self.end_compute_pass();
+
+        self.encoder.copy_buffer_to_buffer(
+            &resource.buffer,
+            resource.offset(),
+            &read_buffer,
+            0,
+            size,
+        );
+
+        // Flush all commands to the queue, so GPU gets started on copying to the staging buffer.
+        self.sync(SyncType::Flush);
+
+        let (sender, receiver) = async_channel::bounded(1);
+        let slice = read_buffer.slice(..);
+        slice.map_async(wgpu::MapMode::Read, move |v| {
+            sender
+                .try_send(v)
+                .expect("Unable to send buffer slice result to async channel.");
+        });
+
         let device = self.device.clone();
-        let buffer = self.create_read_buffer(binding);
 
         Box::pin(async move {
-            let buffer_slice = buffer.slice(..);
-            let (sender, receiver) = async_channel::bounded(1);
-
-            buffer_slice.map_async(wgpu::MapMode::Read, move |v| {
-                sender
-                    .try_send(v)
-                    .expect("Unable to send buffer slice result to async channel.")
-            });
-
+            // Now wait for the GPU to finish.
             device.poll(wgpu::Maintain::Wait);
 
-            let result = receiver
+            let slice = read_buffer.slice(..);
+
+            receiver
                 .recv()
                 .await
-                .expect("Unable to receive buffer slice result.");
+                .expect("Unable to receive buffer slice result.")
+                .expect("Failed to map buffer");
 
-            if let Ok(()) = result {
-                let data = buffer_slice.get_mapped_range();
-                let result = bytemuck::cast_slice(&data).to_vec();
+            let data = slice.get_mapped_range();
+            let result = bytemuck::cast_slice(&data).to_vec();
 
-                drop(data);
-                buffer.unmap();
-                result
-            } else {
-                panic!("Unable to read buffer {:?}", result)
-            }
+            drop(data);
+            read_buffer.unmap();
+
+            result
         })
     }
 
@@ -225,7 +207,8 @@ where
         &mut self,
         binding: server::Binding<Self>,
     ) -> <Self::Storage as cubecl_runtime::storage::ComputeStorage>::Resource {
-        self.memory_management.get(binding.memory)
+        let handle = self.memory_management.get(binding.memory);
+        self.memory_management.storage().get(&handle)
     }
 
     /// When we create a new handle from existing data, we use custom allocations so that we don't
@@ -234,68 +217,28 @@ where
     /// This is important, otherwise the compute passes are going to be too small and we won't be able to
     /// fully utilize the GPU.
     fn create(&mut self, data: &[u8]) -> server::Handle<Self> {
-        let handle = server::Handle::new(self.memory_management.reserve(data.len(), || {
-            flush_tasks(
-                &mut self.encoder,
-                &self.queue,
-                &self.device,
-                &mut self.tasks_count,
-                &mut self.staging_belt,
-            );
-            self.device.poll(wgpu::Maintain::Wait);
-        }));
+        // Reserve memory on some storage we haven't yet used this command queue.
+        let memory = self
+            .memory_management
+            .reserve(data.len(), &self.compute_storage_used);
 
-        let non_zero_len = NonZeroU64::new(data.len() as u64);
+        let handle = Handle::new(memory);
 
-        // If there's nothing to copy, don't need to do any work here.
-        if let Some(len) = non_zero_len {
-            let binding = handle.clone().binding();
-            let resource = self.memory_management.get(binding.memory);
+        if let Some(len) = NonZero::new(data.len() as u64) {
+            let resource = self.get_resource(handle.clone().binding());
 
-            if data.len() < SMALL_ALLOC_SIZE {
-                // Use a staging belt if the allocation is small enough. This is faster than allocating a new buffer.
-                // Ideally, we could use queue.write_buffer_with(), which seems to be the recommended method for performance,
-                // but that doesn't seem to work, as we might re-use a buffer multiple times, and need to schedule this
-                // precisely in the encoder.
-                let mut write_buf = self.staging_belt.write_buffer(
-                    &mut self.encoder,
-                    &resource.buffer,
-                    resource.offset(),
-                    len,
-                    &self.device,
-                );
-                write_buf.copy_from_slice(data);
-            } else {
-                let buffer_src = Arc::new(self.device.create_buffer_init(&BufferInitDescriptor {
-                    label: Some("Buffer Src"),
-                    contents: data,
-                    usage: wgpu::BufferUsages::COPY_SRC,
-                }));
-                self.encoder.copy_buffer_to_buffer(
-                    &buffer_src,
-                    0,
-                    &resource.buffer,
-                    resource.offset(),
-                    buffer_src.size(),
-                );
-            }
-            self.tasks_count += 1;
+            // Write to the staging buffer. Next queue submission this will copy the data to the GPU.
+            self.queue
+                .write_buffer_with(&resource.buffer, resource.offset(), len)
+                .expect("Failed to write to staging buffer.")
+                .copy_from_slice(data);
         }
 
         handle
     }
 
     fn empty(&mut self, size: usize) -> server::Handle<Self> {
-        server::Handle::new(self.memory_management.reserve(size, || {
-            flush_tasks(
-                &mut self.encoder,
-                &self.queue,
-                &self.device,
-                &mut self.tasks_count,
-                &mut self.staging_belt,
-            );
-            self.device.poll(wgpu::Maintain::Wait);
-        }))
+        server::Handle::new(self.memory_management.reserve(size, &[]))
     }
 
     unsafe fn execute(
@@ -308,27 +251,54 @@ where
         let pipeline = self.pipeline(kernel, mode);
         let group_layout = pipeline.get_bind_group_layout(0);
 
-        let memory_handles = bindings
-            .into_iter()
-            .map(|binding| self.memory_management.get(binding.memory))
-            .collect::<Vec<_>>();
+        // Store all the resources we'll be using. This could be eliminated if
+        // there was a way to tie the lifetime of the resource to the memory handle.
+        let resources: Vec<_> = bindings
+            .iter()
+            .map(|binding| {
+                let resource_handle = self.memory_management.get(binding.memory.clone());
+                // Keep track of the storage we've used so far.
+                self.compute_storage_used.push(resource_handle.id);
 
-        let entries = memory_handles
+                self.memory_management.storage().get(&resource_handle)
+            })
+            .collect();
+
+        let entries = &resources
             .iter()
             .enumerate()
-            .map(|(i, buffer)| wgpu::BindGroupEntry {
+            .map(|(i, r)| wgpu::BindGroupEntry {
                 binding: i as u32,
-                resource: buffer.as_binding(),
+                resource: r.as_binding(),
             })
             .collect::<Vec<_>>();
 
         let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: None,
             layout: &group_layout,
-            entries: &entries,
+            entries,
         });
 
-        self.register_compute(pipeline, bind_group, count);
+        // First resolve the dispatch buffer if needed. The weird ordering is because the lifetime of this
+        // needs to be longer than the compute pass, so we can't do this just before dispatching.
+        let dispatch_resource = match count.clone() {
+            CubeCount::Dynamic(binding) => Some(self.get_resource(binding)),
+            _ => None,
+        };
+
+        let pass = self.start_compute_pass();
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+
+        match count {
+            CubeCount::Static(x, y, z) => {
+                pass.dispatch_workgroups(x, y, z);
+            }
+            CubeCount::Dynamic(_) => {
+                let resource = dispatch_resource.as_ref().unwrap();
+                pass.dispatch_workgroups_indirect(&resource.buffer, resource.offset());
+            }
+        }
 
         if self.tasks_count >= self.tasks_max {
             self.sync(SyncType::Flush);
@@ -336,41 +306,24 @@ where
     }
 
     fn sync(&mut self, sync_type: SyncType) {
-        flush_tasks(
-            &mut self.encoder,
-            &self.queue,
-            &self.device,
-            &mut self.tasks_count,
-            &mut self.staging_belt,
-        );
+        // End the current compute pass.
+        self.end_compute_pass();
+        let new_encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Command Encoder"),
+            });
+        let encoder = std::mem::replace(&mut self.encoder, new_encoder);
+        self.queue.submit([encoder.finish()]);
 
-        // Cleanup allocations and deallocations.
-        self.memory_management.storage().perform_deallocations();
+        self.tasks_count = 0;
+        self.compute_storage_used.clear();
 
         if sync_type == SyncType::Wait {
             self.device.poll(wgpu::Maintain::Wait);
         }
+
+        // Cleanup allocations and deallocations.
+        self.memory_management.storage().perform_deallocations();
     }
-}
-
-/// Flush tasks using the [command encoder](CommandEncoder).
-///
-/// This implementation is decoupled from both the [server](WgpuServer) and [memory management](MemoryManagement).
-/// This decoupling allows for safe usage within sync callbacks when allocating memory buffers.
-fn flush_tasks(
-    encoder: &mut CommandEncoder,
-    queue: &wgpu::Queue,
-    device: &wgpu::Device,
-    tasks_count: &mut usize,
-    staging_belt: &mut StagingBelt,
-) {
-    staging_belt.finish();
-
-    let mut new_encoder =
-        device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-    core::mem::swap(&mut new_encoder, encoder);
-
-    queue.submit(Some(new_encoder.finish()));
-    *tasks_count = 0;
-    staging_belt.recall();
 }

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -20,13 +20,10 @@ pub struct WgpuServer<MM: MemoryManagement<WgpuStorage>> {
     memory_management: MM,
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,
-
     encoder: CommandEncoder,
     current_pass: Option<ComputePass<'static>>,
     tasks_count: usize,
-    // TODO: Is this better as a hashset?
     compute_storage_used: Vec<StorageId>,
-
     pipelines: HashMap<KernelId, Arc<ComputePipeline>>,
     tasks_max: usize,
     logger: DebugLogger,

--- a/crates/cubecl-wgpu/src/compute/storage.rs
+++ b/crates/cubecl-wgpu/src/compute/storage.rs
@@ -116,7 +116,7 @@ impl ComputeStorage for WgpuStorage {
             mapped_at_creation: false,
         }));
 
-        self.memory.insert(id.clone(), buffer);
+        self.memory.insert(id, buffer);
 
         StorageHandle::new(id, StorageUtilization::Full(size))
     }
@@ -126,6 +126,9 @@ impl ComputeStorage for WgpuStorage {
     }
 
     fn copy(&mut self, from: &StorageHandle, to: &StorageHandle) {
+        // TODO: The semantics of this seems really strange, as we might be copying before other commands
+        // are flushed & done. Ideally, we should pass in the actual current encoder and queue commands there
+        // or remove the need to copy entirely. This is not used at the moment.
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -117,7 +117,7 @@ fn create_client(
     MutexComputeChannel<WgpuServer<DynamicMemoryManagement<WgpuStorage>>>,
 > {
     let limits = device_wgpu.limits();
-    let storage = WgpuStorage::new(device_wgpu.clone(), queue.clone());
+    let storage = WgpuStorage::new(device_wgpu.clone());
     let memory_management = DynamicMemoryManagement::new(
         storage,
         DynamicMemoryManagementOptions::preset(


### PR DESCRIPTION
This PR significantly reduces CPU overhead, and slightly optimizes GPU performance, of cube on wgpu. It got a bit bigger than intended, as there was a cascade of things to do so bear with me!

## Outline

- Wgpu 22.0.0 has a new method on ComputePass `leak_lifetime` which allows using the compute pass without a complicated lifetime. It's still safe, there's runtime checks as well, just means you have to be more careful. This allows cube CL to batch executions into one Compute pass, which is faster.

- However, you can't use encoder.copy_buffer_to_buffer while a compute pass is still open. Since client.create() gets called before each execute, this prevents the compute pass optimization from really working.

- The way client.create() works is sub-optimal anyway: queue.write_buffer_with is faster, and on most GPUs doesn't need a staging buffer & copy at all, saving CPU and GPU work. This should also be a nice saving when eg. uploading a batch of data for training.

- Using queue.write_buffer_with is tricky however. The GPU memory gets written at the start of the command buffer submitted to the queue. This doesn't work with pooled memory though! Cube might want an order like  `kernel A -> write_buffer -> kernel B`. Writing first means kernel A stamps over the memory.

- So, we need a way to _not_ use memory used earlier in the pass. I've considered some other options, like a separate memory pool for create() allocations, but ultimately have gone with the approach that also applies to [this issue](https://github.com/tracel-ai/burn/issues/1996), where you can exclude a set of resources to use when allocating. For this case, we only need to not overlap memory regions not whole buffers, but that would get more complicated and isn't worth it probably.

- An earlier attempt at the issue above was to exclude ChunkId's. This is ok but a bit strange. The requirement is really to not share buffers. In the implementation one chunk == one buffer so it could work, but that raises the question why there's ChunkIds in the first place. This seemed viable to simplify, so the API just maps StorageIds -> chunk metadata. This saves some overhead & lookups as well.

- The current pool code was generic over the chunk and slice type, and mocked these for testing. That meant I couldn't get the storage ID however, and imho this abstraction & mocking isn't great. I've removed this and made the tests work with a "real" setup which exercises more parts of the code. This might catch some more bugs.

- The sync() method in mm.alloc() and mm.reserve() made all of this tricker as well and with gnarlier semantics (how to deal with writes that happen soon as we sync?). This doesn't seem to be used atm and imho sounds like trouble in general! I'veremoved this for now, but lmk if I'm missing the crucial reason it should be there.

- The ability of ComputeStorage to copy buffers is also a bit problematic, as it probably also needs to be ordered properly within the encoder. I've just left a note of this for now as it's not currently used, I'm not sure what the plans are for extending the max memory but would be great if it could be done without copying.

## Benchmarks

Some benchmarks on my burn gaussian splatting code:

Inference CPU
<img width="720" alt="image" src="https://github.com/user-attachments/assets/9ca40ce9-1a07-4826-a752-61ed60894e34">

Inference + GPU sync
<img width="720" alt="image" src="https://github.com/user-attachments/assets/374468f1-7e34-47c4-a0ae-9a12827263eb">

Training step CPU
<img width="720" alt="image" src="https://github.com/user-attachments/assets/7420393f-b520-497f-b7d4-268300a0bdee">

## Possible future work
- Merge all constants into a single info struct for wgsl. Allocating small 4 byte buffers for each float isn't very efficient.
- Mark these constant buffers as uniform memory. This might require a separate pool of 'uniform buffers' after all, not sure.
- More memory juggling to solve https://github.com/tracel-ai/burn/issues/1996
- Remove the SmallMemoryPool - I suspect if all allocations for uniforms were batched it would be redundant.
- Remove the simple memory allocator as the new dynamic one is probably better all around.