### PR TITLE
Fix no-std + wasm infinite loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,6 @@ strum = { version = "0.26.3", features = ["derive"] }
 tracel-xtask = { version = "~1.0" }
 
 portable-atomic = { version = "1.9" }
-portable-atomic-util = { version = "0.2.2", features = [
-    "alloc",
-] } # alloc is for no_std
 pretty_assertions = "1.4"
 
 # Async

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ syn = { version = "2", features = ["full", "extra-traits", "visit-mut"] }
 strum = { version = "0.26.3", features = ["derive"] }
 tracel-xtask = { version = "~1.0" }
 
+portable-atomic = { version = "1.9" }
 portable-atomic-util = { version = "0.2.2", features = [
     "alloc",
 ] } # alloc is for no_std

--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -38,6 +38,7 @@ spin = { workspace = true, features = ["mutex", "spin_mutex"] }
 embassy-futures = { version = "0.1.1" }
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
+portable-atomic = { workspace = true, features = ["unsafe-assume-single-core"] }
 portable-atomic-util = { workspace = true }
 spin = { workspace = true, features = [
     "mutex",

--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -30,16 +30,13 @@ spin = { workspace = true }         # using in place of use std::sync::Mutex;
 
 # Only activate futures for std env
 futures-lite = { workspace = true, features = ["std"], default-features = false, optional = true }
+embassy-futures = { version = "0.1.1" }
 
 [target.'cfg(target_has_atomic = "ptr")'.dependencies]
 spin = { workspace = true, features = ["mutex", "spin_mutex"] }
 
-[target.'cfg(not(features = "std"))'.dependencies]
-embassy-futures = { version = "0.1.1" }
-
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic = { workspace = true, features = ["unsafe-assume-single-core"] }
-portable-atomic-util = { workspace = true }
 spin = { workspace = true, features = [
     "mutex",
     "spin_mutex",

--- a/crates/cubecl-common/src/future.rs
+++ b/crates/cubecl-common/src/future.rs
@@ -3,12 +3,17 @@ use core::future::Future;
 
 /// Block until the [future](Future) is completed and returns the result.
 pub fn block_on<O>(fut: impl Future<Output = O>) -> O {
-    #[cfg(not(feature = "std"))]
+    #[cfg(target_family = "wasm")]
+    {
+        super::reader::read_sync(fut)
+    }
+
+    #[cfg(all(not(target_family = "wasm"), not(feature = "std")))]
     {
         embassy_futures::block_on(fut)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(all(not(target_family = "wasm"), feature = "std"))]
     {
         futures_lite::future::block_on(fut)
     }

--- a/crates/cubecl-common/src/reader.rs
+++ b/crates/cubecl-common/src/reader.rs
@@ -1,27 +1,4 @@
-#[cfg(target_has_atomic = "ptr")]
-use alloc::{sync::Arc, task::Wake};
-
-#[cfg(not(target_has_atomic = "ptr"))]
-use portable_atomic_util::{task::Wake, Arc};
-
-use core::{
-    future::Future,
-    task::{Context, Poll, Waker},
-};
-
-struct DummyWaker;
-
-#[cfg(target_has_atomic = "ptr")]
-impl Wake for DummyWaker {
-    fn wake(self: Arc<Self>) {}
-    fn wake_by_ref(self: &Arc<Self>) {}
-}
-
-#[cfg(not(target_has_atomic = "ptr"))]
-impl Wake for DummyWaker {
-    fn wake(_this: Arc<Self>) {}
-    fn wake_by_ref(_this: &Arc<Self>) {}
-}
+use core::future::Future;
 
 /// Read a future synchronously.
 ///
@@ -37,21 +14,15 @@ pub fn read_sync<F: Future<Output = T>, T>(f: F) -> T {
 /// On WASM futures cannot block, so this only succeeds if the future returns immediately.
 /// otherwise this returns None.
 pub fn try_read_sync<F: Future<Output = T>, T>(f: F) -> Option<T> {
-    // Create a dummy context.
-    let waker = Waker::from(Arc::new(DummyWaker));
-    let mut context = Context::from_waker(&waker);
-
-    // Pin & poll the future. Some backends don't do async readbacks, and instead immediately get
-    // the data. This let's us detect when a future is synchronous and doesn't require any waiting.
-    let mut pinned = core::pin::pin!(f);
-
-    match pinned.as_mut().poll(&mut context) {
-        Poll::Ready(output) => Some(output),
-        // On platforms that support it, now just block on the future and drive it to completion.
-        #[cfg(all(not(target_family = "wasm"), feature = "std"))]
-        Poll::Pending => Some(super::future::block_on(pinned)),
-        // Otherwise, just bail and return None - this futures will have to be read back asynchronously.
-        #[cfg(any(target_family = "wasm", not(feature = "std")))]
-        Poll::Pending => None,
+    #[cfg(target_family = "wasm")]
+    {
+        match embassy_futures::poll_once(f) {
+            Poll::Ready(output) => Some(output),
+            _ => None,
+        }
+    }
+    #[cfg(not(target_family = "wasm"))]
+    {
+        Some(super::future::block_on(f))
     }
 }

--- a/crates/cubecl-common/src/reader.rs
+++ b/crates/cubecl-common/src/reader.rs
@@ -11,9 +11,16 @@ use core::{
 
 struct DummyWaker;
 
+#[cfg(target_has_atomic = "ptr")]
 impl Wake for DummyWaker {
     fn wake(self: Arc<Self>) {}
     fn wake_by_ref(self: &Arc<Self>) {}
+}
+
+#[cfg(not(target_has_atomic = "ptr"))]
+impl Wake for DummyWaker {
+    fn wake(_this: Arc<Self>) {}
+    fn wake_by_ref(_this: &Arc<Self>) {}
 }
 
 /// Read a future synchronously.

--- a/crates/cubecl-common/src/reader.rs
+++ b/crates/cubecl-common/src/reader.rs
@@ -16,6 +16,8 @@ pub fn read_sync<F: Future<Output = T>, T>(f: F) -> T {
 pub fn try_read_sync<F: Future<Output = T>, T>(f: F) -> Option<T> {
     #[cfg(target_family = "wasm")]
     {
+        use core::task::Poll;
+
         match embassy_futures::poll_once(f) {
             Poll::Ready(output) => Some(output),
             _ => None,

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -292,7 +292,7 @@ impl WgpuServer {
                     .chunks_exact(8)
                     .map(|x| u64::from_le_bytes(x.try_into().unwrap()))
                     .collect::<Vec<_>>();
-                let delta = data[1] - data[0];
+                let delta = u64::checked_sub(data[1], data[0]).unwrap_or(1);
                 Duration::from_secs_f64(delta as f64 * period)
             })
         } else {


### PR DESCRIPTION
### Fix wasm infinite loop

Reading the documentation, it's not possible to block on a future in `wasm`, this is why we had `read_sync` and `try_read_sync`. However the `block_on` function provided by embassy is essentially an infinite loop, which would never finish on `wasm`. I simply reuse the `read_sync` function instead.

### Fix no-std

The `Waker` trait used in `read_sync` isn't the the same when real atomics are available, so I simply fixed that. I'm unsure if we should expose `read_sync` and `try_read_sync` anymore since we can use `block_on` instead.

We could expose `try_block_on` which would call `catch_unwind` in `std` environments and `try_read_sync` in `wasm` environments. But I'm unsure yet if it's a good idea.