### PR TITLE
Add `for in` syntax for immutable arrays, tensors and slices

### DIFF
--- a/crates/cubecl-core/src/frontend/element/slice.rs
+++ b/crates/cubecl-core/src/frontend/element/slice.rs
@@ -1,7 +1,8 @@
 use std::marker::PhantomData;
 
 use super::{
-    Array, CubePrimitive, CubeType, ExpandElement, ExpandElementTyped, Init, SharedMemory, Tensor,
+    Array, CubePrimitive, CubeType, ExpandElement, ExpandElementTyped, Init, SharedMemory,
+    SizedContainer, Tensor,
 };
 use crate::{
     frontend::indexation::Index,
@@ -57,6 +58,25 @@ impl<'a, C: CubeType> Init for ExpandElementTyped<SliceMut<'a, C>> {
     fn init(self, _context: &mut crate::prelude::CubeContext) -> Self {
         // The type can't be deeply cloned/copied.
         self
+    }
+}
+
+impl<'a, C: CubeType<ExpandType = ExpandElementTyped<C>>> SizedContainer for Slice<'a, C> {
+    type Item = C;
+}
+
+impl<'a, T: CubeType> Iterator for Slice<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unexpanded!()
+    }
+}
+impl<'a, T: CubeType> Iterator for &Slice<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unexpanded!()
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/tensor.rs
+++ b/crates/cubecl-core/src/frontend/element/tensor.rs
@@ -1,4 +1,4 @@
-use super::{ExpandElementBaseInit, ExpandElementTyped, LaunchArgExpand};
+use super::{ExpandElementBaseInit, ExpandElementTyped, LaunchArgExpand, SizedContainer};
 use crate::{
     frontend::{
         indexation::Index, ArgSettings, CubeContext, CubePrimitive, CubeType, ExpandElement,
@@ -241,5 +241,17 @@ impl<T: CubeType> ExpandElementTyped<T> {
     // Expanded version of rank.
     pub fn __expand_rank_method(self, _context: &mut CubeContext) -> ExpandElementTyped<u32> {
         ExpandElement::Plain(Variable::Rank).into()
+    }
+}
+
+impl<T: CubeType<ExpandType = ExpandElementTyped<T>>> SizedContainer for Tensor<T> {
+    type Item = T;
+}
+
+impl<T: CubeType> Iterator for &Tensor<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unexpanded!()
     }
 }

--- a/crates/cubecl-core/src/frontend/operation/assignation.rs
+++ b/crates/cubecl-core/src/frontend/operation/assignation.rs
@@ -91,7 +91,7 @@ pub mod index {
 
     use super::*;
 
-    pub fn expand<A: CubeType + CubeIndex<u32>>(
+    pub fn expand<A: CubeType + CubeIndex<ExpandElementTyped<u32>>>(
         context: &mut CubeContext,
         array: ExpandElementTyped<A>,
         index: ExpandElementTyped<u32>,


### PR DESCRIPTION
Adds `for item in array` syntax for `&Array`, `&Tensor` and `Slice`. This currently only implements immutable iterators until we can figure out a way to implement mutable references into arrays.

# Testing
Adds a frontend and a runtime test to ensure it works properly.