### PR TITLE
Matmul/tensor reference

### DIFF
--- a/crates/cubecl-core/src/frontend/container/tensor/base.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/base.rs
@@ -266,6 +266,10 @@ impl<T: CubeType> CubeType for *const Tensor<T> {
     type ExpandType = ExpandElementTyped<Tensor<T>>;
 }
 
+impl<T: CubeType> CubeType for *mut Tensor<T> {
+    type ExpandType = ExpandElementTyped<Tensor<T>>;
+}
+
 impl<C: CubeType> ExpandElementBaseInit for Tensor<C> {
     fn init_elem(_context: &mut crate::prelude::CubeContext, elem: ExpandElement) -> ExpandElement {
         // The type can't be deeply cloned/copied.
@@ -280,6 +284,12 @@ impl<E: CubePrimitive> IntoRuntime for Tensor<E> {
 }
 
 impl<E: CubePrimitive> IntoRuntime for *const Tensor<E> {
+    fn __expand_runtime_method(self, _context: &mut CubeContext) -> Self::ExpandType {
+        unimplemented!("Tensor can't exist at compile time")
+    }
+}
+
+impl<E: CubePrimitive> IntoRuntime for *mut Tensor<E> {
     fn __expand_runtime_method(self, _context: &mut CubeContext) -> Self::ExpandType {
         unimplemented!("Tensor can't exist at compile time")
     }

--- a/crates/cubecl-core/src/frontend/container/tensor/base.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/base.rs
@@ -262,6 +262,10 @@ impl<T: CubeType> CubeType for Tensor<T> {
     type ExpandType = ExpandElementTyped<Tensor<T>>;
 }
 
+impl<T: CubeType> CubeType for *const Tensor<T> {
+    type ExpandType = ExpandElementTyped<Tensor<T>>;
+}
+
 impl<C: CubeType> ExpandElementBaseInit for Tensor<C> {
     fn init_elem(_context: &mut crate::prelude::CubeContext, elem: ExpandElement) -> ExpandElement {
         // The type can't be deeply cloned/copied.
@@ -271,6 +275,12 @@ impl<C: CubeType> ExpandElementBaseInit for Tensor<C> {
 
 impl<E: CubePrimitive> IntoRuntime for Tensor<E> {
     fn __expand_runtime_method(self, _context: &mut CubeContext) -> Self::ExpandType {
-        unimplemented!("Array can't exist at compile time")
+        unimplemented!("Tensor can't exist at compile time")
+    }
+}
+
+impl<E: CubePrimitive> IntoRuntime for *const Tensor<E> {
+    fn __expand_runtime_method(self, _context: &mut CubeContext) -> Self::ExpandType {
+        unimplemented!("Tensor can't exist at compile time")
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/batch/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/base.rs
@@ -28,9 +28,9 @@ pub trait Matmul<EG: Numeric>:
 {
     /// Performs batchwise matrix multiplication over tensors.
     fn execute(
-        lhs: Tensor<Line<EG>>,
-        rhs: Tensor<Line<EG>>,
-        out: Tensor<Line<EG>>,
+        lhs: &Tensor<Line<EG>>,
+        rhs: &Tensor<Line<EG>>,
+        out: &mut Tensor<Line<EG>>,
         #[comptime] config: Self::Config,
     );
 }

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -40,9 +40,9 @@ impl<
     > batch::Matmul<EG> for Matmul<EG, ES, GMM>
 {
     fn execute(
-        lhs: Tensor<Line<EG>>,
-        rhs: Tensor<Line<EG>>,
-        out: Tensor<Line<EG>>,
+        lhs: &Tensor<Line<EG>>,
+        rhs: &Tensor<Line<EG>>,
+        out: &mut Tensor<Line<EG>>,
         #[comptime] config: Self::Config,
     ) {
         // TODO row/col/swizzle
@@ -123,9 +123,9 @@ impl<
 #[cube(launch_unchecked)]
 // TODO input as references
 fn launch<EG: Numeric, BMM: batch::Matmul<EG>>(
-    lhs: Tensor<Line<EG>>,
-    rhs: Tensor<Line<EG>>,
-    out: Tensor<Line<EG>>,
+    lhs: &Tensor<Line<EG>>,
+    rhs: &Tensor<Line<EG>>,
+    out: &mut Tensor<Line<EG>>,
     #[comptime] config: BMM::Config,
 ) {
     BMM::execute(lhs, rhs, out, config);

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -121,7 +121,6 @@ impl<
 }
 
 #[cube(launch_unchecked)]
-// TODO input as references
 fn launch<EG: Numeric, BMM: batch::Matmul<EG>>(
     lhs: &Tensor<Line<EG>>,
     rhs: &Tensor<Line<EG>>,

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view/cyclic_loading.rs
@@ -7,7 +7,7 @@ use crate::matmul::components::{Ident, MatrixLayout};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use super::base::TensorView;
+use super::base::TensorReader;
 
 #[derive(CubeType, Clone, Copy)]
 /// Loads the content of all tiles in the tensor view using all planes,
@@ -28,7 +28,7 @@ impl PlaneMapper for CyclicLoading {
 #[cube]
 impl CyclicLoading {
     pub fn load_to_slice<EG: Numeric, ES: Numeric, G: Config>(
-        read_view: &TensorView<EG>,
+        read_view: &TensorReader<EG>,
         slice: &mut SliceMut<'_, Line<ES>>,
         #[comptime] ident: Ident,
         #[comptime] config: G,

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view/loader.rs
@@ -5,17 +5,17 @@ use crate::matmul::components::{global, Ident};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use super::base::TensorView;
+use super::base::TensorReader;
 
 #[derive(CubeType)]
 pub struct LhsLoader<EG: Numeric, ES: Numeric> {
-    pub tensor_view: TensorView<EG>,
+    pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
 }
 
 #[derive(CubeType)]
 pub struct RhsLoader<EG: Numeric, ES: Numeric> {
-    pub tensor_view: TensorView<EG>,
+    pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
 }
 
@@ -29,7 +29,7 @@ impl<EG: Numeric, ES: Numeric> LhsLoader<EG, ES> {
         #[comptime] config: G,
     ) -> Self {
         let stage = Stage::new::<G::SmmConfig>(Ident::Lhs, config.to_smm_config());
-        let tensor_view = TensorView::new(tensor, x_offset, y_offset, nth_batch);
+        let tensor_view = TensorReader::new(tensor, x_offset, y_offset, nth_batch);
 
         LhsLoader::<EG, ES> { tensor_view, stage }
     }
@@ -45,7 +45,7 @@ impl<EG: Numeric, ES: Numeric> RhsLoader<EG, ES> {
         #[comptime] config: G,
     ) -> Self {
         let stage = Stage::new::<G::SmmConfig>(Ident::Rhs, config.to_smm_config());
-        let tensor_view = TensorView::new(tensor, x_offset, y_offset, nth_batch);
+        let tensor_view = TensorReader::new(tensor, x_offset, y_offset, nth_batch);
 
         RhsLoader::<EG, ES> { tensor_view, stage }
     }

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view/loader.rs
@@ -22,7 +22,7 @@ pub struct RhsLoader<EG: Numeric, ES: Numeric> {
 #[cube]
 impl<EG: Numeric, ES: Numeric> LhsLoader<EG, ES> {
     pub fn new<G: global::Config>(
-        tensor: Tensor<Line<EG>>,
+        tensor: &Tensor<Line<EG>>,
         x_offset: u32,
         y_offset: u32,
         nth_batch: u32,
@@ -38,7 +38,7 @@ impl<EG: Numeric, ES: Numeric> LhsLoader<EG, ES> {
 #[cube]
 impl<EG: Numeric, ES: Numeric> RhsLoader<EG, ES> {
     pub fn new<G: global::Config>(
-        tensor: Tensor<Line<EG>>,
+        tensor: &Tensor<Line<EG>>,
         x_offset: u32,
         y_offset: u32,
         nth_batch: u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view/tilewise_unloading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view/tilewise_unloading.rs
@@ -4,7 +4,7 @@ use crate::matmul::components::Ident;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use super::base::TensorView;
+use super::base::TensorWriter;
 
 #[derive(CubeType)]
 /// Writes the contents of a tile to the tensor view using a single plane,
@@ -25,7 +25,7 @@ impl PlaneMapper for TilewiseUnloading {
 #[cube]
 impl TilewiseUnloading {
     pub fn unload_from_slice<EG: Numeric, ES: Numeric, G: Config>(
-        write_view: &mut TensorView<EG>,
+        write_view: &mut TensorWriter<EG>,
         slice: &Slice<'_, Line<ES>>,
         tile_x: u32,
         tile_y: u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view/unloader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view/unloader.rs
@@ -23,7 +23,7 @@ impl<EG: Numeric> global::Unloader<EG> for Unloader<EG> {
 
 #[cube]
 impl<EG: Numeric> Unloader<EG> {
-    pub fn new(tensor: Tensor<Line<EG>>, x_offset: u32, y_offset: u32, batch_offset: u32) -> Self {
+    pub fn new(tensor: &Tensor<Line<EG>>, x_offset: u32, y_offset: u32, batch_offset: u32) -> Self {
         Unloader::<EG> {
             tensor_view: TensorView::new(tensor, x_offset, y_offset, batch_offset),
         }

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view/unloader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view/unloader.rs
@@ -2,14 +2,13 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::matmul::components::global;
+use crate::matmul::components::global::tensor_view::base::TensorWriter;
 use crate::matmul::components::global::tensor_view::tilewise_unloading::TilewiseUnloading;
 use crate::matmul::components::stage::StageWriter;
 
-use super::base::TensorView;
-
 #[derive(CubeType)]
 pub struct Unloader<EG: Numeric> {
-    pub tensor_view: TensorView<EG>,
+    pub tensor_view: TensorWriter<EG>,
 }
 
 #[cube]
@@ -23,9 +22,14 @@ impl<EG: Numeric> global::Unloader<EG> for Unloader<EG> {
 
 #[cube]
 impl<EG: Numeric> Unloader<EG> {
-    pub fn new(tensor: &Tensor<Line<EG>>, x_offset: u32, y_offset: u32, batch_offset: u32) -> Self {
+    pub fn new(
+        tensor: &mut Tensor<Line<EG>>,
+        x_offset: u32,
+        y_offset: u32,
+        batch_offset: u32,
+    ) -> Self {
         Unloader::<EG> {
-            tensor_view: TensorView::new(tensor, x_offset, y_offset, batch_offset),
+            tensor_view: TensorWriter::new(tensor, x_offset, y_offset, batch_offset),
         }
     }
 }


### PR DESCRIPTION
Matmul now takes tensor references as input, rather than owned tensors. 

It used to take owned tensors because (somehow) cube allowed it with the way I used them, and it simplified the tensor view, which could own it instead of owning a reference. 

But for further improvements I needed the tensor as a reference. In the tensor view I turned the Tensor into a pointer and used unchecked indexing. 