### PR TITLE
Refactor/timestamps

### DIFF
--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -27,6 +27,7 @@ derive-new = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 spin = { workspace = true }         # using in place of use std::sync::Mutex;
+log = { workspace = true }
 
 # Only activate futures for std env
 futures-lite = { workspace = true, features = ["std"], default-features = false, optional = true }

--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -34,7 +34,7 @@ pub enum TimestampsError {
     /// Collecting timestamps is disabled, make sure to enable it.
     Disabled,
     /// Collecting timestamps isn't available.
-    Unavailabled,
+    Unavailable,
     /// En unknown error occured while collecting timestamps.
     Unknown(String),
 }
@@ -179,7 +179,7 @@ pub trait Benchmark {
     /// Wait for computation to complete and return hardware reported
     /// computation duration.
     fn sync_elapsed(&self) -> TimestampsResult {
-        Err(TimestampsError::Unavailabled)
+        Err(TimestampsError::Unavailable)
     }
 
     /// Run the benchmark a number of times.
@@ -243,7 +243,7 @@ pub trait Benchmark {
                 TimestampsError::Disabled => {
                     panic!("Collecting timestamps is deactivated, make sure to enable it before running the benchmark");
                 }
-                TimestampsError::Unavailabled => start.elapsed(),
+                TimestampsError::Unavailable => start.elapsed(),
                 TimestampsError::Unknown(err) => {
                     panic!("An unknown error occured while collecting the timestamps when benchmarking: {err}");
                 }

--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -32,7 +32,7 @@ impl Display for TimingMethod {
 #[derive(Debug)]
 pub enum TimestampsError {
     /// Collecting timestamps is disabled, make sure to enable it.
-    Deactivated,
+    Disabled,
     /// Collecting timestamps isn't available.
     Unavailabled,
     /// En unknown error occured while collecting timestamps.
@@ -240,7 +240,7 @@ pub trait Benchmark {
         match result {
             Ok(time) => time,
             Err(err) => match err {
-                TimestampsError::Deactivated => {
+                TimestampsError::Disabled => {
                     panic!("Collecting timestamps is deactivated, make sure to enable it before running the benchmark");
                 }
                 TimestampsError::Unavailabled => start.elapsed(),

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -229,7 +229,7 @@ impl ComputeServer for CudaServer {
                 *start_time = Instant::now();
                 Ok(duration)
             }
-            KernelTimestamps::Disabled => Err(TimestampsError::Deactivated),
+            KernelTimestamps::Disabled => Err(TimestampsError::Disabled),
         };
 
         async move { duration }
@@ -256,7 +256,9 @@ impl ComputeServer for CudaServer {
     }
 
     fn disable_timestamps(&mut self) {
-        self.ctx.timestamps.disable();
+        if self.logger.profile_level().is_none() {
+            self.ctx.timestamps.disable();
+        }
     }
 }
 

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -214,7 +214,7 @@ impl ComputeServer for CudaServer {
 
         let ctx = self.get_context();
         ctx.sync();
-        async move { () }
+        async move {}
     }
 
     fn sync_elapsed(&mut self) -> impl Future<Output = TimestampsResult> + 'static {

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -220,7 +220,7 @@ impl ComputeServer for HipServer {
 
         let ctx = self.get_context();
         ctx.sync();
-        async move { () }
+        async move {}
     }
 
     fn sync_elapsed(&mut self) -> impl Future<Output = TimestampsResult> + 'static {

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -10,16 +10,16 @@ use cubecl_hip_sys::{hiprtcResult_HIPRTC_SUCCESS, HIP_SUCCESS};
 use cubecl_runtime::debug::{DebugLogger, ProfileLevel};
 use cubecl_runtime::memory_management::MemoryUsage;
 use cubecl_runtime::storage::BindingResource;
-use cubecl_runtime::ExecutionMode;
 use cubecl_runtime::{
     memory_management::MemoryManagement,
     server::{self, ComputeServer},
 };
+use cubecl_runtime::{ExecutionMode, TimestampsError, TimestampsResult};
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::future::Future;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 #[derive(Debug)]
 pub struct HipServer {
@@ -33,7 +33,7 @@ pub(crate) struct HipContext {
     stream: cubecl_hip_sys::hipStream_t,
     memory_management: MemoryManagement<HipStorage>,
     module_names: HashMap<KernelId, HipCompiledKernel>,
-    work_start_time: Option<Instant>,
+    timestamps: KernelTimestamps,
 }
 
 #[derive(Debug)]
@@ -42,6 +42,28 @@ struct HipCompiledKernel {
     func: cubecl_hip_sys::hipFunction_t,
     cube_dim: CubeDim,
     shared_mem_bytes: usize,
+}
+
+#[derive(Debug)]
+enum KernelTimestamps {
+    Inferred { start_time: Instant },
+    Disabled,
+}
+
+impl KernelTimestamps {
+    fn enable(&mut self) {
+        if !matches!(self, Self::Disabled) {
+            return;
+        }
+
+        *self = Self::Inferred {
+            start_time: Instant::now(),
+        };
+    }
+
+    fn disable(&mut self) {
+        *self = Self::Disabled;
+    }
 }
 
 unsafe impl Send for HipServer {}
@@ -193,16 +215,29 @@ impl ComputeServer for HipServer {
 
     fn flush(&mut self) {}
 
-    fn sync(&mut self) -> impl Future<Output = Duration> + 'static {
+    fn sync(&mut self) -> impl Future<Output = ()> + 'static {
         self.logger.profile_summary();
 
         let ctx = self.get_context();
         ctx.sync();
-        let duration = ctx
-            .work_start_time
-            .map(|t| t.elapsed())
-            .unwrap_or(Duration::from_secs_f32(0.0));
-        ctx.work_start_time = None;
+        async move { () }
+    }
+
+    fn sync_elapsed(&mut self) -> impl Future<Output = TimestampsResult> + 'static {
+        self.logger.profile_summary();
+
+        let ctx = self.get_context();
+        ctx.sync();
+
+        let duration = match &mut ctx.timestamps {
+            KernelTimestamps::Inferred { start_time } => {
+                let duration = start_time.elapsed();
+                *start_time = Instant::now();
+                Ok(duration)
+            }
+            KernelTimestamps::Disabled => Err(TimestampsError::Deactivated),
+        };
+
         async move { duration }
     }
 
@@ -217,6 +252,14 @@ impl ComputeServer for HipServer {
             ),
         )
     }
+
+    fn enable_timestamps(&mut self) {
+        self.ctx.timestamps.enable();
+    }
+
+    fn disable_timestamps(&mut self) {
+        self.ctx.timestamps.disable();
+    }
 }
 
 impl HipContext {
@@ -230,7 +273,7 @@ impl HipContext {
             module_names: HashMap::new(),
             stream,
             context,
-            work_start_time: None,
+            timestamps: KernelTimestamps::Disabled,
         }
     }
 
@@ -401,12 +444,14 @@ impl HipContext {
 }
 
 impl HipServer {
-    /// Create a new cuda server.
-    pub(crate) fn new(ctx: HipContext) -> Self {
-        Self {
-            ctx,
-            logger: DebugLogger::default(),
+    /// Create a new hip server.
+    pub(crate) fn new(mut ctx: HipContext) -> Self {
+        let logger = DebugLogger::default();
+        if logger.profile_level().is_some() {
+            ctx.timestamps.enable();
         }
+
+        Self { ctx, logger }
     }
 
     fn get_context(&mut self) -> &mut HipContext {

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -235,7 +235,7 @@ impl ComputeServer for HipServer {
                 *start_time = Instant::now();
                 Ok(duration)
             }
-            KernelTimestamps::Disabled => Err(TimestampsError::Deactivated),
+            KernelTimestamps::Disabled => Err(TimestampsError::Disabled),
         };
 
         async move { duration }
@@ -258,7 +258,9 @@ impl ComputeServer for HipServer {
     }
 
     fn disable_timestamps(&mut self) {
-        self.ctx.timestamps.disable();
+        if self.logger.profile_level().is_none() {
+            self.ctx.timestamps.disable();
+        }
     }
 }
 

--- a/crates/cubecl-runtime/src/base.rs
+++ b/crates/cubecl-runtime/src/base.rs
@@ -18,6 +18,8 @@ pub enum ExecutionMode {
     Unchecked,
 }
 
+pub use cubecl_common::benchmark::{TimestampsError, TimestampsResult};
+
 impl<Device, Server, Channel> Default for ComputeRuntime<Device, Server, Channel>
 where
     Device: core::hash::Hash + PartialEq + Eq + Clone + core::fmt::Debug,

--- a/crates/cubecl-runtime/src/channel/base.rs
+++ b/crates/cubecl-runtime/src/channel/base.rs
@@ -1,5 +1,5 @@
 use core::future::Future;
-use cubecl_common::stub::Duration;
+use cubecl_common::benchmark::TimestampsResult;
 
 use crate::{
     server::{Binding, ComputeServer, CubeCount, Handle},
@@ -39,11 +39,20 @@ pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send
     /// Flush outstanding work of the server.
     fn flush(&self);
 
-    /// Perform some synchronization of commands on the server.
+    /// Wait for the completion of every task in the server.
+    fn sync(&self) -> impl Future<Output = ()> + Send;
+
+    /// Wait for the completion of every task in the server.
     ///
     /// Returns the (approximate) total amount of GPU work done since the last sync.
-    fn sync(&self) -> impl Future<Output = Duration> + Send;
+    fn sync_elapsed(&self) -> impl Future<Output = TimestampsResult> + Send;
 
     /// Get the current memory usage of the server.
     fn memory_usage(&self) -> crate::memory_management::MemoryUsage;
+
+    /// Enable collecting timestamps.
+    fn enable_timestamps(&self);
+
+    /// Disable collecting timestamps.
+    fn disable_timestamps(&self);
 }

--- a/crates/cubecl-runtime/src/channel/cell.rs
+++ b/crates/cubecl-runtime/src/channel/cell.rs
@@ -4,7 +4,7 @@ use crate::storage::BindingResource;
 use crate::ExecutionMode;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use cubecl_common::stub::Duration;
+use cubecl_common::benchmark::TimestampsResult;
 
 /// A channel using a [ref cell](core::cell::RefCell) to access the server with mutability.
 ///
@@ -80,7 +80,7 @@ where
         self.server.borrow_mut().flush()
     }
 
-    async fn sync(&self) -> Duration {
+    async fn sync(&self) {
         let future = {
             let mut server = self.server.borrow_mut();
             server.sync()
@@ -88,8 +88,24 @@ where
         future.await
     }
 
+    async fn sync_elapsed(&self) -> TimestampsResult {
+        let future = {
+            let mut server = self.server.borrow_mut();
+            server.sync_elapsed()
+        };
+        future.await
+    }
+
     fn memory_usage(&self) -> crate::memory_management::MemoryUsage {
         self.server.borrow_mut().memory_usage()
+    }
+
+    fn enable_timestamps(&self) {
+        self.server.borrow_mut().enable_timestamps();
+    }
+
+    fn disable_timestamps(&self) {
+        self.server.borrow_mut().disable_timestamps();
     }
 }
 

--- a/crates/cubecl-runtime/src/channel/mpsc.rs
+++ b/crates/cubecl-runtime/src/channel/mpsc.rs
@@ -44,6 +44,8 @@ where
     SyncElapsed(Callback<TimestampsResult>),
     Sync(Callback<()>),
     GetMemoryUsage(Callback<MemoryUsage>),
+    EnableTimestamps,
+    DisableTimestamps,
 }
 
 impl<Server> MpscComputeChannel<Server>
@@ -92,6 +94,12 @@ where
                         }
                         Message::GetMemoryUsage(callback) => {
                             callback.send(server.memory_usage()).await.unwrap();
+                        }
+                        Message::EnableTimestamps => {
+                            server.enable_timestamps();
+                        }
+                        Message::DisableTimestamps => {
+                            server.disable_timestamps();
                         }
                     };
                 }
@@ -202,11 +210,17 @@ where
     }
 
     fn enable_timestamps(&self) {
-        todo!();
+        self.state
+            .sender
+            .send_blocking(Message::EnableTimestamps)
+            .unwrap();
     }
 
     fn disable_timestamps(&self) {
-        todo!();
+        self.state
+            .sender
+            .send_blocking(Message::DisableTimestamps)
+            .unwrap();
     }
 }
 

