### PR TITLE
Fix inplace operation autotune

### DIFF
--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -1,6 +1,5 @@
 use core::{fmt::Display, hash::Hash};
 use hashbrown::HashMap;
-use std::sync::Arc;
 
 use crate::{channel::ComputeChannel, client::ComputeClient, server::ComputeServer};
 
@@ -49,7 +48,7 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
         &self,
         id: &ID,
         client: &ComputeClient<S, C>,
-        autotune_operation_set: Arc<dyn AutotuneOperationSet<AK, Out>>,
+        autotune_operation_set: Box<dyn AutotuneOperationSet<AK, Out>>,
     ) -> Out
     where
         S: ComputeServer + 'static,

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -26,7 +26,7 @@ pub trait AutotuneOperationSet<K: Send + Sync + 'static, Output = ()>: Send + Sy
     /// Returns the operation for the given index, matching the order
     /// returned by autotunables. Operation obtained here runs on original tensors
     /// Nb: The 0 index is used a "good default".
-    fn fastest(&self, fastest_index: usize) -> Box<dyn AutotuneOperation<Output>>;
+    fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation<Output>>;
 
     /// Compute a checksum that can invalidate outdated cached auto-tune results.
     #[cfg(autotune_persistent_cache)]

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -9,7 +9,6 @@ use std::panic::{resume_unwind, AssertUnwindSafe};
 
 use alloc::boxed::Box;
 use alloc::string::ToString;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use cubecl_common::benchmark::{BenchmarkComputations, BenchmarkDurations};
 
@@ -31,8 +30,13 @@ type BenchError = ManuallyDrop<Box<dyn Any + Send>>;
 /// Executes autotune benchmarking and caching
 pub struct Tuner<K: AutotuneKey> {
     tune_cache: TuneCache<K>,
-    results_send: Sender<(K, usize)>,
-    results_rec: Receiver<(K, usize)>,
+    results_send: Sender<AutotuneMessage<K>>,
+    results_rec: Receiver<AutotuneMessage<K>>,
+}
+
+struct AutotuneMessage<K> {
+    key: K,
+    fastest_index: usize,
 }
 
 #[allow(clippy::new_without_default)]
