### PR TITLE
Fix/no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ async-channel = "2.3"
 wasm-bindgen-futures = "0.4.45"
 dirs = "5.0.1"
 md5 = "0.7.0"
-futures-lite = "2.3.0"
 weak-table = "0.3"
 web-time = "1.1.0"
 
@@ -70,6 +69,9 @@ portable-atomic-util = { version = "0.2.2", features = [
     "alloc",
 ] } # alloc is for no_std
 pretty_assertions = "1.4"
+
+# Async
+futures = { version = "0.3", default-features = false }
 
 [profile.dev]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ portable-atomic-util = { version = "0.2.2", features = [
 pretty_assertions = "1.4"
 
 # Async
-futures = { version = "0.3", default-features = false }
+futures-lite = { version = "2.3.0", default-features = false }
 embassy-futures = { version = "0.1.1" } # for no-std
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ pretty_assertions = "1.4"
 
 # Async
 futures = { version = "0.3", default-features = false }
+embassy-futures = { version = "0.1.1" } # for no-std
 
 [profile.dev]
 opt-level = 2

--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -15,10 +15,11 @@ version.workspace = true
 
 [features]
 default = ["std"]
-std = ["rand/std"]
+std = ["rand/std", "futures/std"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
+web-time = { workspace = true }
 
 [dependencies]
 # ** Please make sure all dependencies support no_std when std is disabled **
@@ -26,8 +27,7 @@ derive-new = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 spin = { workspace = true }         # using in place of use std::sync::Mutex;
-futures-lite = { workspace = true }
-web-time = { workspace = true }
+futures = { workspace = true, features= ["executor", "alloc"] }
 
 [target.'cfg(target_has_atomic = "ptr")'.dependencies]
 spin = { workspace = true, features = ["mutex", "spin_mutex"] }

--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 
 [features]
 default = ["std"]
-std = ["rand/std", "futures/std"]
+std = ["rand/std", "futures"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
@@ -27,10 +27,15 @@ derive-new = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 spin = { workspace = true }         # using in place of use std::sync::Mutex;
-futures = { workspace = true, features= ["executor", "alloc"] }
+
+# Only activate futures for std env
+futures = { workspace = true, features = ["executor"], default-features = false, optional = true }
 
 [target.'cfg(target_has_atomic = "ptr")'.dependencies]
 spin = { workspace = true, features = ["mutex", "spin_mutex"] }
+
+[target.'cfg(not(features = "std"))'.dependencies]
+embassy-futures = { version = "0.1.1" }
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic-util = { workspace = true }

--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 
 [features]
 default = ["std"]
-std = ["rand/std", "futures"]
+std = ["rand/std", "futures-lite"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
@@ -29,7 +29,7 @@ serde = { workspace = true }
 spin = { workspace = true }         # using in place of use std::sync::Mutex;
 
 # Only activate futures for std env
-futures = { workspace = true, features = ["executor"], default-features = false, optional = true }
+futures-lite = { workspace = true, features = ["std"], default-features = false, optional = true }
 
 [target.'cfg(target_has_atomic = "ptr")'.dependencies]
 spin = { workspace = true, features = ["mutex", "spin_mutex"] }

--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -3,9 +3,9 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Display;
-use web_time::Duration;
-
 use serde::{Deserialize, Serialize};
+
+use super::stub::Duration;
 
 /// Results of a benchmark run.
 #[derive(new, Debug, Default, Clone, Serialize, Deserialize)]

--- a/crates/cubecl-common/src/future.rs
+++ b/crates/cubecl-common/src/future.rs
@@ -1,0 +1,22 @@
+use alloc::boxed::Box;
+use core::{any, future::Future};
+
+/// Block until the [future](Future) is completed and returns the result.
+pub fn block_on<O>(fut: impl Future<Output = O>) -> O {
+    futures::executor::block_on(fut)
+}
+
+/// Tries to catch panics within the future.
+pub async fn catch_unwind<O>(
+    future: impl Future<Output = O>,
+) -> Result<O, Box<dyn any::Any + Send>> {
+    #[cfg(not(target_family = "wasm"))]
+    {
+        use core::panic::AssertUnwindSafe;
+        use futures::FutureExt;
+
+        AssertUnwindSafe(future).catch_unwind().await
+    }
+    #[cfg(target_family = "wasm")]
+    Ok(future.await)
+}

--- a/crates/cubecl-common/src/future.rs
+++ b/crates/cubecl-common/src/future.rs
@@ -10,7 +10,7 @@ pub fn block_on<O>(fut: impl Future<Output = O>) -> O {
 
     #[cfg(feature = "std")]
     {
-        futures::executor::block_on(fut)
+        futures_lite::future::block_on(fut)
     }
 }
 
@@ -21,7 +21,7 @@ pub async fn catch_unwind<O>(
     #[cfg(all(not(target_family = "wasm"), feature = "std"))]
     {
         use core::panic::AssertUnwindSafe;
-        use futures::FutureExt;
+        use futures_lite::FutureExt;
         AssertUnwindSafe(future).catch_unwind().await
     }
 

--- a/crates/cubecl-common/src/future.rs
+++ b/crates/cubecl-common/src/future.rs
@@ -26,7 +26,7 @@ pub async fn catch_unwind<O>(
     }
 
     #[cfg(any(target_family = "wasm", not(feature = "std")))]
-    { 
+    {
         Ok(future.await)
     }
 }

--- a/crates/cubecl-common/src/future.rs
+++ b/crates/cubecl-common/src/future.rs
@@ -1,22 +1,32 @@
 use alloc::boxed::Box;
-use core::{any, future::Future};
+use core::future::Future;
 
 /// Block until the [future](Future) is completed and returns the result.
 pub fn block_on<O>(fut: impl Future<Output = O>) -> O {
-    futures::executor::block_on(fut)
+    #[cfg(not(feature = "std"))]
+    {
+        embassy_futures::block_on(fut)
+    }
+
+    #[cfg(feature = "std")]
+    {
+        futures::executor::block_on(fut)
+    }
 }
 
 /// Tries to catch panics within the future.
 pub async fn catch_unwind<O>(
     future: impl Future<Output = O>,
-) -> Result<O, Box<dyn any::Any + Send>> {
-    #[cfg(not(target_family = "wasm"))]
+) -> Result<O, Box<dyn core::any::Any + core::marker::Send>> {
+    #[cfg(all(not(target_family = "wasm"), feature = "std"))]
     {
         use core::panic::AssertUnwindSafe;
         use futures::FutureExt;
-
         AssertUnwindSafe(future).catch_unwind().await
     }
-    #[cfg(target_family = "wasm")]
-    Ok(future.await)
+
+    #[cfg(any(target_family = "wasm", not(feature = "std")))]
+    { 
+        Ok(future.await)
+    }
 }

--- a/crates/cubecl-common/src/lib.rs
+++ b/crates/cubecl-common/src/lib.rs
@@ -22,4 +22,7 @@ pub mod benchmark;
 /// notation.
 pub mod reader;
 
+/// Future utils with a compatible API for native, non-std and wasm environments.
+pub mod future;
+
 extern crate alloc;

--- a/crates/cubecl-common/src/reader.rs
+++ b/crates/cubecl-common/src/reader.rs
@@ -42,7 +42,7 @@ pub fn try_read_sync<F: Future<Output = T>, T>(f: F) -> Option<T> {
         Poll::Ready(output) => Some(output),
         // On platforms that support it, now just block on the future and drive it to completion.
         #[cfg(all(not(target_family = "wasm"), feature = "std"))]
-        Poll::Pending => Some(futures_lite::future::block_on(pinned)),
+        Poll::Pending => Some(super::future::block_on(pinned)),
         // Otherwise, just bail and return None - this futures will have to be read back asynchronously.
         #[cfg(any(target_family = "wasm", not(feature = "std")))]
         Poll::Pending => None,

--- a/crates/cubecl-common/src/stub.rs
+++ b/crates/cubecl-common/src/stub.rs
@@ -153,3 +153,8 @@ impl<T: core::fmt::Debug> SyncOnceCell<T> {
         }
     }
 }
+
+#[cfg(not(target_family = "wasm"))]
+pub use core::time::Duration;
+#[cfg(target_family = "wasm")]
+pub use web_time::Duration;

--- a/crates/cubecl-core/Cargo.toml
+++ b/crates/cubecl-core/Cargo.toml
@@ -23,8 +23,8 @@ template = []
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.2.0", default-features = false }
 
 bytemuck = { workspace = true }
-cubecl-common = { path = "../cubecl-common", version = "0.2.0" }
-cubecl-macros = { path = "../cubecl-macros", version = "0.2.0" }
+cubecl-common = { path = "../cubecl-common", version = "0.2.0", default-features = false }
+cubecl-macros = { path = "../cubecl-macros", version = "0.2.0", default-features = false }
 derive-new = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 num-traits = { workspace = true }

--- a/crates/cubecl-core/src/lib.rs
+++ b/crates/cubecl-core/src/lib.rs
@@ -6,6 +6,9 @@ extern crate derive_new;
 /// Cube Frontend Types.
 pub mod frontend;
 
+/// Some future utilities that work across environments.
+pub use cubecl_common::future;
+
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
 pub use frontend::cmma;
 

--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -20,8 +20,8 @@ default = [
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 
 [dependencies]
-cubecl-common = { path = "../cubecl-common", version = "0.2.0" }
-cubecl-core = { path = "../cubecl-core", version = "0.2.0" }
+cubecl-common = { path = "../cubecl-common", version = "0.2.0", default-features = false }
+cubecl-core = { path = "../cubecl-core", version = "0.2.0", default-features = false }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.2.0", default-features = false, features = [
   "channel-mutex",
 ] }

--- a/crates/cubecl-opt/Cargo.toml
+++ b/crates/cubecl-opt/Cargo.toml
@@ -6,8 +6,8 @@ readme.workspace = true
 version.workspace = true
 
 [dependencies]
-cubecl-common = { path = "../cubecl-common", version = "0.2.0" }
-cubecl-core = { path = "../cubecl-core", version = "0.2.0" }
+cubecl-common = { path = "../cubecl-common", version = "0.2.0", default-features = false }
+cubecl-core = { path = "../cubecl-core", version = "0.2.0", default-features = false }
 num = { version = "0.4" }
 petgraph = { version = "0.6" }
 stable-vec = { version = "0.4" }

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -22,7 +22,7 @@ default = [
 std = ["cubecl-common/std"]
 channel-mutex = []
 channel-cell = []
-channel-mpsc = ["dep:async-channel", "dep:futures-lite"] # Assume std
+channel-mpsc = ["dep:async-channel"] # Assume std
 storage-bytes = []
 exclusive-memory-only = []
 
@@ -31,10 +31,7 @@ cubecl-common = { path = "../cubecl-common", version = "0.2.0", default-features
 derive-new = { workspace = true }
 log = { workspace = true }
 hashbrown = { workspace = true }
-
-web-time = { workspace = true }
 async-channel = { workspace = true, optional = true }
-futures-lite = { workspace = true, optional = true }
 
 # Persistent cache deps - has to match the autotune_persistent_cache cfg.
 [target.'cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))'.dependencies]

--- a/crates/cubecl-runtime/src/channel/base.rs
+++ b/crates/cubecl-runtime/src/channel/base.rs
@@ -1,5 +1,5 @@
 use core::future::Future;
-use web_time::Duration;
+use cubecl_common::stub::Duration;
 
 use crate::{
     server::{Binding, ComputeServer, CubeCount, Handle},

--- a/crates/cubecl-runtime/src/channel/cell.rs
+++ b/crates/cubecl-runtime/src/channel/cell.rs
@@ -1,11 +1,10 @@
-use web_time::Duration;
-
 use super::ComputeChannel;
 use crate::server::{Binding, ComputeServer, CubeCount, Handle};
 use crate::storage::BindingResource;
 use crate::ExecutionMode;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use cubecl_common::stub::Duration;
 
 /// A channel using a [ref cell](core::cell::RefCell) to access the server with mutability.
 ///

--- a/crates/cubecl-runtime/src/channel/mpsc.rs
+++ b/crates/cubecl-runtime/src/channel/mpsc.rs
@@ -55,7 +55,7 @@ where
         let _handle = thread::spawn(move || {
             // Run the whole procedure as one blocking future. This is much simpler than trying
             // to use some multithreaded executor.
-            futures_lite::future::block_on(async {
+            cubecl_common::future::block_on(async {
                 while let Ok(message) = receiver.recv().await {
                     match message {
                         Message::Read(binding, callback) => {

--- a/crates/cubecl-runtime/src/channel/mutex.rs
+++ b/crates/cubecl-runtime/src/channel/mutex.rs
@@ -1,11 +1,10 @@
-use web_time::Duration;
-
 use super::ComputeChannel;
 use crate::server::{Binding, ComputeServer, CubeCount, Handle};
 use crate::storage::BindingResource;
 use crate::ExecutionMode;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use cubecl_common::stub::Duration;
 use spin::Mutex;
 
 /// The MutexComputeChannel ensures thread-safety by locking the server

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use web_time::Duration;
+use cubecl_common::stub::Duration;
 
 /// The ComputeClient is the entry point to require tasks from the ComputeServer.
 /// It should be obtained for a specific device via the Compute struct.

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -221,7 +221,9 @@ impl<K: AutotuneKey> Tuner<K> {
 fn spawn_benchmark_task(future: impl Future<Output = ()> + 'static) {
     // Spawn the tuning as a task.
     #[cfg(target_family = "wasm")]
-    wasm_bindgen_futures::spawn_local(future);
+    {
+        wasm_bindgen_futures::spawn_local(future);
+    }
 
     // It is totally possible here to run the tuning on a thread, which woulp startup time,
     // but might have two downsides:

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -1,7 +1,7 @@
+use cubecl_common::stub::Duration;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
-use web_time::Duration;
 
 use cubecl_runtime::memory_management::MemoryUsage;
 use cubecl_runtime::server::CubeCount;

--- a/crates/cubecl-spirv/Cargo.toml
+++ b/crates/cubecl-spirv/Cargo.toml
@@ -6,7 +6,7 @@ readme.workspace = true
 version.workspace = true
 
 [dependencies]
-cubecl-common = { path = "../cubecl-common", version = "0.2.0" }
+cubecl-common = { path = "../cubecl-common", version = "0.2.0", default-features = false }
 cubecl-core = { path = "../cubecl-core", version = "0.2.0" }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.2.0", default-features = false, features = [
     "channel-mutex",

--- a/crates/cubecl-wgpu-spirv/Cargo.toml
+++ b/crates/cubecl-wgpu-spirv/Cargo.toml
@@ -14,8 +14,8 @@ default = [
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 
 [dependencies]
-cubecl-common = { path = "../cubecl-common", version = "0.2.0" }
-cubecl-core = { path = "../cubecl-core", version = "0.2.0" }
+cubecl-common = { path = "../cubecl-common", version = "0.2.0", default-features = false }
+cubecl-core = { path = "../cubecl-core", version = "0.2.0", default-features = false }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.2.0", default-features = false, features = [
     "channel-mutex",
 ] }

--- a/crates/cubecl-wgpu-spirv/Cargo.toml
+++ b/crates/cubecl-wgpu-spirv/Cargo.toml
@@ -29,7 +29,6 @@ wgpu = { version = "22.0.0", features = [
 ] }
 
 async-channel = { workspace = true }
-futures-lite = { workspace = true }
 derive-new = { workspace = true }
 hashbrown = { workspace = true }
 log = { workspace = true }

--- a/crates/cubecl-wgpu-spirv/src/lib.rs
+++ b/crates/cubecl-wgpu-spirv/src/lib.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 
 use std::sync::Arc;
 
+use cubecl_common::future;
 use cubecl_core::{
     channel::MutexComputeChannel,
     client::ComputeClient,
@@ -14,7 +15,6 @@ use cubecl_wgpu::{
     create_wgpu_setup, init_memory_management, AutoGraphicsApi, RuntimeOptions, Vulkan, WgpuDevice,
     WgpuStorage,
 };
-use futures_lite::future;
 use server::WgpuSpirvServer;
 use wgpu::hal;
 

--- a/crates/cubecl-wgpu-spirv/src/server.rs
+++ b/crates/cubecl-wgpu-spirv/src/server.rs
@@ -3,6 +3,7 @@ use std::{future::Future, num::NonZero};
 
 use super::WgpuStorage;
 use alloc::{borrow::Cow, sync::Arc};
+use cubecl_common::future;
 use cubecl_core::{compute::DebugInformation, prelude::*, server::Handle, Feature, KernelId};
 use cubecl_runtime::{
     debug::DebugLogger,
@@ -13,7 +14,6 @@ use cubecl_runtime::{
 };
 use cubecl_spirv::SpirvCompiler;
 use cubecl_wgpu::WgpuPoll;
-use futures_lite::future;
 use hashbrown::HashMap;
 use wgpu::{
     hal::{self, vulkan},

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -30,7 +30,6 @@ bytemuck = { workspace = true }
 wgpu = { version = "22.0.0", features = ["fragile-send-sync-non-atomic-wasm"] }
 
 async-channel = { workspace = true }
-futures-lite = { workspace = true }
 derive-new = { workspace = true }
 hashbrown = { workspace = true }
 log = { workspace = true }

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -20,8 +20,8 @@ exclusive-memory-only = []
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 
 [dependencies]
-cubecl-common = { path = "../cubecl-common", version = "0.2.0" }
-cubecl-core = { path = "../cubecl-core", version = "0.2.0" }
+cubecl-common = { path = "../cubecl-common", version = "0.2.0", default-features = false }
+cubecl-core = { path = "../cubecl-core", version = "0.2.0", default-features = false }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.2.0", default-features = false, features = [
     "channel-mutex",
 ] }

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -4,6 +4,7 @@ use crate::compiler::wgsl::WgslCompiler;
 
 use super::WgpuStorage;
 use alloc::{borrow::Cow, sync::Arc};
+use cubecl_common::future;
 use cubecl_core::{compute::DebugInformation, prelude::*, server::Handle, Feature, KernelId};
 use cubecl_runtime::{
     debug::DebugLogger,
@@ -12,7 +13,6 @@ use cubecl_runtime::{
     storage::{BindingResource, ComputeStorage},
     ExecutionMode,
 };
-use futures_lite::future;
 use hashbrown::HashMap;
 use wgpu::{
     CommandEncoder, ComputePass, ComputePipeline, QuerySet, QuerySetDescriptor, QueryType,

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -4,12 +4,12 @@ use crate::{
     AutoGraphicsApi, GraphicsApi, WgpuDevice,
 };
 use alloc::sync::Arc;
+use cubecl_common::future;
 use cubecl_core::{Feature, Runtime};
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
 use cubecl_runtime::memory_management::{MemoryDeviceProperties, MemoryManagement};
 use cubecl_runtime::DeviceProperties;
 use cubecl_runtime::{channel::MutexComputeChannel, client::ComputeClient, ComputeRuntime};
-use futures_lite::future;
 use wgpu::DeviceDescriptor;
 
 /// Runtime that uses the [wgpu] crate with the wgsl compiler. This is used in the Wgpu backend.

--- a/crates/cubecl/Cargo.toml
+++ b/crates/cubecl/Cargo.toml
@@ -39,7 +39,6 @@ cubecl-cuda = { path = "../cubecl-cuda", version = "0.2.0", default-features = f
 cubecl-linalg = { path = "../cubecl-linalg", version = "0.2.0", default-features = false, optional = true }
 cubecl-wgpu = { path = "../cubecl-wgpu", version = "0.2.0", default-features = false, optional = true }
 cubecl-wgpu-spirv = { path = "../cubecl-wgpu-spirv", version = "0.2.0", default-features = false, optional = true }
-futures-lite.workspace = true
 
 [dev-dependencies]
 half = { workspace = true }

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -3,9 +3,9 @@ use std::marker::PhantomData;
 
 use cubecl::benchmark::Benchmark;
 use cubecl::frontend::Float;
+use cubecl::future;
 use cubecl_linalg::matmul;
 use cubecl_linalg::tensor::TensorHandle;
-use futures_lite::future;
 
 impl<R: Runtime, E: Float> Benchmark for MatmulBench<R, E> {
     type Args = (TensorHandle<R, E>, TensorHandle<R, E>);

--- a/crates/cubecl/benches/unary.rs
+++ b/crates/cubecl/benches/unary.rs
@@ -5,8 +5,8 @@ use std::marker::PhantomData;
 use half::f16;
 
 use cubecl::benchmark::Benchmark;
+use cubecl::future;
 use cubecl_linalg::tensor::TensorHandle;
-use futures_lite::future;
 
 #[cube(launch)]
 fn execute<F: Float>(lhs: &Tensor<F>, rhs: &Tensor<F>, out: &mut Tensor<F>) {


### PR DESCRIPTION
Some simple things are different across `wasm`, `native` and `no-std`. Since we are using more `async` stuff, I created the `futures` module in `cubecl-common` to handles more cases.