### PR TITLE
Fix pico support due to unsafe assumption

### DIFF
--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -37,7 +37,7 @@ embassy-futures = { version = "0.1.1" }
 spin = { workspace = true, features = ["mutex", "spin_mutex"] }
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
-portable-atomic = { workspace = true, features = ["unsafe-assume-single-core"] }
+portable-atomic = { workspace = true }
 spin = { workspace = true, features = [
     "mutex",
     "spin_mutex",

--- a/crates/cubecl-common/build.rs
+++ b/crates/cubecl-common/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    if let Ok(family) = std::env::var("CARGO_CFG_TARGET_FAMILY") {
+        if family == "wasm" {
+            println!("cargo:rustc-cfg=portable_atomic_unsafe_assume_single_core");
+        }
+    }
+}


### PR DESCRIPTION
This just basically changes from using portable atomic's `unsafe-assume-single-core` feature flag to using the cfg flag `portable_atomic_unsafe_assume_single_core`. In the build script it enables only if the target family is wasm.

This fixes burn's [#2389](https://github.com/tracel-ai/burn/issues/2389).