### PR TITLE
Support destructuring tuples in cube macro

### DIFF
--- a/crates/cubecl-core/tests/frontend/tuple.rs
+++ b/crates/cubecl-core/tests/frontend/tuple.rs
@@ -8,6 +8,13 @@ pub fn tuple_const() -> (UInt, UInt) {
     (x, y)
 }
 
+#[cube]
+pub fn tuple_destructuring() -> (UInt, UInt) {
+    let x = (UInt::new(0), UInt::new(1));
+    let (a, b) = x;
+    (a + UInt::new(1), b)
+}
+
 mod tests {
     use super::*;
     use cubecl_core::{
@@ -37,6 +44,33 @@ mod tests {
 
         cpa!(scope, x = zero);
         cpa!(scope, y = one);
+
+        scope.operations
+    }
+
+    #[test]
+    fn cube_tuple_destructuring() {
+        let mut context = CubeContext::root();
+
+        tuple_destructuring::__expand(&mut context);
+        let scope = context.into_scope();
+
+        assert_eq!(scope.operations, inline_macro_ref_tuple_destructuring());
+    }
+
+    fn inline_macro_ref_tuple_destructuring() -> Vec<Operation> {
+        let context = CubeContext::root();
+
+        let mut scope = context.into_scope();
+        let a = scope.create_local(Item::new(Elem::UInt));
+        let b = scope.create_local(Item::new(Elem::UInt));
+
+        let zero: Variable = 0u32.into();
+        let one: Variable = 1u32.into();
+
+        cpa!(scope, a = zero);
+        cpa!(scope, b = one);
+        cpa!(scope, a = a + 1u32);
 
         scope.operations
     }

--- a/crates/cubecl-macros/src/codegen_function/variable.rs
+++ b/crates/cubecl-macros/src/codegen_function/variable.rs
@@ -42,6 +42,7 @@ pub(crate) fn codegen_array_lit(array: &syn::ExprArray) -> TokenStream {
 /// let x = ...
 /// let x: T = ...
 /// let _ = ...
+/// let (a, b) = ...
 /// let mut _ = ...
 pub(crate) fn codegen_local(
     local: &syn::Local,
@@ -57,6 +58,12 @@ pub(crate) fn codegen_local(
             _ => todo!("Codegen: Unsupported typed path {:?}", pat_type.pat),
         },
         syn::Pat::Wild(wild) => wild.underscore_token.to_token_stream(),
+        syn::Pat::Tuple(_) => {
+            // destructuring pattern; we can just return it as is
+            return quote::quote! {
+                #local
+            };
+        }
         _ => todo!("Codegen: Declaration {:?} is unsupported.", local.pat),
     };
 


### PR DESCRIPTION
I'm trying to convert the reduce kernels to use the `#[cube]` macro: https://github.com/tracel-ai/burn/pull/2117

One problem I'm running into is that the accumulator for some of the kernels is a tuple, and tuple destructuring doesn't seem to be supported currently.

This PR adds tuple destructuring, with a unit test