### PR TITLE
Fix device creation for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ paste = "1.0.15"
 proc-macro2 = "1.0.86"
 quote = "1.0.36"
 syn = { version = "2", features = ["full", "extra-traits", "visit-mut"] }
+cfg-if = "1.0.0"
 
 ### For xtask crate ###
 strum = { version = "0.26.3", features = ["derive"] }

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -43,6 +43,8 @@ hashbrown = { workspace = true }
 log = { workspace = true }
 web-time = { workspace = true }
 
+cfg-if = { workspace = true }
+
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.4.0", features = [
     "export_tests",

--- a/crates/cubecl-wgpu/src/graphics.rs
+++ b/crates/cubecl-wgpu/src/graphics.rs
@@ -88,9 +88,14 @@ impl GraphicsApi for AutoGraphicsApi {
         }
 
         // In a no_std environment or if the environment variable is not set
-        #[cfg(target_os = "macos")]
-        return wgpu::Backend::Metal;
-        #[cfg(not(target_os = "macos"))]
-        return wgpu::Backend::Vulkan;
+        cfg_if::cfg_if! {
+            if #[cfg(target_family = "wasm")] {
+                wgpu::Backend::BrowserWebGpu
+            } else if #[cfg(target_os = "macos")] {
+                 wgpu::Backend::Metal
+            } else {
+                wgpu::Backend::Vulkan
+            }
+        }
     }
 }


### PR DESCRIPTION
I had renamed select_adapter to request_adapter, but forgot to update the wasm version.

To prevent this in the future, I've merged the two functions and conditionally compile in the inner function.

My bad, though it'd be good if CI could do a build for wasm32-unknown-unknown to catch these things!