### PR TITLE
Fix concurrency problems with autotune.

### DIFF
--- a/crates/cubecl-macros/src/generate/autotune.rs
+++ b/crates/cubecl-macros/src/generate/autotune.rs
@@ -159,6 +159,7 @@ impl AutotuneOperations {
         let ty = self.ty.as_ref();
         let fields = &self.input_fields;
         quote! {
+            #[derive(Debug)]
             pub struct #name #generics #where_clause {
                 #ty
                 #(#fields),*
@@ -346,6 +347,7 @@ impl AutotuneOperations {
             .iter()
             .filter(|it| it.ident.as_ref().unwrap() != key);
         quote! {
+            #[derive(Debug)]
             pub struct #name #generics #where_clause {
                 #ty
                 #(#fields),*

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -32,6 +32,7 @@ cubecl-common = { path = "../cubecl-common", version = "0.2.0", default-features
 derive-new = { workspace = true }
 hashbrown = { workspace = true }
 log = { workspace = true }
+async-lock = { version = "3.4.0" }
 
 # Persistent cache deps - has to match the autotune_persistent_cache cfg.
 [target.'cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))'.dependencies]
@@ -54,6 +55,7 @@ spin = { workspace = true, features = [
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen-futures = { workspace = true }
+async-lock = { version = "3.4.0" }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -55,7 +55,6 @@ spin = { workspace = true, features = [
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen-futures = { workspace = true }
-async-lock = { version = "3.4.0" }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -172,7 +172,7 @@ where
     ///
     /// # Example
     ///
-    /// ```
+    /// ```ignore
     /// server.enable_timestamps();
     /// // Run your benchmarks/operations
     /// let duration = server.sync_elapsed();

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -54,11 +54,15 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
         S: ComputeServer + 'static,
         C: ComputeChannel<S> + 'static,
     {
+        let mut should_init = true;
+
         // We avoid locking in write mode when possible.
         // (this makes us potentially check the cache twice, but allows to avoid
         // locking the state if the cache is hit)
         if let Some(state) = self.state.read().as_ref() {
             if let Some(tuner) = state.get(id) {
+                should_init = false;
+
                 let key = autotune_operation_set.key();
                 if let Some(index) = tuner.autotune_fastest(&key) {
                     let op = autotune_operation_set.fastest(index);
@@ -67,20 +71,45 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             }
         }
 
-        // We have to run the autotune.
-        let mut state = self.state.write();
-        let map = state.get_or_insert_with(Default::default);
+        if should_init {
+            let mut state = self.state.write();
+            let map = state.get_or_insert_with(Default::default);
 
-        let tuner = if let Some(tuner) = map.get_mut(id) {
-            tuner
-        } else {
-            let name = self.name.replace("::", "-");
-            let tuner = Tuner::new(&name, &id.to_string());
-            map.insert(id.clone(), tuner);
-            map.get_mut(id).unwrap()
-        };
+            if !map.contains_key(id) {
+                let name = self.name.replace("::", "-");
+                let tuner = Tuner::new(&name, &id.to_string());
+                map.insert(id.clone(), tuner);
+            };
+        }
 
-        tuner.execute_autotune(autotune_operation_set, client)
+        // Running benchmarks shound't lock the tuner, since an autotune can recursively use the
+        // same tuner.
+        //
+        // # Example
+        //
+        // ```
+        // tune_1 start
+        // tune_2 start
+        // tune_2 save
+        // tune_1 save
+        // ```
+        let mut result = None;
+        if let Some(state) = self.state.read().as_ref() {
+            if let Some(tuner) = state.get(id) {
+                result = Some(tuner.execute_autotune(autotune_operation_set, client));
+            }
+        }
+
+        if let Some(result) = result {
+            let mut state = self.state.write();
+            let map = state.get_or_insert_with(Default::default);
+
+            if let Some(tuner) = map.get_mut(id) {
+                return tuner.register_autotune(result);
+            }
+        }
+
+        panic!("Unable to autotune");
     }
 
     /// Return the autotune result given a key.

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -42,7 +42,7 @@ pub trait AutotuneOperationSet<K: Send + Sync + 'static, Output = ()>: Send + Sy
 }
 
 /// Contains operation to run and inputs on which to run it
-pub trait AutotuneOperation<Output = ()> {
+pub trait AutotuneOperation<Output = ()>: core::fmt::Debug {
     /// Runs the operation
     fn execute(self: Box<Self>) -> Output;
 

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -32,7 +32,6 @@ impl<S: ComputeServer, C: ComputeChannel<S>, Out> TuneBenchmark<S, C, Out> {
             .profile(|| async {
                 let num_samples = 10;
                 let mut durations = vec![];
-                let _ = self.client.sync_elapsed().await;
 
                 for _ in 0..num_samples {
                     AutotuneOperation::execute(self.operation.clone());

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -31,7 +31,7 @@ impl<S: ComputeServer, C: ComputeChannel<S>, Out> TuneBenchmark<S, C, Out> {
             .client
             .profile(|| async {
                 let num_samples = 10;
-                let mut durations = vec![];
+                let mut durations = Vec::with_capacity(num_samples);
 
                 for _ in 0..num_samples {
                     AutotuneOperation::execute(self.operation.clone());

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -23,25 +23,39 @@ impl<S: ComputeServer, C: ComputeChannel<S>, Out> TuneBenchmark<S, C, Out> {
     /// Benchmark how long this operation takes for a number of samples.
     pub async fn sample_durations(&self) -> BenchmarkDurations {
         // If the inner operation need autotuning as well, we need to call it before.
+        let _ = self.client.sync().await;
         AutotuneOperation::execute(self.operation.clone());
         let _ = self.client.sync().await;
 
-        let num_samples = 10;
-        let mut durations = vec![];
-        self.client.enable_timestamps();
-        for _ in 0..num_samples {
-            let _ = self.client.sync_elapsed().await;
-            AutotuneOperation::execute(self.operation.clone());
-            // For benchmarks - we need to wait for all tasks to complete before returning.
-            let duration = self
-                .client
-                .sync_elapsed()
-                .await
-                .expect("Timestamps to be enabled");
-            durations.push(duration);
-        }
+        let durations = self
+            .client
+            .profile(|| async {
+                let num_samples = 10;
+                let mut durations = vec![];
+                let _ = self.client.sync_elapsed().await;
 
-        self.client.disable_timestamps();
+                for _ in 0..num_samples {
+                    AutotuneOperation::execute(self.operation.clone());
+                    // For benchmarks - we need to wait for all tasks to complete before returning.
+                    let duration = match self.client.sync_elapsed().await {
+                        Ok(val) => val,
+                        Err(err) => {
+                            #[cfg(not(target_family = "wasm"))]
+                            panic!("Error while autotuning an operation: {:?}", err);
+
+                            #[cfg(target_family = "wasm")]
+                            {
+                                // We can't panic inside a future on wasm.
+                                log::warn!("Error while autotuning an operation: {:?}", err);
+                                continue;
+                            }
+                        }
+                    };
+                    durations.push(duration);
+                }
+                durations
+            })
+            .await;
 
         BenchmarkDurations {
             timing_method: TimingMethod::DeviceOnly,

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -59,7 +59,7 @@ impl<K: AutotuneKey> Tuner<K> {
         self.tune_cache.find_fastest(key)
     }
 
-    /// Register the [result](AutotuneResult) after finishing the benchmarks.
+    /// Registers the [results](AutotuneResult) from [execute_autotune()](Self::execute_autotune).
     pub fn register_autotune<Out: Send>(&mut self, result: AutotuneResult<K, Out>) -> Out {
         self.tune_cache
             .cache_insert(result.key.clone(), result.fastest_index);
@@ -91,11 +91,11 @@ impl<K: AutotuneKey> Tuner<K> {
         self.start_autotuning(send, set.as_ref(), client);
 
         if let Ok(msg) = rec.try_recv() {
-            return AutotuneResult {
+            AutotuneResult {
                 key: msg.key,
                 fastest_index: msg.fastest_index,
                 set,
-            };
+            }
         } else {
             panic!("Unable to perform autotune.");
         }

--- a/crates/cubecl-runtime/tests/dummy/kernel.rs
+++ b/crates/cubecl-runtime/tests/dummy/kernel.rs
@@ -1,11 +1,12 @@
 use cubecl_runtime::storage::BytesResource;
 
 /// The DummyKernel trait should be implemented for every supported operation
-pub trait DummyKernel: Sync + Send + 'static {
+pub trait DummyKernel: Sync + Send + 'static + core::fmt::Debug {
     fn compute(&self, resources: &mut [&BytesResource]);
 }
 
 /// Contains the algorithm for element-wise addition
+#[derive(Debug)]
 pub struct DummyElementwiseAddition;
 
 impl DummyKernel for DummyElementwiseAddition {

--- a/crates/cubecl-runtime/tests/dummy/tune/autotune_operations.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/autotune_operations.rs
@@ -9,7 +9,7 @@ use derive_new::new;
 
 use crate::dummy::{DummyChannel, DummyKernel, DummyServer};
 
-#[derive(new)]
+#[derive(new, Debug)]
 /// Extended kernel that accounts for additional parameters, i.e. needed
 /// information that does not count as an input/output.
 pub struct OneKernelAutotuneOperation {

--- a/crates/cubecl-runtime/tests/dummy/tune/kernels.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/kernels.rs
@@ -6,11 +6,18 @@ use crate::dummy::DummyKernel;
 
 const SLEEP_MS: u64 = 1;
 
+#[derive(Debug)]
 pub struct DummyElementwiseAdditionSlowWrong;
+#[derive(Debug)]
 pub struct DummyElementwiseMultiplication;
+#[derive(Debug)]
 pub struct DummyElementwiseMultiplicationSlowWrong;
+
+#[derive(Debug)]
 pub struct CacheTestFastOn3;
+#[derive(Debug)]
 pub struct CacheTestSlowOn3;
+#[derive(Debug)]
 pub struct ParameteredKernel;
 
 impl DummyKernel for DummyElementwiseAdditionSlowWrong {


### PR DESCRIPTION
This PR fixes two concurrency issues in the tuner implementation:

1. Deadlock potential: When an autotune operation spawns another autotune operation on the same tuner, it could create deadlocks due to recursive locking.

2. Race condition in duration collection: When multiple autotuning tasks run simultaneously on the same server, one task could incorrectly consume duration measurements meant for another task.