### PR TITLE
Fix validate checksum

### DIFF
--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -101,12 +101,11 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             let map = state.get_or_insert_with(Default::default);
 
             if let Some(tuner) = map.get_mut(id) {
-                match tuner.fastest_with_checksum(autotune_operation_set.as_ref()) {
-                    TuneCacheResult::Hit { fastest_index } => {
-                        let op = autotune_operation_set.fastest(fastest_index);
-                        return op.execute();
-                    }
-                    _ => {}
+                if let TuneCacheResult::Hit { fastest_index } =
+                    tuner.fastest_with_checksum(autotune_operation_set.as_ref())
+                {
+                    let op = autotune_operation_set.fastest(fastest_index);
+                    return op.execute();
                 }
             }
         }

--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -108,11 +108,11 @@ impl<K: AutotuneKey> TuneCache<K> {
 
         #[cfg(autotune_persistent_cache)]
         if val.checksum_checked {
-            return TuneCacheResult::Hit {
+            TuneCacheResult::Hit {
                 fastest_index: val.fastest_index,
-            };
+            }
         } else {
-            return TuneCacheResult::Unchecked;
+            TuneCacheResult::Unchecked
         }
 
         #[cfg(not(autotune_persistent_cache))]

--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -13,7 +13,7 @@ use std_imports::*;
 #[cfg(autotune_persistent_cache)]
 use serde::{Deserialize, Serialize};
 
-use super::AutotuneKey;
+use super::{AutotuneKey, AutotuneOperationSet};
 use hashbrown::HashMap;
 
 #[cfg(autotune_persistent_cache)]
@@ -63,6 +63,9 @@ pub enum TuneCacheResult {
     },
     /// No operation is found yet.
     Miss,
+    /// An operation is found, but checksum isn't done.
+    #[cfg(autotune_persistent_cache)]
+    Unchecked,
 }
 
 impl<K: AutotuneKey> TuneCache<K> {
@@ -95,18 +98,60 @@ impl<K: AutotuneKey> TuneCache<K> {
         }
     }
 
-    pub(crate) fn find_fastest(&self, key: &K) -> Option<usize> {
-        let val = self.in_memory_cache.get(key)?;
+    pub(crate) fn fastest(&self, key: &K) -> TuneCacheResult {
+        let val = self.in_memory_cache.get(key);
+
+        let val = match val {
+            Some(val) => val,
+            None => return TuneCacheResult::Miss,
+        };
 
         #[cfg(autotune_persistent_cache)]
         if val.checksum_checked {
-            Some(val.fastest_index)
+            return TuneCacheResult::Hit {
+                fastest_index: val.fastest_index,
+            };
         } else {
-            None
+            return TuneCacheResult::Unchecked;
         }
 
         #[cfg(not(autotune_persistent_cache))]
-        Some(val.fastest_index)
+        TuneCacheResult::Hit {
+            fastest_index: val.fastest_index,
+        }
+    }
+
+    #[cfg(autotune_persistent_cache)]
+    pub(crate) fn fastest_with_checksum<Out>(
+        &mut self,
+        set: &dyn AutotuneOperationSet<K, Out>,
+    ) -> TuneCacheResult {
+        let key = set.key();
+        let result = self.in_memory_cache.get_mut(&key);
+
+        let CacheEntry {
+            #[cfg(autotune_persistent_cache)]
+            checksum_checked,
+            fastest_index,
+        } = match result {
+            Some(val) => val,
+            None => return TuneCacheResult::Miss,
+        };
+
+        if !*checksum_checked {
+            let checksum = set.compute_checksum();
+            let persistent_entry = self
+                .persistent_cache
+                .get(&key)
+                .expect("Both caches should be in sync");
+            if checksum != persistent_entry.checksum {
+                return TuneCacheResult::Miss;
+            }
+            *checksum_checked = true;
+        }
+        TuneCacheResult::Hit {
+            fastest_index: *fastest_index,
+        }
     }
 
     pub(crate) fn cache_insert(&mut self, key: K, fastest_index: usize) {


### PR DESCRIPTION
With the recent deadlock fix, I broke the checksum validation which removed the speedup from the autotune cache.