--- a/crates/cubecl-runtime/src/channel/mutex.rs
+++ b/crates/cubecl-runtime/src/channel/mutex.rs
@@ -4,7 +4,7 @@ use crate::storage::BindingResource;
 use crate::ExecutionMode;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use cubecl_common::stub::Duration;
+use cubecl_common::benchmark::TimestampsResult;
 use spin::Mutex;
 
 /// The MutexComputeChannel ensures thread-safety by locking the server
@@ -73,7 +73,7 @@ where
         self.server.lock().flush();
     }
 
-    async fn sync(&self) -> Duration {
+    async fn sync(&self) {
         // Nb: The order here is really important - the mutex guard has to be dropped before
         // the future is polled. Just calling lock().sync().await can deadlock.
         let fut = {
@@ -83,7 +83,25 @@ where
         fut.await
     }
 
+    async fn sync_elapsed(&self) -> TimestampsResult {
+        // Nb: The order here is really important - the mutex guard has to be dropped before
+        // the future is polled. Just calling lock().sync().await can deadlock.
+        let fut = {
+            let mut server = self.server.lock();
+            server.sync_elapsed()
+        };
+        fut.await
+    }
+
     fn memory_usage(&self) -> crate::memory_management::MemoryUsage {
         self.server.lock().memory_usage()
+    }
+
+    fn enable_timestamps(&self) {
+        self.server.lock().enable_timestamps();
+    }
+
+    fn disable_timestamps(&self) {
+        self.server.lock().disable_timestamps();
     }
 }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use cubecl_common::stub::Duration;
+use cubecl_common::benchmark::TimestampsResult;
 
 /// The ComputeClient is the entry point to require tasks from the ComputeServer.
 /// It should be obtained for a specific device via the Compute struct.
@@ -100,8 +100,13 @@ where
     }
 
     /// Wait for the completion of every task in the server.