@@ -55,41 +59,44 @@ impl<K: AutotuneKey> Tuner<K> {
     /// Execute the fastest autotune operation if known, otherwise perform some benchmarks before.
     pub fn execute_autotune<S, C, Out: Send + 'static>(
         &mut self,
-        set: Arc<dyn AutotuneOperationSet<K, Out>>,
+        set: Box<dyn AutotuneOperationSet<K, Out>>,
         client: &ComputeClient<S, C>,
     ) -> Out
     where
         S: ComputeServer + 'static,
         C: ComputeChannel<S> + 'static,
     {
-        match self.tune_cache.try_cache(set.clone()) {
+        let set = match self.tune_cache.try_cache(set) {
             // Cache hit -> return straight away.
             super::TuneCacheResult::Hit(ops) => return AutotuneOperation::execute(ops),
             // Pending -> wait for the cache to be filled.
-            super::TuneCacheResult::Pending => {}
+            super::TuneCacheResult::Pending(set) => set,
             // Never seen before -> Start autotuning.
-            super::TuneCacheResult::Miss => {
-                self.start_autotuning(set.clone(), client);
+            super::TuneCacheResult::Miss(set) => {
+                self.start_autotuning(set.as_ref(), client);
+                set
             }
         };
 
         // Collect any new cache results that have come in.
-        while let Ok((key, fastest_index)) = self.results_rec.try_recv() {
-            self.tune_cache.cache_insert(key.clone(), fastest_index);
+        while let Ok(msg) = self.results_rec.try_recv() {
+            self.tune_cache
+                .cache_insert(msg.key.clone(), msg.fastest_index);
 
             #[cfg(autotune_persistent_cache)]
             {
                 let checksum = set.compute_checksum();
                 self.tune_cache
-                    .persistent_cache_insert(key, checksum, fastest_index);
+                    .persistent_cache_insert(msg.key, checksum, msg.fastest_index);
                 self.tune_cache.save();
             }
         }
 
         // Check to see if value is now cached. If not, just use a default operation.
-        let operation = match self.tune_cache.try_cache(set.clone()) {
+        let operation = match self.tune_cache.try_cache(set) {
             super::TuneCacheResult::Hit(ops) => ops,
-            _ => set.fastest(0),
+            super::TuneCacheResult::Pending(set) => set.fastest(0),
+            super::TuneCacheResult::Miss(set) => set.fastest(0),
         };
 
         AutotuneOperation::execute(operation)
@@ -101,7 +108,7 @@ impl<K: AutotuneKey> Tuner<K> {
         Out: Send + 'static,
     >(
         &mut self,
-        set: Arc<dyn AutotuneOperationSet<K, Out>>,
+        set: &dyn AutotuneOperationSet<K, Out>,
         client: &ComputeClient<S, C>,
     ) {
         let key = set.key();
@@ -120,7 +127,7 @@ impl<K: AutotuneKey> Tuner<K> {
 
             let mut bench_times = vec![];
             for (i, op) in autotunables.into_iter().enumerate() {
-                let res = Self::run_benchmark(set.as_ref(), &key, i, op, &client).await;
+                let res = Self::run_benchmark(set, &key, i, op, &client).await;
                 let timings = res.map(|t| (i, BenchmarkComputations::new(&t), t));
                 bench_times.push(timings);
             }
@@ -143,7 +150,7 @@ impl<K: AutotuneKey> Tuner<K> {
             log::info!("Fastest result {fastest_name}-{key}. \n Top 3 times: {top_times:?}",);
 
             sender
-                .try_send((key, fastest_index))
+                .try_send(AutotuneMessage { key, fastest_index })
                 .expect("Autotune results channel closed");
         });
     }

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::DummyServer;
 use cubecl_runtime::channel::MutexComputeChannel;
 use cubecl_runtime::client::ComputeClient;
@@ -24,7 +22,7 @@ pub static TEST_TUNER: LocalTuner<String, String> = LocalTuner::new(TUNER_PREFIX
 
 pub fn autotune_execute(
     client: &ComputeClient<DummyServer, MutexComputeChannel<DummyServer>>,
-    set: Arc<dyn AutotuneOperationSet<String>>,
+    set: Box<dyn AutotuneOperationSet<String>>,
 ) {
     TEST_TUNER.execute(&TUNER_DEVICE_ID.to_string(), client, set)
 }

--- a/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
@@ -58,7 +58,7 @@ impl AutotuneOperationSet<String> for AdditionAutotuneOperationSet {
         ]
     }
 
-    fn fastest(&self, fastest_index: usize) -> Box<dyn AutotuneOperation> {
+    fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation> {
         self.autotunables()[fastest_index].clone()
     }
 }
@@ -103,7 +103,7 @@ impl AutotuneOperationSet<String> for MultiplicationAutotuneOperationSet {
         ]
     }
 
-    fn fastest(&self, fastest_index: usize) -> Box<dyn AutotuneOperation> {
+    fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation> {
         self.autotunables()[fastest_index].clone()
     }
 }
@@ -151,7 +151,7 @@ impl AutotuneOperationSet<String> for CacheTestAutotuneOperationSet {
         ]
     }
 
-    fn fastest(&self, fastest_index: usize) -> Box<dyn AutotuneOperation> {
+    fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation> {
         self.autotunables()[fastest_index].clone()
     }
 

--- a/crates/cubecl-runtime/tests/integration_test.rs
+++ b/crates/cubecl-runtime/tests/integration_test.rs
@@ -71,7 +71,7 @@ fn autotune_basic_addition_execution() {
 
     let addition_autotune_kernel =
         dummy::AdditionAutotuneOperationSet::new(client.clone(), shapes, handles);
-    autotune_execute(&client, Arc::new(addition_autotune_kernel));
+    autotune_execute(&client, Box::new(addition_autotune_kernel));
 
     let obtained_resource = client.read(out.binding());
 
@@ -94,7 +94,7 @@ fn autotune_basic_multiplication_execution() {
 
     let multiplication_autotune_kernel =
         dummy::MultiplicationAutotuneOperationSet::new(client.clone(), shapes, handles);
-    autotune_execute(&client, Arc::new(multiplication_autotune_kernel));
+    autotune_execute(&client, Box::new(multiplication_autotune_kernel));
 
     let obtained_resource = client.read(out.binding());
 
@@ -132,8 +132,8 @@ fn autotune_cache_same_key_return_a_cache_hit() {
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_1, handles_1);
     let cache_test_autotune_kernel_2 =
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_2, handles_2);
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel_1));
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel_2));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel_1));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel_2));
 
     let obtained_resource = client.read(out_2.binding());
 
@@ -176,8 +176,8 @@ fn autotune_cache_no_cache_on_disk_return_a_cache_miss() {
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_1, handles_1);
     let cache_test_autotune_kernel_2 =
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_2, handles_2);
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel_1));
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel_2));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel_1));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel_2));
 
     // read the resource which should update the cache on disk
     let obtained_resource = client.read(out_2.binding());
@@ -216,7 +216,7 @@ fn autotune_cache_file_path_creation_works_when_path_does_not_exist_yet() {
 
     let cache_test_autotune_kernel =
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes, handles);
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel));
 
     assert!(
         parent_dir.exists(),
@@ -250,8 +250,8 @@ fn autotune_cache_different_keys_return_a_cache_miss() {
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_1, handles_1);
     let cache_test_autotune_kernel_2 =
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_2, handles_2);
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel_1));
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel_2));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel_1));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel_2));
 
     let obtained_resource = client.read(out_2.binding());
 
@@ -277,7 +277,7 @@ fn autotune_cache_different_checksums_return_a_cache_miss() {
     let handles_1 = vec![lhs_1.binding(), rhs_1.binding(), out_1.binding()];
     let cache_test_autotune_kernel_1 =
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_1, handles_1);
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel_1));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel_1));
 
     TEST_TUNER.clear();
 
@@ -290,7 +290,7 @@ fn autotune_cache_different_checksums_return_a_cache_miss() {
     let mut cache_test_autotune_kernel_2 =
         dummy::CacheTestAutotuneOperationSet::new(client.clone(), shapes_2, handles_2);
     cache_test_autotune_kernel_2.generate_random_checksum = true;
-    autotune_execute(&client, Arc::new(cache_test_autotune_kernel_2));
+    autotune_execute(&client, Box::new(cache_test_autotune_kernel_2));
 
     let obtained_resource = client.read(out_2.binding());
 


### PR DESCRIPTION
I had to put back the `Box` instead of the `Arc` in the tuner to make sure that inputs don't have more references pointing to them because of the autotune set.

I thought that wrapping the set into an `Arc` would only impact the benchmarks, but in fact, it could slow down the actual operations by preventing any in-place operations.