### PR TITLE
Automatically enable autotune_persistent_cache only on desktop platforms

### DIFF
--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -16,7 +16,6 @@ default = [
   "cubecl-common/default",
   "cubecl-core/default",
 ]
-autotune = []
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 
 [dependencies]

--- a/crates/cubecl-macros/src/analyzer.rs
+++ b/crates/cubecl-macros/src/analyzer.rs
@@ -80,16 +80,22 @@ impl VariableAnalyzer {
                             for pat in pat_tuple.elems.iter() {
                                 let (id, is_comptime) = find_local_declaration_ident(pat);
                                 if let Some(id) = id {
-                                    self.variable_tracker
-                                        .analyze_declare(id.to_string(), depth, is_comptime);
+                                    self.variable_tracker.analyze_declare(
+                                        id.to_string(),
+                                        depth,
+                                        is_comptime,
+                                    );
                                 }
                             }
                         }
                         _ => {
                             let (id, is_comptime) = find_local_declaration_ident(&local.pat);
                             if let Some(id) = id {
-                                self.variable_tracker
-                                    .analyze_declare(id.to_string(), depth, is_comptime);
+                                self.variable_tracker.analyze_declare(
+                                    id.to_string(),
+                                    depth,
+                                    is_comptime,
+                                );
                             }
                         }
                     }

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -17,15 +17,13 @@ default = [
     "channel-mpsc",
     "channel-cell",
     "storage-bytes",
-    "autotune-persistent-cache",
-    "cubecl-common/default"
+    "cubecl-common/default",
 ]
 std = ["cubecl-common/std"]
 channel-mutex = []
 channel-cell = []
 channel-mpsc = ["dep:async-channel", "dep:pollster"] # Assume std
 storage-bytes = []
-autotune-persistent-cache = ["dirs", "md5", "serde", "serde_json"] # Assume std
 
 [dependencies]
 cubecl-common = { path = "../cubecl-common", version = "0.1.1", default-features = false }
@@ -33,12 +31,16 @@ derive-new = { workspace = true }
 spin = { workspace = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
-dirs = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-serde_json = { workspace = true, features = ["std"], optional = true }
-md5 = { workspace = true, optional = true }
+
 pollster = { workspace = true, optional = true }
 async-channel = { workspace = true, optional = true }
+
+# Persistent cache deps - has to match the autotune_persistent_cache cfg.
+[target.'cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))'.dependencies]
+dirs = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
+md5 = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 web-time = { workspace = true }
@@ -46,6 +48,9 @@ web-time = { workspace = true }
 [dev-dependencies]
 serial_test = { workspace = true }
 rand = { workspace = true }
+
+[build-dependencies]
+cfg_aliases = "0.2.1"
 
 [[bench]]
 name = "dynamic"

--- a/crates/cubecl-runtime/build.rs
+++ b/crates/cubecl-runtime/build.rs
@@ -3,6 +3,6 @@ use cfg_aliases::cfg_aliases;
 fn main() {
     // Setup cfg aliases
     cfg_aliases! {
-        autotune_persistent_cache: { any(target_os = "windows", target_os = "linux", target_os = "macos") },
+        autotune_persistent_cache: { all(feature = "std", any(target_os = "windows", target_os = "linux", target_os = "macos")) },
     }
 }

--- a/crates/cubecl-runtime/build.rs
+++ b/crates/cubecl-runtime/build.rs
@@ -1,0 +1,8 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    // Setup cfg aliases
+    cfg_aliases! {
+        autotune_persistent_cache: { any(target_os = "windows", target_os = "linux", target_os = "macos") },
+    }
+}

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -5,7 +5,7 @@ use core::fmt::{Debug, Display};
 use core::hash::Hash;
 
 /// Default checksum for an operation set
