### PR TITLE
Handle empty tensors (must bind at minimum 4 bytes on wgpu)

### DIFF
--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -207,9 +207,13 @@ where
             .copied()
             .chain(self.copy_handles_used.iter().map(|x| x.0))
             .collect::<Vec<_>>();
-        let memory = self.memory_management.reserve(data.len(), &total_handles);
+        let num_bytes = data.len();
 
-        if let Some(len) = NonZero::new(data.len() as u64) {
+        // Handle empty tensors (must bind at minimum 4 bytes)
+        let reserve_size = core::cmp::max(num_bytes, 4);
+        let memory = self.memory_management.reserve(reserve_size, &total_handles);
+
+        if let Some(len) = NonZero::new(num_bytes as u64) {
             let resource_handle = self.memory_management.get(memory.clone().binding());
 
             // Dont re-use this handle for writing until the queue is flushed. All writes


### PR DESCRIPTION
Some operations could return empty tensors (e.g., `argwhere` for a tensor where all elements are zero).

Trying to return an empty tensor with 0 byte alloc would fail on wgpu, as encountered in Burn issues ([2180](https://github.com/tracel-ai/burn/issues/2180), [1946](https://github.com/tracel-ai/burn/issues/1946)).

We can handle empty tensors by allocating 4 bytes (minimum required by wgpu).

We get the same result as other backends:
```rust
Tensor {
  data:
[],
  shape:  [0, 1],
  device:  BestAvailable,
  backend:  "fusion<jit<wgpu>>",
  kind:  "Int",
  dtype:  "i32",
}
```