### PR TITLE
Add subcube and mma support for HIP compiler

### DIFF
--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -28,14 +28,14 @@ impl Display for TimingMethod {
     }
 }
 
-/// Error that can occured when collecting timestamps from a device.
+/// Error that can occurred when collecting timestamps from a device.
 #[derive(Debug)]
 pub enum TimestampsError {
     /// Collecting timestamps is disabled, make sure to enable it.
     Disabled,
     /// Collecting timestamps isn't available.
     Unavailable,
-    /// En unknown error occured while collecting timestamps.
+    /// An unknown error occurred while collecting timestamps.
     Unknown(String),
 }
 
@@ -245,7 +245,7 @@ pub trait Benchmark {
                 }
                 TimestampsError::Unavailable => start.elapsed(),
                 TimestampsError::Unknown(err) => {
-                    panic!("An unknown error occured while collecting the timestamps when benchmarking: {err}");
+                    panic!("An unknown error occurred while collecting the timestamps when benchmarking: {err}");
                 }
             },
         }

--- a/crates/cubecl-core/src/runtime.rs
+++ b/crates/cubecl-core/src/runtime.rs
@@ -47,5 +47,6 @@ pub enum Feature {
         k: u8,
         n: u8,
     },
+    CmmaWarpSize(i32),
     Type(Elem),
 }

--- a/crates/cubecl-core/src/runtime_tests/cmma.rs
+++ b/crates/cubecl-core/src/runtime_tests/cmma.rs
@@ -101,6 +101,8 @@ pub fn test_simple_1<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
         kernel_simple_1::launch::<R>(
             &client,
             CubeCount::Static(1, 1, 1),
+            // For HIP, change dim to:
+            // CubeDim::new(32, 1, 1),
             CubeDim::new(16, 16, 1),
             ArrayArg::from_raw_parts(&lhs, 256, 1),
             ArrayArg::from_raw_parts(&rhs, 256, 1),

--- a/crates/cubecl-cpp/src/cuda/mod.rs
+++ b/crates/cubecl-cpp/src/cuda/mod.rs
@@ -1,6 +1,6 @@
 use crate::shared::{Dialect, Variable};
 
-const MMA_NAMESPACE: &str =  "nvcuda::wmma";
+const MMA_NAMESPACE: &str = "nvcuda::wmma";
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Cuda;
@@ -43,6 +43,6 @@ impl Dialect for Cuda {
     }
 
     fn mma_namespace() -> &'static str {
-        MMA_NAMESPACE 
+        MMA_NAMESPACE
     }
 }

--- a/crates/cubecl-cpp/src/cuda/mod.rs
+++ b/crates/cubecl-cpp/src/cuda/mod.rs
@@ -1,5 +1,7 @@
 use crate::shared::{Dialect, Variable};
 
+const MMA_NAMESPACE: &str =  "nvcuda::wmma";
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Cuda;
 
@@ -38,5 +40,9 @@ impl Dialect for Cuda {
     }
     fn warp_any(out: &Variable<Self>) -> String {
         format!("__any_sync(-1, {out})")
+    }
+
+    fn mma_namespace() -> &'static str {
+        MMA_NAMESPACE 
     }
 }

--- a/crates/cubecl-cpp/src/cuda/mod.rs
+++ b/crates/cubecl-cpp/src/cuda/mod.rs
@@ -1,4 +1,4 @@
-use crate::shared::Dialect;
+use crate::shared::{Dialect, Variable};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Cuda;
@@ -16,10 +16,27 @@ impl Dialect for Cuda {
     fn include_runtime(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("#include <cuda_runtime.h>\n")
     }
+
     fn bfloat16_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("__nv_bfloat16")
     }
     fn bfloat162_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("__nv_bfloat162")
+    }
+
+    fn warp_shuffle(input: &Variable<Self>, id: &Variable<Self>) -> String {
+        format!("__shfl_sync(-1, {input}, {id})")
+    }
+    fn warp_shuffle_xor(out: &Variable<Self>) -> String {
+        format!("__shfl_xor_sync(-1, {out}, offset)")
+    }
+    fn warp_shuffle_down(out: &Variable<Self>) -> String {
+        format!("__shfl_down_sync(-1, {out}, offset)")
+    }
+    fn warp_all(out: &Variable<Self>) -> String {
+        format!("__all_sync(-1, {out})")
+    }
+    fn warp_any(out: &Variable<Self>) -> String {
+        format!("__any_sync(-1, {out})")
     }
 }

--- a/crates/cubecl-cpp/src/hip/mod.rs
+++ b/crates/cubecl-cpp/src/hip/mod.rs
@@ -1,5 +1,7 @@
 use crate::shared::{Dialect, Variable};
 
+const MMA_NAMESPACE: &str =  "rocwmma";
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Hip;
 
@@ -12,7 +14,7 @@ impl Dialect for Hip {
         f.write_str("#include <hip/hip_bfloat16.h>\n")
     }
     fn include_wmma(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("#include <mma.h>\n")
+        f.write_str("#include <rocwmma/rocwmma.hpp>\n")
     }
     fn include_runtime(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("#include <hip/hip_runtime.h>\n")
@@ -40,5 +42,9 @@ impl Dialect for Hip {
     }
     fn warp_any(out: &Variable<Self>) -> String {
         format!("__any({out})")
+    }
+
+    fn mma_namespace() -> &'static str {
+        MMA_NAMESPACE
     }
 }

