### PR TITLE
Add if as a value expression

### DIFF
--- a/crates/cubecl-core/src/frontend/const_expand.rs
+++ b/crates/cubecl-core/src/frontend/const_expand.rs
@@ -6,6 +6,12 @@ pub trait OptionExt<T: CubeType> {
         _context: &mut CubeContext,
         other: impl FnOnce(&mut CubeContext) -> T::ExpandType,
     ) -> T::ExpandType;
+
+    fn __expand_unwrap_or_method(
+        self,
+        _context: &mut CubeContext,
+        other: T::ExpandType,
+    ) -> T::ExpandType;
 }
 
 impl<T: CubeType + Into<T::ExpandType>> OptionExt<T> for Option<T> {
@@ -15,5 +21,13 @@ impl<T: CubeType + Into<T::ExpandType>> OptionExt<T> for Option<T> {
         other: impl FnOnce(&mut CubeContext) -> <T as CubeType>::ExpandType,
     ) -> <T as CubeType>::ExpandType {
         self.map(Into::into).unwrap_or_else(|| other(context))
+    }
+
+    fn __expand_unwrap_or_method(
+        self,
+        _context: &mut CubeContext,
+        other: <T as CubeType>::ExpandType,
+    ) -> <T as CubeType>::ExpandType {
+        self.map(Into::into).unwrap_or(other)
     }
 }

--- a/crates/cubecl-core/src/frontend/element/cast.rs
+++ b/crates/cubecl-core/src/frontend/element/cast.rs
@@ -39,13 +39,10 @@ pub trait BitCast: CubePrimitive {
         unexpanded!()
     }
 