-    pub async fn sync(&self) -> Duration {
+    pub async fn sync(&self) {
         self.channel.sync().await
+    }
+
+    /// Wait for the completion of every task in the server.
+    pub async fn sync_elapsed(&self) -> TimestampsResult {
+        self.channel.sync_elapsed().await
     }
 
     /// Get the features supported by the compute server.
@@ -112,5 +117,15 @@ where
     /// Get the current memory usage of this client.
     pub fn memory_usage(&self) -> MemoryUsage {
         self.channel.memory_usage()
+    }
+
+    /// Enable collecting timestamps.
+    pub fn enable_timestamps(&self) {
+        self.channel.enable_timestamps();
+    }
+
+    /// Disable collecting timestamps.
+    pub fn disable_timestamps(&self) {
+        self.channel.disable_timestamps();
     }
 }

--- a/crates/cubecl-runtime/src/server.rs
+++ b/crates/cubecl-runtime/src/server.rs
@@ -7,7 +7,8 @@ use crate::{
     ExecutionMode,
 };
 use alloc::vec::Vec;
-use core::{fmt::Debug, future::Future, time::Duration};
+use core::{fmt::Debug, future::Future};
+use cubecl_common::benchmark::TimestampsResult;
 
 /// The compute server is responsible for handling resources and computations over resources.
 ///
@@ -56,12 +57,21 @@ where
     fn flush(&mut self);
 
     /// Wait for the completion of every task in the server.
+    fn sync(&mut self) -> impl Future<Output = ()> + Send + 'static;
+
+    /// Wait for the completion of every task in the server.
     ///
     /// Returns the (approximate) total amount of GPU work done since the last sync.
