### PR TITLE
Periodic memory cleanup (ExclusivePages only)

### DIFF
--- a/crates/cubecl-runtime/src/memory_management/base.rs
+++ b/crates/cubecl-runtime/src/memory_management/base.rs
@@ -58,11 +58,7 @@ impl std::fmt::Display for MemoryUsage {
         let usage_percentage = (self.bytes_in_use as f32 / self.bytes_reserved as f32) * 100.0;
         let padding_percentage = (self.bytes_padding as f32 / self.bytes_in_use as f32) * 100.0;
         writeln!(f, "Memory Usage Report:")?;
-        writeln!(
-            f,
-            "  Number of allocations: {}",
-            bytes_format(self.number_allocs)
-        )?;
+        writeln!(f, "  Number of allocations: {}", self.number_allocs)?;
         writeln!(f, "  Bytes in use: {}", bytes_format(self.bytes_in_use))?;
         writeln!(
             f,

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -1,4 +1,3 @@
-use core::usize;
 use std::collections::BTreeSet;
 
 use super::{
@@ -39,6 +38,8 @@ const EXP_BIN_SIZES: [usize; 200] = [
     1879048192, 2013265920, 2147483648, 2415919104, 2684354560, 2952790016, 3221225472, 3489660928,
     3758096384, 4026531840,
 ];
+
+const MB: usize = 1024 * 1024;
 
 impl MemoryPool for DynamicPool {
     fn get(&self, binding: &SliceBinding) -> Option<&StorageHandle> {
@@ -176,13 +177,8 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> {
                         //
                         // This also +- follows zipfs law https://en.wikipedia.org/wiki/Zipf%27s_law
                         // which is an ok assumption for the distribution of allocations.
-                        let MB = 1024 * 1024;
                         let base_period = 1000;
-                        let dealloc_period = base_period + 1024 * MB / (s as u64);
-
-                        // let dealloc_period = (base_period / s).round() as usize;
-
-                        println!("Deallocing {} with period {}", s, dealloc_period);
+                        let dealloc_period = base_period + 1024 * MB as u64 / (s as u64);
 
                         MemoryPoolOptions {
                             page_size: s,

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -81,6 +81,12 @@ impl MemoryPool for DynamicPool {
             DynamicPool::Exclusive(m) => m.max_alloc_size(),
         }
     }
+    fn cleanup<Storage: ComputeStorage>(&mut self, storage: &mut Storage) {
+        match self {
+            DynamicPool::Sliced(m) => m.cleanup(storage),
+            DynamicPool::Exclusive(m) => m.cleanup(storage),
+        }
+    }
 }
 
 /// Reserves and keeps track of chunks of memory in the storage, and slices upon these chunks.
@@ -202,6 +208,13 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> {
         pools.sort_by(|pool1, pool2| usize::cmp(&pool1.max_alloc_size(), &pool2.max_alloc_size()));
 
         Self { pools, storage }
+    }
+
+    /// Cleanup allocations in pools that are deemed unnecesarry.
+    pub fn cleanup(&mut self) {
+        for pool in self.pools.iter_mut() {
+            pool.cleanup(&mut self.storage);
+        }
     }
 }
 

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
@@ -51,4 +51,6 @@ pub trait MemoryPool {
         -> SliceHandle;
 
     fn get_memory_usage(&self) -> MemoryUsage;
+
+    fn cleanup<Storage: ComputeStorage>(&mut self, storage: &mut Storage);
 }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
@@ -52,5 +52,5 @@ pub trait MemoryPool {
 
     fn get_memory_usage(&self) -> MemoryUsage;
 
-    fn cleanup<Storage: ComputeStorage>(&mut self, storage: &mut Storage);
+    fn cleanup<Storage: ComputeStorage>(&mut self, storage: &mut Storage, alloc_nr: u64);
 }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
@@ -161,7 +161,7 @@ impl MemoryPool for SlicedPool {
         }
     }
 
-    fn cleanup<Storage: ComputeStorage>(&mut self, _storage: &mut Storage) {
+    fn cleanup<Storage: ComputeStorage>(&mut self, _storage: &mut Storage, _alloc_nr: u64) {
         // This pool doesn't do any shrinking currently.
     }
 }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
@@ -160,6 +160,10 @@ impl MemoryPool for SlicedPool {
             bytes_reserved: self.slices.iter().map(|s| s.1.storage.size()).sum(),
         }
     }
+
+    fn cleanup<Storage: ComputeStorage>(&mut self, _storage: &mut Storage) {
+        // This pool doesn't do any shrinking currently.
+    }
 }
 
 impl SlicedPool {

--- a/crates/cubecl-runtime/src/memory_management/mod.rs
+++ b/crates/cubecl-runtime/src/memory_management/mod.rs
@@ -33,6 +33,12 @@ pub struct MemoryPoolOptions {
     ///
     /// Useful when you know in advance how much memory you'll need.
     pub chunk_num_prealloc: usize,
+    /// Period after which allocations are deemed unused and deallocated.
+    ///
+    /// This period is measured in the number of allocations in the parent allocator. If a page
+    /// in the pool was unused for the entire period, it will be deallocated. This period is
+    /// approximmate, as checks are only done occasionally.
+    pub dealloc_period: Option<u64>,
 }
 
 /// High level configuration of memory management.

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -517,6 +517,7 @@ impl ComputeServer for WgpuServer {
         self.storage_locked.clear_locked();
 
         // Cleanup allocations and deallocations.
+        self.memory_management.cleanup();
         self.memory_management.storage().perform_deallocations();
     }
 


### PR DESCRIPTION
The ExclusivePages memory allocator unfortunately can suffer from really bad memory fragmentation. The bin sizes are quite fine grained so if your tensors jump between pages they can leave a ton of now unused pages behind.

To combat this, I've added a simple form of deallocation / cleanup to the allocator. It's defined as "if in the last N allocations a page was entirely unused, deallocate it". To make this an efficient check, every N allocations an unused page is marked for deallocation. If N allocations later it is stil marked, we actually deallocate it.

Furthermore, different bins benefit from different frequencies of deallocations. Smaller pages are less wasteful anyway and have more churn, assuming that allocations very roughly follow zipfs law https://en.wikipedia.org/wiki/Zipf%27s_law. So, the frequency in which buckets check for deallocation is made proportional to how big they are.

Running 2000 steps of my model:

```
// Before
Memory usage: Memory Usage Report:
  Number of allocations: 52
  Bytes in use: 938.79 MB
  Bytes used for padding: 848 B
  Total bytes reserved: 9.24 GB
  Usage efficiency: 10.16%
  Padding overhead: 0.00%
33.68s

// After
Memory usage: Memory Usage Report:
  Number of allocations: 48
  Bytes in use: 936.34 MB
  Bytes used for padding: 492 B
  Total bytes reserved: 1.70 GB
  Usage efficiency: 54.92%
  Padding overhead: 0.00%
```
I expect "normal" ML models wouldn't be this bad, but if you have a lot of dynamic shapes this really fragments memory quite badly.

CPU performance should be very minimally impacted as this is all checked infrequently. There is some more churn in allocation but I haven't been able to measure a noticable slowdown (and a very noticable speedup when your GPU runs out of memory!).

The slices allocator should probably use a similair mechanism but really benefits from this much less, as a page can be used for many more different sizes, so haven't looked into it yet.