### PR TITLE
Format floating point values with the maximum precision possible

### DIFF
--- a/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
@@ -244,7 +244,7 @@ impl Display for Item {
 fn format_number(num: f64) -> String {
     let formatted = format!("{:.34}", num);
     let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
-    trimmed.to_string()
+    trimmed.to_string() + "f"
 }
 
 impl Display for Variable {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
@@ -283,8 +283,8 @@ impl Display for Variable {
                     FloatKind::BF16 => {
                         todo!("Unsupported")
                     }
-                    FloatKind::F32 => f.write_fmt(format_args!("{}f", *val as f32)),
-                    FloatKind::F64 => f.write_fmt(format_args!("{}f", { *val })),
+                    FloatKind::F32 => f.write_fmt(format_args!("{:.34}f", *val as f32)),
+                    FloatKind::F64 => f.write_fmt(format_args!("{:.34}f", { *val })),
                 },
                 ConstantScalarValue::UInt(val) => f.write_fmt(format_args!("{}u", *val as u32)),
                 ConstantScalarValue::Bool(val) => f.write_fmt(format_args!("{}", val)),

--- a/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
@@ -241,6 +241,12 @@ impl Display for Item {
     }
 }
 
+fn format_number(num: f64) -> String {
+    let formatted = format!("{:.34}", num);
+    let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
+    trimmed.to_string()
+}
+
 impl Display for Variable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -283,8 +289,7 @@ impl Display for Variable {
                     FloatKind::BF16 => {
                         todo!("Unsupported")
                     }
-                    FloatKind::F32 => f.write_fmt(format_args!("{:.34}f", *val as f32)),
-                    FloatKind::F64 => f.write_fmt(format_args!("{:.34}f", { *val })),
+                    FloatKind::F32 | FloatKind::F64 => f.write_str(&format_number(*val)),
                 },
                 ConstantScalarValue::UInt(val) => f.write_fmt(format_args!("{}u", *val as u32)),
                 ConstantScalarValue::Bool(val) => f.write_fmt(format_args!("{}", val)),


### PR DESCRIPTION
Currently, values like f32::MAX, f32::MIN get rounded which causes some compilers (Tint) to trip up.

Instead, round to maximum number of digits precision floats can have, see:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b35da437be3ef6a6056c6cf9f52c1b7a

For various takes. Also trim trailing zeros so tests don't have to be adjusted.

I originally thought the issue was storing the 32 bit constants in 64 bit values, but actually all 32 bit values are exactly representable in a 64 bit float, that's not the issue.