### PR TITLE
Fix deadlock

### DIFF
--- a/crates/cubecl-wgpu-spirv/Cargo.toml
+++ b/crates/cubecl-wgpu-spirv/Cargo.toml
@@ -32,6 +32,7 @@ async-channel = { workspace = true }
 derive-new = { workspace = true }
 hashbrown = { workspace = true }
 log = { workspace = true }
+web-time = { workspace = true }
 
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.2.0", features = [

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -33,6 +33,7 @@ async-channel = { workspace = true }
 derive-new = { workspace = true }
 hashbrown = { workspace = true }
 log = { workspace = true }
+web-time = { workspace = true }
 
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.2.0", features = [


### PR DESCRIPTION
Fix deadlock when running sync().

This was a bad bug after #174 


The intention was to write timestamp 0 and 1 for the first compute pass, and only 1 for every pass afterwards.

Instead, because we immediatly set the start time we only ever write timestamp 1, which combined with the following problem https://github.com/gfx-rs/wgpu/issues/3612 meant a deadlock.

Also update the wgpu-spirv server to this version, and move the profiling code so it really is just at the start/end of execute instead of interwoven.

Lastly, use web_time::Instant. This isn't available in std but wgpu doesnt' work on no_std anyway. Would be nice to add to cubecl_common but seems there's no good core version.