### PR TITLE
Add features for each supported datatype

### DIFF
--- a/crates/cubecl-core/src/runtime.rs
+++ b/crates/cubecl-core/src/runtime.rs
@@ -47,4 +47,5 @@ pub enum Feature {
         k: u8,
         n: u8,
     },
+    Type(Elem),
 }

--- a/crates/cubecl-cpp/src/lib.rs
+++ b/crates/cubecl-cpp/src/lib.rs
@@ -3,6 +3,8 @@ extern crate derive_new;
 
 mod shared;
 
+pub use shared::register_supported_types;
+
 /// Format CPP code.
 pub mod formatter;
 

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -5,9 +5,9 @@ use cubecl_core::{
     ir::{
         self as gpu, ConstantScalarValue, Elem, Item, Metadata, ReusingAllocator, Scope, Variable,
     },
-    Compiler,
+    Compiler, Feature,
 };
-use cubecl_runtime::ExecutionMode;
+use cubecl_runtime::{DeviceProperties, ExecutionMode};
 
 use super::{Instruction, VariableSettings, WarpInstruction};
 
@@ -842,4 +842,23 @@ fn has_length(var: &gpu::Variable) -> bool {
             | gpu::Variable::GlobalOutputArray { .. }
             | gpu::Variable::Slice { .. }
     )
+}
+
+pub fn register_supported_types(props: &mut DeviceProperties<Feature>) {
+    use cubecl_core::ir::{Elem, FloatKind, IntKind};
+
+    let supported_types = [
+        Elem::UInt,
+        Elem::Int(IntKind::I32),
+        Elem::AtomicInt(IntKind::I32),
+        Elem::AtomicUInt,
+        Elem::Float(FloatKind::BF16),
+        Elem::Float(FloatKind::F16),
+        Elem::Float(FloatKind::F32),
+        Elem::Bool,
+    ];
+
+    for ty in supported_types {
+        props.register_feature(Feature::Type(ty));
+    }
 }

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -16,7 +16,7 @@ use crate::{
     compute::{CudaContext, CudaServer, CudaStorage},
     device::CudaDevice,
 };
-use cubecl_cpp::CudaCompiler;
+use cubecl_cpp::{register_supported_types, CudaCompiler};
 
 /// The values that control how a WGPU Runtime will perform its calculations.
 #[derive(Default)]
@@ -80,6 +80,7 @@ fn create_client(device: &CudaDevice, options: RuntimeOptions) -> ComputeClient<
     let cuda_ctx = CudaContext::new(memory_management, stream, ctx, arch);
     let mut server = CudaServer::new(cuda_ctx);
     let mut device_props = DeviceProperties::new(&[Feature::Subcube], mem_properties);
+    register_supported_types(&mut device_props);
     register_wmma_features(&mut device_props, server.arch_version());
 
     ComputeClient::new(MutexComputeChannel::new(server), device_props)

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -1,4 +1,4 @@
-use cubecl_cpp::HipCompiler;
+use cubecl_cpp::{register_supported_types, HipCompiler};
 
 use cubecl_core::{Feature, MemoryConfiguration, Runtime};
 use cubecl_hip_sys::HIP_SUCCESS;
@@ -72,7 +72,8 @@ fn create_client(device: &HipDevice, options: RuntimeOptions) -> ComputeClient<S
     );
     let hip_ctx = HipContext::new(memory_management, stream, ctx);
     let server = HipServer::new(hip_ctx);
-    let device_props = DeviceProperties::new(&[Feature::Subcube], mem_properties);
+    let mut device_props = DeviceProperties::new(&[Feature::Subcube], mem_properties);
+    register_supported_types(&mut device_props);
     // TODO
     // register_wmma_features(&mut device_props);
 