--- a/crates/cubecl-cpp/src/hip/mod.rs
+++ b/crates/cubecl-cpp/src/hip/mod.rs
@@ -10,7 +10,7 @@ impl Dialect for Hip {
         f.write_str("#include <hip/hip_fp16.h>\n")
     }
     fn include_bf16(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // "hip_bf16.h" triggers redifinition errors during compilation
+        // "hip_bf16.h" triggers redefinition errors during compilation
         f.write_str("#include <hip/hip_bfloat16.h>\n")
     }
     fn include_wmma(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/cubecl-cpp/src/hip/mod.rs
+++ b/crates/cubecl-cpp/src/hip/mod.rs
@@ -1,4 +1,4 @@
-use crate::shared::Dialect;
+use crate::shared::{Dialect, Variable};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Hip;
@@ -17,11 +17,28 @@ impl Dialect for Hip {
     fn include_runtime(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("#include <hip/hip_runtime.h>\n")
     }
+
     fn bfloat16_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("hip_bfloat16")
     }
     fn bfloat162_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // "hip_bfloat16.h" has no "hip_bfloat162" type
         f.write_str("hip_bfloat16")
+    }
+
+    fn warp_shuffle(input: &Variable<Self>, id: &Variable<Self>) -> String {
+        format!("__shfl({input}, {id})")
+    }
+    fn warp_shuffle_xor(out: &Variable<Self>) -> String {
+        format!("__shfl_xor({out}, offset)")
+    }
+    fn warp_shuffle_down(out: &Variable<Self>) -> String {
+        format!("__shfl_down({out}, offset)")
+    }
+    fn warp_all(out: &Variable<Self>) -> String {
+        format!("__all({out})")
+    }
+    fn warp_any(out: &Variable<Self>) -> String {
+        format!("__any({out})")
     }
 }

--- a/crates/cubecl-cpp/src/hip/mod.rs
+++ b/crates/cubecl-cpp/src/hip/mod.rs
@@ -1,6 +1,6 @@
 use crate::shared::{Dialect, Variable};
 
-const MMA_NAMESPACE: &str =  "rocwmma";
+const MMA_NAMESPACE: &str = "rocwmma";
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Hip;

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -12,7 +12,9 @@ use cubecl_core::{
 };
 use cubecl_runtime::{DeviceProperties, ExecutionMode};
 
-use super::{Instruction, UnaryInstruction, Variable as CppVariable, VariableSettings, WarpInstruction};
+use super::{
+    Instruction, UnaryInstruction, Variable as CppVariable, VariableSettings, WarpInstruction,
+};
 
 pub(super) static COUNTER_TMP_VAR: std::sync::atomic::AtomicU32 =
     std::sync::atomic::AtomicU32::new(0);

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -32,6 +32,8 @@ pub trait Dialect: Default + Clone + Copy + Debug + Send + Sync + Eq + Hash + 's
     fn warp_shuffle_down(out: &CppVariable<Self>) -> String;
     fn warp_all(out: &CppVariable<Self>) -> String;
     fn warp_any(out: &CppVariable<Self>) -> String;
+    // Matrix-Multiple Accumulate
+    fn mma_namespace() -> &'static str;
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -818,7 +820,7 @@ impl<D: Dialect> CppCompiler<D> {
         }
     }
 
