### PR TITLE
Fix cuda bugs

### DIFF
--- a/crates/cubecl-core/src/ir/macros.rs
+++ b/crates/cubecl-core/src/ir/macros.rs
@@ -119,6 +119,15 @@ macro_rules! cpa {
             cpa!(binary $lhs, $rhs, $out)
         ));
     };
+    // out = select(cond, then, or_else)
+    ($scope:expr, $out:ident = select($cond:expr, $then:expr, $or_else:expr)) => {
+        $scope.register($crate::ir::Branch::Select($crate::ir::Select{
+            cond: $cond,
+            then: $then,
+            or_else: $or_else,
+            out: $out,
+        }));
+    };
     // out = lhs << rhs
     ($scope:expr, $out: ident = $lhs:ident << $rhs:ident) => {
         cpa!($scope, $out = shift_left($lhs, $rhs))

--- a/crates/cubecl-cuda/src/compiler/binary.rs
+++ b/crates/cubecl-cuda/src/compiler/binary.rs
@@ -37,26 +37,47 @@ pub trait Binary {
         rhs: &Variable,
         out: &Variable,
     ) -> core::fmt::Result {
-        let item_out = out.item();
-
         let optimized = Variable::optimized_args([*lhs, *rhs, *out]);
-        let [lhs, rhs, out] = optimized.args;
+        let [lhs, rhs, out_optimized] = optimized.args;
+
+        let item_out_original = out.item();
+        let item_out_optimized = out_optimized.item();
+
         let index = match optimized.optimization_factor {
-            Some(factor) => item_out.vectorization / factor,
-            None => item_out.vectorization,
+            Some(factor) => item_out_optimized.vectorization / factor,
+            None => item_out_optimized.vectorization,
         };
 
-        let out = out.fmt_left();
-        writeln!(f, "{out} = {item_out}{{")?;
-        for i in 0..index {
-            let lhsi = lhs.index(i);
-            let rhsi = rhs.index(i);
+        let mut write_op = |lhs: &Variable, rhs: &Variable, out: &Variable, item_out: Item| {
+            let out = out.fmt_left();
+            writeln!(f, "{out} = {item_out}{{")?;
+            for i in 0..index {
+                let lhsi = lhs.index(i);
+                let rhsi = rhs.index(i);
 
-            Self::format_scalar(f, lhsi, rhsi, item_out)?;
-            f.write_str(", ")?;
+                Self::format_scalar(f, lhsi, rhsi, item_out)?;
+                f.write_str(", ")?;
+            }
+
+            f.write_str("};\n")
+        };
+
+        if item_out_original == item_out_optimized {
+            write_op(&lhs, &rhs, out, item_out_optimized)
+        } else {
+            let out_tmp = Variable::tmp(item_out_optimized);
+
+            write_op(&lhs, &rhs, &out_tmp, item_out_optimized)?;
+
+            let out = out.fmt_left();
+
+            writeln!(
+                f,
+                "{out} = reinterpret_cast<{item_out_original}&>({out_tmp});\n"
+            )?;
+
+            Ok(())
         }
-
-        f.write_str("};\n")
     }
 }
 

--- a/crates/cubecl-cuda/src/compiler/element.rs
+++ b/crates/cubecl-cuda/src/compiler/element.rs
@@ -264,11 +264,11 @@ impl Variable {
 
     pub fn tmp(item: Item) -> Self {
         let inc = COUNTER_TMP_VAR.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let out_tmp = Variable::Tmp {
+
+        Variable::Tmp {
             id: inc as u16,
             item,
-        };
-        out_tmp
+        }
     }
 
     pub fn optimized_args<const N: usize>(args: [Self; N]) -> OptimizedArgs<N> {

--- a/crates/cubecl-cuda/src/compiler/element.rs
+++ b/crates/cubecl-cuda/src/compiler/element.rs
@@ -2,7 +2,7 @@ use cubecl_core::ir::{self as gpu, ConstantScalarValue};
 use half::{bf16, f16};
 use std::fmt::Display;
 
-use super::Fragment;
+use super::{Fragment, COUNTER_TMP_VAR};
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub enum Elem {
@@ -130,6 +130,7 @@ impl Component for Variable {
             Variable::BlockIdxGlobal => Item::scalar(Elem::U32),
             Variable::BlockDimGlobal => Item::scalar(Elem::U32),
             Variable::GridDimGlobal => Item::scalar(Elem::U32),
+            Variable::Tmp { item, .. } => *item,
         }
     }
 
@@ -173,6 +174,7 @@ pub enum Variable {
     GridDimY,
     GridDimZ,
     WmmaFragment { id: u16, frag: Fragment, depth: u8 },
+    Tmp { id: u16, item: Item },
 }
 
 impl Display for Variable {
@@ -244,6 +246,7 @@ impl Display for Variable {
                 depth,
             } => write!(f, "frag_{index}_{depth}"),
             Variable::GridDimGlobal => f.write_str("gridDimGlobal"),
+            Self::Tmp { id, .. } => write!(f, "_tmp_{id}"),
         }
     }
 }
@@ -257,6 +260,15 @@ pub struct OptimizedArgs<const N: usize> {
 impl Variable {
     pub fn is_optimized(&self) -> bool {
         self.item().is_optimized()
+    }
+
+    pub fn tmp(item: Item) -> Self {
+        let inc = COUNTER_TMP_VAR.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let out_tmp = Variable::Tmp {
+            id: inc as u16,
+            item,
+        };
+        out_tmp
     }
 
     pub fn optimized_args<const N: usize>(args: [Self; N]) -> OptimizedArgs<N> {
@@ -364,6 +376,7 @@ impl Variable {
             Variable::BlockIdxGlobal => true,
             Variable::BlockDimGlobal => true,
             Variable::GridDimGlobal => true,
+            Variable::Tmp { .. } => false,
         }
     }
 
@@ -384,6 +397,7 @@ impl FmtLeft for Variable {
     fn fmt_left(&self) -> String {
         match self {
             Self::ConstLocal { item, .. } => format!("const {item} {self}"),
+            Variable::Tmp { item, .. } => format!("{item} {self}"),
             var => format!("{var}"),
         }
     }
@@ -393,6 +407,7 @@ impl FmtLeft for IndexedVariable {
     fn fmt_left(&self) -> String {
         match self.var {
             Variable::ConstLocal { item, .. } => format!("const {item} {self}"),
+            Variable::Tmp { item, .. } => format!("{item} {self}"),
             _ => format!("{self}"),
         }
     }

--- a/crates/cubecl-cuda/src/compiler/instruction.rs
+++ b/crates/cubecl-cuda/src/compiler/instruction.rs
@@ -45,6 +45,12 @@ pub enum Instruction {
     Sub(BinaryInstruction),
     Index(BinaryInstruction),
     IndexAssign(BinaryInstruction),
+    CheckedIndex {
+        len: Variable,
+        lhs: Variable,
+        rhs: Variable,
+        out: Variable,
+    },
     Assign(UnaryInstruction),
     RangeLoop {
         i: Variable,
@@ -207,6 +213,21 @@ impl Display for Instruction {
             Instruction::ShiftLeft(it) => ShiftLeft::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::ShiftRight(it) => ShiftRight::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::Index(it) => Index::format(f, &it.lhs, &it.rhs, &it.out),
+            Instruction::CheckedIndex { len, lhs, rhs, out } => {
+                let item_out = out.item();
+                if let Elem::Atomic(inner) = item_out.elem {
+                    write!(f, "{inner}* {out} = &{lhs}[{rhs}];")
+                } else {
+                    let out = out.fmt_left();
+                    write!(f, "{out} = ({rhs} < {len}) ? ")?;
+                    Index::format_scalar(f, *lhs, *rhs, item_out)?;
+                    if item_out.vectorization == 1 {
+                        writeln!(f, " : {item_out}(0);")
+                    } else {
+                        writeln!(f, " : {item_out}{{}};")
+                    }
+                }
+            }
             Instruction::IndexAssign(it) => IndexAssign::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::Copy {
                 input,

--- a/crates/cubecl-cuda/src/compiler/instruction.rs
+++ b/crates/cubecl-cuda/src/compiler/instruction.rs
@@ -44,12 +44,6 @@ pub enum Instruction {
     Mul(BinaryInstruction),
     Sub(BinaryInstruction),
     Index(BinaryInstruction),
-    CheckedIndex {
-        len: Variable,
-        lhs: Variable,
-        rhs: Variable,
-        out: Variable,
-    },
     IndexAssign(BinaryInstruction),
     Assign(UnaryInstruction),
     RangeLoop {
@@ -213,21 +207,21 @@ impl Display for Instruction {
             Instruction::ShiftLeft(it) => ShiftLeft::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::ShiftRight(it) => ShiftRight::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::Index(it) => Index::format(f, &it.lhs, &it.rhs, &it.out),
-            Instruction::CheckedIndex { len, lhs, rhs, out } => {
-                let item_out = out.item();
-                if let Elem::Atomic(inner) = item_out.elem {
-                    write!(f, "{inner}* {out} = &{lhs}[{rhs}];")
-                } else {
-                    let out = out.fmt_left();
-                    write!(f, "{out} = ({rhs} < {len}) ? ")?;
-                    Index::format_scalar(f, *lhs, *rhs, item_out)?;
-                    if item_out.vectorization == 1 {
-                        writeln!(f, " : {item_out}(0);")
-                    } else {
-                        writeln!(f, " : {item_out}{{}};")
-                    }
-                }
-            }
+            // Instruction::CheckedIndex { len, lhs, rhs, out } => {
+            //     let item_out = out.item();
+            //     if let Elem::Atomic(inner) = item_out.elem {
+            //         write!(f, "{inner}* {out} = &{lhs}[{rhs}];")
+            //     } else {
+            //         let out = out.fmt_left();
+            //         write!(f, "{out} = ({rhs} < {len}) ? ")?;
+            //         Index::format_scalar(f, *lhs, *rhs, item_out)?;
+            //         if item_out.vectorization == 1 {
+            //             writeln!(f, " : {item_out}(0);")
+            //         } else {
+            //             writeln!(f, " : {item_out}{{}};")
+            //         }
+            //     }
+            // }
             Instruction::IndexAssign(it) => IndexAssign::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::Copy {
                 input,

--- a/crates/cubecl-cuda/src/compiler/instruction.rs
+++ b/crates/cubecl-cuda/src/compiler/instruction.rs
@@ -207,21 +207,6 @@ impl Display for Instruction {
             Instruction::ShiftLeft(it) => ShiftLeft::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::ShiftRight(it) => ShiftRight::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::Index(it) => Index::format(f, &it.lhs, &it.rhs, &it.out),
-            // Instruction::CheckedIndex { len, lhs, rhs, out } => {
-            //     let item_out = out.item();
-            //     if let Elem::Atomic(inner) = item_out.elem {
-            //         write!(f, "{inner}* {out} = &{lhs}[{rhs}];")
-            //     } else {
-            //         let out = out.fmt_left();
-            //         write!(f, "{out} = ({rhs} < {len}) ? ")?;
-            //         Index::format_scalar(f, *lhs, *rhs, item_out)?;
-            //         if item_out.vectorization == 1 {
-            //             writeln!(f, " : {item_out}(0);")
-            //         } else {
-            //             writeln!(f, " : {item_out}{{}};")
-            //         }
-            //     }
-            // }
             Instruction::IndexAssign(it) => IndexAssign::format(f, &it.lhs, &it.rhs, &it.out),
             Instruction::Copy {
                 input,

--- a/crates/cubecl-cuda/src/compute/mod.rs
+++ b/crates/cubecl-cuda/src/compute/mod.rs
@@ -3,3 +3,14 @@ mod storage;
 
 pub use server::*;
 pub use storage::*;
+
+#[allow(clippy::uninit_vec)]
+pub fn uninit_vec<I>(len: usize) -> Vec<I> {
+    let mut data = Vec::with_capacity(len);
+
+    unsafe {
+        data.set_len(len);
+    };
+
+    data
+}

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -232,7 +232,6 @@ impl CudaContext {
         unsafe {
             cudarc::driver::result::stream::synchronize(self.stream).unwrap();
         };
-        self.memory_management.storage().flush();
     }
 
     fn compile_kernel(

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -1,7 +1,7 @@
 use crate::compiler::{format_cpp_code, CudaCompiler};
 
 use super::storage::CudaStorage;
-use super::CudaResource;
+use super::{uninit_vec, CudaResource};
 use cubecl_common::reader::{reader_from_concrete, Reader};
 use cubecl_common::sync_type::SyncType;
 use cubecl_core::compute::DebugInformation;
@@ -61,24 +61,13 @@ impl CudaServer {
             binding.offset_end,
         );
 
-        let mut data = Self::uninit_vec(resource.size() as usize);
+        let mut data = uninit_vec(resource.size() as usize);
 
         unsafe {
             cudarc::driver::result::memcpy_dtoh_async(&mut data, resource.ptr, ctx.stream).unwrap();
         };
 
         ctx.sync();
-
-        data
-    }
-
-    #[allow(clippy::uninit_vec)]
-    fn uninit_vec(len: usize) -> Vec<u8> {
-        let mut data = Vec::with_capacity(len);
-
-        unsafe {
-            data.set_len(len);
-        };
 
         data
     }

--- a/crates/cubecl-cuda/src/device.rs
+++ b/crates/cubecl-cuda/src/device.rs
@@ -1,4 +1,10 @@
-#[derive(new, Clone, Debug, PartialEq, Eq, Default, Hash)]
+#[derive(new, Clone, PartialEq, Eq, Default, Hash)]
 pub struct CudaDevice {
     pub index: usize,
+}
+
+impl core::fmt::Debug for CudaDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Cuda({})", self.index)
+    }
 }


### PR DESCRIPTION
* When executing operations on half2 and bhalf2, we didn't cast the result back to the original type (Unary + Binary fix). I had to create temporary variables to correctly do the casting, but all of these things can probably be optimized by the CUDA compiler. At least it now has more information about the best instructions.
* We still had some invalid memory reference errors with CUDA, so I looked into it and found it wasn't out-of-bounds access, but pointer slot movement. The active slices were cleared during sync, but adding items to them could trigger a reordering of items, which caused the pointer sent to CUDA to become invalid. Instead, I simply use a fixed vector and circle around it to avoid any reallocation.
* Some unary operations are not available in half precision (only float), so I handled those cases with automatic casting.