### PR TITLE
Allow creating kernels with no runtime

### DIFF
--- a/crates/cubecl-core/src/frontend/container/array/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/array/launch.rs
@@ -13,8 +13,8 @@ use super::Array;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct ArrayCompilationArg {
-    inplace: Option<u16>,
-    vectorisation: Vectorization,
+    pub inplace: Option<u16>,
+    pub vectorisation: Vectorization,
 }
 
 /// Tensor representation with a reference to the [server handle](cubecl_runtime::server::Handle).

--- a/crates/cubecl-core/src/frontend/container/sequence/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/sequence/launch.rs
@@ -28,7 +28,7 @@ impl<'a, R: Runtime, T: LaunchArg> SequenceArg<'a, R, T> {
 }
 
 pub struct SequenceCompilationArg<C: LaunchArg> {
-    values: Vec<C::CompilationArg>,
+    pub values: Vec<C::CompilationArg>,
 }
 
 impl<C: LaunchArg> Clone for SequenceCompilationArg<C> {

--- a/crates/cubecl-core/src/frontend/container/tensor/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/launch.rs
@@ -48,8 +48,8 @@ impl<'a, R: Runtime> core::fmt::Debug for TensorHandleRef<'a, R> {
 /// Compilation argument for a [tensor](Tensor).
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct TensorCompilationArg {
-    inplace: Option<u16>,
-    vectorisation: Vectorization,
+    pub inplace: Option<u16>,
+    pub vectorisation: Vectorization,
 }
 
 impl<C: CubePrimitive> LaunchArgExpand for Tensor<C> {

--- a/crates/cubecl-cuda/tests/common.rs
+++ b/crates/cubecl-cuda/tests/common.rs
@@ -1,38 +1,37 @@
-use std::{io::Write, process::Command};
+use std::{io::Write, num::NonZero, process::Command};
 
 use cubecl_core::{
-    client::ComputeClient,
-    prelude::{ArrayArg, TensorArg},
-    server, Compiler, ExecutionMode, Kernel, Runtime,
+    prelude::{ArrayCompilationArg, TensorCompilationArg},
+    Compiler, CubeDim, ExecutionMode, Kernel, KernelSettings, Runtime,
 };
-use cubecl_cuda::{CudaDevice, CudaRuntime};
+use cubecl_cuda::CudaRuntime;
 
-type Client = ComputeClient<<CudaRuntime as Runtime>::Server, <CudaRuntime as Runtime>::Channel>;
-type Handle = server::Handle;
-
-pub fn client() -> Client {
-    let device = CudaDevice::new(0);
-    CudaRuntime::client(&device)
+pub fn settings() -> KernelSettings {
+    KernelSettings::default().cube_dim(CubeDim::default())
 }
 
 #[allow(unused)]
-pub fn handle(client: &Client) -> Handle {
-    client.empty(1)
+pub fn tensor() -> TensorCompilationArg {
+    TensorCompilationArg {
+        inplace: None,
+        vectorisation: NonZero::new(1),
+    }
 }
 
 #[allow(unused)]
-pub fn tensor(tensor: &Handle) -> TensorArg<'_, CudaRuntime> {
-    unsafe { TensorArg::from_raw_parts(tensor, &[1], &[1], 1) }
+pub fn tensor_vec(vec: u8) -> TensorCompilationArg {
+    TensorCompilationArg {
+        inplace: None,
+        vectorisation: NonZero::new(vec),
+    }
 }
 
 #[allow(unused)]
-pub fn tensor_vec(tensor: &Handle, vec: u8) -> TensorArg<'_, CudaRuntime> {
-    unsafe { TensorArg::from_raw_parts(tensor, &[1], &[1], vec) }
-}
-
-#[allow(unused)]
-pub fn array(tensor: &Handle) -> ArrayArg<'_, CudaRuntime> {
-    unsafe { ArrayArg::from_raw_parts(tensor, 1, 1) }
+pub fn array() -> ArrayCompilationArg {
+    ArrayCompilationArg {
+        inplace: None,
+        vectorisation: NonZero::new(1),
+    }
 }
 
 pub fn compile(kernel: impl Kernel) -> String {

--- a/crates/cubecl-cuda/tests/main.rs
+++ b/crates/cubecl-cuda/tests/main.rs
@@ -1,8 +1,13 @@
 use common::*;
+use constant_array_kernel::ConstantArrayKernel;
 use cubecl_core as cubecl;
-use cubecl_core::{prelude::*, CubeCount, CubeDim};
+use cubecl_core::prelude::*;
 use cubecl_cuda::CudaRuntime;
+use execute_unary_kernel::ExecuteUnaryKernel;
+use kernel_sum::KernelSum;
 use pretty_assertions::assert_eq;
+use sequence_for_loop_kernel::SequenceForLoopKernel;
+use slice_assign_kernel::SliceAssignKernel;
 
 mod common;
 
@@ -16,16 +21,7 @@ pub fn slice_assign_kernel(input: &Tensor<f32>, output: &mut Tensor<f32>) {
 
 #[test]
 pub fn slice_assign() {
-    let client = client();
-    let input = handle(&client);
-    let output = handle(&client);
-
-    let kernel = slice_assign_kernel::create_dummy_kernel::<CudaRuntime>(
-        CubeCount::Static(1, 1, 1),
-        CubeDim::new(1, 1, 1),
-        tensor(&input),
-        tensor(&output),
-    );
+    let kernel = SliceAssignKernel::<CudaRuntime>::new(settings(), tensor(), tensor());
     let expected = include_str!("slice_assign.cu").replace("\r\n", "\n");
     let expected = expected.trim();
     assert_eq!(compile(kernel), expected);
@@ -43,14 +39,8 @@ pub fn kernel_sum(output: &mut Tensor<f32>) {
 
 #[test]
 pub fn subcube_sum() {
-    let client = client();
-    let output = handle(&client);
+    let kernel = KernelSum::<CudaRuntime>::new(settings(), tensor());
 
-    let kernel = kernel_sum::create_dummy_kernel::<CudaRuntime>(
-        CubeCount::Static(1, 1, 1),
-        CubeDim::new(4, 1, 1),
-        tensor(&output),
-    );
     let expected = include_str!("subcube_sum.cu").replace("\r\n", "\n");
     let expected = expected.trim();
     assert_eq!(compile(kernel), expected);
@@ -73,14 +63,7 @@ pub fn sequence_for_loop_kernel(output: &mut Array<f32>) {
 
 #[test]
 pub fn sequence_for_loop() {
-    let client = client();
-    let output = handle(&client);
-
-    let kernel = sequence_for_loop_kernel::create_dummy_kernel::<CudaRuntime>(
-        CubeCount::Static(1, 1, 1),
-        CubeDim::default(),
-        array(&output),
-    );
+    let kernel = SequenceForLoopKernel::<CudaRuntime>::new(settings(), array());
     let expected = include_str!("sequence_for_loop.cu").replace("\r\n", "\n");
     let expected = expected.trim();
     assert_eq!(compile(kernel), expected);
@@ -101,17 +84,11 @@ fn execute_unary_kernel<F: Float>(lhs: &Tensor<F>, rhs: &Tensor<F>, out: &mut Te
 
 #[test]
 pub fn unary_bench() {
-    let client = client();
-    let lhs = handle(&client);
-    let rhs = handle(&client);
-    let out = handle(&client);
-
-    let kernel = execute_unary_kernel::create_dummy_kernel::<f32, CudaRuntime>(
-        CubeCount::Static(1, 1, 1),
-        CubeDim::default(),
-        tensor_vec(&lhs, 4),
-        tensor_vec(&rhs, 4),
-        tensor_vec(&out, 4),
+    let kernel = ExecuteUnaryKernel::<f32, CudaRuntime>::new(
+        settings(),
+        tensor_vec(4),
+        tensor_vec(4),
+        tensor_vec(4),
     );
     let expected = include_str!("unary_bench.cu").replace("\r\n", "\n");
     let expected = expected.trim();
@@ -129,16 +106,9 @@ fn constant_array_kernel<F: Float>(out: &mut Tensor<F>, #[comptime] data: Vec<u3
 
 #[test]
 pub fn constant_array() {
-    let client = client();
-    let out = handle(&client);
     let data: Vec<u32> = vec![3, 5, 1];
 
-    let kernel = constant_array_kernel::create_dummy_kernel::<f32, CudaRuntime>(
-        CubeCount::Static(1, 1, 1),
-        CubeDim::default(),
-        tensor_vec(&out, 1),
-        data,
-    );
+    let kernel = ConstantArrayKernel::<f32, CudaRuntime>::new(settings(), tensor(), data);
     let expected = include_str!("constant_array.cu").replace("\r\n", "\n");
     assert_eq!(compile(kernel), expected);
 }

--- a/crates/cubecl-wgpu/tests/common.rs
+++ b/crates/cubecl-wgpu/tests/common.rs
@@ -1,38 +1,39 @@
+use std::num::NonZero;
+
 use cubecl_core::{
-    client::ComputeClient,
-    prelude::{ArrayArg, TensorArg},
-    server::Handle,
-    Compiler, ExecutionMode, Kernel, Runtime,
+    prelude::{ArrayCompilationArg, TensorCompilationArg},
+    Compiler, CubeDim, ExecutionMode, Kernel, KernelSettings, Runtime,
 };
-use cubecl_wgpu::{WgpuDevice, WgpuRuntime, WgslCompiler};
+use cubecl_wgpu::{WgpuRuntime, WgslCompiler};
 
 pub type TestRuntime = WgpuRuntime<WgslCompiler>;
 
-type Client = ComputeClient<<TestRuntime as Runtime>::Server, <TestRuntime as Runtime>::Channel>;
-
-pub fn client() -> Client {
-    let device = WgpuDevice::default();
-    TestRuntime::client(&device)
+pub fn settings(dim_x: u32, dim_y: u32) -> KernelSettings {
+    KernelSettings::default().cube_dim(CubeDim::new(dim_x, dim_y, 1))
 }
 
 #[allow(unused)]
-pub fn handle(client: &Client) -> Handle {
-    client.empty(1)
+pub fn tensor() -> TensorCompilationArg {
+    TensorCompilationArg {
+        inplace: None,
+        vectorisation: NonZero::new(1),
+    }
 }
 
 #[allow(unused)]
-pub fn tensor(tensor: &Handle) -> TensorArg<'_, TestRuntime> {
-    unsafe { TensorArg::from_raw_parts(tensor, &[1], &[1], 1) }
+pub fn tensor_vec(vectorization: u8) -> TensorCompilationArg {
+    TensorCompilationArg {
+        inplace: None,
+        vectorisation: NonZero::new(vectorization),
+    }
 }
 
 #[allow(unused)]
-pub fn tensor_vec(tensor: &Handle, vectorization: u8) -> TensorArg<'_, TestRuntime> {
-    unsafe { TensorArg::from_raw_parts(tensor, &[1], &[1], vectorization) }
-}
-
-#[allow(unused)]
-pub fn array(tensor: &Handle) -> ArrayArg<'_, TestRuntime> {
-    unsafe { ArrayArg::from_raw_parts(tensor, 1, 1) }
+pub fn array() -> ArrayCompilationArg {
+    ArrayCompilationArg {
+        inplace: None,
+        vectorisation: NonZero::new(1),
+    }
 }
 
 pub fn compile(kernel: impl Kernel) -> String {


### PR DESCRIPTION
Makes the fields on the `CompilationArgs` public so a kernel can be created and compiled without a working runtime. This helps with codegen tests or potentially precompiling kernels.