### PR TITLE
Add select (ternary)

### DIFF
--- a/crates/cubecl-core/src/frontend/operation/branch.rs
+++ b/crates/cubecl-core/src/frontend/operation/branch.rs
@@ -1,5 +1,12 @@
 use crate::prelude::CubePrimitive;
 
+/// Executes both branches, *then* selects a value based on the condition. This *should* be
+/// branchless, but might depend on the compiler.
+///
+/// # Safety
+///
+/// Since both branches are *evaluated* regardless of the condition, both branches must be *valid*
+/// regardless of the condition. Illegal memory accesses should not be done in either branch.
 pub fn select<C: CubePrimitive>(condition: bool, then: C, or_else: C) -> C {
     if condition {
         then

--- a/crates/cubecl-core/src/frontend/operation/branch.rs
+++ b/crates/cubecl-core/src/frontend/operation/branch.rs
@@ -1,0 +1,39 @@
+use crate::prelude::CubePrimitive;
+
+pub fn select<C: CubePrimitive>(condition: bool, then: C, or_else: C) -> C {
+    if condition {
+        then
+    } else {
+        or_else
+    }
+}
+
+pub mod select {
+    use crate::{
+        ir::{Branch, Select},
+        prelude::*,
+    };
+
+    pub fn expand<C: CubePrimitive>(
+        context: &mut CubeContext,
+        condition: ExpandElementTyped<bool>,
+        then: ExpandElementTyped<C>,
+        or_else: ExpandElementTyped<C>,
+    ) -> ExpandElementTyped<C> {
+        let cond = condition.expand.consume();
+        let then = then.expand.consume();
+        let or_else = or_else.expand.consume();
+
+        let output = context.create_local_binding(then.item());
+        let out = *output;
+
+        context.register(Branch::Select(Select {
+            cond,
+            then,
+            or_else,
+            out,
+        }));
+
+        output.into()
+    }
+}

--- a/crates/cubecl-core/src/frontend/operation/mod.rs
+++ b/crates/cubecl-core/src/frontend/operation/mod.rs
@@ -1,6 +1,7 @@
 mod assignation;
 mod base;
 mod binary;
+mod branch;
 mod clamp;
 mod cmp;
 mod fma;
@@ -9,6 +10,7 @@ mod unary;
 pub use assignation::*;
 pub use base::*;
 pub use binary::*;
+pub use branch::*;
 pub use clamp::*;
 pub use cmp::*;
 pub use fma::*;

--- a/crates/cubecl-core/src/ir/branch.rs
+++ b/crates/cubecl-core/src/ir/branch.rs
@@ -8,6 +8,8 @@ pub enum Branch {
     If(If),
     /// An if else statement.
     IfElse(IfElse),
+    // A select statement/ternary
+    Select(Select),
     /// A switch statement
     Switch(Switch),
     /// A range loop.
@@ -33,6 +35,15 @@ pub struct IfElse {
     pub cond: Variable,
     pub scope_if: Scope,
     pub scope_else: Scope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[allow(missing_docs)]
+pub struct Select {
+    pub cond: Variable,
+    pub then: Variable,
+    pub or_else: Variable,
+    pub out: Variable,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -43,6 +43,13 @@ pub fn kernel_switch_or_arm(output: &mut Array<f32>, case: u32) {
     }
 }
 
+#[cube(launch)]
+pub fn kernel_select(output: &mut Array<f32>, cond: u32) {
+    if UNIT_POS == 0 {
+        output[0] = select(cond == 1, 3.0, 5.0);
+    }
+}
+
 pub fn test_switch_statement<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
     let handle = client.create(f32::as_bytes(&[0.0, 1.0]));
 
@@ -119,34 +126,71 @@ pub fn test_switch_or_branch<R: Runtime>(client: ComputeClient<R::Server, R::Cha
     assert_eq!(actual[0], 3.0);
 }
 
+pub fn test_select<R: Runtime>(client: ComputeClient<R::Server, R::Channel>, cond: bool) {
+    let handle = client.create(f32::as_bytes(&[0.0]));
+
+    let vectorization = 1;
+
+    let cond_u32 = if cond { 1 } else { 0 };
+
+    kernel_select::launch::<R>(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::default(),
+        unsafe { ArrayArg::from_raw_parts(&handle, 1, vectorization) },
+        ScalarArg::new(cond_u32),
+    );
+
+    let actual = client.read(handle.binding());
+    let actual = f32::from_bytes(&actual);
+
+    if cond {
+        assert_eq!(actual[0], 3.0);
+    } else {
+        assert_eq!(actual[0], 5.0);
+    }
+}
+
 #[allow(missing_docs)]
 #[macro_export]
-macro_rules! testgen_switch {
+macro_rules! testgen_branch {
     () => {
         use super::*;
 
         #[test]
         fn test_switch_statement() {
             let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::switch::test_switch_statement::<TestRuntime>(client);
+            cubecl_core::runtime_tests::branch::test_switch_statement::<TestRuntime>(client);
         }
 
         #[test]
         fn test_switch_used_as_value() {
             let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::switch::test_switch_used_as_value::<TestRuntime>(client);
+            cubecl_core::runtime_tests::branch::test_switch_used_as_value::<TestRuntime>(client);
         }
 
         #[test]
         fn test_switch_default() {
             let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::switch::test_switch_default::<TestRuntime>(client);
+            cubecl_core::runtime_tests::branch::test_switch_default::<TestRuntime>(client);
         }
 
         #[test]
         fn test_switch_or_branch() {
             let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::switch::test_switch_or_branch::<TestRuntime>(client);
+            cubecl_core::runtime_tests::branch::test_switch_or_branch::<TestRuntime>(client);
+        }
+
+        #[test]
+        fn test_select_true() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::branch::test_select::<TestRuntime>(client, true);
+        }
+
+        #[test]
+        fn test_select_false() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::branch::test_select::<TestRuntime>(client, false);
         }
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod assign;
 pub mod binary;
+pub mod branch;
 pub mod cmma;
 pub mod const_match;
 pub mod constants;
@@ -8,7 +9,6 @@ pub mod launch;
 pub mod sequence;
 pub mod slice;
 pub mod subcube;
-pub mod switch;
 pub mod topology;
 pub mod unary;
 
@@ -23,7 +23,7 @@ macro_rules! testgen_all {
         cubecl_core::testgen_cmma!();
         cubecl_core::testgen_slice!();
         cubecl_core::testgen_assign!();
-        cubecl_core::testgen_switch!();
+        cubecl_core::testgen_branch!();
         cubecl_core::testgen_constants!();
         cubecl_core::testgen_topology!();
         cubecl_core::testgen_sequence!();

--- a/crates/cubecl-cuda/src/compiler/base.rs
+++ b/crates/cubecl-cuda/src/compiler/base.rs
@@ -320,6 +320,12 @@ impl CudaCompiler {
                     })
                     .collect(),
             }),
+            gpu::Branch::Select(op) => instructions.push(Instruction::Select {
+                cond: self.compile_variable(op.cond),
+                then: self.compile_variable(op.then),
+                or_else: self.compile_variable(op.or_else),
+                out: self.compile_variable(op.out),
+            }),
             gpu::Branch::Return => instructions.push(Instruction::Return),
             gpu::Branch::Break => instructions.push(Instruction::Break),
             gpu::Branch::RangeLoop(mut range_loop) => instructions.push(Instruction::RangeLoop {

--- a/crates/cubecl-cuda/src/compiler/instruction.rs
+++ b/crates/cubecl-cuda/src/compiler/instruction.rs
@@ -65,6 +65,12 @@ pub enum Instruction {
         instructions_if: Vec<Self>,
         instructions_else: Vec<Self>,
     },
+    Select {
+        cond: Variable,
+        then: Variable,
+        or_else: Variable,
+        out: Variable,
+    },
     Switch {
         value: Variable,
         instructions_default: Vec<Self>,
@@ -246,6 +252,14 @@ for ({i_ty} {i} = {start}; {i} {cmp} {end}; {increment}) {{
                     f.write_fmt(format_args!("{i}"))?;
                 }
                 f.write_str("}\n")
+            }
+            Instruction::Select {
+                cond,
+                then,
+                or_else,
+                out,
+            } => {
+                writeln!(f, "{out} = ({cond}) ? {then} : {or_else};")
             }
             Instruction::Switch {
                 value,

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -396,6 +396,12 @@ impl WgslCompiler {
                 instructions_if: self.compile_scope(&mut op.scope_if),
                 instructions_else: self.compile_scope(&mut op.scope_else),
             }),
+            cube::Branch::Select(op) => instructions.push(wgsl::Instruction::Select {
+                cond: self.compile_variable(op.cond),
+                then: self.compile_variable(op.then),
+                or_else: self.compile_variable(op.or_else),
+                out: self.compile_variable(op.out),
+            }),
             cube::Branch::Switch(mut op) => instructions.push(wgsl::Instruction::Switch {
                 value: self.compile_variable(op.value),
                 instructions_default: self.compile_scope(&mut op.scope_default),

--- a/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
@@ -41,6 +41,12 @@ pub enum Instruction {
         instructions_if: Vec<Instruction>,
         instructions_else: Vec<Instruction>,
     },
+    Select {
+        cond: Variable,
+        then: Variable,
+        or_else: Variable,
+        out: Variable,
+    },
     Switch {
         value: Variable,
         instructions_default: Vec<Instruction>,
@@ -626,6 +632,15 @@ for (var {i}: {i_ty} = {start}; {i} {cmp} {end}; {increment}) {{
                     write!(f, "{i}")?;
                 }
                 f.write_str("}\n")
+            }
+            Instruction::Select {
+                cond,
+                then,
+                or_else,
+                out,
+            } => {
+                let out = out.fmt_left();
+                writeln!(f, "{out} = select({or_else}, {then}, {cond});")
             }
             Instruction::Switch {
                 value,


### PR DESCRIPTION
## Changes

Adds a `select` function that represents ternaries in CUDA, or `select` in `wgsl`.
I decided to use the name from `wgsl` because it represents the concept quite well, but used the argument order of ternaries because that's much more intuitive. `wgsl` uses `select(or_else, then, cond)` but that's entirely down to it being derived from the `mix` interpolation function in GLSL. So I think we should keep the more intuitive `cond`, `then`, `or_else` order.

## Reasoning
Select limits branching and can allow for completely SSA kernels. `wgsl` will execute both branches for example, then (afaik) executes `then & cond + or_else & !cond`. This allows conditional assign without any branching or intermediate variables.

## Important caviat
Since the goal of this is to *avoid* branching, both values will be evaluated regardless of the condition. This cannot safely be used for things like bounds checking (unless we know the access is safe regardless of the condition, i.e. checking if convolution position is in padding).

## Testing

Adds runtime tests to ensure `select` works properly.