### PR TITLE
Add prefetching to into_contiguous

### DIFF
--- a/crates/cubecl-core/src/ir/branch.rs
+++ b/crates/cubecl-core/src/ir/branch.rs
@@ -4,6 +4,7 @@ use super::{Elem, Item, Scope, Variable};
 use serde::{Deserialize, Serialize};
 
 /// All branching types.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Branch {
     /// An if statement.

--- a/crates/cubecl-core/src/ir/operation.rs
+++ b/crates/cubecl-core/src/ir/operation.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [Procedure] expansions can safely use all operation variants.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[allow(dead_code, missing_docs)] // Some variants might not be used with different flags
+#[allow(dead_code, missing_docs, clippy::large_enum_variant)] // Some variants might not be used with different flags
 pub enum Operation {
     Operator(Operator),
     Metadata(Metadata),

--- a/crates/cubecl-linalg/src/tensor/contiguous.rs
+++ b/crates/cubecl-linalg/src/tensor/contiguous.rs
@@ -29,29 +29,70 @@ fn into_contiguous_kernel<N: CubePrimitive>(
     input: &Tensor<Line<N>>,
     output: &mut Tensor<Line<N>>,
     #[comptime] rank: Option<u32>,
+    #[comptime] elems_per_thread: u32,
 ) {
-    let offset_output = ABSOLUTE_POS;
+    let offset_output = ABSOLUTE_POS * elems_per_thread;
+    let vec = vectorization_of(input);
 
     if offset_output >= output.len() {
         return;
     }
 
-    let offset_input = index_offset_with_layout::<N, N>(
-        input,
-        output,
-        offset_output,
-        0,
-        rank.unwrap_or_else(|| output.rank()),
-        rank.is_some(),
-    );
+    let mut registers = Array::vectorized(elems_per_thread, vec);
 
-    output[offset_output] = input[offset_input];
+    #[unroll]
+    for i in 0..elems_per_thread {
+        let offset_input = index_offset_with_layout::<N, N>(
+            input,
+            output,
+            offset_output + i,
+            0,
+            rank.unwrap_or_else(|| output.rank()),
+            rank.is_some(),
+        );
+
+        registers[i] = input[offset_input];
+    }
+
+    #[unroll]
+    for i in 0..elems_per_thread {
+        output[offset_output + i] = registers[i];
+    }
 }
 
 /// Make a jit tensor contiguous.
 pub fn into_contiguous<R: Runtime, E: CubePrimitive>(
     client: &ComputeClient<R::Server, R::Channel>,
     input: TensorHandleRef<'_, R>,
+) -> TensorHandle<R, E> {
+    let num_elems: usize = input.shape.iter().product();
+    // Vectorization is only enabled when the last dimension is contiguous.
+    let rank = input.strides.len();
+    let vectorization_factor = tensor_line_size(
+        R::supported_line_sizes(),
+        input.shape,
+        input.strides,
+        rank - 1,
+    );
+    let num_vecs = num_elems / vectorization_factor as usize;
+    let approx_sm = 64;
+    let approx_simul_vecs = approx_sm * CubeDim::default().num_elems();
+    let elems_per_unit = match num_vecs as u32 / approx_simul_vecs {
+        0..2 => 1,
+        2..4 => 2,
+        4..8 => 4,
+        8.. => 8,
+    };
+
+    // TODO: Benchmark to find good default prefetch, for now preserve existing behaviour
+    into_contiguous_prefetch(client, input, elems_per_unit)
+}
+
+/// Make a jit tensor contiguous.
+pub fn into_contiguous_prefetch<R: Runtime, E: CubePrimitive>(
+    client: &ComputeClient<R::Server, R::Channel>,
+    input: TensorHandleRef<'_, R>,
+    elems_per_unit: u32,
 ) -> TensorHandle<R, E> {
     // Vectorization is only enabled when the last dimension is contiguous.
     let rank = input.strides.len();
@@ -62,10 +103,12 @@ pub fn into_contiguous<R: Runtime, E: CubePrimitive>(
         rank - 1,
     );
 
+    let num_elems_per_unit = vectorization_factor as u32 * elems_per_unit;
+
     let num_elems: usize = input.shape.iter().product();
     let cube_dim = CubeDim::default();
     let cube_count =
-        calculate_cube_count_elemwise(num_elems / vectorization_factor as usize, cube_dim);
+        calculate_cube_count_elemwise(num_elems / num_elems_per_unit as usize, cube_dim);
     let handle = client.empty(num_elems * E::as_elem().size());
     let output = TensorHandle::new_contiguous(input.shape.to_vec(), handle);
 
@@ -77,6 +120,7 @@ pub fn into_contiguous<R: Runtime, E: CubePrimitive>(
             input.as_tensor_arg(vectorization_factor),
             output.as_ref().as_tensor_arg(vectorization_factor),
             Some(rank as u32),
+            elems_per_unit,
         );
     }
 


### PR DESCRIPTION
Adds prefetching to the `into_contiguous` kernel, with a heuristic to find the number of elements per unit by default and the option to explicitly pass the number. This improves performance by up to 2x.

# Performance
There's currently no dedicated benchmark for `into_contiguous`, but the time for executing both `into_contiguous` kernels for `implicit_gemm` went from ~1.25-1.3ms with no prefetching to ~700-750µs with prefetch 8 for the large (16x16x512x512) input tensor, and prefetch 1 for the much smaller (64x16x3x3) weight tensor.
The Nsight profiler shows extreme memory latency stalls with no prefetch (86% of stall reasons, and it's the second most frequent stall overall), with prefetch the stalls are mostly balanced and all the most common stalls are now in the GEMM kernel.