### PR TITLE
Skip zero initialization of workgroup memory

### DIFF
--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -111,7 +111,10 @@ where
                     layout: None,
                     module: &module,
                     entry_point: "main",
-                    compilation_options: Default::default(),
+                    compilation_options: wgpu::PipelineCompilationOptions {
+                        zero_initialize_workgroup_memory: false,
+                        ..Default::default()
+                    },
                     cache: None,
                 }),
         )


### PR DESCRIPTION
CUDA kernels don't rely on workgroup memory being initialized to anything in particular, so no need to require this in wgpu, as it's not like cube kernels can rely on this fact anyway. On WebGPU this still happens for security reasons, but on native platforms this can be skipped.

Should save some marginal amount of performance, and maybe some kernels accidentally working on wgpu but not cuda.