### PR TITLE
more precision required

### DIFF
--- a/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
@@ -209,7 +209,7 @@ fn assert_result<EG: Float + CubeElement + Display, R: Runtime>(
     out: Handle,
 ) {
     let expected = matmul_cpu_reference(lhs, rhs, problem);
-    if let Err(e) = assert_equals_approx::<R, EG>(&client, out, &expected, 10e-2) {
+    if let Err(e) = assert_equals_approx::<R, EG>(&client, out, &expected, 10e-5) {
         panic!("{}", e);
     }
 }


### PR DESCRIPTION
Matmul's flex32 test could pass even with no compute at all, because epsilon was too large. 