### PR TITLE
Fix legacy kernels by auto-casting unary ops

### DIFF
--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -21,7 +21,7 @@ pub trait WgpuCompiler: Compiler {
         mode: ExecutionMode,
     ) -> Arc<ComputePipeline>;
 
-    #[expect(async_fn_in_trait, reason = "Only used locally")]
+    #[allow(async_fn_in_trait)]
     async fn request_device(adapter: &Adapter) -> (Device, Queue);
     fn register_features(adapter: &Adapter, device: &Device, props: &mut DeviceProperties<Feature>);
 }


### PR DESCRIPTION
Cast unary ops where input must match output to the output type automatically. This shouldn't happen with macro kernels, but while we have legacy kernels it's required to make them work properly with non-standard float/int types.
Also revert `expect` for now to fix the CI build on `burn`.