### PR TITLE
Fix asynchronous autotuning for wasm

### DIFF
--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -93,10 +93,6 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             TuneCacheResult::Hit { fastest_index } => {
                 return autotune_operation_set.fastest(fastest_index).execute();
             }
-            #[cfg(autotune_persistent_cache)]
-            TuneCacheResult::Unchecked => {
-                panic!("Should have checked the cache already.")
-            }
             TuneCacheResult::Miss => {
                 // We don't know the results yet, start autotuning.
                 //
@@ -120,6 +116,10 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             TuneCacheResult::Pending => {
                 // We're waiting for results to come in.
             }
+            #[cfg(autotune_persistent_cache)]
+            TuneCacheResult::Unchecked => {
+                panic!("Should have checked the cache already.")
+            }
         };
 
         let fastest = {
@@ -133,7 +133,6 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             match tuner.fastest(&key) {
                 TuneCacheResult::Hit { fastest_index } => {
                     // Theres a known good value - just run it.
-                    //
                     fastest_index
                 }
                 TuneCacheResult::Pending => {

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -93,6 +93,7 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             TuneCacheResult::Hit { fastest_index } => {
                 return autotune_operation_set.fastest(fastest_index).execute();
             }
+            #[cfg(autotune_persistent_cache)]
             TuneCacheResult::Unchecked => {
                 panic!("Should have checked the cache already.")
             }
@@ -142,6 +143,7 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
                 TuneCacheResult::Miss => {
                     panic!("Should have at least started autotuning");
                 }
+                #[cfg(autotune_persistent_cache)]
                 TuneCacheResult::Unchecked => {
                     panic!("Should have checked the cache.")
                 }

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -54,102 +54,100 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
         S: ComputeServer + 'static,
         C: ComputeChannel<S> + 'static,
     {
-        // We avoid locking in write mode when possible.
-        //
-        // This makes us potentially check the cache twice, but allows to avoid
-        // locking the state if the cache is hit.
-        let mut should_init = true;
-        #[cfg(autotune_persistent_cache)]
-        let mut should_perform_checksum = false;
+        let key = autotune_operation_set.key();
 
-        if let Some(state) = self.state.read().as_ref() {
-            if let Some(tuner) = state.get(id) {
-                // Tuner exists for the given ID.
-                should_init = false;
-
-                let key = autotune_operation_set.key();
-                match tuner.fastest(&key) {
-                    TuneCacheResult::Hit { fastest_index } => {
-                        let op = autotune_operation_set.fastest(fastest_index);
-                        return op.execute();
-                    }
-                    TuneCacheResult::Miss => {}
-                    #[cfg(autotune_persistent_cache)]
-                    TuneCacheResult::Unchecked => {
-                        should_perform_checksum = true;
-                    }
-                }
-            }
-        }
-
-        // If we are not able to get a tuner for the given ID, we have to create one.
-        if should_init {
-            let mut state = self.state.write();
-            let map = state.get_or_insert_with(Default::default);
-
-            if !map.contains_key(id) {
-                let name = self.name.replace("::", "-");
-                let tuner = Tuner::new(&name, &id.to_string());
-                map.insert(id.clone(), tuner);
-            };
-        }
-
-        // When loading the first time the result of an autotune set, we need to verify the checksum.
-        #[cfg(autotune_persistent_cache)]
-        if should_perform_checksum {
-            let mut state = self.state.write();
-            let map = state.get_or_insert_with(Default::default);
-
-            if let Some(tuner) = map.get_mut(id) {
-                if let TuneCacheResult::Hit { fastest_index } =
-                    tuner.fastest_with_checksum(autotune_operation_set.as_ref())
-                {
+        // If this is cached and ready, use the operation.
+        if let Some(map) = self.state.read().as_ref() {
+            if let Some(tuner) = map.get(id) {
+                if let TuneCacheResult::Hit { fastest_index } = tuner.fastest(&key) {
                     let op = autotune_operation_set.fastest(fastest_index);
                     return op.execute();
                 }
             }
         }
 
-        // Running benchmarks shound't lock the tuner, since an autotune operation can recursively use the
-        // same tuner.
-        //
-        // # Example
-        //
-        // ```
-        // - tune_1 start
-        //   - tune_2 start
-        //   - tune_2 save
-        // - tune_1 save
-        // ```
-        let mut result = None;
-        if let Some(state) = self.state.read().as_ref() {
-            if let Some(tuner) = state.get(id) {
-                result = Some(tuner.execute_autotune(autotune_operation_set, client));
-            }
-        }
-
-        // We store the autotune result if present.
-        if let Some(result) = result {
+        // Create the tuner if needed, and update some state like
+        // checksums if need be.
+        let fastest = {
             let mut state = self.state.write();
             let map = state.get_or_insert_with(Default::default);
+            let tuner = map.entry(id.clone()).or_insert_with(move || {
+                let name = self.name.replace("::", "-");
+                Tuner::new(&name, &id.to_string())
+            });
 
-            if let Some(tuner) = map.get_mut(id) {
-                return tuner.register_autotune(result);
+            #[allow(unused_mut)]
+            let mut fastest = tuner.fastest(&key);
+
+            // If the cache checksum hasn't been checked, do so now, and retry.
+            #[cfg(autotune_persistent_cache)]
+            if matches!(fastest, TuneCacheResult::Unchecked) {
+                let checksum = autotune_operation_set.compute_checksum();
+                tuner.validate_checksum(&key, &checksum);
+                fastest = tuner.fastest(&key);
             }
-        }
+            fastest
+        };
 
-        // The Result and Tuner for this ID must exist at this point since we validated them earlier.
-        unreachable!();
-    }
-
-    /// Return the autotune result given a key.
-    pub fn autotune_result(&self, id: &ID, key: &AK) -> TuneCacheResult {
-        if let Some(state) = self.state.read().as_ref() {
-            if let Some(tuner) = state.get(id) {
-                return tuner.fastest(key);
+        match fastest {
+            TuneCacheResult::Hit { fastest_index } => {
+                return autotune_operation_set.fastest(fastest_index).execute();
             }
-        }
+            TuneCacheResult::Unchecked => {
+                panic!("Should have checked the cache already.")
+            }
+            TuneCacheResult::Miss => {
+                // We don't know the results yet, start autotuning.
+                //
+                // Running benchmarks shound't lock the tuner, since an autotune operation can recursively use the
+                // same tuner.
+                //
+                // # Example
+                //
+                // ```
+                // - tune_1 start
+                //   - tune_2 start
+                //   - tune_2 save
+                // - tune_1 save
+                // ```
+                let state = self.state.read();
+                let state = state.as_ref().expect("Should be initialzied");
+                let tuner = state.get(id).expect("Should be initialized");
 
-        TuneCacheResult::Miss
+                tuner.execute_autotune(autotune_operation_set.as_ref(), client);
+            }
+            TuneCacheResult::Pending => {
+                // We're waiting for results to come in.
+            }
+        };
+
+        let fastest = {
+            let mut state = self.state.write();
+            let state = state.as_mut().expect("Should be initialzied");
+            let tuner = state.get_mut(id).expect("Should be initialized");
+            // Now read all results that have come in since.
+            tuner.resolve();
+
+            // Check again what the fastest option is, new results might have come in.
+            match tuner.fastest(&key) {
+                TuneCacheResult::Hit { fastest_index } => {
+                    // Theres a known good value - just run it.
+                    //
+                    fastest_index
+                }
+                TuneCacheResult::Pending => {
+                    // If we still don't know, just execute a default index.
+                    0
+                }
+                TuneCacheResult::Miss => {
+                    panic!("Should have at least started autotuning");
+                }
+                TuneCacheResult::Unchecked => {
+                    panic!("Should have checked the cache.")
+                }
+            }
+        };
+
+        autotune_operation_set.fastest(fastest).execute()
     }
 }

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -31,15 +31,9 @@ pub trait AutotuneOperationSet<K: Send + 'static, Output: Send + 'static = ()>: 
     fn fastest(self: Box<Self>, fastest_index: usize) -> Box<dyn AutotuneOperation<Output>>;
 
     /// Compute a checksum that can invalidate outdated cached auto-tune results.
+    #[cfg(autotune_persistent_cache)]
     fn compute_checksum(&self) -> String {
-        #[cfg(autotune_persistent_cache)]
-        {
-            compute_checksum(&self.autotunables())
-        }
-        #[cfg(not(autotune_persistent_cache))]
-        {
-            "".to_owned()
-        }
+        compute_checksum(&self.autotunables())
     }
 
     /// Enable or disable certain indices from being benchmarked based on the key

--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -13,7 +13,7 @@ use std_imports::*;
 #[cfg(autotune_persistent_cache)]
 use serde::{Deserialize, Serialize};
 
-use super::{AutotuneKey, AutotuneOperationSet};
+use super::AutotuneKey;
 use hashbrown::HashMap;
 
 #[cfg(autotune_persistent_cache)]
@@ -28,10 +28,12 @@ pub fn get_persistent_cache_file_path(prefix: &str) -> PathBuf {
 
 /// In-memory cache entry
 #[derive(Debug)]
-pub(crate) struct CacheEntry {
-    #[cfg(autotune_persistent_cache)]
-    checksum_checked: bool,
-    fastest_index: usize,
+pub(crate) enum CacheEntry {
+    Done {
+        checksum_matches: Option<bool>,
+        fastest_index: usize,
+    },
+    Pending,
 }
 
 /// Persistent cache entry
@@ -61,11 +63,12 @@ pub enum TuneCacheResult {
         /// The index of the fastest operation to execute.
         fastest_index: usize,
     },
+    /// The operation might be cached, but we don't know yet whether the checksum is valid.
+    Unchecked,
+    /// We don't know yet what is fastest, but are waiting for a result to come in.
+    Pending,
     /// No operation is found yet.
     Miss,
-    /// An operation is found, but checksum isn't done.
-    #[cfg(autotune_persistent_cache)]
-    Unchecked,
 }
 
 impl<K: AutotuneKey> TuneCache<K> {
@@ -98,68 +101,67 @@ impl<K: AutotuneKey> TuneCache<K> {
         }
     }
 
-    pub(crate) fn fastest(&self, key: &K) -> TuneCacheResult {
-        let val = self.in_memory_cache.get(key);
+    pub fn fastest(&self, key: &K) -> TuneCacheResult {
+        let result = self.in_memory_cache.get(key);
 
-        let val = match val {
-            Some(val) => val,
-            None => return TuneCacheResult::Miss,
+        let Some(val) = result else {
+            return TuneCacheResult::Miss;
         };
 
-        #[cfg(autotune_persistent_cache)]
-        if val.checksum_checked {
-            TuneCacheResult::Hit {
-                fastest_index: val.fastest_index,
+        match val {
+            CacheEntry::Done {
+                checksum_matches,
+                fastest_index,
+            } => {
+                if cfg!(autotune_persistent_cache) {
+                    match checksum_matches {
+                        None | Some(false) => TuneCacheResult::Miss, // Don't know yet - can't use this.
+                        Some(true) => TuneCacheResult::Hit {
+                            fastest_index: *fastest_index,
+                        },
+                    }
+                } else {
+                    let _ = checksum_matches;
+                    TuneCacheResult::Hit {
+                        fastest_index: *fastest_index,
+                    }
+                }
             }
-        } else {
-            TuneCacheResult::Unchecked
-        }
-
-        #[cfg(not(autotune_persistent_cache))]
-        TuneCacheResult::Hit {
-            fastest_index: val.fastest_index,
+            CacheEntry::Pending {} => TuneCacheResult::Pending,
         }
     }
 
     #[cfg(autotune_persistent_cache)]
-    pub(crate) fn fastest_with_checksum<Out>(
-        &mut self,
-        set: &dyn AutotuneOperationSet<K, Out>,
-    ) -> TuneCacheResult {
-        let key = set.key();
-        let result = self.in_memory_cache.get_mut(&key);
-
-        let CacheEntry {
-            #[cfg(autotune_persistent_cache)]
-            checksum_checked,
-            fastest_index,
-        } = match result {
-            Some(val) => val,
-            None => return TuneCacheResult::Miss,
+    pub fn validate_checksum(&mut self, key: &K, checksum: &str) {
+        let result = self.in_memory_cache.get_mut(key);
+        let Some(val) = result else {
+            return;
         };
 
-        if !*checksum_checked {
-            let checksum = set.compute_checksum();
-            let persistent_entry = self
-                .persistent_cache
-                .get(&key)
-                .expect("Both caches should be in sync");
-            if checksum != persistent_entry.checksum {
-                return TuneCacheResult::Miss;
+        if let CacheEntry::Done {
+            checksum_matches, ..
+        } = val
+        {
+            if checksum_matches.is_none() {
+                let persistent_entry = self
+                    .persistent_cache
+                    .get(key)
+                    .expect("Both caches should be in sync");
+
+                *checksum_matches = Some(checksum == persistent_entry.checksum);
             }
-            *checksum_checked = true;
         }
-        TuneCacheResult::Hit {
-            fastest_index: *fastest_index,
-        }
+    }
+
+    pub(crate) fn mark_pending(&mut self, key: K) {
+        self.in_memory_cache.insert(key, CacheEntry::Pending);
     }
 
     pub(crate) fn cache_insert(&mut self, key: K, fastest_index: usize) {
         self.in_memory_cache.insert(
             key,
-            CacheEntry {
-                #[cfg(autotune_persistent_cache)]
-                checksum_checked: true,
+            CacheEntry::Done {
+                checksum_matches: Some(true),
                 fastest_index,
             },
         );
@@ -209,8 +211,8 @@ impl<K: AutotuneKey> TuneCache<K> {
         for (key, entry) in self.persistent_cache.iter() {
             self.in_memory_cache.insert(
                 key.clone(),
-                CacheEntry {
-                    checksum_checked: false,
+                CacheEntry::Done {
+                    checksum_matches: None,
                     fastest_index: entry.fastest_index,
                 },
             );

--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -64,6 +64,7 @@ pub enum TuneCacheResult {
         fastest_index: usize,
     },
     /// The operation might be cached, but we don't know yet whether the checksum is valid.
+    #[cfg(autotune_persistent_cache)]
     Unchecked,
     /// We don't know yet what is fastest, but are waiting for a result to come in.
     Pending,

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -1,56 +1,58 @@
-use async_channel::Sender;
+use async_channel::{Receiver, Sender};
 use cubecl_common::future;
 
 use core::future::Future;
-use core::{any::Any, mem::ManuallyDrop};
+use core::mem::ManuallyDrop;
 use cubecl_common::stub::Duration;
 
 #[cfg(all(not(target_family = "wasm"), feature = "std"))]
 use std::panic::resume_unwind;
 
-use alloc::boxed::Box;
 use alloc::string::ToString;
 use alloc::vec::Vec;
-use cubecl_common::benchmark::{BenchmarkComputations, BenchmarkDurations};
+use cubecl_common::benchmark::BenchmarkComputations;
 
 use crate::channel::ComputeChannel;
 use crate::client::ComputeClient;
 use crate::server::ComputeServer;
-use crate::tune::{AutotuneOperation, AutotuneOperationSet, TuneBenchmark, TuneCache};
+use crate::tune::{AutotuneOperationSet, TuneBenchmark, TuneCache};
 
 use super::{AutotuneKey, TuneCacheResult};
-
-/// An error that occurred during benchmarking. If other benches succeeded, ignore this bench and
-/// continue gracefully. If all benches fail, panic.
-/// This error cannot be acted on in any way, because it's an opaque unwind object, and must be
-/// `ManuallyDrop` because dropping it can cause unwinding to proceed. It can only
-/// be passed to `resume_unwind` to continue the panic.
-type BenchError = ManuallyDrop<Box<dyn Any + Send>>;
 
 #[derive(Debug)]
 /// Executes autotune benchmarking and caching
 pub struct Tuner<K: AutotuneKey> {
     tune_cache: TuneCache<K>,
-}
-
-struct AutotuneMessage<K> {
-    key: K,
-    fastest_index: usize,
+    channel: (Sender<AutotuneMessage<K>>, Receiver<AutotuneMessage<K>>),
 }
 
 /// Result from running benchmarks.
-pub struct AutotuneResult<K, Out> {
-    key: K,
-    fastest_index: usize,
-    set: Box<dyn AutotuneOperationSet<K, Out>>,
+enum AutotuneMessage<K> {
+    Done {
+        key: K,
+        fastest_index: usize,
+        checksum: String,
+    },
+    Starting {
+        key: K,
+    },
+}
+
+/// Error from running autotune.
+pub enum AutotuneError {
+    /// An unknown error happended.
+    Unknown(String),
 }
 
 #[allow(clippy::new_without_default)]
 impl<K: AutotuneKey> Tuner<K> {
     /// Returns a tuner with cache initialized from persistent cache
     pub fn new(name: &str, device_id: &str) -> Self {
+        let channel = async_channel::unbounded();
+
         Self {
             tune_cache: TuneCache::new(name, device_id),
+            channel,
         }
     }
 
@@ -59,64 +61,44 @@ impl<K: AutotuneKey> Tuner<K> {
         self.tune_cache.fastest(key)
     }
 
-    /// Registers the [results](AutotuneResult) from [execute_autotune()](Self::execute_autotune).
-    pub fn register_autotune<Out: Send>(&mut self, result: AutotuneResult<K, Out>) -> Out {
-        self.tune_cache
-            .cache_insert(result.key.clone(), result.fastest_index);
-
-        #[cfg(autotune_persistent_cache)]
-        {
-            let checksum = result.set.compute_checksum();
-            self.tune_cache
-                .persistent_cache_insert(result.key, checksum, result.fastest_index);
-            self.tune_cache.save();
-        }
-        let op = result.set.fastest(result.fastest_index);
-
-        AutotuneOperation::execute(op)
-    }
-
-    #[cfg(autotune_persistent_cache)]
     /// Fetch the fastest autotune operation index for an autotune key and validate the checksum.
-    pub fn fastest_with_checksum<Out: Send>(
-        &mut self,
-        set: &dyn AutotuneOperationSet<K, Out>,
-    ) -> TuneCacheResult {
-        self.tune_cache.fastest_with_checksum(set)
+    #[cfg(autotune_persistent_cache)]
+    pub fn validate_checksum(&mut self, key: &K, checksum: &str) {
+        self.tune_cache.validate_checksum(key, checksum)
     }
 
-    /// Execute the fastest autotune operation if known, otherwise perform some benchmarks before.
-    pub fn execute_autotune<S, C, Out: Send + 'static>(
-        &self,
-        set: Box<dyn AutotuneOperationSet<K, Out>>,
-        client: &ComputeClient<S, C>,
-    ) -> AutotuneResult<K, Out>
-    where
-        S: ComputeServer + 'static,
-        C: ComputeChannel<S> + 'static,
-    {
-        let (send, rec) = async_channel::bounded(1);
+    /// Wait for async results to come in.
+    pub fn resolve(&mut self) {
+        while let Ok(msg) = self.channel.1.try_recv() {
+            match msg {
+                AutotuneMessage::Done {
+                    key,
+                    fastest_index,
+                    checksum,
+                } => {
+                    self.tune_cache.cache_insert(key.clone(), fastest_index);
 
-        self.start_autotuning(send, set.as_ref(), client);
-
-        if let Ok(msg) = rec.try_recv() {
-            AutotuneResult {
-                key: msg.key,
-                fastest_index: msg.fastest_index,
-                set,
+                    #[cfg(autotune_persistent_cache)]
+                    {
+                        self.tune_cache
+                            .persistent_cache_insert(key, checksum, fastest_index);
+                        self.tune_cache.save();
+                    }
+                }
+                AutotuneMessage::Starting { key } => {
+                    self.tune_cache.mark_pending(key);
+                }
             }
-        } else {
-            panic!("Unable to perform autotune.");
         }
     }
 
-    fn start_autotuning<
+    /// Execute benchmarks to find out what the fastest operation is.
+    pub fn execute_autotune<
         S: ComputeServer + 'static,
         C: ComputeChannel<S> + 'static,
         Out: Send + 'static,
     >(
         &self,
-        sender: Sender<AutotuneMessage<K>>,
         set: &dyn AutotuneOperationSet<K, Out>,
         client: &ComputeClient<S, C>,
     ) {
@@ -130,17 +112,24 @@ impl<K: AutotuneKey> Tuner<K> {
             .filter(|(index, _)| set.should_run(&key, *index))
             .collect();
 
+        let client = client.clone();
+        let sender = self.channel.0.clone();
+        let checksum = set.compute_checksum();
+
         if autotunables.len() == 1 {
             sender
-                .try_send(AutotuneMessage {
+                .try_send(AutotuneMessage::Done {
                     key,
                     fastest_index: autotunables[0].0,
+                    checksum,
                 })
                 .expect("Autotune results channel closed");
             return;
         }
 
-        let client = client.clone();
+        sender
+            .try_send(AutotuneMessage::Starting { key: key.clone() })
+            .expect("Autotune results channel closed");
 
         spawn_benchmark_task(async move {
             #[derive(new, Debug)]
@@ -154,7 +143,18 @@ impl<K: AutotuneKey> Tuner<K> {
 
             for (index, op) in autotunables.into_iter() {
                 let name = op.name().to_string();
-                let result = Self::run_benchmark(op, &client).await.map(|durations| {
+                let tuner = TuneBenchmark::new(op, client.clone());
+
+                let sample_fut = tuner.sample_durations();
+                let sample_fut = future::catch_unwind(sample_fut);
+                let result = sample_fut.await;
+
+                let result = result.map_err(|e| {
+                    log::warn!("Caught error while benchmarking, falling back to next operation.");
+                    ManuallyDrop::new(e)
+                });
+
+                let result = result.map(|durations| {
                     log::info!("Name: {name} => {}", durations);
                     BenchResult::new(name, index, BenchmarkComputations::new(&durations))
                 });
@@ -162,7 +162,7 @@ impl<K: AutotuneKey> Tuner<K> {
                 bench_results.push(result);
             }
 
-            // Panic if all tuners panicked.
+            // // Panic if all tuners panicked.
             #[cfg(all(feature = "std", not(target_family = "wasm")))]
             if bench_results.iter().all(|result| result.is_err()) {
                 let first_error = bench_results.into_iter().next().unwrap().err().unwrap();
@@ -207,37 +207,29 @@ impl<K: AutotuneKey> Tuner<K> {
             };
 
             sender
-                .try_send(AutotuneMessage { key, fastest_index })
+                .send(AutotuneMessage::Done {
+                    key,
+                    fastest_index,
+                    checksum,
+                })
+                .await
                 .expect("Autotune results channel closed");
         });
     }
-
-    async fn run_benchmark<S: ComputeServer, C: ComputeChannel<S>, Out>(
-        operation: Box<dyn AutotuneOperation<Out>>,
-        client: &ComputeClient<S, C>,
-    ) -> Result<BenchmarkDurations, BenchError> {
-        let tuner = TuneBenchmark::new(operation, client.clone());
-        future::catch_unwind(tuner.sample_durations())
-            .await
-            .map_err(|e| {
-                log::warn!("Caught error while benchmarking, falling back to next operation.");
-                ManuallyDrop::new(e)
-            })
-    }
 }
 
-fn spawn_benchmark_task(future: impl Future<Output = ()> + 'static) {
-    // Spawn the tuning as a task.
+fn spawn_benchmark_task(future: impl Future<Output = ()> + Send + 'static) {
+    // On wasm, spawn the tunin as a detached task.
     #[cfg(target_family = "wasm")]
-    {
-        wasm_bindgen_futures::spawn_local(future);
-    }
+    wasm_bindgen_futures::spawn_local(future);
 
-    // It is totally possible here to run the tuning on a thread, which woulp startup time,
+    // On native, it is possible to run the tuning on a thread, which could help startup times,
     // but might have two downsides:
-    // - Benchmarks now need a "warmup" time until a good kernel is selected.
-    // - Tuning might be less precise, as it's possible that other operations are
+    // - Benchmarks would need a "warmup" time until a good kernel is selected.
+    // - Tuning could be less precise, as it's possible that other operations are
     //   submitted while tuning, which might skew results.
+    //
+    // So, for now, just block on the future.
     #[cfg(not(target_family = "wasm"))]
     future::block_on(future);
 }

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -225,7 +225,7 @@ impl<K: AutotuneKey> Tuner<K> {
 }
 
 fn spawn_benchmark_task(future: impl Future<Output = ()> + Send + 'static) {
-    // On wasm, spawn the tunin as a detached task.
+    // On wasm, spawn the tuning as a detached task.
     #[cfg(target_family = "wasm")]
     wasm_bindgen_futures::spawn_local(future);
 


### PR DESCRIPTION
Fix tuning on wasm. This uses a slightly different approach from https://github.com/tracel-ai/cubecl/pull/203. In principle all autotuning is asynchronous, it just happens that native blocks on completion to make sure the message is sent. In the future, if needed (for eg. startup times), the tuning can happen on a thread (the Future is now Send as well).

This required some futzing with mutability, including with how checksums are handled. There is now a validate_checksum which writes the checksum state, instead of fastest having mut access or having a fastest_with_checksum. The checksum is now an Option<bool> to also store that we checked but failed.

The locking for the local tuner is still done carefully which I think prevents all the deadlocks, but, I haven't worked on that much so please do double check it!

> read only, check fast cache
> Write, create values if needed, validate checksums
> Read only, run autotune if needed
> Write, listen for messages of new results (which may or may not arrive immediately from step 3)

Tested on native & Wasm