--- a/crates/cubecl-spirv/src/item.rs
+++ b/crates/cubecl-spirv/src/item.rs
@@ -276,12 +276,7 @@ impl Elem {
             Elem::Void => b.type_void(),
             Elem::Bool => b.type_bool(),
             Elem::Int(width, _) => b.type_int(*width, 0),
-            Elem::Float(width) => {
-                if *width == 16 {
-                    b.capabilities.insert(Capability::Float16);
-                }
-                b.type_float(*width)
-            }
+            Elem::Float(width) => b.type_float(*width),
         };
         if b.debug && !b.state.debug_types.contains(&id) {
             b.debug_name(id, format!("{self}"));

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -10,8 +10,9 @@ use cubecl_core::{
     ir::{self as cube, HybridAllocator},
     prelude::CompiledKernel,
     server::ComputeServer,
+    Feature,
 };
-use cubecl_runtime::ExecutionMode;
+use cubecl_runtime::{DeviceProperties, ExecutionMode};
 use wgpu::{ComputePipeline, DeviceDescriptor, ShaderModuleDescriptor};
 
 /// Wgsl Compiler.
@@ -140,8 +141,26 @@ impl WgpuCompiler for WgslCompiler {
     fn register_features(
         _adapter: &wgpu::Adapter,
         _device: &wgpu::Device,
-        _props: &mut cubecl_runtime::DeviceProperties<cubecl_core::Feature>,
+        props: &mut DeviceProperties<Feature>,
     ) {
+        register_types(props);
+    }
+}
+
+fn register_types(props: &mut DeviceProperties<Feature>) {
+    use cubecl_core::ir::{Elem, FloatKind, IntKind};
+
+    let supported_types = [
+        Elem::UInt,
+        Elem::Int(IntKind::I32),
+        Elem::AtomicInt(IntKind::I32),
+        Elem::AtomicUInt,
+        Elem::Float(FloatKind::F32),
+        Elem::Bool,
+    ];
+
+    for ty in supported_types {
+        props.register_feature(Feature::Type(ty));
     }
 }
 

--- a/cubecl-book/src/SUMMARY.md
+++ b/cubecl-book/src/SUMMARY.md
@@ -8,5 +8,6 @@
   - [Comptime](./core-features/comptime.md)
   - [Vectorization](./core-features/vectorization.md)
   - [Autotune](./core-features/autotune.md)
+  - [Hardware Features](./core-features/features.md)
 - [Language Support](./language-support/summary.md)
   - [Trait Support](./language-support/trait.md)

--- a/cubecl-book/src/core-features/features.md
+++ b/cubecl-book/src/core-features/features.md
@@ -1,0 +1,52 @@
+# Querying hardware features
+
+Some features and datatypes are only supported on some hardware or some backends. They can be
+queried with:
+
+```rust, ignore
+client.properties().feature_enabled(feature)
+```
+
+Also see [`Feature`](https://docs.rs/cubecl/latest/cubecl/enum.Feature.html).
+
+## Overview
+
+### Features
+
+Also requires device support
+
+| Feature | CUDA | ROCm | WGPU (WGSL) | WGPU (SPIR-V) |
+| ------- | ---- | ---- | ----------- | ------------- |
+| Subcube | ✔️   | ✔️   | ✔️          | ✔️            |
+| CMMA    | ✔️   | ✔️   | ❌          | ✔️            |
+
+### Datatypes
+
+| Type | CUDA | ROCm | WGPU (WGSL) | WGPU (SPIR-V) |
+| ---- | ---- | ---- | ----------- | ------------- |
+| u8   | ❌   | ❌   | ❌          | ❌            |
+| u16  | ❌   | ❌   | ❌          | ❌            |
+| u32  | ✔️   | ✔️   | ✔️          | ✔️            |
+| u64  | ❌   | ❌   | ❌          | ❌            |
+| i8   | ❌   | ❌   | ❌          | ❌            |
+| i16  | ❌   | ❌   | ❌          | ❌            |
+| i32  | ✔️   | ✔️   | ✔️          | ✔️            |
+| i64  | ❌   | ❌   | ❌          | ✔️            |
+| f16  | ✔️   | ✔️   | ❌          | ✔️            |
+| bf16 | ✔️   | ✔️   | ❌          | ❌            |
+| f32  | ✔️   | ✔️   | ✔️          | ✔️            |
+| f64  | ❌   | ❌   | ❌          | ✔️            |
+| bool | ✔️   | ✔️   | ✔️          | ✔️            |
+
+## Subcube
+
+Subcube level operations, i.e.
+[`subcube_sum`](https://docs.rs/cubecl/latest/cubecl/frontend/fn.subcube_sum.html),
+[`subcube_elect`](https://docs.rs/cubecl/latest/cubecl/frontend/fn.subcube_elect.html).
+
+## Cooperative Matrix Multiply-Add (CMMA)
+
+Subcube-level cooperative matrix multiply-add operations. Maps to `wmma` in CUDA and
+`CooperativeMatrixMultiply` in SPIR-V. Features are registered for each size and datatype that is
+supported by the hardware. For supported functions, see
+[`cmma`](https://docs.rs/cubecl/latest/cubecl/frontend/cmma/index.html).


### PR DESCRIPTION
Adds a feature for each `Elem` type supported by the backend. Preparation for adding 8 and 16 bit integer types.
Adds a page to the book describing optional hardware/backend features and how to query their availability.
Also fixes the features set by SPIR-V, it was missing a feature required for accessing 16 bit types from storage buffers.