### PR TITLE
cubecl-hip for linux targets only

### DIFF
--- a/crates/cubecl-hip/Cargo.toml
+++ b/crates/cubecl-hip/Cargo.toml
@@ -25,7 +25,7 @@ cubecl-cpp = { path = "../cubecl-cpp", version = "0.2.0", default-features = fal
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.2.0", default-features = false, features = [
   "channel-mutex",
 ] }
-cubecl-hip-sys = { version = "~0.0", default-features = false, features = ["rocm_622"] }
+cubecl-hip-sys = { version = "0.0.5", default-features = false, features = ["rocm_622"] }
 
 bytemuck = { workspace = true }
 

--- a/crates/cubecl-hip/src/lib.rs
+++ b/crates/cubecl-hip/src/lib.rs
@@ -1,15 +1,20 @@
+#[allow(unused_imports)]
 #[macro_use]
 extern crate derive_new;
 extern crate alloc;
 
-mod compute;
-mod device;
-mod runtime;
-
+#[cfg(target_os = "linux")]
+pub mod compute;
+#[cfg(target_os = "linux")]
+pub mod device;
+#[cfg(target_os = "linux")]
+pub mod runtime;
+#[cfg(target_os = "linux")]
 pub use device::*;
-
+#[cfg(target_os = "linux")]
 pub use runtime::HipRuntime;
 
+#[cfg(target_os = "linux")]
 #[cfg(test)]
 mod tests {
     pub type TestRuntime = crate::HipRuntime;


### PR DESCRIPTION
Declare `cubecl-hip` modules and export them only for Linux targets.