### PR TITLE
Fix sign conversion in SPIR-V

### DIFF
--- a/crates/cubecl-spirv/src/item.rs
+++ b/crates/cubecl-spirv/src/item.rs
@@ -211,7 +211,6 @@ impl Item {
                            (width_other, signed_other)| {
             let sign_differs = signed_self != signed_other;
             let width_differs = width_self != width_other;
-            println!("{self:?}, {other:?}");
             match (sign_differs, width_differs) {
                 (true, true) => {
                     let sign_swap = swap_sign(b, obj, None, width_self, signed_other);

--- a/crates/cubecl-spirv/src/subgroup.rs
+++ b/crates/cubecl-spirv/src/subgroup.rs
@@ -42,7 +42,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             Subcube::Sum(op) => {
                 self.compile_unary_op(op, out, |b, out_ty, ty, input, out| {
                     match out_ty.elem() {
-                        Elem::Int(_, false) => b.group_non_uniform_i_add(
+                        Elem::Int(_, _) => b.group_non_uniform_i_add(
                             ty,
                             Some(out),
                             subgroup,
@@ -58,7 +58,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                             input,
                             None,
                         ),
-                        _ => unreachable!(),
+                        elem => unreachable!("{elem}"),
                     }
                     .unwrap();
                 });


### PR DESCRIPTION
Small fix to properly convert sign on SPIR-V and fix burn tests with non-standard int sizes