-    fn compile_matrix_ident(&mut self, ident: gpu::MatrixIdent) -> super::FragmentIdent {
+    fn compile_matrix_ident(&mut self, ident: gpu::MatrixIdent) -> super::FragmentIdent<D> {
         match ident {
             gpu::MatrixIdent::A => super::FragmentIdent::A,
             gpu::MatrixIdent::B => super::FragmentIdent::B,
@@ -829,7 +831,7 @@ impl<D: Dialect> CppCompiler<D> {
     fn compile_matrix_layout(
         &mut self,
         layout: gpu::MatrixLayout,
-    ) -> Option<super::FragmentLayout> {
+    ) -> Option<super::FragmentLayout<D>> {
         match layout {
             gpu::MatrixLayout::ColMajor => Some(super::FragmentLayout::ColMajor),
             gpu::MatrixLayout::RowMajor => Some(super::FragmentLayout::RowMajor),

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -12,18 +12,26 @@ use cubecl_core::{
 };
 use cubecl_runtime::{DeviceProperties, ExecutionMode};
 
-use super::{Instruction, UnaryInstruction, VariableSettings, WarpInstruction};
+use super::{Instruction, UnaryInstruction, Variable as CppVariable, VariableSettings, WarpInstruction};
 
 pub(super) static COUNTER_TMP_VAR: std::sync::atomic::AtomicU32 =
     std::sync::atomic::AtomicU32::new(0);
 
 pub trait Dialect: Default + Clone + Copy + Debug + Send + Sync + Eq + Hash + 'static {
+    // includes
     fn include_f16(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     fn include_bf16(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     fn include_wmma(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     fn include_runtime(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
+    // types
     fn bfloat16_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     fn bfloat162_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
+    // warp instructions (all threads participating)
+    fn warp_shuffle(input: &CppVariable<Self>, id: &CppVariable<Self>) -> String;
+    fn warp_shuffle_xor(out: &CppVariable<Self>) -> String;
+    fn warp_shuffle_down(out: &CppVariable<Self>) -> String;
+    fn warp_all(out: &CppVariable<Self>) -> String;
+    fn warp_any(out: &CppVariable<Self>) -> String;
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cubecl-cpp/src/shared/mma.rs
+++ b/crates/cubecl-cpp/src/shared/mma.rs
@@ -3,26 +3,28 @@ use std::fmt::Display;
 use super::{Component, Dialect, Elem, Variable};
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
-pub enum FragmentIdent {
+pub enum FragmentIdent<D: Dialect> {
     A,
     B,
     Accumulator,
+    _Dialect(std::marker::PhantomData<D>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
-pub enum FragmentLayout {
+pub enum FragmentLayout<D: Dialect> {
     ColMajor,
     RowMajor,
+    _Dialect(std::marker::PhantomData<D>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Fragment<D: Dialect> {
-    pub ident: FragmentIdent,
+    pub ident: FragmentIdent<D>,
     pub m: u8,
     pub n: u8,
     pub k: u8,
     pub elem: Elem<D>,
-    pub layout: Option<FragmentLayout>,
+    pub layout: Option<FragmentLayout<D>>,
 }
 
 /// Warp Matrix-Multiply and Accumulate Instruction.
@@ -38,7 +40,7 @@ pub enum WmmaInstruction<D: Dialect> {
         frag: Variable<D>,
         value: Variable<D>,
         stride: Variable<D>,
-        layout: Option<FragmentLayout>,
+        layout: Option<FragmentLayout<D>>,
     },
     /// Executes D=A*B+C;
     ///
@@ -54,44 +56,49 @@ pub enum WmmaInstruction<D: Dialect> {
         output: Variable<D>,
         frag: Variable<D>,
         stride: Variable<D>,
-        layout: FragmentLayout,
+        layout: FragmentLayout<D>,
     },
 }
 
-impl Display for FragmentLayout {
+impl<D: Dialect> Display for FragmentLayout<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let namespace = D::mma_namespace();
         match self {
-            FragmentLayout::ColMajor => f.write_str("nvcuda::wmma::col_major"),
-            FragmentLayout::RowMajor => f.write_str("nvcuda::wmma::row_major"),
+            FragmentLayout::ColMajor => f.write_str(format!("{namespace}::col_major").as_str()),
+            FragmentLayout::RowMajor => f.write_str(format!("{namespace}::row_major").as_str()),
+            FragmentLayout::_Dialect(_) => Ok(()),
         }
     }
 }
 
-impl Display for FragmentIdent {
+impl<D: Dialect> Display for FragmentIdent<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let namespace = D::mma_namespace();
         match self {
-            FragmentIdent::A => f.write_str("nvcuda::wmma::matrix_a"),
-            FragmentIdent::B => f.write_str("nvcuda::wmma::matrix_b"),
-            FragmentIdent::Accumulator => f.write_str("nvcuda::wmma::accumulator"),
+            FragmentIdent::A => write!(f, "{namespace}::matrix_a"),
+            FragmentIdent::B => write!(f, "{namespace}::matrix_b"),
+            FragmentIdent::Accumulator => write!(f, "{namespace}::accumulator"),
+            FragmentIdent::_Dialect(_) => Ok(()),
         }
     }
 }
 
 impl<D: Dialect> Display for Fragment<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let namespace = D::mma_namespace();
         let elem = match self.elem {
-            Elem::TF32 => "nvcuda::wmma::precision::tf32".to_string(),
+            Elem::TF32 => format!("{namespace}::precision::tf32".to_string()),
             elem => format!("{elem}"),
         };
         match self.layout {
             Some(layout) => write!(
                 f,
-                "nvcuda::wmma::fragment<{}, {}, {}, {}, {}, {}>",
+                "{namespace}::fragment<{}, {}, {}, {}, {}, {}>",
                 self.ident, self.m, self.n, self.k, elem, layout
             ),
             None => write!(
                 f,
-                "nvcuda::wmma::fragment<{}, {}, {}, {}, {}>",
+                "{namespace}::fragment<{}, {}, {}, {}, {}>",
                 self.ident, self.m, self.n, self.k, elem,
             ),
         }
@@ -100,9 +107,10 @@ impl<D: Dialect> Display for Fragment<D> {
 
 impl<D: Dialect> Display for WmmaInstruction<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let namespace = D::mma_namespace();
         match self {
             WmmaInstruction::Fill { frag, value } => {
-                writeln!(f, "nvcuda::wmma::fill_fragment({frag}, {value});")
+                writeln!(f, "{namespace}::fill_fragment({frag}, {value});")
             }
             WmmaInstruction::Load {
                 frag,
@@ -113,11 +121,11 @@ impl<D: Dialect> Display for WmmaInstruction<D> {
                 let item = value.item();
                 if item.vectorization > 1 {
                     let elem = item.elem;
-                    writeln!(f, "nvcuda::wmma::load_matrix_sync({frag}, reinterpret_cast<{elem} *>({value}), {stride});")
+                    writeln!(f, "{namespace}::load_matrix_sync({frag}, reinterpret_cast<{elem} *>({value}), {stride});")
                 } else {
                     writeln!(
                         f,
-                        "nvcuda::wmma::load_matrix_sync({frag}, {value}, {stride});"
+                        "{namespace}::load_matrix_sync({frag}, {value}, {stride});"
                     )
                 }
             }
@@ -128,17 +136,18 @@ impl<D: Dialect> Display for WmmaInstruction<D> {
                 layout: Some(layout),
             } => {
                 let layout = match layout {
-                    FragmentLayout::ColMajor => "nvcuda::wmma::mem_col_major",
-                    FragmentLayout::RowMajor => "nvcuda::wmma::mem_row_major",
+                    FragmentLayout::ColMajor => format!("{namespace}::mem_col_major"),
+                    FragmentLayout::RowMajor => format!("{namespace}::mem_row_major"),
+                    FragmentLayout::_Dialect(_) => "".to_string(),
                 };
                 let item = value.item();
                 if item.vectorization > 1 {
                     let elem = item.elem;
-                    writeln!(f, "nvcuda::wmma::load_matrix_sync({frag}, reinterpret_cast<{elem} *>({value}), {stride}, {layout});")
+                    writeln!(f, "{namespace}::load_matrix_sync({frag}, reinterpret_cast<{elem} *>({value}), {stride}, {layout});")
                 } else {
                     writeln!(
                         f,
-                        "nvcuda::wmma::load_matrix_sync({frag}, {value}, {stride}, {layout});"
+                        "{namespace}::load_matrix_sync({frag}, {value}, {stride}, {layout});"
                     )
                 }
             }
@@ -149,7 +158,7 @@ impl<D: Dialect> Display for WmmaInstruction<D> {
                 frag_d,
             } => writeln!(
                 f,
-                "nvcuda::wmma::mma_sync({frag_d}, {frag_a}, {frag_b}, {frag_c});"
+                "{namespace}::mma_sync({frag_d}, {frag_a}, {frag_b}, {frag_c});"
             ),
             WmmaInstruction::Store {
                 output,
@@ -158,8 +167,9 @@ impl<D: Dialect> Display for WmmaInstruction<D> {
                 layout,
             } => {
                 let layout = match layout {
-                    FragmentLayout::ColMajor => "nvcuda::wmma::mem_col_major",
-                    FragmentLayout::RowMajor => "nvcuda::wmma::mem_row_major",
+                    FragmentLayout::ColMajor => format!("{namespace}::mem_col_major"),
+                    FragmentLayout::RowMajor => format!("{namespace}::mem_row_major"),
+                    FragmentLayout::_Dialect(_) => "".to_string(),
                 };
 
                 let item = output.item();
@@ -167,12 +177,12 @@ impl<D: Dialect> Display for WmmaInstruction<D> {
                     let elem = item.elem;
                     writeln!(
                         f,
-                        "nvcuda::wmma::store_matrix_sync(reinterpret_cast<{elem} *>({output}), {frag}, {stride}, {layout});"
+                        "{namespace}::store_matrix_sync(reinterpret_cast<{elem} *>({output}), {frag}, {stride}, {layout});"
                     )
                 } else {
                     writeln!(
                         f,
-                        "nvcuda::wmma::store_matrix_sync({output}, {frag}, {stride}, {layout});"
+                        "{namespace}::store_matrix_sync({output}, {frag}, {stride}, {layout});"
                     )
                 }
             }

--- a/crates/cubecl-cpp/src/shared/mma.rs
+++ b/crates/cubecl-cpp/src/shared/mma.rs
@@ -87,7 +87,7 @@ impl<D: Dialect> Display for Fragment<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let namespace = D::mma_namespace();
         let elem = match self.elem {
-            Elem::TF32 => format!("{namespace}::precision::tf32".to_string()),
+            Elem::TF32 => format!("{namespace}::precision::tf32"),
             elem => format!("{elem}"),
         };
         match self.layout {

--- a/crates/cubecl-cpp/src/shared/warp.rs
+++ b/crates/cubecl-cpp/src/shared/warp.rs
@@ -90,8 +90,7 @@ unsigned int mask = __activemask();
 unsigned int leader = __ffs(mask) - 1;
 {out} = threadIdx.x % warpSize == leader;
             "
-                )
-            }
+                ),
             WarpInstruction::All { input, out } => {
                 let __all = D::warp_all(out);
                 write!(

--- a/crates/cubecl-cpp/src/shared/warp.rs
+++ b/crates/cubecl-cpp/src/shared/warp.rs
@@ -90,7 +90,7 @@ unsigned int mask = __activemask();
 unsigned int leader = __ffs(mask) - 1;
 {out} = threadIdx.x % warpSize == leader;
             "
-                ),
+            ),
             WarpInstruction::All { input, out } => {
                 let __all = D::warp_all(out);
                 write!(

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -122,6 +122,7 @@ fn register_wmma_features(properties: &mut DeviceProperties<Feature>, arch: u32)
     }
 
     if wmma {
+        properties.register_feature(Feature::CmmaWarpSize(32));
         // Types fully supported.
         for (a, b, c) in [
             (

--- a/crates/cubecl-hip/src/arch.rs
+++ b/crates/cubecl-hip/src/arch.rs
@@ -59,6 +59,7 @@ impl AMDArchitecture {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     // Reference: https://github.com/ROCm/rocWMMA/blob/develop/docs/api-reference/api-reference-guide.rst
     //
     //                                        i     o    c    m   n   k

--- a/crates/cubecl-hip/src/arch.rs
+++ b/crates/cubecl-hip/src/arch.rs
@@ -1,0 +1,325 @@
+use std::str::FromStr;
+
+use cubecl_core::{
+    ir::{Elem, FloatKind},
+    Feature,
+};
+use cubecl_runtime::DeviceProperties;
+
+pub enum AMDArchitecture {
+    // RDNA
+    // gfx1100, gfx1101, gfx1102
+    GFX11,
+    // CDNA
+    GFX908,
+    GFX90A,
+    // gfx940, gfx941, gfx942
+    GFX94,
+    // Not particularly specific architecture
+    Other,
+}
+
+impl FromStr for AMDArchitecture {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let norm = s.to_lowercase();
+        if norm.starts_with("gfx11") {
+            Ok(AMDArchitecture::GFX11)
+        } else if norm == "gfx908" {
+            Ok(AMDArchitecture::GFX908)
+        } else if norm == "gfx90a" {
+            Ok(AMDArchitecture::GFX90A)
+        } else if norm.starts_with("gfx94") {
+            Ok(AMDArchitecture::GFX94)
+        } else {
+            Ok(AMDArchitecture::Other)
+        }
+    }
+}
+
+impl AMDArchitecture {
+    pub fn warp_size(&self) -> i32 {
+        // CDNA supports wave64 (gfx9 and gfx940+) and RDNA wave32 (gfx11)
+        match self {
+            AMDArchitecture::GFX11 => 32,
+            AMDArchitecture::GFX908 | AMDArchitecture::GFX90A | AMDArchitecture::GFX94 => 64,
+            AMDArchitecture::Other => 0,
+        }
+    }
+
+    // TODO verify that rocWMMA is installed on the system
+    pub fn is_wmma_capable(&self) -> bool {
+        match self {
+            AMDArchitecture::GFX11
+            | AMDArchitecture::GFX908
+            | AMDArchitecture::GFX90A
+            | AMDArchitecture::GFX94 => true,
+            AMDArchitecture::Other => false,
+        }
+    }
+
+    // Reference: https://github.com/ROCm/rocWMMA/blob/develop/docs/api-reference/api-reference-guide.rst
+    //
+    //                                        i     o    c    m   n   k
+    fn get_wmma_combinations(&self) -> Vec<(Elem, Elem, Elem, Vec<(u8, u8, u8)>)> {
+        match self {
+            AMDArchitecture::GFX11 => {
+                // For gfx11 the supported tile dimensions are always the same
+                //                                   m   n   k
+                let tdims = vec![(16, 16, 16), (16, 16, 32)];
+                let types = vec![
+                    (
+                        Elem::Float(FloatKind::F16), // i
+                        Elem::Float(FloatKind::F32), // o
+                        Elem::Float(FloatKind::F32), // c
+                    ),
+                    (
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F32),
+                    ),
+                    (
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::F32),
+                        Elem::Float(FloatKind::F32),
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::F32),
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                    ),
+                ];
+                types
+                    .into_iter()
+                    .map(|(i, o, c)| {
+                        let dimensions = tdims.clone();
+                        (i, o, c, dimensions)
+                    })
+                    .collect()
+            }
+            AMDArchitecture::GFX908 => {
+                vec![
+                    (
+                        Elem::Float(FloatKind::F32), // i
+                        Elem::Float(FloatKind::F32), // o
+                        Elem::Float(FloatKind::F32), // c
+                        vec![
+                            //m  n   k
+                            (16, 16, 4),
+                            (16, 16, 8),
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 2),
+                            (32, 32, 4),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F32),
+                        Elem::Float(FloatKind::F32),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F32),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::F32),
+                        Elem::Float(FloatKind::F32),
+                        vec![
+                            (16, 16, 8),
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 4),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::F32),
+                        vec![
+                            (16, 16, 8),
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 4),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                        vec![
+                            (16, 16, 8),
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 4),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                ]
+            }
+            AMDArchitecture::GFX90A | AMDArchitecture::GFX94 => {
+                vec![
+                    (
+                        Elem::Float(FloatKind::F32), // i
+                        Elem::Float(FloatKind::F32), // o
+                        Elem::Float(FloatKind::F32), // c
+                        vec![
+                            //m  n   k
+                            (16, 16, 4),
+                            (16, 16, 8),
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 2),
+                            (32, 32, 4),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F32),
+                        Elem::Float(FloatKind::F32),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F32),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                        Elem::Float(FloatKind::F16),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::F32),
+                        Elem::Float(FloatKind::F32),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::F32),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                        Elem::Float(FloatKind::BF16),
+                        vec![
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                ]
+            }
+            AMDArchitecture::Other => vec![],
+        }
+    }
+
+    pub fn register_wmma_features(&self, properties: &mut DeviceProperties<Feature>) {
+        if !self.is_wmma_capable() {
+            return;
+        }
+        properties.register_feature(Feature::CmmaWarpSize(self.warp_size()));
+        for (i, o, c, tdims) in self.get_wmma_combinations() {
+            for (m, n, k) in tdims {
+                properties.register_feature(Feature::Cmma {
+                    a: i,
+                    b: o,
+                    c,
+                    m,
+                    n,
+                    k,
+                });
+            }
+        }
+    }
+}

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -450,6 +450,9 @@ impl HipContext {
                 bindings.as_mut_ptr(),
                 std::ptr::null_mut(),
             );
+            if status == cubecl_hip_sys::hipError_t_hipErrorOutOfMemory {
+                panic!("Error: Cannot launch kernel (Out of memory)\n{}", kernel_id)
+            }
             assert_eq!(status, HIP_SUCCESS, "Should launch the kernel");
         };
     }

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -341,7 +341,8 @@ impl HipContext {
         let include_option_cstr = CString::new(include_option).unwrap();
         // needed for rocWMMA extension to compile
         let cpp_std_option_cstr = CString::new("--std=c++17").unwrap();
-        let mut options: Vec<*const i8> = vec![cpp_std_option_cstr.as_ptr(), include_option_cstr.as_ptr()];
+        let mut options: Vec<*const i8> =
+            vec![cpp_std_option_cstr.as_ptr(), include_option_cstr.as_ptr()];
         unsafe {
             let options_ptr = options.as_mut_ptr();
             let status =

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -188,7 +188,6 @@ impl ComputeServer for HipServer {
             .collect::<Vec<_>>();
 
         if let Some(level) = profile_level {
-            ctx.sync();
             let start = std::time::SystemTime::now();
             ctx.execute_task(kernel_id, count, resources);
             ctx.sync();
@@ -211,6 +210,7 @@ impl ComputeServer for HipServer {
                 .register_profiled(info, start.elapsed().unwrap());
         } else {
             ctx.execute_task(kernel_id, count, resources);
+            ctx.sync();
         }
     }
 

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -339,7 +339,9 @@ impl HipContext {
         let include_path = include_path();
         let include_option = format!("-I{}", include_path.display());
         let include_option_cstr = CString::new(include_option).unwrap();
-        let mut options: Vec<*const i8> = vec![include_option_cstr.as_ptr()];
+        // needed for rocWMMA extension to compile
+        let cpp_std_option_cstr = CString::new("--std=c++17").unwrap();
+        let mut options: Vec<*const i8> = vec![cpp_std_option_cstr.as_ptr(), include_option_cstr.as_ptr()];
         unsafe {
             let options_ptr = options.as_mut_ptr();
             let status =

--- a/crates/cubecl-hip/src/lib.rs
+++ b/crates/cubecl-hip/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate derive_new;
 extern crate alloc;
 
+pub mod arch;
 #[cfg(target_os = "linux")]
 pub mod compute;
 #[cfg(target_os = "linux")]

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -55,7 +55,7 @@ fn create_client(device: &HipDevice, options: RuntimeOptions) -> ComputeClient<S
             .to_str()
             .unwrap();
     };
-    let arch = AMDArchitecture::from_str(&prop_arch_name).unwrap();
+    let arch = AMDArchitecture::from_str(prop_arch_name).unwrap();
     assert_eq!(prop_warp_size, arch.warp_size());
 
     unsafe {

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -1,3 +1,5 @@
+use std::{ffi::CStr, mem::MaybeUninit, str::FromStr};
+
 use cubecl_cpp::{register_supported_types, HipCompiler};
 
 use cubecl_core::{Feature, MemoryConfiguration, Runtime};
@@ -10,6 +12,7 @@ use cubecl_runtime::{
 };
 
 use crate::{
+    arch::AMDArchitecture,
     compute::{HipContext, HipServer, HipStorage},
     device::HipDevice,
 };
@@ -34,6 +37,27 @@ const MEMORY_OFFSET_ALIGNMENT: u64 = 32;
 
 fn create_client(device: &HipDevice, options: RuntimeOptions) -> ComputeClient<Server, Channel> {
     let mut ctx: cubecl_hip_sys::hipCtx_t = std::ptr::null_mut();
+
+    #[allow(unused_assignments)]
+    let mut prop_warp_size = 0;
+    #[allow(unused_assignments)]
+    let mut prop_arch_name = "";
+    unsafe {
+        let mut ll_device_props = MaybeUninit::uninit();
+        let status = cubecl_hip_sys::hipGetDevicePropertiesR0600(
+            ll_device_props.as_mut_ptr(),
+            device.index as cubecl_hip_sys::hipDevice_t,
+        );
+        assert_eq!(status, HIP_SUCCESS, "Should get device properties");
+        let ll_device_props = ll_device_props.assume_init();
+        prop_warp_size = ll_device_props.warpSize;
+        prop_arch_name = CStr::from_ptr(ll_device_props.gcnArchName.as_ptr())
+            .to_str()
+            .unwrap();
+    };
+    let arch = AMDArchitecture::from_str(&prop_arch_name).unwrap();
+    assert_eq!(prop_warp_size, arch.warp_size());
+
     unsafe {
         let status =
             cubecl_hip_sys::hipCtxCreate(&mut ctx, 0, device.index as cubecl_hip_sys::hipDevice_t);
@@ -74,8 +98,7 @@ fn create_client(device: &HipDevice, options: RuntimeOptions) -> ComputeClient<S
     let server = HipServer::new(hip_ctx);
     let mut device_props = DeviceProperties::new(&[Feature::Subcube], mem_properties);
     register_supported_types(&mut device_props);
-    // TODO
-    // register_wmma_features(&mut device_props);
+    arch.register_wmma_features(&mut device_props);
 
     ComputeClient::new(MutexComputeChannel::new(server), device_props)
 }
@@ -104,7 +127,3 @@ impl Runtime for HipRuntime {
         &[8, 4, 2]
     }
 }
-
-// TODO
-// fn register_wmma_features(_properties: &mut DeviceProperties<Feature>) {
-// }

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view/base.rs
@@ -20,7 +20,7 @@ pub struct TensorView<E: Numeric> {
 
 #[cube]
 impl<EG: Numeric> TensorView<EG> {
-    /// Instanciate a view over the given tensor, pre-fetching needed strides and shapes
+    /// Instantiate a view over the given tensor, pre-fetching needed strides and shapes
     pub fn new(
         tensor: Tensor<Line<EG>>,
         x_offset: u32,

--- a/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
@@ -15,7 +15,7 @@ pub struct Stage<ES: Numeric> {
 
 #[cube]
 impl<ES: Numeric> Stage<ES> {
-    /// Instanciate a new stage for the given identifier
+    /// Instantiate a new stage for the given identifier
     pub fn new<S: Config>(#[comptime] ident: Ident, #[comptime] config: S) -> Stage<ES> {
         let smem = SharedMemory::new_lined(
             comptime!(config.stage_dim(ident).num_elements() / config.line_size(ident)),

--- a/crates/cubecl-linalg/src/matmul/kernels/cmma_matmul/dispatch.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/cmma_matmul/dispatch.rs
@@ -7,7 +7,7 @@ use crate::matmul::components::tile::plane::PlaneMma16x16x16;
 use crate::matmul::components::tile::Matmul;
 use crate::matmul::components::MatmulProblem;
 
-/// Launch informations for a matmul
+/// Launch information for a matmul
 pub trait MatmulLaunchDispatch {
     const PLANE_DIM: u32;
     type StageSize: StageSize;

--- a/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
@@ -134,16 +134,12 @@ fn tensor_raw_parts<EG: Float + CubeElement, R: Runtime>(
 ) -> TensorRawParts<EG> {
     match ident {
         Ident::Lhs => {
-            let original_data: Vec<EG> =
-                generate_random_data(tensor_size(problem, Ident::Lhs) as usize);
+            let original_data: Vec<EG> = generate_random_data(tensor_size(problem, Ident::Lhs));
             let data = match problem.lhs_layout {
                 MatrixLayout::RowMajor => original_data.clone(),
-                MatrixLayout::ColMajor => transpose::<EG>(
-                    &original_data,
-                    problem.num_batches() as usize,
-                    problem.m as usize,
-                    problem.k as usize,
-                ),
+                MatrixLayout::ColMajor => {
+                    transpose::<EG>(&original_data, problem.num_batches(), problem.m, problem.k)
+                }
             };
 
             TensorRawParts {
@@ -154,16 +150,12 @@ fn tensor_raw_parts<EG: Float + CubeElement, R: Runtime>(
             }
         }
         Ident::Rhs => {
-            let original_data: Vec<EG> =
-                generate_random_data(tensor_size(problem, Ident::Rhs) as usize);
+            let original_data: Vec<EG> = generate_random_data(tensor_size(problem, Ident::Rhs));
             let data = match problem.rhs_layout {
                 MatrixLayout::RowMajor => original_data.clone(),
-                MatrixLayout::ColMajor => transpose::<EG>(
-                    &original_data,
-                    problem.num_batches() as usize,
-                    problem.k as usize,
-                    problem.n as usize,
-                ),
+                MatrixLayout::ColMajor => {
+                    transpose::<EG>(&original_data, problem.num_batches(), problem.k, problem.n)
+                }
             };
 
             TensorRawParts {
@@ -174,8 +166,7 @@ fn tensor_raw_parts<EG: Float + CubeElement, R: Runtime>(
             }
         }
         Ident::Out => {
-            let handle =
-                client.empty(tensor_size(problem, Ident::Out) as usize * EG::as_elem().size());
+            let handle = client.empty(tensor_size(problem, Ident::Out) * EG::as_elem().size());
             let shape = shape(problem, Ident::Out);
             let strides = strides(problem, Ident::Out);
 
@@ -209,7 +200,7 @@ fn assert_result<EG: Float + CubeElement + Display, R: Runtime>(
     out: Handle,
 ) {
     let expected = matmul_cpu_reference(lhs, rhs, problem);
-    if let Err(e) = assert_equals_approx::<R, EG>(&client, out, &expected, 10e-5) {
+    if let Err(e) = assert_equals_approx::<R, EG>(client, out, &expected, 10e-5) {
         panic!("{}", e);
     }
 }

--- a/crates/cubecl-linalg/src/matmul/tests/cmma_old/test_cases.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_old/test_cases.rs
@@ -114,6 +114,7 @@ pub(crate) fn test_cmma<R: Runtime, F: Float + CubeElement + Display>(
         assert_equals_approx::<R, F>(&client, out.handle, &expected, 0.01)
     } else {
         // Cmma unavailable, nothing to do
+        println!("Skipped (cmma not supported)");
         Ok(())
     }
 }

--- a/crates/cubecl-linalg/src/matmul/tests/test_utils.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_utils.rs
@@ -66,9 +66,9 @@ pub(crate) fn matmul_cpu_reference<EG: Numeric + CubeElement>(
     rhs: &[EG],
     problem: &MatmulProblem<EG>,
 ) -> Vec<EG> {
-    let m = problem.m as usize;
-    let n = problem.n as usize;
-    let k = problem.k as usize;
+    let m = problem.m;
+    let n = problem.n;
+    let k = problem.k;
     let b = problem.num_batches();
 
     let mut out = vec![EG::from_int(0); m * n * b];

--- a/crates/cubecl-macros/src/parse/kernel.rs
+++ b/crates/cubecl-macros/src/parse/kernel.rs
@@ -237,7 +237,7 @@ impl Launch {
         let func = KernelFn::from_sig_and_block(
             // When generating code, this function will be wrapped in
             // a module. By setting the visibility to pub here, we
-            // ensure that the function is visibile outside that
+            // ensure that the function is visible outside that
             // module.
             Visibility::Public(parse_quote![pub]),
             function.sig,

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -108,7 +108,7 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
                 // - tune_1 save
                 // ```
                 let state = self.state.read();
-                let state = state.as_ref().expect("Should be initialzied");
+                let state = state.as_ref().expect("Should be initialized");
                 let tuner = state.get(id).expect("Should be initialized");
 
                 tuner.execute_autotune(autotune_operation_set.as_ref(), client);
@@ -124,7 +124,7 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
 
         let fastest = {
             let mut state = self.state.write();
-            let state = state.as_mut().expect("Should be initialzied");
+            let state = state.as_mut().expect("Should be initialized");
             let tuner = state.get_mut(id).expect("Should be initialized");
             // Now read all results that have come in since.
             tuner.resolve();

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -41,7 +41,7 @@ enum AutotuneMessage<K> {
 
 /// Error from running autotune.
 pub enum AutotuneError {
-    /// An unknown error happended.
+    /// An unknown error happened.
     Unknown(String),
 }
 

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -98,19 +98,34 @@ fn main() {
 
     #[cfg(all(feature = "hip", target_os = "linux"))]
     {
-        // TODO: randomly hangs on sync after kernel launch
-        run::<cubecl::hip::HipRuntime, f32>(Default::default(), matmul::Strategy::PlaneMma);
+        // TODO: unless annotated OOM, all the benches can randomly hang
+        // Full-precision ----------------------------------------------------
+        // Tiling2D
         run::<cubecl::hip::HipRuntime, f32>(
             Default::default(),
             matmul::Strategy::Tiling2D(Default::default()),
         );
-
+        // PlaneMma
+        // run::<cubecl::hip::HipRuntime, f32>(Default::default(), matmul::Strategy::PlaneMma);
+        // CmmaOld
+        // run::<cubecl::hip::HipRuntime, f32>(Default::default(), matmul::Strategy::CmmaOld(Default::default()));
+        // Accelerated
+        run::<cubecl::hip::HipRuntime, f32>(Default::default(), matmul::Strategy::Accelerated);
+        // Half-precision ----------------------------------------------------
+        // Tiling2D
         run::<cubecl::hip::HipRuntime, half::f16>(
             Default::default(),
             matmul::Strategy::Tiling2D(Default::default()),
         );
-        // TODO: OOM
-        run::<cubecl::hip::HipRuntime, half::f16>(Default::default(), matmul::Strategy::PlaneMma);
+        // PlaneMma: OOM
+        // run::<cubecl::hip::HipRuntime, half::f16>(Default::default(), matmul::Strategy::PlaneMma);
+        // CmmaOld: OOM
+        // run::<cubecl::hip::HipRuntime, half::f16>(Default::default(), matmul::Strategy::CmmaOld(Default::default()));
+        // Accelerated
+        run::<cubecl::hip::HipRuntime, half::f16>(
+            Default::default(),
+            matmul::Strategy::Accelerated,
+        );
     }
 
     #[cfg(feature = "cuda")]

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -86,13 +86,24 @@ fn main() {
 
     #[cfg(all(feature = "hip", target_os = "linux"))]
     {
+        // TODO: randomly hangs on sync after kernel launch
+        run::<cubecl::hip::HipRuntime, f32>(
+            Default::default(),
+            MatmulKind::Cmma,
+        );
         run::<cubecl::hip::HipRuntime, f32>(
             Default::default(),
             matmul::Strategy::Tiling2D(Default::default()),
         );
+
         run::<cubecl::hip::HipRuntime, half::f16>(
             Default::default(),
             matmul::Strategy::Tiling2D(Default::default()),
+        );
+        // TODO: OOM
+        run::<cubecl::hip::HipRuntime, half::f16>(
+            Default::default(),
+            MatmulKind::Cmma,
         );
     }
 

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -86,17 +86,20 @@ fn main() {
 
     #[cfg(feature = "wgpu-spirv")]
     {
-        run::<cubecl::wgpu::WgpuRuntime<cubecl::wgpu::spirv::SpirvCompiler>, f32>(Default::default(), matmul::Strategy::Tiling2D(Default::default()));
-        run::<cubecl::wgpu::WgpuRuntime<cubecl::wgpu::spirv::SpirvCompiler>, f32>(Default::default(), matmul::Strategy::PlaneMma);
+        run::<cubecl::wgpu::WgpuRuntime<cubecl::wgpu::spirv::SpirvCompiler>, f32>(
+            Default::default(),
+            matmul::Strategy::Tiling2D(Default::default()),
+        );
+        run::<cubecl::wgpu::WgpuRuntime<cubecl::wgpu::spirv::SpirvCompiler>, f32>(
+            Default::default(),
+            matmul::Strategy::PlaneMma,
+        );
     }
 
     #[cfg(all(feature = "hip", target_os = "linux"))]
     {
         // TODO: randomly hangs on sync after kernel launch
-        run::<cubecl::hip::HipRuntime, f32>(
-            Default::default(),
-            matmul::Strategy::PlaneMma,
-        );
+        run::<cubecl::hip::HipRuntime, f32>(Default::default(), matmul::Strategy::PlaneMma);
         run::<cubecl::hip::HipRuntime, f32>(
             Default::default(),
             matmul::Strategy::Tiling2D(Default::default()),
@@ -107,10 +110,7 @@ fn main() {
             matmul::Strategy::Tiling2D(Default::default()),
         );
         // TODO: OOM
-        run::<cubecl::hip::HipRuntime, half::f16>(
-            Default::default(),
-            matmul::Strategy::PlaneMma,
-        );
+        run::<cubecl::hip::HipRuntime, half::f16>(Default::default(), matmul::Strategy::PlaneMma);
     }
 
     #[cfg(feature = "cuda")]

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -84,12 +84,18 @@ fn main() {
         run::<cubecl::wgpu::WgpuRuntime, f32>(Default::default(), matmul::Strategy::PlaneMma);
     }
 
+    #[cfg(feature = "wgpu-spirv")]
+    {
+        run::<cubecl::wgpu::WgpuRuntime<cubecl::wgpu::spirv::SpirvCompiler>, f32>(Default::default(), matmul::Strategy::Tiling2D(Default::default()));
+        run::<cubecl::wgpu::WgpuRuntime<cubecl::wgpu::spirv::SpirvCompiler>, f32>(Default::default(), matmul::Strategy::PlaneMma);
+    }
+
     #[cfg(all(feature = "hip", target_os = "linux"))]
     {
         // TODO: randomly hangs on sync after kernel launch
         run::<cubecl::hip::HipRuntime, f32>(
             Default::default(),
-            MatmulKind::Cmma,
+            matmul::Strategy::PlaneMma,
         );
         run::<cubecl::hip::HipRuntime, f32>(
             Default::default(),
@@ -103,7 +109,7 @@ fn main() {
         // TODO: OOM
         run::<cubecl::hip::HipRuntime, half::f16>(
             Default::default(),
-            MatmulKind::Cmma,
+            matmul::Strategy::PlaneMma,
         );
     }
 

--- a/crates/cubecl/benches/unary.rs
+++ b/crates/cubecl/benches/unary.rs
@@ -84,13 +84,6 @@ struct UnaryBench<R: Runtime, E> {
 }
 
 #[allow(dead_code)]
-#[derive(Debug)]
-enum MatmulKind {
-    Tiling2d,
-    Cmma,
-}
-
-#[allow(dead_code)]
 fn run<R: Runtime, E: frontend::Float>(device: R::Device, vectorization: u8) {
     let client = R::client(&device);
     client.enable_timestamps();


### PR DESCRIPTION
On our AMD machine MMA matmul kernel is ~50% faster than Tiling2D. This is roughly the same as SPIR-V.

The `arch.rs` file list all the supported data format and matrix sizes.

There are still stability issues:
- random synchronization hangs after kernel launch in matmul benches, it happens both on full and half precision
- constant OOM error in half precision with MMA in matmul benches