### PR TITLE
Add macro to automatically generate common cases for autotune

### DIFF
--- a/crates/cubecl-core/src/lib.rs
+++ b/crates/cubecl-core/src/lib.rs
@@ -23,7 +23,7 @@ pub use codegen::*;
 pub use pod::*;
 pub use runtime::*;
 
-pub use cubecl_macros::{comptime, cube, CubeLaunch, CubeType};
+pub use cubecl_macros::*;
 pub use cubecl_runtime::benchmark;
 
 /// An approximation of the subcube dimension.

--- a/crates/cubecl-macros/src/generate/autotune.rs
+++ b/crates/cubecl-macros/src/generate/autotune.rs
@@ -1,0 +1,407 @@
+use darling::FromDeriveInput;
+use ident_case::RenameRule;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::{DeriveInput, Index, ItemFn, Member};
+
+use crate::{
+    parse::autotune::{
+        AutotuneKey, AutotuneKeyField, AutotuneOp, AutotuneOpArgs, AutotuneOperations,
+        AutotuneOperationsArgs,
+    },
+    paths::tune_type,
+};
+
+impl AutotuneKey {
+    fn generate_fmt_str(&self) -> String {
+        let name = self.ident.to_string();
+        let fields = self.data.as_ref().take_struct().unwrap();
+        if self.is_tuple() {
+            let fields: Vec<&str> = fields.iter().map(|_| "{:?}").collect();
+            let fields = fields.join(", ");
+            format!("{name}({fields})")
+        } else {
+            let fields: Vec<String> = fields
+                .iter()
+                .map(|field| {
+                    let name = field.name.clone().unwrap_or_else(|| {
+                        RenameRule::PascalCase
+                            .apply_to_field(field.ident.as_ref().unwrap().to_string())
+                    });
+
+                    format!("{name}: {{:?}}")
+                })
+                .collect();
+            let fields = fields.join(", ");
+            format!("{name} - {fields}")
+        }
+    }
+
+    fn generate_fmt(&self) -> TokenStream {
+        let name = &self.ident;
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+        let fmt_str = self.generate_fmt_str();
+        let fields = self.data.as_ref().take_struct().unwrap();
+        let fmt_args = fields.iter().enumerate().map(|(i, field)| {
+            if let Some(ident) = field.ident.as_ref() {
+                quote![self.#ident]
+            } else {
+                let idx = Index::from(i);
+                quote![self.#idx]
+            }
+        });
+        let fmt_call = quote![write!(f, #fmt_str, #(#fmt_args),*)];
+        quote! {
+            impl #generics ::core::fmt::Display for #name #generic_names #where_clause {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    #fmt_call
+                }
+            }
+        }
+    }
+
+    fn generate_new(&self) -> TokenStream {
+        let name = &self.ident;
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+        let vis = &self.vis;
+        let new_fn = match self.is_tuple() {
+            true => self.generate_new_fn_tuple(),
+            false => self.generate_new_fn_named(),
+        };
+
+        quote! {
+            impl #generics #name #generic_names #where_clause {
+                #[allow(clippy::too_many_arguments)]
+                #vis #new_fn
+            }
+        }
+    }
+
+    fn generate_new_fn_named(&self) -> TokenStream {
+        let fields = self.data.as_ref().take_struct().unwrap();
+        let new_args = fields.iter().map(|it| {
+            let name = it.ident.as_ref().unwrap();
+            let ty = &it.ty;
+            quote![#name: #ty]
+        });
+        let field_inits = fields.iter().map(|field| {
+            let name = field.ident.as_ref().unwrap();
+            let init = field_init(field, Member::Named(name.clone()));
+            quote![#name: #init]
+        });
+
+        quote! {
+            fn new(#(#new_args),*) -> Self {
+                Self {
+                    #(#field_inits),*
+                }
+            }
+        }
+    }
+
+    fn generate_new_fn_tuple(&self) -> TokenStream {
+        let fields = self.data.as_ref().take_struct().unwrap();
+        let new_args = fields.iter().enumerate().map(|(i, field)| {
+            let name = format_ident!("{i}_");
+            let ty = &field.ty;
+            quote![#name: #ty]
+        });
+        let field_inits = fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| field_init(field, Member::Unnamed(Index::from(i))));
+
+        quote! {
+            fn new(#(#new_args),*) -> Self {
+                Self (
+                    #(#field_inits),*
+                )
+            }
+        }
+    }
+
+    fn generate_key_impl(&self) -> TokenStream {
+        let key = tune_type("AutotuneKey");
+        let name = &self.ident;
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+        quote![impl #generics #key for #name #generic_names #where_clause {}]
+    }
+}
+
+fn field_init(field: &AutotuneKeyField, member: Member) -> TokenStream {
+    let anchor_fn = tune_type("anchor");
+    field
+        .anchor
+        .as_ref()
+        .map(|anchor| {
+            let max = anchor.max();
+            quote![#anchor_fn(#member, #max)]
+        })
+        .unwrap_or_else(|| member.to_token_stream())
+}
+
+pub fn generate_autotune_key(input: DeriveInput) -> syn::Result<TokenStream> {
+    let key = AutotuneKey::from_derive_input(&input)?;
+    let display = key.generate_fmt();
+    let new = key.generate_new();
+    let key_impl = key.generate_key_impl();
+    Ok(quote! {
+        #display
+        #new
+        #key_impl
+    })
+}
+
+impl AutotuneOperations {
+    fn generate_struct(&self) -> TokenStream {
+        let name = &self.name;
+        let generics = &self.generics;
+        let where_clause = &generics.where_clause;
+        let ty = self.ty.as_ref();
+        let fields = &self.input_fields;
+        quote! {
+            pub struct #name #generics #where_clause {
+                #ty
+                #(#fields),*
+            }
+        }
+    }
+
+    fn generate_tunables_fn(&self) -> TokenStream {
+        let operation = tune_type("AutotuneOperation");
+        let output = &self.output;
+        let fields = self.input_fields.iter().map(|field| {
+            let name = field.ident.as_ref().unwrap();
+            quote![let #name = &self.#name;]
+        });
+
+        let body = &self.tunables_fn;
+        quote! {
+            #[allow(unused)]
+            fn autotunables(&self) -> ::std::vec::Vec<Box<dyn #operation<#output>>> {
+                #(#fields)*
+                #body
+            }
+        }
+    }
+
+    fn generate_fastest_fn(&self) -> TokenStream {
+        let operation = tune_type("AutotuneOperation");
+        let output = &self.output;
+        let (_, generics, _) = self.generics.split_for_impl();
+        let generics = generics.as_turbofish();
+        let fields: Vec<_> = self
+            .input_fields
+            .iter()
+            .filter(|it| it.ident.as_ref().unwrap() != &self.key)
+            .map(|field| {
+                let name = field.ident.as_ref().unwrap();
+                quote![self.#name]
+            })
+            .collect();
+        let ops = self
+            .operations
+            .iter()
+            .enumerate()
+            .map(|(i, op)| quote![#i => Box::new(#op #generics::new(#(#fields),*))]);
+
+        quote! {
+            fn fastest(
+                self: Box<Self>,
+                fastest_index: usize,
+            ) -> Box<dyn #operation<#output>> {
+                match fastest_index {
+                    #(#ops,)*
+                    _ => panic!("Fastest index is out of bound"),
+                }
+            }
+        }
+    }
+
+    fn generate_autotune_impl(&self) -> TokenStream {
+        let opset = tune_type("AutotuneOperationSet");
+        let checksum = tune_type("compute_checksum");
+
+        let name = &self.name;
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+        let key = &self.key;
+        let key_ty = &self.key_ty;
+        let output = &self.output;
+        let tunables = self.generate_tunables_fn();
+        let fastest = self.generate_fastest_fn();
+
+        quote! {
+            impl #generics #opset<#key_ty, #output> for #name #generic_names #where_clause {
+                fn key(&self) -> #key_ty {
+                    self.#key.clone()
+                }
+
+                fn compute_checksum(&self) -> String {
+                    #checksum(&self.autotunables())
+                }
+
+                #tunables
+                #fastest
+            }
+        }
+    }
+
+    fn generate_new(&self) -> TokenStream {
+        if let Some(create_key) = self.create_key.as_ref() {
+            let name = &self.name;
+            let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+            let ty = self
+                .ty
+                .is_some()
+                .then(|| quote![__ty: ::core::marker::PhantomData,]);
+            let key = &self.key;
+            let args = self
+                .input_fields
+                .iter()
+                .filter(|it| it.ident.as_ref().unwrap() != key)
+                .map(|field| {
+                    let name = field.ident.as_ref().unwrap();
+                    let ty = &field.ty;
+                    quote![#name: #ty]
+                });
+            let field_names: Vec<_> = self
+                .input_fields
+                .iter()
+                .filter(|it| it.ident.as_ref().unwrap() != key)
+                .map(|field| {
+                    let name = field.ident.as_ref().unwrap();
+                    quote![#name]
+                })
+                .collect();
+
+            quote! {
+                impl #generics #name #generic_names #where_clause {
+                    pub fn new(#(#args),*) -> Self {
+                        Self {
+                            #key: #create_key(#(&#field_names),*),
+                            #ty
+                            #(#field_names),*
+                        }
+                    }
+                }
+            }
+        } else {
+            TokenStream::new()
+        }
+    }
+}
+
+pub fn generate_autotune_set(
+    item: ItemFn,
+    args: AutotuneOperationsArgs,
+) -> syn::Result<TokenStream> {
+    let opset = AutotuneOperations::from_item_fn(item, args)?;
+    let struct_ = opset.generate_struct();
+    let impl_ = opset.generate_autotune_impl();
+    let new = opset.generate_new();
+
+    Ok(quote! {
+        #struct_
+        #impl_
+        #new
+    })
+}
+
+impl AutotuneOp {
+    fn generate_struct(&self) -> TokenStream {
+        let name = &self.name;
+        let generics = &self.generics;
+        let where_clause = &generics.where_clause;
+        let ty = self.ty.as_ref();
+        let fields = &self.input_fields;
+        quote! {
+            pub struct #name #generics #where_clause {
+                #ty
+                #(#fields),*
+            }
+        }
+    }
+
+    fn generate_autotune_impl(&self) -> TokenStream {
+        let operation = tune_type("AutotuneOperation");
+
+        let name = &self.name;
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+        let turbofish = generic_names.as_turbofish();
+        let output = &self.output;
+        let func_name = &self.operation.sig.ident;
+        let func_args = self.input_fields.iter().map(|field| {
+            let name = field.ident.as_ref().unwrap();
+            quote![self.#name]
+        });
+        let ty = self.ty.is_some().then(|| {
+            quote! {
+                __ty: ::core::marker::PhantomData,
+            }
+        });
+        let clones = self.input_fields.iter().map(|field| {
+            let name = field.ident.as_ref().unwrap();
+            quote![#name: self.#name.clone()]
+        });
+
+        quote! {
+            impl #generics #operation<#output> for #name #generic_names #where_clause {
+                fn execute(self: Box<Self>) -> #output {
+                    #func_name #turbofish(#(#func_args),*)
+                }
+
+                fn clone(&self) -> Box<dyn #operation<#output>> {
+                    Box::new(Self {
+                        #ty
+                        #(#clones),*
+                    })
+                }
+            }
+        }
+    }
+
+    fn generate_new(&self) -> TokenStream {
+        let name = &self.name;
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+        let ty = self
+            .ty
+            .is_some()
+            .then(|| quote![__ty: ::core::marker::PhantomData,]);
+        let args = self.input_fields.iter().map(|field| {
+            let name = field.ident.as_ref().unwrap();
+            let ty = &field.ty;
+            quote![#name: #ty]
+        });
+        let field_names = self.input_fields.iter().map(|field| {
+            let name = field.ident.as_ref().unwrap();
+            quote![#name]
+        });
+
+        quote! {
+            impl #generics #name #generic_names #where_clause {
+                pub fn new(#(#args),*) -> Self {
+                    Self {
+                        #ty
+                        #(#field_names),*
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn generate_autotune_op(item: ItemFn, args: AutotuneOpArgs) -> syn::Result<TokenStream> {
+    let func = item.to_token_stream();
+    let opset = AutotuneOp::from_item_fn(item, args);
+    let struct_ = opset.generate_struct();
+    let impl_ = opset.generate_autotune_impl();
+    let new = opset.generate_new();
+
+    Ok(quote! {
+        #func
+
+        #struct_
+        #impl_
+        #new
+    })
+}

--- a/crates/cubecl-macros/src/generate/mod.rs
+++ b/crates/cubecl-macros/src/generate/mod.rs
@@ -1,3 +1,4 @@
+pub mod autotune;
 pub mod cube_trait;
 pub mod cube_type;
 pub mod expression;

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -155,6 +155,7 @@ pub fn derive_autotune_key(input: TokenStream) -> TokenStream {
 /// * `name` - the name of the generated operations struct (default: `PascalCaseFnName`)
 /// * `key` - the name of the key input parameter (default: `key`)
 /// * `create_key` - path to function that creates the key. If not specified, `new` must be implemented manually.
+/// * `should_run` - path to override function for the `should_run` function of the set.
 /// * `operations` - ordered list of operations returned by this tune set
 ///
 /// # Example

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -150,6 +150,13 @@ pub fn derive_autotune_key(input: TokenStream) -> TokenStream {
 /// Crates a tuning set with a specific signature. This should be combined with derive([AutotuneKey])
 /// and [`tune_op`]`.
 ///
+/// # Arguments
+///
+/// * `name` - the name of the generated operations struct (default: `PascalCaseFnName`)
+/// * `key` - the name of the key input parameter (default: `key`)
+/// * `create_key` - path to function that creates the key. If not specified, `new` must be implemented manually.
+/// * `operations` - ordered list of operations returned by this tune set
+///
 /// # Example
 ///
 /// ```ignore

--- a/crates/cubecl-macros/src/parse/autotune.rs
+++ b/crates/cubecl-macros/src/parse/autotune.rs
@@ -54,6 +54,7 @@ pub struct AutotuneOperationsArgs {
     name: Option<Ident>,
     key: Option<Ident>,
     create_key: Option<Path>,
+    should_run: Option<Path>,
     operations: PathList,
 }
 
@@ -67,6 +68,7 @@ pub struct AutotuneOperations {
     pub ty: Option<TokenStream>,
     pub tunables_fn: Block,
     pub create_key: Option<Path>,
+    pub should_run: Option<Path>,
     pub operations: Vec<Path>,
 }
 
@@ -121,6 +123,7 @@ impl AutotuneOperations {
             tunables_fn: *item.block,
             key,
             create_key: args.create_key,
+            should_run: args.should_run,
             output,
             operations,
         })

--- a/crates/cubecl-macros/src/parse/autotune.rs
+++ b/crates/cubecl-macros/src/parse/autotune.rs
@@ -1,0 +1,179 @@
+use std::str::FromStr;
+
+use darling::{ast::Data, util::PathList, FromDeriveInput, FromField, FromMeta};
+use ident_case::RenameRule;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::{
+    parse_quote, punctuated::Punctuated, Block, Field, GenericParam, Generics, Ident, ItemFn, Path,
+    ReturnType, Type, Visibility,
+};
+
+#[derive(FromDeriveInput)]
+#[darling(supports(struct_any))]
+pub struct AutotuneKey {
+    pub ident: Ident,
+    pub vis: Visibility,
+    pub generics: Generics,
+    pub data: Data<(), AutotuneKeyField>,
+}
+
+impl AutotuneKey {
+    pub fn is_tuple(&self) -> bool {
+        self.data.as_ref().take_struct().unwrap().is_tuple()
+    }
+}
+
+#[derive(FromField)]
+#[darling(attributes(autotune))]
+pub struct AutotuneKeyField {
+    pub ident: Option<Ident>,
+    pub ty: Type,
+    pub anchor: Option<Anchor>,
+    pub name: Option<String>,
+}
+
+#[derive(FromMeta)]
+pub enum Anchor {
+    #[darling(word)]
+    Unlimited,
+    Max(usize),
+}
+
+impl Anchor {
+    pub fn max(&self) -> TokenStream {
+        match self {
+            Anchor::Unlimited => quote![None],
+            Anchor::Max(value) => quote![Some(#value)],
+        }
+    }
+}
+
+#[derive(FromMeta)]
+pub struct AutotuneOperationsArgs {
+    name: Option<Ident>,
+    key: Option<Ident>,
+    create_key: Option<Path>,
+    operations: PathList,
+}
+
+pub struct AutotuneOperations {
+    pub name: Ident,
+    pub generics: Generics,
+    pub key: Ident,
+    pub key_ty: Type,
+    pub output: Type,
+    pub input_fields: Vec<Field>,
+    pub ty: Option<TokenStream>,
+    pub tunables_fn: Block,
+    pub create_key: Option<Path>,
+    pub operations: Vec<Path>,
+}
+
+impl AutotuneOperations {
+    pub fn from_item_fn(item: ItemFn, args: AutotuneOperationsArgs) -> syn::Result<Self> {
+        let name = args.name.unwrap_or_else(|| {
+            let name = RenameRule::PascalCase.apply_to_field(item.sig.ident.to_string());
+            format_ident!("{name}")
+        });
+        let key = args.key.unwrap_or_else(|| format_ident!("key"));
+        let generics = item.sig.generics.clone();
+        let fields = item.sig.inputs.iter().map(|input| parse_quote!(#input));
+        let ty = (!generics.params.is_empty()).then(|| {
+            let names = generics.params.iter().map(|it| match it {
+                GenericParam::Lifetime(lifetime_param) => {
+                    let mut param = lifetime_param.clone();
+                    param.bounds = Punctuated::new();
+                    param.colon_token = None;
+                    param.to_token_stream()
+                }
+                GenericParam::Type(type_param) => type_param.ident.to_token_stream(),
+                GenericParam::Const(const_param) => const_param.ident.to_token_stream(),
+            });
+            quote![__ty: ::core::marker::PhantomData<(#(#names),*)>,]
+        });
+        let output = match item.sig.output {
+            ReturnType::Default => parse_quote![()],
+            ReturnType::Type(_, ty) => *ty,
+        };
+
+        let operations = args
+            .operations
+            .to_strings()
+            .into_iter()
+            .map(|s| syn::parse2(TokenStream::from_str(&s).unwrap()).unwrap())
+            .collect();
+
+        let input_fields: Vec<Field> = fields.collect();
+        let key_ty = input_fields
+            .iter()
+            .find(|field| field.ident.as_ref().unwrap() == &key)
+            .ok_or_else(|| syn::Error::new_spanned(item.sig.inputs, "Missing key from inputs"))?
+            .ty
+            .clone();
+
+        Ok(Self {
+            name,
+            generics,
+            input_fields,
+            ty,
+            key_ty,
+            tunables_fn: *item.block,
+            key,
+            create_key: args.create_key,
+            output,
+            operations,
+        })
+    }
+}
+
+#[derive(FromMeta)]
+pub struct AutotuneOpArgs {
+    name: Option<Ident>,
+}
+
+pub struct AutotuneOp {
+    pub name: Ident,
+    pub generics: Generics,
+    pub input_fields: Vec<Field>,
+    pub ty: Option<TokenStream>,
+    pub operation: ItemFn,
+    pub output: Type,
+}
+
+impl AutotuneOp {
+    pub fn from_item_fn(item: ItemFn, args: AutotuneOpArgs) -> Self {
+        let name = args.name.unwrap_or_else(|| {
+            let name = RenameRule::PascalCase.apply_to_field(item.sig.ident.to_string());
+            format_ident!("{name}")
+        });
+        let generics = item.sig.generics.clone();
+        let fields = item.sig.inputs.iter().map(|input| parse_quote!(#input));
+        let ty = (!generics.params.is_empty()).then(|| {
+            let names = generics.params.iter().map(|it| match it {
+                GenericParam::Lifetime(lifetime_param) => {
+                    let mut param = lifetime_param.clone();
+                    param.bounds = Punctuated::new();
+                    param.colon_token = None;
+                    param.to_token_stream()
+                }
+                GenericParam::Type(type_param) => type_param.ident.to_token_stream(),
+                GenericParam::Const(const_param) => const_param.ident.to_token_stream(),
+            });
+            quote![__ty: ::core::marker::PhantomData<(#(#names),*)>,]
+        });
+        let output = match item.sig.output.clone() {
+            ReturnType::Default => parse_quote![()],
+            ReturnType::Type(_, ty) => *ty,
+        };
+
+        Self {
+            name,
+            generics,
+            input_fields: fields.collect(),
+            ty,
+            output,
+            operation: item,
+        }
+    }
+}

--- a/crates/cubecl-macros/src/parse/mod.rs
+++ b/crates/cubecl-macros/src/parse/mod.rs
@@ -1,5 +1,6 @@
 use syn::{visit_mut::VisitMut, GenericParam, TypeParam};
 
+pub mod autotune;
 pub mod branch;
 pub mod cube_trait;
 pub mod cube_type;

--- a/crates/cubecl-macros/src/paths.rs
+++ b/crates/cubecl-macros/src/paths.rs
@@ -16,6 +16,12 @@ const PRELUDE_PATH: LazyCell<Path> = LazyCell::new(|| {
     path.segments.push(format_ident!("prelude").into());
     path
 });
+#[allow(clippy::declare_interior_mutable_const)]
+const TUNE_PATH: LazyCell<Path> = LazyCell::new(|| {
+    let mut path = core_path();
+    path.segments.push(format_ident!("tune").into());
+    path
+});
 
 pub fn frontend_path() -> Path {
     #[allow(clippy::borrow_interior_mutable_const)]
@@ -25,6 +31,11 @@ pub fn frontend_path() -> Path {
 pub fn prelude_path() -> Path {
     #[allow(clippy::borrow_interior_mutable_const)]
     PRELUDE_PATH.clone()
+}
+
+pub fn tune_path() -> Path {
+    #[allow(clippy::borrow_interior_mutable_const)]
+    TUNE_PATH.clone()
 }
 
 pub fn core_path() -> Path {
@@ -48,6 +59,13 @@ pub fn frontend_type(ty: &str) -> Path {
 
 pub fn prelude_type(ty: &str) -> Path {
     let mut path = prelude_path();
+    let ident = format_ident!("{ty}");
+    path.segments.push(ident.into());
+    path
+}
+
+pub fn tune_type(ty: &str) -> Path {
+    let mut path = tune_path();
     let ident = format_ident!("{ty}");
     path.segments.push(ident.into());
     path

--- a/crates/cubecl-runtime/src/tune/mod.rs
+++ b/crates/cubecl-runtime/src/tune/mod.rs
@@ -5,6 +5,7 @@ mod tune_cache;
 mod tuner;
 mod util;
 
+pub use crate::tune_with;
 pub use local::*;
 pub use operation::*;
 pub use tune_benchmark::*;

--- a/crates/cubecl-runtime/src/tune/mod.rs
+++ b/crates/cubecl-runtime/src/tune/mod.rs
@@ -3,9 +3,11 @@ mod operation;
 mod tune_benchmark;
 mod tune_cache;
 mod tuner;
+mod util;
 
 pub use local::*;
 pub use operation::*;
 pub use tune_benchmark::*;
 pub use tune_cache::*;
 pub use tuner::*;
+pub use util::*;

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -32,6 +32,12 @@ pub trait AutotuneOperationSet<K, Output = ()>: Send {
     fn compute_checksum(&self) -> String {
         compute_checksum(&self.autotunables())
     }
+
+    /// Enable or disable certain indices from being benchmarked based on the key
+    #[allow(unused)]
+    fn should_run(&self, key: &K, index: usize) -> bool {
+        true
+    }
 }
 
 /// Contains operation to run and inputs on which to run it

--- a/crates/cubecl-runtime/src/tune/util.rs
+++ b/crates/cubecl-runtime/src/tune/util.rs
@@ -12,3 +12,14 @@ pub fn anchor(x: usize, max: Option<usize>) -> usize {
         power_of_2
     }
 }
+
+/// Tune the operation set with these benchmark inputs
+#[macro_export]
+macro_rules! tune_with {
+    ($($args:expr),*) => {
+        ($($args),*)
+    };
+    ($($args:expr,)*) => {
+        ($($args),*)
+    };
+}

--- a/crates/cubecl-runtime/src/tune/util.rs
+++ b/crates/cubecl-runtime/src/tune/util.rs
@@ -1,0 +1,14 @@
+use core::cmp::min;
+
+/// Anchor a number to a power of 2.
+///
+/// Useful when creating autotune keys.
+pub fn anchor(x: usize, max: Option<usize>) -> usize {
+    let exp = f32::ceil(f32::log2(x as f32)) as u32;
+    let power_of_2 = 2_u32.pow(exp) as usize;
+    if let Some(max) = max {
+        min(power_of_2, max)
+    } else {
+        power_of_2
+    }
+}

--- a/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
@@ -483,57 +483,16 @@ impl Display for Instruction {
             Instruction::LowerEqual { lhs, rhs, out } => comparison(lhs, rhs, out, "<=", f),
             Instruction::GreaterEqual { lhs, rhs, out } => comparison(lhs, rhs, out, ">=", f),
             Instruction::NotEqual { lhs, rhs, out } => comparison(lhs, rhs, out, "!=", f),
-            Instruction::Assign { input, out } => match out.item() {
-                Item::Vec4(elem) => {
-                    let input0 = input.index(0);
-                    let input1 = input.index(1);
-                    let input2 = input.index(2);
-                    let input3 = input.index(3);
-
-                    f.write_fmt(format_args!(
-                        "{out} = vec4(
-    {elem}({input0}),
-    {elem}({input1}),
-    {elem}({input2}),
-    {elem}({input3}),
-);
-"
-                    ))
+            Instruction::Assign { input, out } => {
+                if input.elem().is_atomic() {
+                    f.write_fmt(format_args!("let {out} = &{input};\n"))
+                } else if input.item() != out.item() {
+                    let item = out.item();
+                    f.write_fmt(format_args!("{out} = {item}({input});\n"))
+                } else {
+                    f.write_fmt(format_args!("{out} = {input};\n"))
                 }
-                Item::Vec3(elem) => {
-                    let input0 = input.index(0);
-                    let input1 = input.index(1);
-                    let input2 = input.index(2);
-
-                    f.write_fmt(format_args!(
-                        "{out} = vec3(
-    {elem}({input0}),
-    {elem}({input1}),
-    {elem}({input2}),
-);
-"
-                    ))
-                }
-                Item::Vec2(elem) => {
-                    let input0 = input.index(0);
-                    let input1 = input.index(1);
-
-                    f.write_fmt(format_args!(
-                        "{out} = vec2(
-    {elem}({input0}),
-    {elem}({input1}),
-);
-"
-                    ))
-                }
-                Item::Scalar(elem) => {
-                    if elem.is_atomic() {
-                        f.write_fmt(format_args!("let {out} = &{input};\n"))
-                    } else {
-                        f.write_fmt(format_args!("{out} = {elem}({input});\n"))
-                    }
-                }
-            },
+            }
             Instruction::Stride { dim, position, out } => f.write_fmt(format_args!(
                 "{out} = info[({position}u * rank_2) + {dim} + 1u];\n"
             )),


### PR DESCRIPTION
Adds a small proc macro to generate the autotune boilerplate in most common cases.
See examples in doc comments for how they would be used.

