### PR TITLE
Allow users to specify timing method (cpu/gpu) to use when running a benchmark

### DIFF
--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -7,9 +7,32 @@ use serde::{Deserialize, Serialize};
 
 use super::stub::Duration;
 
+/// How a benchmark's execution times are measured.
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+pub enum TimingMethod {
+    /// Time measurements come from CPU timing of execution + sync
+    /// calls.
+    #[default]
+    CPU,
+    /// Time measurements come from hardware reported timestamps
+    /// coming from a sync call.
+    GPU,
+}
+
+impl Display for TimingMethod {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TimingMethod::CPU => f.write_str("cpu"),
+            TimingMethod::GPU => f.write_str("gpu"),
+        }
+    }
+}
+
 /// Results of a benchmark run.
 #[derive(new, Debug, Default, Clone, Serialize, Deserialize)]
 pub struct BenchmarkDurations {
+    /// How these durations were measured.
+    pub timing_method: TimingMethod,
     /// All durations of the run, in the order they were benchmarked
     pub durations: Vec<Duration>,
 }
@@ -56,11 +79,13 @@ impl Display for BenchmarkDurations {
             max,
         } = computed;
         let num_sample = self.durations.len();
+        let timing_method = self.timing_method;
 
         f.write_str(
             format!(
                 "
 ―――――――― Result ―――――――――
+  Timing      {timing_method}
   Samples     {num_sample}
   Mean        {mean:.3?}
   Variance    {variance:.3?}
@@ -134,10 +159,12 @@ pub trait Benchmark {
     fn shapes(&self) -> Vec<Vec<usize>> {
         vec![]
     }
-    /// Wait for computed to be over
-    fn sync(&self);
+    /// Wait for computation to complete and return hardware reported
+    /// computation duration.
+    fn sync(&self) -> Duration;
     /// Run the benchmark a number of times.
-    fn run(&self) -> BenchmarkDurations {
+    #[allow(unused_variables)]
+    fn run(&self, timing_method: TimingMethod) -> BenchmarkDurations {
         #[cfg(not(feature = "std"))]
         panic!("Attempting to run benchmark in a no-std environment");
         #[cfg(feature = "std")]
@@ -151,16 +178,30 @@ pub trait Benchmark {
             let mut durations = Vec::with_capacity(self.num_samples());
 
             for _ in 0..self.num_samples() {
-                self.sync();
-                let start = std::time::Instant::now();
-                self.execute(args.clone());
-                self.sync();
-                // Register the duration
-                durations.push(start.elapsed());
+                match timing_method {
+                    TimingMethod::CPU => durations.push(self.run_one_cpu(args.clone())),
+                    TimingMethod::GPU => durations.push(self.run_one_gpu(args.clone())),
+                }
             }
 
-            BenchmarkDurations { durations }
+            BenchmarkDurations {
+                timing_method,
+                durations,
+            }
         }
+    }
+    #[cfg(feature = "std")]
+    /// Collect one sample with timing on the CPU.
+    fn run_one_cpu(&self, args: Self::Args) -> Duration {
+        let start = std::time::Instant::now();
+        self.execute(args);
+        self.sync();
+        start.elapsed()
+    }
+    /// Collect one sample with timing on the GPU.
+    fn run_one_gpu(&self, args: Self::Args) -> Duration {
+        self.execute(args);
+        self.sync()
     }
 }
 
@@ -201,7 +242,7 @@ impl Display for BenchmarkResult {
 
 #[cfg(feature = "std")]
 /// Runs the given benchmark on the device and prints result and information.
-pub fn run_benchmark<BM>(benchmark: BM) -> BenchmarkResult
+pub fn run_benchmark<BM>(benchmark: BM, timing_method: TimingMethod) -> BenchmarkResult
 where
     BM: Benchmark,
 {
@@ -214,7 +255,7 @@ where
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
-    let durations = benchmark.run();
+    let durations = benchmark.run(timing_method);
     BenchmarkResult {
         raw: durations.clone(),
         computed: BenchmarkComputations::new(&durations),
@@ -234,6 +275,7 @@ mod tests {
     #[test]
     fn test_min_max_median_durations_even_number_of_samples() {
         let durations = BenchmarkDurations {
+            timing_method: TimingMethod::CPU,
             durations: vec![
                 Duration::new(10, 0),
                 Duration::new(20, 0),
@@ -251,6 +293,7 @@ mod tests {
     #[test]
     fn test_min_max_median_durations_odd_number_of_samples() {
         let durations = BenchmarkDurations {
+            timing_method: TimingMethod::CPU,
             durations: vec![
                 Duration::new(18, 5),
                 Duration::new(20, 0),
@@ -267,6 +310,7 @@ mod tests {
     #[test]
     fn test_mean_duration() {
         let durations = BenchmarkDurations {
+            timing_method: TimingMethod::CPU,
             durations: vec![
                 Duration::new(10, 0),
                 Duration::new(20, 0),
@@ -281,6 +325,7 @@ mod tests {
     #[test]
     fn test_variance_duration() {
         let durations = BenchmarkDurations {
+            timing_method: TimingMethod::CPU,
             durations: vec![
                 Duration::new(10, 0),
                 Duration::new(20, 0),

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -1,7 +1,7 @@
 use crate::channel::ComputeChannel;
 use crate::client::ComputeClient;
 use crate::server::ComputeServer;
-use cubecl_common::benchmark::BenchmarkDurations;
+use cubecl_common::benchmark::{BenchmarkDurations, TimingMethod};
 
 use super::AutotuneOperation;
 use alloc::boxed::Box;
@@ -32,6 +32,9 @@ impl<S: ComputeServer, C: ComputeChannel<S>, Out> TuneBenchmark<S, C, Out> {
             let duration = self.client.sync().await;
             durations.push(duration);
         }
-        BenchmarkDurations { durations }
+        BenchmarkDurations {
+            timing_method: TimingMethod::GPU,
+            durations,
+        }
     }
 }

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -33,7 +33,7 @@ impl<S: ComputeServer, C: ComputeChannel<S>, Out> TuneBenchmark<S, C, Out> {
             durations.push(duration);
         }
         BenchmarkDurations {
-            timing_method: TimingMethod::GPU,
+            timing_method: TimingMethod::DeviceOnly,
             durations,
         }
     }

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -214,7 +214,7 @@ impl<K: AutotuneKey> Tuner<K> {
                 })
         } else {
             Ok(BenchmarkDurations::new(
-                TimingMethod::GPU,
+                TimingMethod::DeviceOnly,
                 vec![Duration::MAX],
             ))
         }

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -11,7 +11,7 @@ use std::panic::resume_unwind;
 use alloc::boxed::Box;
 use alloc::string::ToString;
 use alloc::vec::Vec;
-use cubecl_common::benchmark::{BenchmarkComputations, BenchmarkDurations};
+use cubecl_common::benchmark::{BenchmarkComputations, BenchmarkDurations, TimingMethod};
 
 use crate::channel::ComputeChannel;
 use crate::client::ComputeClient;
@@ -213,7 +213,10 @@ impl<K: AutotuneKey> Tuner<K> {
                     ManuallyDrop::new(e)
                 })
         } else {
-            Ok(BenchmarkDurations::new(vec![Duration::MAX]))
+            Ok(BenchmarkDurations::new(
+                TimingMethod::GPU,
+                vec![Duration::MAX],
+            ))
         }
     }
 }

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -1,11 +1,13 @@
 use cubecl::prelude::*;
 use std::marker::PhantomData;
 
-use cubecl::benchmark::Benchmark;
+use cubecl::benchmark::{Benchmark, TimingMethod};
 use cubecl::frontend::Float;
 use cubecl::future;
 use cubecl_linalg::matmul;
 use cubecl_linalg::tensor::TensorHandle;
+
+use std::time::Duration;
 
 impl<R: Runtime, E: Float> Benchmark for MatmulBench<R, E> {
     type Args = (TensorHandle<R, E>, TensorHandle<R, E>);
@@ -41,8 +43,8 @@ impl<R: Runtime, E: Float> Benchmark for MatmulBench<R, E> {
         format!("matmul-{}-{}-{:?}", R::name(), E::as_elem(), self.kind).to_lowercase()
     }
 
-    fn sync(&self) {
-        future::block_on(self.client.sync());
+    fn sync(&self) -> Duration {
+        future::block_on(self.client.sync())
     }
 }
 
@@ -78,7 +80,7 @@ fn run<R: Runtime, E: Float>(device: R::Device, kind: MatmulKind) {
         _e: PhantomData,
     };
     println!("{}", bench.name());
-    println!("{}", bench.run());
+    println!("{}", bench.run(TimingMethod::CPU));
 }
 
 fn main() {

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -80,7 +80,7 @@ fn run<R: Runtime, E: Float>(device: R::Device, kind: MatmulKind) {
         _e: PhantomData,
     };
     println!("{}", bench.name());
-    println!("{}", bench.run(TimingMethod::CPU));
+    println!("{}", bench.run(TimingMethod::Full));
 }
 
 fn main() {

--- a/crates/cubecl/benches/unary.rs
+++ b/crates/cubecl/benches/unary.rs
@@ -4,9 +4,10 @@ use std::marker::PhantomData;
 #[cfg(feature = "cuda")]
 use half::f16;
 
-use cubecl::benchmark::Benchmark;
+use cubecl::benchmark::{Benchmark, TimingMethod};
 use cubecl::future;
 use cubecl_linalg::tensor::TensorHandle;
+use std::time::Duration;
 
 #[cube(launch)]
 fn execute<F: Float>(lhs: &Tensor<F>, rhs: &Tensor<F>, out: &mut Tensor<F>) {
@@ -64,8 +65,8 @@ impl<R: Runtime, E: Float> Benchmark for UnaryBench<R, E> {
         .to_lowercase()
     }
 
-    fn sync(&self) {
-        future::block_on(self.client.sync());
+    fn sync(&self) -> Duration {
+        future::block_on(self.client.sync())
     }
 }
 
@@ -95,7 +96,7 @@ fn run<R: Runtime, E: frontend::Float>(device: R::Device, vectorization: u8) {
         _e: PhantomData,
     };
     println!("{}", bench.name());
-    println!("{}", bench.run());
+    println!("{}", bench.run(TimingMethod::CPU));
 }
 
 fn main() {

--- a/crates/cubecl/benches/unary.rs
+++ b/crates/cubecl/benches/unary.rs
@@ -96,7 +96,7 @@ fn run<R: Runtime, E: frontend::Float>(device: R::Device, vectorization: u8) {
         _e: PhantomData,
     };
     println!("{}", bench.name());
-    println!("{}", bench.run(TimingMethod::CPU));
+    println!("{}", bench.run(TimingMethod::Full));
 }
 
 fn main() {


### PR DESCRIPTION
Changes to benchmark.rs stemming from [this conversation](https://discord.com/channels/1038839012602941528/1286391740739358802/1296921922432663663). 

**The problem:** I'm seeing the time required to read timestamps from the GPU completely wash out benchmark results for an FFT kernel I'm writing (which typically has timings in the 10-100 microseconds). Ideally I'd like to be able to have my benchmarks report just those GPU timestamps, rather than the CPU timing of retrieving those GPU timestamps. However, the current implementation of the `Benchmark` trait doesn't allow this.

**Solution:** Since both CPU and GPU timings are useful under different contexts, this change allows the caller of `Benchmark::run` to decide which timing method to use by providing a `TimingMethod` argument. A side-benefit to this is that it is now more explicit how `BenchmarkDurations` is computed. To maintain previous behavior, the matmul and unary benchmarks are set to use `TimingMethod::CPU`.