### PR TITLE
Feat/profiling

### DIFF
--- a/crates/cubecl-core/src/compute/kernel.rs
+++ b/crates/cubecl-core/src/compute/kernel.rs
@@ -177,7 +177,9 @@ pub trait CubeTask: Send + Sync {
     fn id(&self) -> KernelId;
     /// Compile the kernel into source
     fn compile(&self, mode: ExecutionMode) -> CompiledKernel;
-    fn name(&self) -> &'static str;
+    fn name(&self) -> &'static str {
+        core::any::type_name::<Self>()
+    }
 }
 
 /// Wraps a [kernel](Kernel) to create a [cube task](CubeTask).

--- a/crates/cubecl-core/src/id.rs
+++ b/crates/cubecl-core/src/id.rs
@@ -1,24 +1,14 @@
 use cubecl_runtime::ExecutionMode;
 use std::any::{Any, TypeId};
-use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 
 /// Kernel unique identifier.
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
 pub struct KernelId {
-    type_id: core::any::TypeId,
-    info: Option<Info>,
-    mode: Option<ExecutionMode>,
-}
-
-impl Display for KernelId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.info {
-            Some(info) => f.write_fmt(format_args!("{}", info)),
-            None => f.write_str("No info"),
-        }
-    }
+    pub(crate) type_id: core::any::TypeId,
+    pub(crate) info: Option<Info>,
+    pub(crate) mode: Option<ExecutionMode>,
 }
 
 impl KernelId {
@@ -50,12 +40,12 @@ impl KernelId {
 }
 
 /// Extra information
-#[derive(Clone, Debug)]
-struct Info {
+#[derive(Clone)]
+pub(crate) struct Info {
     value: Arc<dyn DynKey>,
 }
 
-impl core::fmt::Display for Info {
+impl core::fmt::Debug for Info {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("{:?}", self.value))
     }

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -129,8 +129,14 @@ impl<MM: MemoryManagement<CudaStorage>> ComputeServer for CudaServer<MM> {
         mode: ExecutionMode,
     ) {
         let mut kernel_id = kernel.id();
-        let name = kernel.name();
         kernel_id.mode(mode);
+
+        let profile_level = self.logger.profile_level();
+        let profile_info = if profile_level.is_some() {
+            Some((kernel.name(), kernel_id.clone()))
+        } else {
+            None
+        };
 
         let count = match count {
             CubeCount::Static(x, y, z) => (x, y, z),
@@ -165,26 +171,31 @@ impl<MM: MemoryManagement<CudaStorage>> ComputeServer for CudaServer<MM> {
             })
             .collect::<Vec<_>>();
 
-        logger.execute(|profile| {
-            if let Some(level) = profile {
-                ctx.sync();
+        if let Some(level) = profile_level {
+            ctx.sync();
+            let start = std::time::SystemTime::now();
+            ctx.execute_task(kernel_id, count, resources);
+            ctx.sync();
 
-                let start = std::time::SystemTime::now();
-                ctx.execute_task(kernel_id.clone(), count, resources);
-                ctx.sync();
-
-                let info = match level {
-                    cubecl_runtime::debug::ProfileLevel::Basic => format!("{name}"),
-                    cubecl_runtime::debug::ProfileLevel::Full => {
-                        format!("{name}: {kernel_id} | CubeCount {count:?}")
+            let (name, kernel_id) = profile_info.unwrap();
+            let info = match level {
+                cubecl_runtime::debug::ProfileLevel::Basic => {
+                    if let Some(val) = name.split("<").next() {
+                        val.split("::").last().unwrap_or(name).to_string()
+                    } else {
+                        name.to_string()
                     }
-                };
-                Some(start.elapsed().unwrap()).map(|duration| (info, duration))
-            } else {
-                ctx.execute_task(kernel_id, count, resources);
-                None
-            }
-        });
+                }
+                cubecl_runtime::debug::ProfileLevel::Full => {
+                    format!("{name}: {kernel_id} CubeCount {count:?}")
+                }
+            };
+
+            self.logger
+                .register_profiled(info, start.elapsed().unwrap());
+        } else {
+            ctx.execute_task(kernel_id, count, resources);
+        }
     }
 
     fn sync(&mut self, sync_type: SyncType) {

--- a/crates/cubecl-cuda/tests/main.rs
+++ b/crates/cubecl-cuda/tests/main.rs
@@ -26,7 +26,8 @@ pub fn slice_assign() {
         tensor(&input),
         tensor(&output),
     );
-    let expected = include_str!("slice_assign.cu").replace("\r\n", "\n");
+    let expected = include_str!("slice_assign.cu").replace("\r\n", "");
+    let expected = expected.trim();
     assert_eq!(compile(kernel), expected);
 }
 
@@ -51,6 +52,7 @@ pub fn subcube_sum() {
         tensor(&output),
     );
     let expected = include_str!("subcube_sum.cu").replace("\r\n", "\n");
+    let expected = expected.trim();
     assert_eq!(compile(kernel), expected);
 }
 
@@ -80,6 +82,7 @@ pub fn sequence_for_loop() {
         array(&output),
     );
     let expected = include_str!("sequence_for_loop.cu").replace("\r\n", "\n");
+    let expected = expected.trim();
     assert_eq!(compile(kernel), expected);
 }
 
@@ -111,5 +114,6 @@ pub fn unary_bench() {
         tensor_vec(&out, 4),
     );
     let expected = include_str!("unary_bench.cu").replace("\r\n", "\n");
+    let expected = expected.trim();
     assert_eq!(compile(kernel), expected);
 }

