### PR TITLE
Fix/cuda/tiling2d load flaky tests

### DIFF
--- a/crates/cubecl-linalg/src/matmul/tests/matmul_tests.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/matmul_tests.rs
@@ -114,6 +114,18 @@ pub fn test_matmul_tiling2d_with_batches<R: Runtime>(device: &R::Device) {
     .test_tiling2d::<R>(device);
 }
 
+pub fn test_matmul_cmma_unvectorizable_shapes<R: Runtime>(device: &R::Device) {
+    MatmulTestCase {
+        m: 63,
+        k: 63,
+        n: 63,
+        batch: 3,
+        factor: 10000.,
+        epsilon: 0.1,
+        compute_f16: true,
+    }.test_cmma::<R>(device);
+}
+
 struct MatmulTestCase {
     m: usize,
     k: usize,

--- a/crates/cubecl-linalg/src/matmul/tests/tiling2d/load_shared_memory.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/tiling2d/load_shared_memory.rs
@@ -29,8 +29,13 @@ fn load_tensor_test<F: Float>(
     let block_size_k = Comptime::map(config, |c| c.block_size_k);
     let block_size_m = Comptime::map(config, |c| c.block_size_m);
     let sm_size = block_size_k * block_size_m / tile_size;
-    let shared_memory =
+    let mut shared_memory =
         SharedMemory::<F>::vectorized(Comptime::get(sm_size), Comptime::get(tile_size));
+
+    for i in range(0u32, Comptime::get(sm_size), Comptime::new(false)) {
+        sm_out[i] = F::vectorized(0., Comptime::get(tile_size));
+        shared_memory[i] = F::vectorized(0., Comptime::get(tile_size));
+    }
 
     let batch_offset = UInt::new(0);
 
@@ -94,8 +99,13 @@ fn load_tensor_permuted_test<F: Float>(
     let block_size_k = Comptime::map(config, |c| c.block_size_k);
     let block_size_m = Comptime::map(config, |c| c.block_size_m);
     let sm_size = block_size_k * block_size_m / tile_size;
-    let shared_memory =
+    let mut shared_memory =
         SharedMemory::<F>::vectorized(Comptime::get(sm_size), Comptime::get(tile_size));
+
+    for i in range(0u32, Comptime::get(sm_size), Comptime::new(false)) {
+        sm_out[i] = F::vectorized(0., Comptime::get(tile_size));
+        shared_memory[i] = F::vectorized(0., Comptime::get(tile_size));
+    }
 
     let batch_offset = UInt::new(0);
 
@@ -159,8 +169,13 @@ fn load_tensor_multiple_tiles_test<F: Float>(
     let block_size_k = Comptime::map(config, |c| c.block_size_k);
     let block_size_m = Comptime::map(config, |c| c.block_size_m);
     let sm_size = block_size_k * block_size_m / tile_size;
-    let shared_memory =
+    let mut shared_memory =
         SharedMemory::<F>::vectorized(Comptime::get(sm_size), Comptime::get(tile_size));
+
+    for i in range(0u32, Comptime::get(sm_size), Comptime::new(false)) {
+        sm_out[i] = F::vectorized(0., Comptime::get(tile_size));
+        shared_memory[i] = F::vectorized(0., Comptime::get(tile_size));
+    }
 
     let unit_row = UInt::new(4) * UNIT_POS_X;
     let unit_col = UInt::new(4) * UNIT_POS_Y;

--- a/crates/cubecl-linalg/src/tests/matmul/cmma/matmul.rs
+++ b/crates/cubecl-linalg/src/tests/matmul/cmma/matmul.rs
@@ -23,5 +23,10 @@ macro_rules! testgen_cmma_matmul {
         pub fn test_matmul_cmma_with_batches() {
             tests::matmul_tests::test_matmul_cmma_with_batches::<TestRuntime>(&Default::default())
         }
+
+        #[test]
+        pub fn test_matmul_cmma_unvectorizable_shapes() {
+            tests::matmul_tests::test_matmul_cmma_unvectorizable_shapes::<TestRuntime>(&Default::default())
+        }
     };
 }


### PR DESCRIPTION
There were flaky tests on Cuda. There shouldn't be anymore. 