-    fn sync(&mut self) -> impl Future<Output = Duration> + Send + 'static;
+    fn sync_elapsed(&mut self) -> impl Future<Output = TimestampsResult> + Send + 'static;
 
     /// The current memory usage of the server.
     fn memory_usage(&self) -> MemoryUsage;
+
+    /// Enable collecting timestamps.
+    fn enable_timestamps(&mut self);
+
+    /// Disable collecting timestamps.
+    fn disable_timestamps(&mut self);
 }
 
 /// Server handle containing the [memory handle](MemoryManagement::Handle).

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -22,11 +22,13 @@ impl<Out> Clone for Box<dyn AutotuneOperation<Out>> {
 impl<S: ComputeServer, C: ComputeChannel<S>, Out> TuneBenchmark<S, C, Out> {
     /// Benchmark how long this operation takes for a number of samples.
     pub async fn sample_durations(&self) -> BenchmarkDurations {
-        let num_samples = 10;
+        // If the inner operation need autotuning as well, we need to call it before.
+        AutotuneOperation::execute(self.operation.clone());
+        let _ = self.client.sync().await;
 
+        let num_samples = 10;
         let mut durations = vec![];
         self.client.enable_timestamps();
-
         for _ in 0..num_samples {
             let _ = self.client.sync_elapsed().await;
             AutotuneOperation::execute(self.operation.clone());

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -25,13 +25,22 @@ impl<S: ComputeServer, C: ComputeChannel<S>, Out> TuneBenchmark<S, C, Out> {
         let num_samples = 10;
 
         let mut durations = vec![];
+        self.client.enable_timestamps();
+
         for _ in 0..num_samples {
-            self.client.sync().await;
+            let _ = self.client.sync_elapsed().await;
             AutotuneOperation::execute(self.operation.clone());
             // For benchmarks - we need to wait for all tasks to complete before returning.
-            let duration = self.client.sync().await;
+            let duration = self
+                .client
+                .sync_elapsed()
+                .await
+                .expect("Timestamps to be enabled");
             durations.push(duration);
         }
+
+        self.client.disable_timestamps();
+
         BenchmarkDurations {
             timing_method: TimingMethod::DeviceOnly,
             durations,

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -38,7 +38,7 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
         mem_properties.clone(),
         MemoryConfiguration::default(),
     );
-    let server = DummyServer::new(memory_management, None);
+    let server = DummyServer::new(memory_management);
     let channel = MutexComputeChannel::new(server);
     ComputeClient::new(channel, DeviceProperties::new(&[], mem_properties))
 }

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -81,7 +81,7 @@ impl ComputeServer for DummyServer {
 
     #[allow(clippy::manual_async_fn)]
     fn sync_elapsed(&mut self) -> impl Future<Output = TimestampsResult> + 'static {
-        async move { Err(cubecl_runtime::TimestampsError::Unavailabled) }
+        async move { Err(cubecl_runtime::TimestampsError::Unavailable) }
     }
 
     fn memory_usage(&self) -> MemoryUsage {

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -76,7 +76,7 @@ impl ComputeServer for DummyServer {
 
     #[allow(clippy::manual_async_fn)]
     fn sync(&mut self) -> impl Future<Output = ()> + 'static {
-        async move { () }
+        async move {}
     }
 
     #[allow(clippy::manual_async_fn)]

--- a/crates/cubecl-wgpu/src/compute/mod.rs
+++ b/crates/cubecl-wgpu/src/compute/mod.rs
@@ -1,3 +1,4 @@
+pub(super) mod poll;
 mod server;
 mod storage;
 

--- a/crates/cubecl-wgpu/src/compute/poll.rs
+++ b/crates/cubecl-wgpu/src/compute/poll.rs
@@ -1,0 +1,73 @@
+#[cfg(not(target_family = "wasm"))]
+mod poll {
+    use std::thread::JoinHandle;
+
+    #[derive(Debug)]
+    pub struct WgpuPoll {
+        active_handle: std::sync::Arc<()>,
+        cancel_sender: std::sync::mpsc::Sender<()>,
+        poll_thread: JoinHandle<()>,
+    }
+
+    impl WgpuPoll {
+        pub fn new(device: std::sync::Arc<wgpu::Device>) -> Self {
+            let active_handle = std::sync::Arc::new(());
+            let thread_check = active_handle.clone();
+
+            let (cancel_sender, cancel_receiver) = std::sync::mpsc::channel();
+            let poll_thread = std::thread::spawn(move || loop {
+                // Check whether the WgpuPoll, this thread, and something else is holding
+                // a handle.
+                if std::sync::Arc::strong_count(&thread_check) > 2 {
+                    device.poll(wgpu::MaintainBase::Poll);
+                } else {
+                    // Do not cancel thread while someone still needs to poll.
+                    if cancel_receiver.try_recv().is_ok() {
+                        break;
+                    }
+
+                    std::thread::park();
+                }
+                std::thread::yield_now();
+            });
+
+            Self {
+                active_handle,
+                cancel_sender,
+                poll_thread,
+            }
+        }
+        /// Get a handle, as long as it's alive the polling will be active.
+        pub fn start_polling(&self) -> std::sync::Arc<()> {
+            let handle = self.active_handle.clone();
+            self.poll_thread.thread().unpark();
+            handle
+        }
+    }
+
+    impl Drop for WgpuPoll {
+        fn drop(&mut self) {
+            self.cancel_sender
+                .send(())
+                .expect("Failed to shutdown polling thread.");
+            self.poll_thread.thread().unpark();
+        }
+    }
+}
+
+// On Wasm, the browser handles the polling loop, so we don't need anything.
+#[cfg(target_family = "wasm")]
+mod poll {
+    #[derive(Debug)]
+    pub struct WgpuPoll {}
+    impl WgpuPoll {
+        pub fn new(_device: alloc::sync::Arc<wgpu::Device>) -> Self {
+            Self {}
+        }
+        pub fn start_polling(&self) -> alloc::sync::Arc<()> {
+            alloc::sync::Arc::new(())
+        }
+    }
+}
+
+pub(crate) use poll::*;

--- a/crates/cubecl-wgpu/src/compute/poll.rs
+++ b/crates/cubecl-wgpu/src/compute/poll.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_family = "wasm"))]
-mod poll {
+mod _impl {
     use std::thread::JoinHandle;
 
     #[derive(Debug)]
@@ -57,7 +57,7 @@ mod poll {
 
 // On Wasm, the browser handles the polling loop, so we don't need anything.
 #[cfg(target_family = "wasm")]
-mod poll {
+mod _impl {
     #[derive(Debug)]
     pub struct WgpuPoll {}
     impl WgpuPoll {
@@ -70,4 +70,4 @@ mod poll {
     }
 }
 
-pub(crate) use poll::*;
+pub(crate) use _impl::*;

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -251,7 +251,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
 
                 return Box::pin(async move {
                     fut.await;
-                    Err(TimestampsError::Deactivated)
+                    Err(TimestampsError::Disabled)
                 });
             }
         };
@@ -449,11 +449,6 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
 
         self.tasks_count += 1;
 
-        // Record the start time of the first compute pass.
-        // if self.command_start_time.is_none() {
-        //     self.command_start_time = Some(Instant::now());
-        // }
-
         pass.set_pipeline(&pipeline);
         pass.set_bind_group(0, &bind_group, &[]);
 
@@ -540,7 +535,7 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
                     None => Ok(duration),
                 },
                 Err(err) => match err {
-                    TimestampsError::Deactivated => Err(err),
+                    TimestampsError::Disabled => Err(err),
                     TimestampsError::Unavailabled => match profiled {
                         Some(profiled) => Ok(profiled),
                         None => Err(err),

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -203,7 +203,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         #[cfg(not(target_family = "wasm"))]
         {
             self.device.poll(wgpu::MaintainBase::Wait);
-            Box::pin(async move { () })
+            Box::pin(async move {})
         }
     }
 
@@ -236,7 +236,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
                     });
 
                     self.encoder
-                        .resolve_query_set(&query_set, 0..2, &resolved, 0);
+                        .resolve_query_set(query_set, 0..2, &resolved, 0);
                     *init = false;
                     TimestampMethod::Buffer(resolved, size)
                 }

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -1,5 +1,6 @@
 use std::{future::Future, marker::PhantomData, num::NonZero, pin::Pin, time::Duration};
 
+use super::poll::WgpuPoll;
 use super::WgpuStorage;
 use crate::compiler::base::WgpuCompiler;
 use alloc::sync::Arc;
@@ -10,85 +11,11 @@ use cubecl_runtime::{
     memory_management::{MemoryHandle, MemoryLock, MemoryManagement},
     server::{self, ComputeServer},
     storage::{BindingResource, ComputeStorage},
-    ExecutionMode,
+    ExecutionMode, TimestampsError, TimestampsResult,
 };
 use hashbrown::HashMap;
 use web_time::Instant;
 use wgpu::{CommandEncoder, ComputePass, ComputePipeline, QuerySet, QuerySetDescriptor, QueryType};
-
-#[cfg(not(target_family = "wasm"))]
-mod poll {
-    use std::thread::JoinHandle;
-
-    #[derive(Debug)]
-    pub struct WgpuPoll {
-        active_handle: std::sync::Arc<()>,
-        cancel_sender: std::sync::mpsc::Sender<()>,
-        poll_thread: JoinHandle<()>,
-    }
-
-    impl WgpuPoll {
-        pub fn new(device: std::sync::Arc<wgpu::Device>) -> Self {
-            let active_handle = std::sync::Arc::new(());
-            let thread_check = active_handle.clone();
-
-            let (cancel_sender, cancel_receiver) = std::sync::mpsc::channel();
-            let poll_thread = std::thread::spawn(move || loop {
-                // Check whether the WgpuPoll, this thread, and something else is holding
-                // a handle.
-                if std::sync::Arc::strong_count(&thread_check) > 2 {
-                    device.poll(wgpu::MaintainBase::Poll);
-                } else {
-                    // Do not cancel thread while someone still needs to poll.
-                    if cancel_receiver.try_recv().is_ok() {
-                        break;
-                    }
-
-                    std::thread::park();
-                }
-                std::thread::yield_now();
-            });
-
-            Self {
-                active_handle,
-                cancel_sender,
-                poll_thread,
-            }
-        }
-        /// Get a handle, as long as it's alive the polling will be active.
-        pub fn start_polling(&self) -> std::sync::Arc<()> {
-            let handle = self.active_handle.clone();
-            self.poll_thread.thread().unpark();
-            handle
-        }
-    }
-
-    impl Drop for WgpuPoll {
-        fn drop(&mut self) {
-            self.cancel_sender
-                .send(())
-                .expect("Failed to shutdown polling thread.");
-            self.poll_thread.thread().unpark();
-        }
-    }
-}
-
-// On Wasm, the browser handles the polling loop, so we don't need anything.
-#[cfg(target_family = "wasm")]
-mod poll {
-    #[derive(Debug)]
-    pub struct WgpuPoll {}
-    impl WgpuPoll {
-        pub fn new(_device: alloc::sync::Arc<wgpu::Device>) -> Self {
-            Self {}
-        }
-        pub fn start_polling(&self) -> alloc::sync::Arc<()> {
-            alloc::sync::Arc::new(())
-        }
-    }
-}
-
-pub use poll::WgpuPoll;
 
 /// Wgpu compute server.
 #[derive(Debug)]
@@ -104,11 +31,45 @@ pub struct WgpuServer<C: WgpuCompiler> {
     logger: DebugLogger,
     poll: WgpuPoll,
     storage_locked: MemoryLock,
-
-    duration_profiled: Duration,
-    command_start_time: Option<Instant>,
-    query_set: Option<QuerySet>,
+    duration_profiled: Option<Duration>,
+    timestamps: KernelTimestamps,
     _compiler: PhantomData<C>,
+}
+
+#[derive(Debug)]
+enum KernelTimestamps {
+    Native { query_set: QuerySet, init: bool },
+    Inferred { start_time: Instant },
+    Disabled,
+}
+
+impl KernelTimestamps {
+    fn enable(&mut self, device: &wgpu::Device) {
+        if !matches!(self, Self::Disabled) {
+            return;
+        }
+
+        if device.features().contains(wgpu::Features::TIMESTAMP_QUERY) {
+            let query_set = device.create_query_set(&QuerySetDescriptor {
+                label: Some("CubeCL profile queries"),
+                ty: QueryType::Timestamp,
+                count: 2,
+            });
+
+            *self = Self::Native {
+                query_set,
+                init: false,
+            };
+        } else {
+            *self = Self::Inferred {
+                start_time: Instant::now(),
+            };
+        };
+    }
+
+    fn disable(&mut self) {
+        *self = Self::Disabled;
+    }
 }
 
 fn create_encoder(device: &wgpu::Device) -> CommandEncoder {
@@ -125,15 +86,12 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         queue: Arc<wgpu::Queue>,
         tasks_max: usize,
     ) -> Self {
-        let queries = if device.features().contains(wgpu::Features::TIMESTAMP_QUERY) {
-            Some(device.create_query_set(&QuerySetDescriptor {
-                label: Some("CubeCL profile queries"),
-                ty: QueryType::Timestamp,
-                count: 2,
-            }))
-        } else {
-            None
-        };
+        let logger = DebugLogger::default();
+        let mut timestamps = KernelTimestamps::Disabled;
+
+        if logger.profile_level().is_some() {
+            timestamps.enable(&device);
+        }
 
         Self {
             memory_management,
@@ -145,11 +103,10 @@ impl<C: WgpuCompiler> WgpuServer<C> {
             storage_locked: MemoryLock::default(),
             pipelines: HashMap::new(),
             tasks_max,
-            logger: DebugLogger::default(),
+            logger,
             poll: WgpuPoll::new(device.clone()),
-            query_set: queries,
-            command_start_time: None,
-            duration_profiled: Duration::from_secs(0),
+            duration_profiled: None,
+            timestamps,
             _compiler: PhantomData,
         }
     }
@@ -230,47 +187,105 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         }
     }
 
-    fn sync_queue(&mut self) -> Pin<Box<dyn Future<Output = Duration> + Send + 'static>> {
-        self.clear_compute_pass();
-        let Some(start_time) = self.command_start_time.take() else {
-            return Box::pin(async move { Duration::from_secs_f64(0.0) });
-        };
+    fn sync_queue(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+        self.flush();
 
-        if let Some(queries) = self.query_set.as_ref() {
-            let period = self.queue.get_timestamp_period() as f64 * 1e-9;
-
-            let size = 2 * size_of::<u64>() as u64;
-            let resolved = self.device.create_buffer(&wgpu::BufferDescriptor {
-                label: None,
-                size,
-                usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::QUERY_RESOLVE,
-                mapped_at_creation: false,
-            });
-
-            self.encoder.resolve_query_set(queries, 0..2, &resolved, 0);
-            let fut = self.read_wgpu_buffer(&resolved, 0, size);
-
-            Box::pin(async move {
-                let data = fut
-                    .await
-                    .chunks_exact(8)
-                    .map(|x| u64::from_le_bytes(x.try_into().unwrap()))
-                    .collect::<Vec<_>>();
-                let delta = u64::checked_sub(data[1], data[0]).unwrap_or(1);
-                Duration::from_secs_f64(delta as f64 * period)
-            })
-        } else {
-            // TODO: This should work queue.on_submitted_work_done() but that
-            // is not yet implemented on wgpu https://github.com/gfx-rs/wgpu/issues/6395
-            //
-            // For now, instead do a dummy readback. This *seems* to wait for the entire
-            // queue to be done.
+        #[cfg(target_family = "wasm")]
+        {
             let dummy = self.empty(32);
             let fut = self.read(dummy.binding());
+
             Box::pin(async move {
                 fut.await;
-                start_time.elapsed()
             })
+        }
+
+        #[cfg(not(target_family = "wasm"))]
+        {
+            self.device.poll(wgpu::MaintainBase::Wait);
+            Box::pin(async move { () })
+        }
+    }
+
+    fn sync_queue_elapsed(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = TimestampsResult> + Send + 'static>> {
+        self.clear_compute_pass();
+
+        enum TimestampMethod {
+            Buffer(wgpu::Buffer, u64),
+            StartTime(Instant),
+        }
+
+        let method = match &mut self.timestamps {
+            KernelTimestamps::Native { query_set, init } => {
+                if !*init {
+                    let fut = self.sync_queue();
+
+                    return Box::pin(async move {
+                        fut.await;
+                        Err(TimestampsError::Unavailabled)
+                    });
+                } else {
+                    let size = 2 * size_of::<u64>() as u64;
+                    let resolved = self.device.create_buffer(&wgpu::BufferDescriptor {
+                        label: None,
+                        size,
+                        usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::QUERY_RESOLVE,
+                        mapped_at_creation: false,
+                    });
+
+                    self.encoder
+                        .resolve_query_set(&query_set, 0..2, &resolved, 0);
+                    *init = false;
+                    TimestampMethod::Buffer(resolved, size)
+                }
+            }
+            KernelTimestamps::Inferred { start_time } => {
+                let mut instant = Instant::now();
+                core::mem::swap(&mut instant, start_time);
+                TimestampMethod::StartTime(instant)
+            }
+            KernelTimestamps::Disabled => {
+                let fut = self.sync_queue();
+
+                return Box::pin(async move {
+                    fut.await;
+                    Err(TimestampsError::Deactivated)
+                });
+            }
+        };
+
+        match method {
+            TimestampMethod::Buffer(resolved, size) => {
+                let period = self.queue.get_timestamp_period() as f64 * 1e-9;
+                let fut = self.read_wgpu_buffer(&resolved, 0, size);
+
+                Box::pin(async move {
+                    let data = fut
+                        .await
+                        .chunks_exact(8)
+                        .map(|x| u64::from_le_bytes(x.try_into().unwrap()))
+                        .collect::<Vec<_>>();
+                    let delta = u64::checked_sub(data[1], data[0]).unwrap_or(1);
+                    let duration = Duration::from_secs_f64(delta as f64 * period);
+
+                    Ok(duration)
+                })
+            }
+            TimestampMethod::StartTime(start_time) => {
+                // TODO: This should work queue.on_submitted_work_done() but that
+                // is not yet implemented on wgpu https://github.com/gfx-rs/wgpu/issues/6395
+                //
+                // For now, instead do a dummy readback. This *seems* to wait for the entire
+                // queue to be done.
+                let dummy = self.empty(32);
+                let fut = self.read(dummy.binding());
+                Box::pin(async move {
+                    fut.await;
+                    Ok(start_time.elapsed())
+                })
+            }
         }
     }
 }
@@ -364,8 +379,14 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
         };
 
         if profile_level.is_some() {
-            let fut = self.sync_queue();
-            self.duration_profiled += future::block_on(fut);
+            let fut = self.sync_queue_elapsed();
+            if let Ok(duration) = future::block_on(fut) {
+                if let Some(profiled) = &mut self.duration_profiled {
+                    *profiled += duration;
+                } else {
+                    self.duration_profiled = Some(duration);
+                }
+            }
         }
 
         // Start execution.
