### PR TITLE
Propagate visibility to CubeLaunch-generated structures.

### DIFF
--- a/crates/cubecl-macros/src/codegen_type/base.rs
+++ b/crates/cubecl-macros/src/codegen_type/base.rs
@@ -54,9 +54,10 @@ impl TypeCodegen {
         }
 
         let generics = self.generics.all_definitions();
+        let vis = &self.vis;
 
         quote! {
-            struct #name #generics {
+            #vis struct #name #generics {
                 #fields
             }
         }


### PR DESCRIPTION
Currently, the Launch structures generated by #[derive(CubeLaunch)] are always private. They should follow the visibility of the initial structures.