### PR TITLE
Perf/cuda fense

### DIFF
--- a/crates/cubecl-cuda/src/compute/fense.rs
+++ b/crates/cubecl-cuda/src/compute/fense.rs
@@ -1,0 +1,54 @@
+use cudarc::driver::sys::{CUevent_flags, CUevent_st, CUevent_wait_flags, CUstream_st};
+
+/// A fense is a simply an [event](CUevent_st) created on a [stream](CUevent_st) that you can wait
+/// until completion.
+///
+/// This is useful for doing synchronization outside of the compute server, which is normally
+/// locked by a mutex or a channel. This allows the server to continue accepting other tasks.
+pub struct Fense {
+    stream: *mut CUstream_st,
+    event: *mut CUevent_st,
+}
+
+// If we don't close the stream or destroy the event, it is safe.
+//
+// # Safety
+//
+// Since streams are never closed and we destroy the event after waiting, which comsumes the
+// [Fense], it is safe.
+unsafe impl Send for Fense {}
+
+impl Fense {
+    /// Create a new [Fense] on the given stream.
+    ///
+    /// # Notes
+    ///
+    /// The [stream](CUevent_st) must be initialized.
+    pub fn new(stream: *mut CUstream_st) -> Self {
+        unsafe {
+            let event =
+                cudarc::driver::result::event::create(CUevent_flags::CU_EVENT_DEFAULT).unwrap();
+            cudarc::driver::result::event::record(event, stream).unwrap();
+
+            Self { stream, event }
+        }
+    }
+
+    /// Wait for the [Fense] to be reached, ensuring that all previous tasks enqueued to the
+    /// [stream](CUstream_st) are completed.
+    ///
+    /// # Notes
+    ///
+    /// The [stream](CUevent_st) must be initialized.
+    pub fn wait(self) {
+        unsafe {
+            cudarc::driver::result::stream::wait_event(
+                self.stream,
+                self.event,
+                CUevent_wait_flags::CU_EVENT_WAIT_DEFAULT,
+            )
+            .unwrap();
+            cudarc::driver::result::event::destroy(self.event).unwrap();
+        }
+    }
+}

--- a/crates/cubecl-cuda/src/compute/mod.rs
+++ b/crates/cubecl-cuda/src/compute/mod.rs
@@ -1,6 +1,8 @@
 mod server;
 mod storage;
 
+pub(crate) mod fense;
+
 pub use server::*;
 pub use storage::*;
 


### PR DESCRIPTION
Use cuda events instead of synching the stream for reading and syncing the server. At some point we might also create a pooling thread, but unsure it's necessary for now.