@@ -406,17 +427,17 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
             // Write out timestamps. The first compute pass writes both a start and end timestamp.
             // the second timestamp writes out only an end stamp.
             let timestamps =
-                self.query_set
-                    .as_ref()
-                    .map(|query_set| wgpu::ComputePassTimestampWrites {
+                if let KernelTimestamps::Native { query_set, init } = &mut self.timestamps {
+                    let result = Some(wgpu::ComputePassTimestampWrites {
                         query_set,
-                        beginning_of_pass_write_index: if self.command_start_time.is_none() {
-                            Some(0)
-                        } else {
-                            None
-                        },
+                        beginning_of_pass_write_index: if !*init { Some(0) } else { None },
                         end_of_pass_write_index: Some(1),
                     });
+                    *init = true;
+                    result
+                } else {
+                    None
+                };
 
             self.encoder
                 .begin_compute_pass(&wgpu::ComputePassDescriptor {
@@ -429,9 +450,9 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
         self.tasks_count += 1;
 
         // Record the start time of the first compute pass.
-        if self.command_start_time.is_none() {
-            self.command_start_time = Some(Instant::now());
-        }
+        // if self.command_start_time.is_none() {
+        //     self.command_start_time = Some(Instant::now());
+        // }
 
         pass.set_pipeline(&pipeline);
         pass.set_bind_group(0, &bind_group, &[]);
@@ -458,22 +479,27 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
             let (name, kernel_id) = profile_info.unwrap();
 
             // Execute the task.
-            let duration = future::block_on(self.sync_queue());
-            self.duration_profiled += duration;
+            if let Ok(duration) = future::block_on(self.sync_queue_elapsed()) {
+                if let Some(profiled) = &mut self.duration_profiled {
+                    *profiled += duration;
+                } else {
+                    self.duration_profiled = Some(duration);
+                }
 
-            let info = match level {
-                ProfileLevel::Basic | ProfileLevel::Medium => {
-                    if let Some(val) = name.split("<").next() {
-                        val.split("::").last().unwrap_or(name).to_string()
-                    } else {
-                        name.to_string()
+                let info = match level {
+                    ProfileLevel::Basic | ProfileLevel::Medium => {
+                        if let Some(val) = name.split("<").next() {
+                            val.split("::").last().unwrap_or(name).to_string()
+                        } else {
+                            name.to_string()
+                        }
                     }
-                }
-                ProfileLevel::Full => {
-                    format!("{name}: {kernel_id} CubeCount {count:?}")
-                }
-            };
-            self.logger.register_profiled(info, duration);
+                    ProfileLevel::Full => {
+                        format!("{name}: {kernel_id} CubeCount {count:?}")
+                    }
+                };
+                self.logger.register_profiled(info, duration);
+            }
         }
     }
 
@@ -493,16 +519,50 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
     }
 
     /// Returns the total time of GPU work this sync completes.
-    fn sync(&mut self) -> impl Future<Output = Duration> + 'static {
+    fn sync(&mut self) -> impl Future<Output = ()> + 'static {
         self.logger.profile_summary();
 
-        let future = self.sync_queue();
+        self.sync_queue()
+    }
+
+    /// Returns the total time of GPU work this sync completes.
+    fn sync_elapsed(&mut self) -> impl Future<Output = TimestampsResult> + 'static {
+        self.logger.profile_summary();
+
+        let future = self.sync_queue_elapsed();
         let profiled = self.duration_profiled;
-        self.duration_profiled = Duration::from_secs(0);
-        async move { future.await + profiled }
+        self.duration_profiled = None;
+
+        async move {
+            match future.await {
+                Ok(duration) => match profiled {
+                    Some(profiled) => Ok(duration + profiled),
+                    None => Ok(duration),
+                },
+                Err(err) => match err {
+                    TimestampsError::Deactivated => Err(err),
+                    TimestampsError::Unavailabled => match profiled {
+                        Some(profiled) => Ok(profiled),
+                        None => Err(err),
+                    },
+                    TimestampsError::Unknown(_) => Err(err),
+                },
+            }
+        }
     }
 
     fn memory_usage(&self) -> cubecl_runtime::memory_management::MemoryUsage {
         self.memory_management.memory_usage()
+    }
+
+    fn enable_timestamps(&mut self) {
+        self.timestamps.enable(&self.device);
+    }
+
+    fn disable_timestamps(&mut self) {
+        // Only disable timestamps if profiling isn't enabled.
+        if self.logger.profile_level().is_none() {
+            self.timestamps.disable();
+        }
     }
 }

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -86,7 +86,6 @@ fn run<R: Runtime, E: Float>(device: R::Device, kind: MatmulKind) {
     };
     println!("{}", bench.name());
     println!("{}", bench.run(TimingMethod::DeviceOnly));
