### PR TITLE
Revert float precision changes to wgsl compiler

### DIFF
--- a/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
@@ -259,8 +259,8 @@ impl Display for Variable {
                     FloatKind::BF16 => {
                         todo!("Unsupported")
                     }
-                    FloatKind::F32 => f.write_fmt(format_args!("{:.9}f", *val as f32)),
-                    FloatKind::F64 => f.write_fmt(format_args!("{:.17}f", { *val })),
+                    FloatKind::F32 => f.write_fmt(format_args!("{}f", *val as f32)),
+                    FloatKind::F64 => f.write_fmt(format_args!("{}f", { *val })),
                 },
                 ConstantScalarValue::UInt(val) => f.write_fmt(format_args!("{}u", *val as u32)),
                 ConstantScalarValue::Bool(val) => f.write_fmt(format_args!("{}", val)),


### PR DESCRIPTION
Revert the precision changes applied in #53.

While the initial PR was merged to fix Burn's [issue with the web image classification example](https://github.com/tracel-ai/burn/issues/2118), this has affected a bunch of wgpu tests.

An alternative has been proposed by using 13 decimal points, which seems to resolve the previously introduced errors in the wgpu tests, but it feels a bit arbitrary.

The original issue will remain open and requires further investigation.