-    fn __expand_bitcast_from<From>(
+    fn __expand_bitcast_from<From: CubePrimitive>(
         context: &mut CubeContext,
-        value: From,
-    ) -> <Self as CubeType>::ExpandType
-    where
-        From: Into<ExpandElement>,
-    {
+        value: ExpandElementTyped<From>,
+    ) -> <Self as CubeType>::ExpandType {
         let value: ExpandElement = value.into();
         let var: Variable = *value;
         let new_var = context.create_local(Item::vectorized(

--- a/crates/cubecl-core/src/frontend/mod.rs
+++ b/crates/cubecl-core/src/frontend/mod.rs
@@ -12,7 +12,7 @@ mod sequence;
 mod subcube;
 mod topology;
 
-pub use branch::{RangeExpand, SteppedRangeExpand};
+pub use branch::{range, range_stepped, RangeExpand, SteppedRangeExpand};
 pub use const_expand::*;
 pub use context::*;
 pub use element::*;

--- a/crates/cubecl-core/src/ir/processing.rs
+++ b/crates/cubecl-core/src/ir/processing.rs
@@ -247,8 +247,8 @@ impl ScopeProcessing {
                     sanitize_constant_scalar_ref_elem(&mut op.cond, Elem::Bool);
                 }
                 Branch::RangeLoop(op) => {
-                    sanitize_constant_scalar_ref_elem(&mut op.start, Elem::UInt);
-                    sanitize_constant_scalar_ref_elem(&mut op.end, Elem::UInt);
+                    sanitize_constant_scalar_ref_var(&mut op.end, &op.start);
+                    sanitize_constant_scalar_ref_var(&mut op.i, &op.start);
                     if let Some(step) = &mut op.step {
                         sanitize_constant_scalar_ref_elem(step, Elem::UInt);
                     }

--- a/crates/cubecl-core/src/ir/scope.rs
+++ b/crates/cubecl-core/src/ir/scope.rs
@@ -295,8 +295,7 @@ impl Scope {
     pub fn process(&mut self) -> ScopeProcessing {
         self.undeclared += self.locals.len() as u16;
 
-        let mut variables = Vec::new();
-        core::mem::swap(&mut self.locals, &mut variables);
+        let mut variables = core::mem::take(&mut self.locals);
 
         for var in self.matrices.drain(..) {
             variables.push(var);

--- a/crates/cubecl-cuda/src/compiler/base.rs
+++ b/crates/cubecl-cuda/src/compiler/base.rs
@@ -370,7 +370,10 @@ impl CudaCompiler {
             }),
             gpu::Operator::Index(op) => {
                 if let ExecutionMode::Checked = self.strategy {
-                    if has_length(&op.lhs) {
+                    // Since atomics must be declared inline (for `wgpu` compatibility), we need to
+                    // disable runtime checks for them. Otherwise the variable would be declared
+                    // inside the `if` scope.
+                    if has_length(&op.lhs) && !op.lhs.item().elem.is_atomic() {
                         self.compile_procedure(
                             instructions,
                             gpu::Procedure::CheckedIndex(gpu::CheckedIndex {
@@ -749,11 +752,11 @@ impl CudaCompiler {
                 gpu::IntKind::I64 => panic!("i64 isn't supported yet"),
             },
             gpu::Elem::AtomicInt(kind) => match kind {
-                gpu::IntKind::I32 => super::Elem::I32,
+                gpu::IntKind::I32 => super::Elem::Atomic(super::AtomicKind::I32),
                 gpu::IntKind::I64 => panic!("atomic<i64> isn't supported yet"),
             },
             gpu::Elem::UInt => super::Elem::U32,
-            gpu::Elem::AtomicUInt => super::Elem::U32,
+            gpu::Elem::AtomicUInt => super::Elem::Atomic(super::AtomicKind::U32),
             gpu::Elem::Bool => super::Elem::Bool,
         }
     }

--- a/crates/cubecl-cuda/src/compiler/binary.rs
+++ b/crates/cubecl-cuda/src/compiler/binary.rs
@@ -1,4 +1,4 @@
-use super::{Component, Variable};
+use super::{Component, Elem, Variable};
 use std::fmt::{Display, Formatter};
 
 pub trait Binary {
@@ -259,6 +259,8 @@ impl Binary for Index {
                 f.write_fmt(format_args!("{out} = {}({lhs}[{rhs}]);\n", item_out.elem))?;
             }
             Ok(())
+        } else if let Elem::Atomic(inner) = item_out.elem {
+            f.write_fmt(format_args!("{inner}* {out} = &{lhs}[{rhs}];\n"))
         } else {
             f.write_fmt(format_args!("{out} = {lhs}[{rhs}];\n"))
         }

--- a/crates/cubecl-cuda/src/compiler/element.rs
+++ b/crates/cubecl-cuda/src/compiler/element.rs
@@ -14,6 +14,22 @@ pub enum Elem {
     I32,
     U32,
     Bool,
+    Atomic(AtomicKind),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
+pub enum AtomicKind {
+    I32,
+    U32,
+}
+
+impl Display for AtomicKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AtomicKind::I32 => f.write_str("int"),
+            AtomicKind::U32 => f.write_str("uint"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
@@ -33,6 +49,7 @@ impl Display for Elem {
             Elem::I32 => f.write_str("int"),
             Elem::U32 => f.write_str("uint"),
             Elem::Bool => f.write_str("bool"),
+            Elem::Atomic(inner) => inner.fmt(f),
         }
     }
 }
@@ -470,6 +487,8 @@ impl Elem {
             Self::I32 => core::mem::size_of::<i32>(),
             Self::U32 => core::mem::size_of::<u32>(),
             Self::Bool => core::mem::size_of::<bool>(),
+            Self::Atomic(AtomicKind::I32) => core::mem::size_of::<i32>(),
+            Self::Atomic(AtomicKind::U32) => core::mem::size_of::<u32>(),
         }
     }
 }

--- a/crates/cubecl-cuda/src/compiler/instruction.rs
+++ b/crates/cubecl-cuda/src/compiler/instruction.rs
@@ -197,10 +197,11 @@ impl Display for Instruction {
                     .map(|step| format!("{i} += {step}"))
                     .unwrap_or_else(|| format!("++{i}"));
                 let cmp = if *inclusive { "<=" } else { "<" };
+                let i_ty = i.item();
 
                 f.write_fmt(format_args!(
                     "
-for (uint {i} = {start}; {i} {cmp} {end}; {increment}) {{
+for ({i_ty} {i} = {start}; {i} {cmp} {end}; {increment}) {{
 "
                 ))?;
                 for instruction in instructions {

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -186,9 +186,6 @@ impl Expression {
             Expression::Array { elements, .. } => elements.iter().all(|it| it.is_const()),
             Expression::Tuple { elements, .. } => elements.iter().all(|it| it.is_const()),
             Expression::CompilerIntrinsic { .. } => true,
-            Expression::MethodCall {
-                receiver, method, ..
-            } => receiver.is_const() && method != "runtime",
             _ => false,
         }
     }

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -1,6 +1,9 @@
 use proc_macro2::Span;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
-use syn::{parse_quote, spanned::Spanned, Expr, Lit, LitInt, Path, PathSegment, RangeLimits, Type};
+use syn::{
+    parse_quote, spanned::Spanned, Expr, ExprUnary, Lit, LitInt, Path, PathSegment, RangeLimits,
+    Type, UnOp,
+};
 
 use crate::{
     expression::{is_intrinsic, Block, Expression},
@@ -48,6 +51,13 @@ impl Expression {
                     ty,
                 }
             }
+            Expr::Unary(ExprUnary {
+                op: UnOp::Neg(_),
+                expr,
+                ..
+            }) if matches!(*expr, Expr::Lit(_)) => Expression::Verbatim {
+                tokens: quote![-{#expr}],
+            },
             Expr::Path(path) => {
                 let name = path.path.get_ident();
                 if let Some(var) = name.and_then(|ident| context.variable(ident)) {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
@@ -553,10 +553,11 @@ impl Display for Instruction {
                     .map(|step| format!("{i} += {step}"))
                     .unwrap_or_else(|| format!("{i}++"));
                 let cmp = if *inclusive { "<=" } else { "<" };
+                let i_ty = i.item();
 
                 f.write_fmt(format_args!(
                     "
-for (var {i}: u32 = {start}; {i} {cmp} {end}; {increment}) {{
+for (var {i}: {i_ty} = {start}; {i} {cmp} {end}; {increment}) {{
 "
                 ))?;
                 for instruction in instructions {


### PR DESCRIPTION
Simulates `if` as a value expression by assigning the return value to an outer variable. As a result, this only works with primitives right now. Also fixes some minor issues I encountered porting my `deformable_conv2d` implementation.

# Testing
All tests pass, new test added for this feature.