-#[cfg(feature = "autotune-persistent-cache")]
+#[cfg(autotune_persistent_cache)]
 pub fn compute_checksum(autotunables: &[Box<dyn AutotuneOperation>]) -> String {
     let mut checksum = String::new();
     autotunables.iter().for_each(|op| {
@@ -28,7 +28,7 @@ pub trait AutotuneOperationSet<K>: Send {
     fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation>;
 
     /// Compute a checksum that can invalidate outdated cached auto-tune results.
-    #[cfg(feature = "autotune-persistent-cache")]
+    #[cfg(autotune_persistent_cache)]
     fn compute_checksum(&self) -> String {
         compute_checksum(&self.autotunables())
     }
@@ -48,7 +48,7 @@ pub trait AutotuneOperation {
     fn clone(&self) -> Box<dyn AutotuneOperation>;
 }
 
-#[cfg(feature = "autotune-persistent-cache")]
+#[cfg(autotune_persistent_cache)]
 /// Trait alias with support for persistent caching
 pub trait AutotuneKey:
     Clone
@@ -63,7 +63,8 @@ pub trait AutotuneKey:
     + Sync
 {
 }
-#[cfg(not(feature = "autotune-persistent-cache"))]
+#[cfg(not(autotune_persistent_cache))]
 /// Trait alias
 pub trait AutotuneKey: Clone + Debug + PartialEq + Eq + Hash + Display {}
+
 impl AutotuneKey for String {}

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -80,7 +80,7 @@ impl<K: AutotuneKey> Tuner<K> {
         log::info!("Fastest result {fastest_name}-{key}");
 
         self.tune_cache.cache_insert(key.clone(), fastest_index);
-        #[cfg(feature = "autotune-persistent-cache")]
+        #[cfg(autotune_persistent_cache)]
         {
             let checksum = autotune_operation_set.compute_checksum();
             self.tune_cache

--- a/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "autotune-persistent-cache")]
+#[cfg(autotune_persistent_cache)]
 use rand::{distributions::Alphanumeric, Rng};
 use std::sync::Arc;
 
-#[cfg(feature = "autotune-persistent-cache")]
+#[cfg(autotune_persistent_cache)]
 use cubecl_runtime::tune::compute_checksum;
 use cubecl_runtime::{
     server::Binding,
@@ -167,7 +167,7 @@ impl AutotuneOperationSet<String> for CacheTestAutotuneOperationSet {
         self.autotunables()[fastest_index].clone()
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(autotune_persistent_cache)]
     fn compute_checksum(&self) -> String {
         if self.generate_random_checksum {
             let rand_string: String = rand::thread_rng()

--- a/crates/cubecl-runtime/tests/integration_test.rs
+++ b/crates/cubecl-runtime/tests/integration_test.rs
@@ -3,8 +3,11 @@ mod dummy;
 use std::sync::Arc;
 
 use crate::dummy::autotune_execute;
+use crate::dummy::TEST_TUNER;
 use crate::dummy::{client, DummyDevice, DummyElementwiseAddition};
-use crate::dummy::{TEST_TUNER, TUNER_DEVICE_ID, TUNER_PREFIX};
+
+#[cfg(autotune_persistent_cache)]
+use crate::dummy::{TUNER_DEVICE_ID, TUNER_PREFIX};
 
 use cubecl_runtime::ComputeRuntime;
 
@@ -139,7 +142,7 @@ fn autotune_cache_same_key_return_a_cache_hit() {
 
 #[test]
 #[serial]
-#[cfg(feature = "std")]
+#[cfg(autotune_persistent_cache)]
 fn autotune_cache_no_cache_on_disk_return_a_cache_miss() {
     TEST_TUNER.clear();
 
@@ -184,7 +187,7 @@ fn autotune_cache_no_cache_on_disk_return_a_cache_miss() {
 
 #[test]
 #[serial]
-#[cfg(feature = "std")]
+#[cfg(autotune_persistent_cache)]
 fn autotune_cache_file_path_creation_works_when_path_does_not_exist_yet() {
     TEST_TUNER.clear();
     // delete the cache file


### PR DESCRIPTION
Currently, the persistent cache fails on platforms without easy access to a filesystem like android and the web. Configuring this as a negative feature becomes quite annoying.

Instead, as per [this discord discussion](https://discord.com/channels/1038839012602941528/1265322519569764403), this just makes it so it's only enabled if on a desktop platform. To save some gnarly cfgs everywhere this using cfg_aliases which might be useful more generally in cube/burn, but lmk if it's preferred to not have this.

There's also a leftover flag in cubecl-cuda for autotune I think. It seems Burn actually handles all the autotune flags, cube doesn't know about them.