### PR TITLE
Support Enum + Const Match

### DIFF
--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -29,6 +29,7 @@ pub trait CubeType {
     }
 }
 
+/// Take the comptime version of the type and put it into runtime.
 pub trait IntoRuntime: CubeType + Sized {
     fn runtime(self) -> Self {
         self

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -29,8 +29,9 @@ pub trait CubeType {
     }
 }
 
-/// Take the comptime version of the type and put it into runtime.
+/// Trait useful for cube types that are also used with comptime.
 pub trait IntoRuntime: CubeType + Sized {
+    /// Make sure a type is actually expanded into its runtime [expand type](CubeType::ExpandType).
     fn runtime(self) -> Self {
         self
     }

--- a/crates/cubecl-core/src/frontend/operation/base.rs
+++ b/crates/cubecl-core/src/frontend/operation/base.rs
@@ -44,8 +44,8 @@ pub(crate) fn binary_expand_fixed_output<F>(
 where
     F: Fn(BinaryOperator) -> Operator,
 {
-    let lhs_var= lhs.consume();
-    let rhs_var= rhs.consume();
+    let lhs_var = lhs.consume();
+    let rhs_var = rhs.consume();
 
     let out = context.create_local_variable(out_item);
 

--- a/crates/cubecl-core/src/runtime_tests/const_match.rs
+++ b/crates/cubecl-core/src/runtime_tests/const_match.rs
@@ -1,0 +1,49 @@
+use crate as cubecl;
+
+use cubecl::prelude::*;
+
+#[derive(CubeType)]
+pub enum Operation {
+    Add(usize),
+    Sub(usize),
+}
+
+#[cube(launch)]
+pub fn kernel_assign(output: &mut Array<f32>) {
+    if UNIT_POS == 0 {
+        let item = 5.0;
+        output[0] = item;
+    }
+}
+
+pub fn test_kernel_const_match<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
+    let handle = client.create(f32::as_bytes(&[0.0, 1.0]));
+
+    let vectorization = 2;
+
+    kernel_assign::launch::<R>(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::default(),
+        unsafe { ArrayArg::from_raw_parts(&handle, 2, vectorization) },
+    );
+
+    let actual = client.read(handle.binding());
+    let actual = f32::from_bytes(&actual);
+
+    assert_eq!(actual[0], 5.0);
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! testgen_const_match {
+    () => {
+        use super::*;
+
+        #[test]
+        fn test_const_match() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::const_match::test_kernel_const_match::<TestRuntime>(client);
+        }
+    };
+}

--- a/crates/cubecl-core/src/runtime_tests/const_match.rs
+++ b/crates/cubecl-core/src/runtime_tests/const_match.rs
@@ -2,36 +2,38 @@ use crate as cubecl;
 
 use cubecl::prelude::*;
 
-#[derive(CubeType)]
+#[derive(CubeType, Clone, Hash, PartialEq, Eq, Debug)]
 pub enum Operation {
-    Add(u32),
-    Min { val: u32 },
+    IndexAssign(u32, u32),
 }
 
 #[cube(launch)]
-pub fn kernel_assign(output: &mut Array<f32>) {
-    if UNIT_POS == 0 {
-        let item = 5.0;
-        output[0] = item;
-    }
+pub fn kernel_const_match_simple(output: &mut Array<f32>, #[comptime] op: Operation) {
+    match op {
+        Operation::IndexAssign(index, value) => {
+            output[index.runtime()] = f32::cast_from(value.runtime());
+        }
+    };
 }
 
 pub fn test_kernel_const_match<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
     let handle = client.create(f32::as_bytes(&[0.0, 1.0]));
 
-    let vectorization = 2;
+    let index = 1;
+    let value = 5.0;
 
-    kernel_assign::launch::<R>(
+    kernel_const_match_simple::launch::<R>(
         &client,
         CubeCount::Static(1, 1, 1),
-        CubeDim::default(),
-        unsafe { ArrayArg::from_raw_parts(&handle, 2, vectorization) },
+        CubeDim::new(1, 1, 1),
+        unsafe { ArrayArg::from_raw_parts(&handle, 2, 1) },
+        Operation::IndexAssign(index as u32, value as u32),
     );
 
     let actual = client.read(handle.binding());
     let actual = f32::from_bytes(&actual);
 
-    assert_eq!(actual[0], 5.0);
+    assert_eq!(actual[index], value);
 }
 
 #[allow(missing_docs)]

--- a/crates/cubecl-core/src/runtime_tests/const_match.rs
+++ b/crates/cubecl-core/src/runtime_tests/const_match.rs
@@ -4,8 +4,8 @@ use cubecl::prelude::*;
 
 #[derive(CubeType)]
 pub enum Operation {
-    Add(usize),
-    Sub(usize),
+    Add(u32),
+    Min { val: u32 },
 }
 
 #[cube(launch)]

--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -26,5 +26,6 @@ macro_rules! testgen_all {
         cubecl_core::testgen_unary!();
         cubecl_core::testgen_binary!();
         cubecl_core::testgen_different_rank!();
+        cubecl_core::testgen_const_match!();
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -1,6 +1,7 @@
 pub mod assign;
 pub mod binary;
 pub mod cmma;
+pub mod const_match;
 pub mod different_rank;
 pub mod launch;
 pub mod sequence;

--- a/crates/cubecl-core/tests/frontend/enum_type.rs
+++ b/crates/cubecl-core/tests/frontend/enum_type.rs
@@ -1,0 +1,31 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+#[allow(dead_code)]
+mod test_compilation {
+    use super::*;
+
+    #[derive(CubeType)]
+    enum VariantNoInput {
+        Add,
+        Min,
+    }
+
+    #[derive(CubeType)]
+    enum SingleVariant {
+        Add(u32),
+    }
+
+    #[derive(CubeType)]
+    enum MultipleVariants {
+        Add(u32),
+        Min(u32, u32),
+    }
+
+    #[derive(CubeType)]
+    enum MultipleVariantsNamed {
+        Add(u32),
+        Min(u32, u32),
+        Mul { lhs: u32, rhs: u32 },
+    }
+}

--- a/crates/cubecl-core/tests/frontend/mod.rs
+++ b/crates/cubecl-core/tests/frontend/mod.rs
@@ -5,6 +5,7 @@ mod cast_kind;
 mod comptime;
 mod constants;
 mod cube_trait;
+mod enum_type;
 mod for_loop;
 mod function_call;
 mod generic_kernel;

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -132,6 +132,16 @@ pub enum Expression {
     Keyword {
         name: syn::Ident,
     },
+    ConstMatch {
+        const_expr: syn::Expr,
+        arms: Vec<ConstMatchArm>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct ConstMatchArm {
+    pub pat: syn::Pat,
+    pub expr: Box<Expression>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -174,6 +184,7 @@ impl Expression {
             Expression::Closure { .. } => None,
             Expression::Keyword { .. } => None,
             Expression::CompilerIntrinsic { .. } => None,
+            Expression::ConstMatch { .. } => None,
         }
     }
 

--- a/crates/cubecl-macros/src/generate/cube_type.rs
+++ b/crates/cubecl-macros/src/generate/cube_type.rs
@@ -1,4 +1,4 @@
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta, FromVariant};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Ident, Type, Visibility};
@@ -316,6 +316,18 @@ impl TypeCodegen {
 }
 
 pub(crate) fn generate_cube_type(ast: &syn::DeriveInput, with_launch: bool) -> TokenStream {
+    match &ast.data {
+        syn::Data::Enum(data) => generate_cube_type_enum(data, with_launch),
+        _ => generate_cube_type_struct(ast, with_launch),
+    }
+}
+
+fn generate_cube_type_enum(data: &syn::DataEnum, with_launch: bool) -> TokenStream {
+
+    todo!();
+}
+
+fn generate_cube_type_struct(ast: &syn::DeriveInput, with_launch: bool) -> TokenStream {
     let codegen = match TypeCodegen::from_derive_input(ast) {
         Ok(codegen) => codegen,
         Err(e) => return e.write_errors(),

--- a/crates/cubecl-macros/src/generate/cube_type/generate.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate.rs
@@ -1,0 +1,12 @@
+use proc_macro2::TokenStream;
+
+use crate::parse::cube_type::CubeType;
+
+impl CubeType {
+    pub fn generate(&self, with_launch: bool) -> TokenStream {
+        match self {
+            CubeType::Enum(data) => data.generate(with_launch),
+            CubeType::Struct(data) => data.generate(with_launch),
+        }
+    }
+}

--- a/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
@@ -1,0 +1,225 @@
+use crate::{
+    parse::cube_type::{CubeTypeEnum, CubeTypeVariant},
+    paths::prelude_type,
+};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+impl CubeTypeEnum {
+    pub fn generate(&self, with_launch: bool) -> TokenStream {
+        assert!(with_launch == false, "Can't create launchable enum yet.");
+
+        let expand_ty = self.expand_ty();
+        let cube_type_impl = self.cube_type_impl();
+        let expand_type_impl = self.expand_type_impl();
+
+        quote! {
+           #expand_ty
+           #cube_type_impl
+           #expand_type_impl
+        }
+    }
+
+    fn expand_ty(&self) -> proc_macro2::TokenStream {
+        let name = &self.name_expand;
+        let variants = self.variants.iter().map(CubeTypeVariant::expand_variant);
+        let generics = &self.generics;
+        let vis = &self.vis;
+
+        quote! {
+            #[derive(Clone)]
+            #vis enum #name #generics {
+                #(#variants),*
+            }
+        }
+    }
+    fn cube_type_impl(&self) -> proc_macro2::TokenStream {
+        let cube_type = prelude_type("CubeType");
+        let name = &self.ident;
+        let name_expand = &self.name_expand;
+
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+
+        quote! {
+            impl #generics #cube_type for #name #generic_names #where_clause {
+                type ExpandType = #name_expand #generic_names;
+            }
+        }
+    }
+
+    fn expand_type_impl(&self) -> proc_macro2::TokenStream {
+        let context = prelude_type("CubeContext");
+        let into_runtime = prelude_type("IntoRuntime");
+        let init = prelude_type("Init");
+
+        let name = &self.ident;
+        let name_expand = &self.name_expand;
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+
+        let body_init = self.match_impl(
+            quote! {self},
+            self.variants
+                .iter()
+                .map(|v| v.init_body(name_expand))
+                .collect(),
+        );
+
+        let body_into_runtime = self.match_impl(
+            quote! {self},
+            self.variants
+                .iter()
+                .map(|v| v.into_runtime_body(name, name_expand))
+                .collect(),
+        );
+
+        quote! {
+            impl #generics #init for #name_expand #generic_names #where_clause {
+                fn init(self, context: &mut #context) -> Self {
+                    #body_init
+                }
+            }
+
+            impl #generics #into_runtime for #name #generic_names #where_clause {
+                fn __expand_runtime_method(self, context: &mut CubeContext) -> Self::ExpandType {
+                    let expand = #body_into_runtime;
+                    #init::init(expand, context)
+                }
+            }
+        }
+    }
+
+    fn match_impl(
+        &self,
+        match_input_tokens: TokenStream,
+        branches: Vec<TokenStream>,
+    ) -> TokenStream {
+        quote! {
+            match #match_input_tokens {
+                #(#branches,)*
+            }
+        }
+    }
+}
+
+impl CubeTypeVariant {
+    fn expand_variant(&self) -> TokenStream {
+        let name = &self.ident;
+        let cube_type = prelude_type("CubeType");
+        let mut named = false;
+
+        let fields = self
+            .fields
+            .iter()
+            .map(|field| {
+                let ty = &field.ty;
+                match &field.ident {
+                    Some(name) => {
+                        named = true;
+                        quote! {#name: <#ty as #cube_type>::ExpandType}
+                    }
+                    None => quote! {<#ty as #cube_type>::ExpandType},
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if named {
+            quote![#name { #(#fields),* } ]
+        } else {
+            quote![#name ( #(#fields),* ) ]
+        }
+    }
+
+    fn into_runtime_body(&self, ident_ty: &Ident, ident_ty_expand: &Ident) -> TokenStream {
+        let name = &self.ident;
+        let into_runtime = prelude_type("IntoRuntime");
+        let (named, names) = self.fields_names();
+        let body = names.iter().map(|name| {
+            if named {
+                quote! {
+                    #name: #into_runtime::__expand_runtime_method(#name, context)
+                }
+            } else {
+                quote! {
+                    #into_runtime::__expand_runtime_method(#name, context)
+                }
+            }
+        });
+
+        let body = if named {
+            quote![#ident_ty_expand::#name { #(#body),*} ]
+        } else {
+            quote![#ident_ty_expand::#name ( #(#body),* ) ]
+        };
+
+        self.run_on_variants(named, ident_ty, &names, body)
+    }
+
+    fn init_body(&self, ident_ty_expand: &Ident) -> TokenStream {
+        let name = &self.ident;
+        let init = prelude_type("Init");
+        let (named, names) = self.fields_names();
+        let body = names.iter().map(|name| {
+            if named {
+                quote! {
+                    #name: #init::init(#name, context)
+                }
+            } else {
+                quote! {
+                    #init::init(#name, context)
+                }
+            }
+        });
+
+        let body = if named {
+            quote![#ident_ty_expand::#name { #(#body),*} ]
+        } else {
+            quote![#ident_ty_expand::#name ( #(#body),* ) ]
+        };
+
+        self.run_on_variants(named, ident_ty_expand, &names, body)
+    }
+
+    fn fields_names(&self) -> (bool, Vec<Ident>) {
+        let mut named = false;
+
+        let names = self
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| match &field.ident {
+                Some(name) => {
+                    named = true;
+                    name.clone()
+                }
+                None => Ident::new(format!("arg_{i}").as_str(), self.ident.span()),
+            })
+            .collect::<Vec<_>>();
+
+        (named, names)
+    }
+
+    fn run_on_variants(
+        &self,
+        named: bool,
+        parent_ty: &Ident,
+        decl: &[Ident],
+        body: TokenStream,
+    ) -> TokenStream {
+        let ident = &self.ident;
+
+        if named {
+            quote! {
+                #parent_ty::#ident {
+                    #(#decl),*
+                } => #body
+            }
+        } else {
+            quote! (
+                #parent_ty::#ident (
+                    #(#decl),*
+                ) => #body
+            )
+        }
+    }
+}

--- a/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
@@ -8,7 +8,7 @@ use syn::Ident;
 
 impl CubeTypeEnum {
     pub fn generate(&self, with_launch: bool) -> TokenStream {
-        assert!(with_launch == false, "Can't create launchable enum yet.");
+        assert!(!with_launch, "Can't create launchable enum yet.");
 
         let expand_ty = self.expand_ty();
         let cube_type_impl = self.cube_type_impl();
@@ -69,7 +69,7 @@ impl CubeTypeEnum {
             quote! {self},
             self.variants
                 .iter()
-                .map(|v| v.into_runtime_body(name, name_expand))
+                .map(|v| v.runtime_body(name, name_expand))
                 .collect(),
         );
 
@@ -124,7 +124,7 @@ impl CubeTypeVariant {
         }
     }
 
-    fn into_runtime_body(&self, ident_ty: &Ident, ident_ty_expand: &Ident) -> TokenStream {
+    fn runtime_body(&self, ident_ty: &Ident, ident_ty_expand: &Ident) -> TokenStream {
         let name = &self.ident;
         let into_runtime = prelude_type("IntoRuntime");
         let body = self.field_names.iter().map(|name| {

--- a/crates/cubecl-macros/src/generate/cube_type/mod.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/mod.rs
@@ -1,0 +1,3 @@
+mod generate;
+mod generate_enum;
+mod generate_struct;

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -3,7 +3,7 @@ use quote::{format_ident, quote, quote_spanned};
 use syn::{spanned::Spanned, Member, PathArguments};
 
 use crate::{
-    expression::{Block, Expression},
+    expression::{Block, ConstMatchArm, Expression},
     operator::Operator,
     paths::{frontend_path, frontend_type, prelude_type},
     scope::Context,
@@ -426,6 +426,26 @@ impl Expression {
             }
             Expression::Verbatim { tokens, .. } => tokens.clone(),
             Expression::Block(block) => block.to_tokens(context),
+            Expression::ConstMatch { const_expr, arms } => {
+                let arms = arms.iter().map(|arm| arm.to_tokens(context));
+
+                quote! {
+                    match #const_expr {
+                        #(#arms,)*
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl ConstMatchArm {
+    pub fn to_tokens(&self, context: &mut Context) -> TokenStream {
+        let path = &self.pat;
+        let expr = self.expr.to_tokens(context);
+
+        quote! {
+            #path => #expr
         }
     }
 }

--- a/crates/cubecl-macros/src/parse/cube_type/mod.rs
+++ b/crates/cubecl-macros/src/parse/cube_type/mod.rs
@@ -1,0 +1,7 @@
+mod parse;
+mod parse_enum;
+mod parse_struct;
+
+pub(crate) use parse::*;
+pub(crate) use parse_enum::*;
+pub(crate) use parse_struct::*;

--- a/crates/cubecl-macros/src/parse/cube_type/parse.rs
+++ b/crates/cubecl-macros/src/parse/cube_type/parse.rs
@@ -1,0 +1,18 @@
+use super::*;
+use darling::FromDeriveInput;
+
+#[derive(Debug)]
+pub(crate) enum CubeType {
+    Enum(CubeTypeEnum),
+    Struct(CubeTypeStruct),
+}
+
+impl FromDeriveInput for CubeType {
+    fn from_derive_input(input: &syn::DeriveInput) -> darling::Result<Self> {
+        match &input.data {
+            syn::Data::Struct(_) => Ok(Self::Struct(CubeTypeStruct::from_derive_input(input)?)),
+            syn::Data::Enum(_) => Ok(Self::Enum(CubeTypeEnum::from_derive_input(input)?)),
+            syn::Data::Union(_) => Err(darling::Error::custom("Union not supported")),
+        }
+    }
+}

--- a/crates/cubecl-macros/src/parse/cube_type/parse_enum.rs
+++ b/crates/cubecl-macros/src/parse/cube_type/parse_enum.rs
@@ -1,0 +1,39 @@
+use darling::FromDeriveInput;
+use syn::{spanned::Spanned, Ident};
+
+#[derive(Debug)]
+pub struct CubeTypeEnum {
+    pub ident: Ident,
+    pub name_expand: Ident,
+    pub variants: Vec<CubeTypeVariant>,
+    pub generics: syn::Generics,
+    pub vis: syn::Visibility,
+}
+
+#[derive(Debug)]
+pub struct CubeTypeVariant {
+    pub ident: Ident,
+    pub fields: syn::Fields,
+}
+
+impl FromDeriveInput for CubeTypeEnum {
+    fn from_derive_input(input: &syn::DeriveInput) -> darling::Result<Self> {
+        match &input.data {
+            syn::Data::Enum(data) => Ok(Self {
+                ident: input.ident.clone(),
+                generics: input.generics.clone(),
+                vis: input.vis.clone(),
+                name_expand: Ident::new(format!("{}Expand", input.ident).as_str(), input.span()),
+                variants: data
+                    .variants
+                    .iter()
+                    .map(|a| CubeTypeVariant {
+                        ident: a.ident.clone(),
+                        fields: a.fields.clone(),
+                    })
+                    .collect(),
+            }),
+            _ => Err(darling::Error::custom("Only enum are supported.")),
+        }
+    }
+}

--- a/crates/cubecl-macros/src/parse/cube_type/parse_struct.rs
+++ b/crates/cubecl-macros/src/parse/cube_type/parse_struct.rs
@@ -6,9 +6,9 @@ use syn::{parse_quote, punctuated::Punctuated, Generics, Ident, Type, Visibility
 
 use crate::paths::prelude_type;
 
-#[derive(FromDeriveInput)]
+#[derive(FromDeriveInput, Debug)]
 #[darling(supports(struct_named, struct_unit), attributes(expand), map = unwrap_fields)]
-pub struct TypeCodegen {
+pub struct CubeTypeStruct {
     pub ident: Ident,
     pub name_launch: Option<Ident>,
     pub name_expand: Option<Ident>,
@@ -19,7 +19,7 @@ pub struct TypeCodegen {
     pub vis: Visibility,
 }
 
-#[derive(FromField, Clone)]
+#[derive(FromField, Clone, Debug)]
 #[darling(attributes(expand))]
 pub struct TypeField {
     pub vis: Visibility,
@@ -28,7 +28,7 @@ pub struct TypeField {
     pub comptime: Flag,
 }
 
-fn unwrap_fields(mut ty: TypeCodegen) -> TypeCodegen {
+fn unwrap_fields(mut ty: CubeTypeStruct) -> CubeTypeStruct {
     // This will be supported inline with the next darling release
     let fields = ty.data.as_ref().take_struct().unwrap().fields;
     ty.fields = fields.into_iter().cloned().collect();
@@ -42,7 +42,7 @@ fn unwrap_fields(mut ty: TypeCodegen) -> TypeCodegen {
     ty
 }
 
-impl TypeCodegen {
+impl CubeTypeStruct {
     pub fn expanded_generics(&self) -> Generics {
         let runtime = prelude_type("Runtime");
         let mut generics = self.generics.clone();

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 use crate::{
-    expression::{is_intrinsic, Block, Expression},
+    expression::{is_intrinsic, Block, ConstMatchArm, Expression},
     operator::Operator,
     scope::Context,
 };
@@ -278,9 +278,20 @@ impl Expression {
             Expr::Match(mat) => {
                 let span = mat.span();
                 let elem = Expression::from_expr(*mat.expr.clone(), context)?;
+
                 if elem.is_const() {
-                    Expression::Verbatim {
-                        tokens: quote![#mat],
+                    let mut arms = Vec::new();
+
+                    for arm in mat.arms.iter() {
+                        arms.push(ConstMatchArm {
+                            pat: arm.pat.clone(),
+                            expr: Box::new(Self::from_expr(arm.body.as_ref().clone(), context)?),
+                        });
+                    }
+
+                    Expression::ConstMatch {
+                        const_expr: mat.expr.as_ref().clone(),
+                        arms,
                     }
                 } else {
                     Err(syn::Error::new(

--- a/examples/fusing/src/lib.rs
+++ b/examples/fusing/src/lib.rs
@@ -1,8 +1,14 @@
 use cubecl::{comptime, prelude::*};
 
-#[derive(CubeLaunch, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(CubeType, Clone, Debug, Hash, PartialEq, Eq)]
+enum OperationKind {
+    Exp,
+    Log,
+}
+
+#[derive(CubeType, Clone, Debug, Hash, PartialEq, Eq)]
 struct Operation {
-    kind: u32,
+    kind: OperationKind,
     input_index: u32,
     output_index: u32,
 }
@@ -19,10 +25,9 @@ fn fusing<F: Float>(
         let input = inputs.index(op.input_index);
         let output = outputs.index_mut(op.output_index);
 
-        if op.kind == 0 {
-            output[ABSOLUTE_POS] = F::exp(input[ABSOLUTE_POS]);
-        } else if op.kind == 1 {
-            output[ABSOLUTE_POS] = F::log(input[ABSOLUTE_POS]);
+        match op.kind {
+            OperationKind::Exp => output[ABSOLUTE_POS] = F::exp(input[ABSOLUTE_POS]),
+            OperationKind::Log => output[ABSOLUTE_POS] = F::log(input[ABSOLUTE_POS]),
         }
     }
 }
@@ -57,12 +62,12 @@ pub fn launch<R: Runtime>(device: &R::Device) {
         ));
 
         ops.push(Operation {
-            kind: 0,
+            kind: OperationKind::Exp,
             input_index: 0,
             output_index: 0,
         });
         ops.push(Operation {
-            kind: 1,
+            kind: OperationKind::Log,
             input_index: 0,
             output_index: 1,
         });


### PR DESCRIPTION
Add support for deriving `CubeType` for enum as well as matching a `comptime` enum, but that generates runtime branches that are inlined.