--- a/crates/cubecl-cuda/tests/subcube_sum.cu
+++ b/crates/cubecl-cuda/tests/subcube_sum.cu
@@ -23,8 +23,8 @@ extern "C" __global__ void kernel(float output_0[], uint info[]) {
 
   l_0_1 = l_0_0;
   {
-    for (int offset = warpSizeChecked / 2; offset > 0; offset /= 2) {
-      l_0_1 += __shfl_down_sync(0xFFFFFFFF, l_0_1, offset);
+    for (int offset = 1; offset < warpSizeChecked; offset *= 2) {
+      l_0_1 += __shfl_xor_sync(-1, l_0_1, offset);
     }
   }
   l_0_2 = threadIdxGlobal == uint(0);

--- a/crates/cubecl-linalg/src/matmul/cmma/config.rs
+++ b/crates/cubecl-linalg/src/matmul/cmma/config.rs
@@ -89,9 +89,7 @@ impl Default for CmmaConfig {
             false,
             WriteOutStrategy::ReuseSmem,
             CubeDispatchStrategy::ColMajor,
-            ComputeLoopOrderStrategy::AllAccumulatorsFirst {
-                reuse_lhs_fragment: true,
-            },
+            ComputeLoopOrderStrategy::AllBuffersFirst,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/cmma/config.rs
+++ b/crates/cubecl-linalg/src/matmul/cmma/config.rs
@@ -88,8 +88,10 @@ impl Default for CmmaConfig {
             16,
             false,
             WriteOutStrategy::ReuseSmem,
-            CubeDispatchStrategy::ColMajor,
-            ComputeLoopOrderStrategy::AllBuffersFirst,
+            CubeDispatchStrategy::RowMajor,
+            ComputeLoopOrderStrategy::AllAccumulatorsFirst {
+                reuse_lhs_fragment: true,
+            },
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/cmma/config.rs
+++ b/crates/cubecl-linalg/src/matmul/cmma/config.rs
@@ -88,7 +88,7 @@ impl Default for CmmaConfig {
             16,
             false,
             WriteOutStrategy::ReuseSmem,
-            CubeDispatchStrategy::RowMajor,
+            CubeDispatchStrategy::ColMajor,
             ComputeLoopOrderStrategy::AllAccumulatorsFirst {
                 reuse_lhs_fragment: true,
             },

--- a/crates/cubecl-runtime/src/debug.rs
+++ b/crates/cubecl-runtime/src/debug.rs
@@ -1,4 +1,4 @@
-use core::fmt::Display;
+use core::{fmt::Display, time::Duration};
 
 #[cfg(feature = "std")]
 use std::{
@@ -7,15 +7,35 @@ use std::{
     path::PathBuf,
 };
 
+#[derive(Debug)]
+/// The various debugging options available.
+pub enum DebugOptions {
+    /// Debug the compilation.
+    Debug,
+    /// Profile each kernel executed.
+    Profile(ProfileLevel),
+    /// Enable all options.
+    All(ProfileLevel),
+}
+
+#[derive(Debug, Copy, Clone)]
+/// Control the amount of info being display when profiling.
+pub enum ProfileLevel {
+    /// Provide only minimal information about kernels being run.
+    Basic,
+    /// Provide more information about kernels being run.
+    Full,
+}
+
 /// Debugging logger.
 #[derive(Debug)]
 pub enum DebugLogger {
     #[cfg(feature = "std")]
     /// Log debugging information into a file.
-    File(DebugFileLogger),
+    File(DebugFileLogger, DebugOptions),
     #[cfg(feature = "std")]
     /// Log debugging information into standard output.
-    Stdout,
+    Stdout(DebugOptions),
     /// Don't log debugging information.
     None,
 }
@@ -45,10 +65,39 @@ impl DebugLogger {
             Ok(val) => val,
             Err(_) => return Self::None,
         };
+        let level = match std::env::var("CUBECL_DEBUG_OPTION") {
+            Ok(val) => val,
+            Err(_) => "debug|profile".to_string(),
+        };
+
+        let mut debug = false;
+        let mut profile = None;
+        level.as_str().split("|").for_each(|flag| match flag {
+            "debug" => {
+                debug = true;
+            }
+            "profile" => {
+                profile = Some(ProfileLevel::Basic);
+            }
+            "profile-full" => {
+                profile = Some(ProfileLevel::Full);
+            }
+            _ => {}
+        });
+
+        let option = if let Some(level) = profile {
+            if debug {
+                DebugOptions::All(level)
+            } else {
+                DebugOptions::Profile(level)
+            }
+        } else {
+            DebugOptions::Debug
+        };
 
         if let Ok(activated) = str::parse::<u8>(&flag) {
             if activated == 1 {
-                return Self::File(DebugFileLogger::new(None));
+                return Self::File(DebugFileLogger::new(None), option);
             } else {
                 return Self::None;
             }
@@ -56,16 +105,51 @@ impl DebugLogger {
 
         if let Ok(activated) = str::parse::<bool>(&flag) {
             if activated {
-                return Self::File(DebugFileLogger::new(None));
+                return Self::File(DebugFileLogger::new(None), option);
             } else {
                 return Self::None;
             }
         };
 
         if let "stdout" = flag.as_str() {
-            Self::Stdout
+            Self::Stdout(option)
         } else {
-            Self::File(DebugFileLogger::new(Some(&flag)))
+            Self::File(DebugFileLogger::new(Some(&flag)), option)
+        }
+    }
+
+    /// Log the argument to a file when the debug logger is activated.
+    pub fn execute<Name, Func>(&mut self, func: Func)
+    where
+        Name: Display,
+        Func: FnOnce(Option<ProfileLevel>) -> Option<(Name, core::time::Duration)>,
+    {
+        let option = match self {
+            #[cfg(feature = "std")]
+            DebugLogger::File(_, option) => option,
+            #[cfg(feature = "std")]
+            DebugLogger::Stdout(option) => option,
+            DebugLogger::None => {
+                func(None);
+                return;
+            }
+        };
+        let profile = match option {
+            DebugOptions::Debug => None,
+            DebugOptions::Profile(level) => Some(*level),
+            DebugOptions::All(level) => Some(*level),
+        };
+
+        if let Some((name, duration)) = func(profile) {
+            match self {
+                #[cfg(feature = "std")]
+                DebugLogger::File(file, _) => {
+                    file.log(&format!("{name} => {duration:?}"));
+                }
+                #[cfg(feature = "std")]
+                DebugLogger::Stdout(_) => println!("{name} => {duration:?}"),
+                _ => (),
+            }
         }
     }
 
@@ -76,13 +160,23 @@ impl DebugLogger {
     {
         match self {
             #[cfg(feature = "std")]
-            DebugLogger::File(file) => {
-                file.log(&arg);
+            DebugLogger::File(file, option) => {
+                match option {
+                    DebugOptions::Debug | DebugOptions::All(_) => {
+                        file.log(&arg);
+                    }
+                    DebugOptions::Profile(_) => (),
+                };
                 arg
             }
             #[cfg(feature = "std")]
-            DebugLogger::Stdout => {
-                println!("{arg}");
+            DebugLogger::Stdout(option) => {
+                match option {
+                    DebugOptions::Debug | DebugOptions::All(_) => {
+                        println!("{arg}");
+                    }
+                    DebugOptions::Profile(_) => (),
+                };
                 arg
             }
             DebugLogger::None => arg,

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -253,6 +253,13 @@ where
         bindings: Vec<server::Binding<Self>>,
         mode: ExecutionMode,
     ) {
+        let profile_level = self.logger.profile_level();
+        let profile_info = if profile_level.is_some() {
+            Some((kernel.name(), kernel.id()))
+        } else {
+            None
+        };
+
         let pipeline = self.pipeline(kernel, mode);
         let group_layout = pipeline.get_bind_group_layout(0);
 
@@ -285,6 +292,13 @@ where
                 resource: r.as_binding(),
             })
             .collect::<Vec<_>>();
+
+        let start = if profile_level.is_some() {
+            self.sync(SyncType::Wait);
+            Some(std::time::SystemTime::now())
+        } else {
+            None
+        };
 
         let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: None,
@@ -326,8 +340,30 @@ where
             }
         }
 
-        if self.tasks_count >= self.tasks_max {
-            self.sync(SyncType::Flush);
+        if let Some(level) = profile_level {
+            let (name, kernel_id) = profile_info.unwrap();
+
+            // Execute the task.
+            self.sync(SyncType::Wait);
+
+            let info = match level {
+                cubecl_runtime::debug::ProfileLevel::Basic => {
+                    if let Some(val) = name.split("<").next() {
+                        val.split("::").last().unwrap_or(name).to_string()
+                    } else {
+                        name.to_string()
+                    }
+                }
+                cubecl_runtime::debug::ProfileLevel::Full => {
+                    format!("{name}: {kernel_id} CubeCount {count:?}")
+                }
+            };
+            self.logger
+                .register_profiled(info, start.unwrap().elapsed().unwrap());
+        } else {
+            if self.tasks_count >= self.tasks_max {
+                self.sync(SyncType::Flush);
+            }
         }
     }
 

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -360,10 +360,8 @@ where
             };
             self.logger
                 .register_profiled(info, start.unwrap().elapsed().unwrap());
-        } else {
-            if self.tasks_count >= self.tasks_max {
-                self.sync(SyncType::Flush);
-            }
+        } else if self.tasks_count >= self.tasks_max {
+            self.sync(SyncType::Flush);
         }
     }
 

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -34,7 +34,7 @@ impl<R: Runtime, E: Float> Benchmark for MatmulBench<R, E> {
     }
 
     fn num_samples(&self) -> usize {
-        100
+        10
     }
 
     fn name(&self) -> String {


### PR DESCRIPTION
Two level of profiling for now:

## Basic

cmd: `CUBECL_DEBUG_OPTION=profile CUBECL_DEBUG_LOG=stdout cargo bench --bench matmul --features cuda-jit`
For 5 kernels:

```
| 7.438437ms | CmmaKernel
| 6.712298ms | CmmaKernel
| 6.683767ms | CmmaKernel
| 7.825637ms | CmmaKernel
| 7.125788ms | CmmaKernel
```

## Full
cmd: `CUBECL_DEBUG_OPTION=profile-full CUBECL_DEBUG_LOG=stdout cargo bench --bench matmul --features cuda-jit`

For 1 kernel:

```
| 7.079846ms | cubecl_linalg::matmul::cmma::base::cmma_kernel::CmmaKernel<half::binary16::f16, half::binary16::f16, cubecl_cuda::runtime::CudaRuntime>: (
    KernelSettings {
        mappings: [],
        vectorization_global: None,
        vectorization_partial: [
            Input {
                pos: 0,
                vectorization: Some (
                    8,
                ),
            },
            Input {
                pos: 1,
                vectorization: Some (
                    8,
                ),
            },
            Output {
                pos: 0,
                vectorization: Some (
                    8,
                ),
            },
        ],
        cube_dim: CubeDim {
            x: 32,
            y: 8,
            z: 1,
        },
        reading_strategy: [],
    },
    ComptimeCmmaInfo {
        block_size_m: 128,
        block_size_k: 16,
        block_size_n: 128,
        tile_size: 16,
        check_m_bounds: false,
        check_k_bounds: false,
        check_n_bounds: false,
        unroll: false,
        coop_dim: 32,
        num_coops: 8,
        num_accumulators: 8,
        write_out_strategy: 1,
        cube_dispatch_strategy: 1,
        compute_loop_order_strategy: 0,
        reuse_lhs_fragment: false,
    },
) CubeCount (16, 16, 8)
```