### PR TITLE
Fix visibility of impl fns getting dropped by the cube macro

### DIFF
--- a/crates/cubecl-core/tests/frontend/cube_impl.rs
+++ b/crates/cubecl-core/tests/frontend/cube_impl.rs
@@ -78,3 +78,26 @@ impl<C: Numeric> ComplexType<C, f32> {
         lhs * f32::cast_from(rhs)
     }
 }
+
+mod foo {
+    use super::*;
+
+    #[derive(CubeType)]
+    pub struct TypeInModule {
+        pub a: u32,
+    }
+
+    #[cube]
+    impl TypeInModule {
+        #[allow(dead_code)]
+        pub fn simple_method(&self, lhs: u32) -> u32 {
+            self.a * lhs
+        }
+    }
+}
+
+#[cube]
+fn call_from_outside_module() {
+    let bar = foo::TypeInModule { a: 0u32 };
+    let _ = bar.simple_method(5);
+}

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -11,6 +11,7 @@ use crate::{
 impl KernelFn {
     pub fn to_tokens_mut(&mut self) -> TokenStream {
         let prelude_path = prelude_path();
+        let vis = &self.vis;
         let sig = &self.sig;
         let body = match &self.body {
             KernelBody::Block(block) => &block.to_tokens(&mut self.context),
@@ -18,7 +19,7 @@ impl KernelFn {
         };
 
         let out = quote! {
-            #sig {
+            #vis #sig {
                 use #prelude_path::IntoRuntime as _;
 
                 #body

--- a/crates/cubecl-macros/src/generate/launch.rs
+++ b/crates/cubecl-macros/src/generate/launch.rs
@@ -26,7 +26,7 @@ impl ToTokens for Launch {
                 use super::*;
 
                 #[allow(unused, clippy::all)]
-                pub #func
+                #func
 
                 #kernel
                 #launch

--- a/crates/cubecl-macros/src/parse/cube_impl.rs
+++ b/crates/cubecl-macros/src/parse/cube_impl.rs
@@ -30,7 +30,7 @@ impl CubeImplItem {
     pub fn from_impl_item(struct_ty_name: &Type, item: ImplItem) -> syn::Result<Vec<Self>> {
         let res = match item {
             ImplItem::Fn(func) => {
-                let mut func = KernelFn::from_sig_and_block(func.sig, func.block)?;
+                let mut func = KernelFn::from_sig_and_block(func.vis, func.sig, func.block)?;
                 let func_name_expand = format_ident!("__expand_{}", func.sig.name);
 
                 let is_method = func
@@ -123,6 +123,7 @@ impl CubeImplItem {
         core::mem::swap(&mut func.body, &mut body);
 
         KernelFn {
+            vis: func.vis.clone(),
             sig: method_sig,
             body,
             context: Context::new(func.context.return_type.clone()),
@@ -172,6 +173,7 @@ impl CubeImplItem {
         };
 
         KernelFn {
+            vis: func.vis.clone(),
             sig: func_sig,
             body: KernelBody::Verbatim(body),
             context: Context::new(func.context.return_type.clone()),

--- a/crates/cubecl-macros/src/parse/cube_trait.rs
+++ b/crates/cubecl-macros/src/parse/cube_trait.rs
@@ -64,7 +64,7 @@ impl CubeTraitImplItem {
     pub fn from_impl_item(item: ImplItem) -> syn::Result<Self> {
         let res = match item {
             ImplItem::Fn(func) => {
-                let mut func = KernelFn::from_sig_and_block(func.sig, func.block)?;
+                let mut func = KernelFn::from_sig_and_block(func.vis, func.sig, func.block)?;
                 func.sig.name = format_ident!("__expand_{}", func.sig.name);
                 CubeTraitImplItem::Fn(func)
             }


### PR DESCRIPTION
**Problem** The cube macro wasn't carrying over the visibility of impl fn items in its code generation for the __expand_ version of fns. While this doesn't cause issues for within-module references to those fns, it does cause compilation errors like `"__expand_{fn_name} is private"` if you try to reference those fns from outside the module. See the PR's added test in `crates/cubecl-core/tests/frontend/cube_impl.rs` for an example exercising this behavior.

**Proposed solution** Add `vis` to `KernelFn`, and output tokens for that `vis` during token generation. In most code paths, `vis` is populated with the source `ImplItem`'s visibility. However, in `Launch`'s code path we set `KernelFn` to have pub visibility to match existing behavior.