-    println!("{}", bench.run(TimingMethod::Full));
 }
 
 fn main() {

--- a/crates/cubecl/benches/unary.rs
+++ b/crates/cubecl/benches/unary.rs
@@ -92,15 +92,18 @@ enum MatmulKind {
 
 #[allow(dead_code)]
 fn run<R: Runtime, E: frontend::Float>(device: R::Device, vectorization: u8) {
+    let client = R::client(&device);
+    client.enable_timestamps();
+
     let bench = UnaryBench::<R, E> {
         shape: vec![32, 512, 2048],
         vectorization,
-        client: R::client(&device),
+        client,
         device,
         _e: PhantomData,
     };
     println!("{}", bench.name());
-    println!("{}", bench.run(TimingMethod::Full));
+    println!("{}", bench.run(TimingMethod::DeviceOnly));
 }
 
 fn main() {

--- a/crates/cubecl/benches/unary.rs
+++ b/crates/cubecl/benches/unary.rs
@@ -1,4 +1,5 @@
 use cubecl::{calculate_cube_count_elemwise, frontend, prelude::*};
+use cubecl_runtime::TimestampsResult;
 use std::marker::PhantomData;
 
 #[cfg(feature = "cuda")]
@@ -7,7 +8,6 @@ use half::f16;
 use cubecl::benchmark::{Benchmark, TimingMethod};
 use cubecl::future;
 use cubecl_linalg::tensor::TensorHandle;
-use std::time::Duration;
 
 #[cube(launch)]
 fn execute<F: Float>(lhs: &Tensor<F>, rhs: &Tensor<F>, out: &mut Tensor<F>) {
@@ -65,8 +65,12 @@ impl<R: Runtime, E: Float> Benchmark for UnaryBench<R, E> {
         .to_lowercase()
     }
 
-    fn sync(&self) -> Duration {
+    fn sync(&self) {
         future::block_on(self.client.sync())
+    }
+
+    fn sync_elapsed(&self) -> TimestampsResult {
+        future::block_on(self.client.sync_elapsed())
     }
 }
 


### PR DESCRIPTION
The timestamps now work with and without profiling, with better error handling to identify the cause of timestamps not working. We can disable timestamps in all runtimes to reduce overhead (mostly for wgpu). We maintain an API that is mostly compatible with the benchmarks written in Burn, which rely on full execution time, to remain comparable to other backends not based on CubeCL.