### PR TITLE
Allow graceful failover when one tunable panics

### DIFF
--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -122,7 +122,10 @@ impl<K: AutotuneKey> Tuner<K> {
             catch_unwind(AssertUnwindSafe(|| {
                 TuneBenchmark::new(operation, client.clone()).run()
             }))
-            .map_err(ManuallyDrop::new)
+            .map_err(|e| {
+                println!("Caught error while benchmarking, falling back to next operation.");
+                ManuallyDrop::new(e)
+            })
         }
         #[cfg(not(feature = "std"))]
         Ok(TuneBenchmark::new(operation, client.clone()).run())

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -21,6 +21,9 @@ use super::AutotuneKey;
 
 /// An error that occured during benchmarking. If other benches succeeded, ignore this bench and
 /// continue gracefully. If all benches fail, panic.
+/// This error cannot be acted on in any way, because it's an opaque unwind object, and must be
+/// `ManuallyDrop` because dropping it can cause unwinding to proceed. It can only
+/// be passed to `resume_unwind` to continue the panic.
 type BenchError = ManuallyDrop<Box<dyn Any + Send>>;
 
 #[derive(Debug)]


### PR DESCRIPTION
Catches panics that occur during the benchmarking phase of autotuning and gracefully falls back to the next algorithm in line.

This allows selecting algorithms based on things like memory constraints (without adding `Result` types all through the memory allocation chain) or even things like potentially unsupported GPU features. Note that this only catches panics during benchmarking, not during regular execution. If an algorithm fails at that point it will still give error feedback to the user.
If all tunables panic, propagates the first panic.

One thing worth mentioning is that while it will gracefully continue to the next algorithm, it will not necessarily continue quietly. The error message still gets printed to the console, which could confuse users. Unfortunately I don't think that can be prevented due to how panic is implemented, the print gets output before unwind gets to the benchmark code where the unwind is caught. This can be prevented with a custom panic hook, but that would affect *all* panics everywhere, which is a bit too intrusive.

### Testing
All existing tuners work as expected with all tests passing, and the fallback works for `im2col` convolution when called with parameters that cause an out of memory error.