### PR TITLE
Added support for target_feature atomics on wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { version = "1.0.119", default-features = false }
 dashmap = "5.5.3"
 hashbrown = "0.14.5"
 spin = { version = "0.9.8", features = ["mutex", "spin_mutex"] }
+rayon = "1"
 
 getrandom = { version = "0.2.15", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = [
@@ -73,6 +74,7 @@ pretty_assertions = "1.4"
 # Async
 embassy-futures = { version = "0.1.1" }                        # for no-std
 futures-lite = { version = "2.3.0", default-features = false }
+futures = "0.3.31"
 
 [profile.dev]
 opt-level = 2

--- a/crates/cubecl-runtime/src/memory_management/base.rs
+++ b/crates/cubecl-runtime/src/memory_management/base.rs
@@ -4,6 +4,7 @@ use alloc::{format, string::String};
 /// Amount of memory in use by this allocator
 /// and statistics on how much memory is reserved and
 /// wasted in total.
+#[derive(Debug)]
 pub struct MemoryUsage {
     /// The number of allocations currently active.
     pub number_allocs: u64,

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -45,6 +45,10 @@ web-time = { workspace = true }
 
 cfg-if = { workspace = true }
 
+[target.'cfg(all(target_arch = "wasm32", target_feature = "atomics"))'.dependencies]
+futures = { workspace = true }
+rayon = { workspace = true }
+
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.4.0", features = [
     "export_tests",

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -1,25 +1,23 @@
-use std::sync::Arc;
-
 use cubecl_core::{
     prelude::CompiledKernel, server::ComputeServer, Compiler, ExecutionMode, Feature,
 };
 use cubecl_runtime::DeviceProperties;
 use wgpu::{Adapter, ComputePipeline, Device, Queue};
 
-use crate::WgpuServer;
+use crate::{Pdrc, WgpuServer, WgpuServerInner};
 
 pub trait WgpuCompiler: Compiler {
     fn compile(
-        server: &mut WgpuServer<Self>,
+        server: &mut WgpuServerInner<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
         mode: ExecutionMode,
     ) -> CompiledKernel<Self>;
 
     fn create_pipeline(
-        server: &mut WgpuServer<Self>,
+        server: &mut WgpuServerInner<Self>,
         kernel: CompiledKernel<Self>,
         mode: ExecutionMode,
-    ) -> Arc<ComputePipeline>;
+    ) -> Pdrc<ComputePipeline>;
 
     #[allow(async_fn_in_trait)]
     async fn request_device(adapter: &Adapter) -> (Device, Queue);

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
 use super::{shader::ComputeShader, ConstantArray, Item, SharedMemory};
 use super::{LocalArray, Subgroup};
@@ -6,6 +6,7 @@ use crate::{
     compiler::{base::WgpuCompiler, wgsl},
     WgpuServer,
 };
+use crate::{Pdrc, WgpuServerInner};
 use cubecl_core::{
     ir::{self as cube, HybridAllocator, UIntKind},
     prelude::CompiledKernel,
@@ -70,10 +71,10 @@ impl cubecl_core::Compiler for WgslCompiler {
 
 impl WgpuCompiler for WgslCompiler {
     fn create_pipeline(
-        server: &mut WgpuServer<Self>,
+        server: &mut WgpuServerInner<Self>,
         kernel: CompiledKernel<Self>,
         mode: ExecutionMode,
-    ) -> Arc<ComputePipeline> {
+    ) -> Pdrc<ComputePipeline> {
         let source = &kernel.source;
         let repr = kernel.repr.unwrap();
         let module = match mode {
@@ -118,7 +119,7 @@ impl WgpuCompiler for WgslCompiler {
                 push_constant_ranges: &[],
             });
 
-        Arc::new(
+        Pdrc::new(
             server
                 .device
                 .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -136,7 +137,7 @@ impl WgpuCompiler for WgslCompiler {
     }
 
     fn compile(
-        _server: &mut WgpuServer<Self>,
+        _server: &mut WgpuServerInner<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
         mode: ExecutionMode,
     ) -> CompiledKernel<Self> {

--- a/crates/cubecl-wgpu/src/compute/poll.rs
+++ b/crates/cubecl-wgpu/src/compute/poll.rs
@@ -58,10 +58,12 @@ mod _impl {
 // On Wasm, the browser handles the polling loop, so we don't need anything.
 #[cfg(target_family = "wasm")]
 mod _impl {
+    use crate::Pdrc;
+
     #[derive(Debug)]
     pub struct WgpuPoll {}
     impl WgpuPoll {
-        pub fn new(_device: alloc::sync::Arc<wgpu::Device>) -> Self {
+        pub fn new(_device: Pdrc<wgpu::Device>) -> Self {
             Self {}
         }
         pub fn start_polling(&self) -> alloc::sync::Arc<()> {

--- a/crates/cubecl-wgpu/src/compute/storage.rs
+++ b/crates/cubecl-wgpu/src/compute/storage.rs
@@ -1,106 +1,242 @@
-use cubecl_runtime::storage::{ComputeStorage, StorageHandle, StorageId, StorageUtilization};
+use cubecl_runtime::storage::{ComputeStorage, StorageHandle, StorageId};
 use hashbrown::HashMap;
-use std::{num::NonZeroU64, sync::Arc};
+use std::num::NonZeroU64;
 
-/// Buffer storage for wgpu.
-pub struct WgpuStorage {
-    memory: HashMap<StorageId, Arc<wgpu::Buffer>>,
-    deallocations: Vec<StorageId>,
-    device: Arc<wgpu::Device>,
-}
+#[cfg(not(all(target_arch = "wasm32", target_feature = "atomics")))]
+mod _impl {
+    use std::sync::Arc;
 
-impl core::fmt::Debug for WgpuStorage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(format!("WgpuStorage {{ device: {:?} }}", self.device).as_str())
-    }
-}
+    use cubecl_runtime::storage::StorageUtilization;
 
-/// The memory resource that can be allocated for wgpu.
-#[derive(new)]
-pub struct WgpuResource {
-    /// The wgpu buffer.
-    pub buffer: Arc<wgpu::Buffer>,
+    use super::*;
 
-    offset: u64,
-    size: u64,
-}
-
-impl WgpuResource {
-    /// Return the binding view of the buffer.
-    pub fn as_wgpu_bind_resource(&self) -> wgpu::BindingResource {
-        let binding = wgpu::BufferBinding {
-            buffer: &self.buffer,
-            offset: self.offset,
-            size: Some(
-                NonZeroU64::new(self.size).expect("0 size resources are not yet supported."),
-            ),
-        };
-        wgpu::BindingResource::Buffer(binding)
+    /// Buffer storage for wgpu.
+    pub struct WgpuStorage {
+        memory: HashMap<StorageId, Arc<wgpu::Buffer>>,
+        deallocations: Vec<StorageId>,
+        device: Arc<wgpu::Device>,
     }
 
-    /// Return the buffer size.
-    pub fn size(&self) -> u64 {
-        self.size
-    }
-
-    /// Return the buffer offset.
-    pub fn offset(&self) -> u64 {
-        self.offset
-    }
-}
-
-/// Keeps actual wgpu buffer references in a hashmap with ids as key.
-impl WgpuStorage {
-    /// Create a new storage on the given [device](wgpu::Device).
-    pub fn new(device: Arc<wgpu::Device>) -> Self {
-        Self {
-            memory: HashMap::new(),
-            deallocations: Vec::new(),
-            device,
+    impl core::fmt::Debug for WgpuStorage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(format!("WgpuStorage {{ device: {:?} }}", self.device).as_str())
         }
     }
 
-    /// Actually deallocates buffers tagged to be deallocated.
-    pub fn perform_deallocations(&mut self) {
-        for id in self.deallocations.drain(..) {
-            if let Some(buffer) = self.memory.remove(&id) {
-                buffer.destroy()
+    /// Keeps actual wgpu buffer references in a hashmap with ids as key.
+    impl WgpuStorage {
+        /// Create a new storage on the given [device](wgpu::Device).
+        pub fn new(device: Arc<wgpu::Device>) -> Self {
+            Self {
+                memory: HashMap::new(),
+                deallocations: Vec::new(),
+                device,
+            }
+        }
+
+        /// Actually deallocates buffers tagged to be deallocated.
+        pub fn perform_deallocations(&mut self) {
+            for id in self.deallocations.drain(..) {
+                if let Some(buffer) = self.memory.remove(&id) {
+                    buffer.destroy()
+                }
             }
         }
     }
+
+    impl ComputeStorage for WgpuStorage {
+        type Resource = WgpuResource;
+
+        // 32 bytes is enough to handle a double4 worth of alignment.
+        // See: https://github.com/gfx-rs/wgpu/issues/3508
+        // NB: cudamalloc and co. actually align to _256_ bytes. Worth
+        // trying this in the future to see if it reduces memory coalescing.
+        const ALIGNMENT: u64 = 32;
+
+        fn get(&mut self, handle: &StorageHandle) -> Self::Resource {
+            let buffer = self.memory.get(&handle.id).unwrap();
+            WgpuResource::new(buffer.clone(), handle.offset(), handle.size())
+        }
+
+        fn alloc(&mut self, size: u64) -> StorageHandle {
+            let id = StorageId::new();
+            let buffer = Arc::new(self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: None,
+                size,
+                usage: wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_SRC
+                    | wgpu::BufferUsages::INDIRECT,
+                mapped_at_creation: false,
+            }));
+
+            self.memory.insert(id, buffer);
+            StorageHandle::new(id, StorageUtilization { offset: 0, size })
+        }
+
+        fn dealloc(&mut self, id: StorageId) {
+            self.deallocations.push(id);
+        }
+    }
+
+    /// The memory resource that can be allocated for wgpu.
+    #[derive(new)]
+    pub struct WgpuResource {
+        /// The wgpu buffer.
+        pub buffer: Arc<wgpu::Buffer>,
+
+        offset: u64,
+        size: u64,
+    }
+
+    impl WgpuResource {
+        /// Return the binding view of the buffer.
+        pub fn as_wgpu_bind_resource(&self) -> wgpu::BindingResource {
+            let binding = wgpu::BufferBinding {
+                buffer: &self.buffer,
+                offset: self.offset,
+                size: Some(
+                    NonZeroU64::new(self.size).expect("0 size resources are not yet supported."),
+                ),
+            };
+            wgpu::BindingResource::Buffer(binding)
+        }
+
+        /// Return the buffer size.
+        pub fn size(&self) -> u64 {
+            self.size
+        }
+
+        /// Return the buffer offset.
+        pub fn offset(&self) -> u64 {
+            self.offset
+        }
+    }
 }
 
-impl ComputeStorage for WgpuStorage {
-    type Resource = WgpuResource;
+#[cfg(all(target_arch = "wasm32", target_feature = "atomics"))]
+mod _impl {
+    use std::rc::Rc;
 
-    // 32 bytes is enough to handle a double4 worth of alignment.
-    // See: https://github.com/gfx-rs/wgpu/issues/3508
-    // NB: cudamalloc and co. actually align to _256_ bytes. Worth
-    // trying this in the future to see if it reduces memory coalescing.
-    const ALIGNMENT: u64 = 32;
+    use crate::{compiler::base::WgpuCompiler, compute::server::ServerCommand};
 
-    fn get(&mut self, handle: &StorageHandle) -> Self::Resource {
-        let buffer = self.memory.get(&handle.id).unwrap();
-        WgpuResource::new(buffer.clone(), handle.offset(), handle.size())
+    use super::*;
+
+    /// Buffer storage for wgpu.
+    pub struct WgpuStorage<C: WgpuCompiler> {
+        deallocations: Vec<StorageId>,
+        tx: std::sync::mpsc::Sender<ServerCommand<C>>,
     }
 
-    fn alloc(&mut self, size: u64) -> StorageHandle {
-        let id = StorageId::new();
-        let buffer = Arc::new(self.device.create_buffer(&wgpu::BufferDescriptor {
-            label: None,
-            size,
-            usage: wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::INDIRECT,
-            mapped_at_creation: false,
-        }));
+    /// Keeps actual wgpu buffer references in a hashmap with ids as key.
+    impl<C: WgpuCompiler> WgpuStorage<C> {
+        /// Create a new storage on the given [device](wgpu::Device).
+        pub fn new(tx: std::sync::mpsc::Sender<ServerCommand<C>>) -> Self {
+            Self {
+                deallocations: Vec::new(),
+                tx,
+            }
+        }
 
-        self.memory.insert(id, buffer);
-        StorageHandle::new(id, StorageUtilization { offset: 0, size })
+        /// Actually deallocates buffers tagged to be deallocated.
+        pub fn perform_deallocations(&mut self) {
+            let (tx, mut rx) = futures::channel::oneshot::channel();
+            self.tx
+                .send(ServerCommand::PerformDeallocations {
+                    tx,
+                    deallocations: self.deallocations.drain(..).collect(),
+                })
+                .expect("Failed to send command to the wgpu server");
+
+            loop {
+                match rx.try_recv() {
+                    Ok(response) => {
+                        if response.is_some() {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        panic!("Failed to receive the response from the wgpu server: {err}")
+                    }
+                }
+            }
+        }
     }
 
-    fn dealloc(&mut self, id: StorageId) {
-        self.deallocations.push(id);
+    impl<C: WgpuCompiler> ComputeStorage for WgpuStorage<C> {
+        type Resource = WgpuResource;
+
+        // 32 bytes is enough to handle a double4 worth of alignment.
+        // See: https://github.com/gfx-rs/wgpu/issues/3508
+        // NB: cudamalloc and co. actually align to _256_ bytes. Worth
+        // trying this in the future to see if it reduces memory coalescing.
+        const ALIGNMENT: u64 = 32;
+
+        fn get(&mut self, handle: &StorageHandle) -> Self::Resource {
+            WgpuResource::new(handle.id, handle.offset(), handle.size())
+        }
+
+        fn alloc(&mut self, size: u64) -> StorageHandle {
+            let (tx, mut rx) = futures::channel::oneshot::channel();
+            self.tx
+                .send(ServerCommand::Alloc { tx, size })
+                .expect("Failed to send command to the wgpu server");
+
+            loop {
+                match rx.try_recv() {
+                    Ok(handle) => {
+                        if let Some(handle) = handle {
+                            return handle;
+                        }
+                    }
+                    Err(err) => {
+                        panic!("Failed to receive the response from the wgpu server: {err}")
+                    }
+                }
+            }
+        }
+
+        fn dealloc(&mut self, id: StorageId) {
+            self.deallocations.push(id);
+        }
+    }
+
+    /// The memory resource that can be allocated for wgpu.
+    #[derive(new)]
+    pub struct WgpuResource {
+        /// The storage id.
+        pub buffer: StorageId,
+        offset: u64,
+        size: u64,
+    }
+
+    impl WgpuResource {
+        /// Return the binding view of the buffer.
+        pub fn as_wgpu_bind_resource<'a>(
+            &self,
+            buffers: &'a HashMap<StorageId, Rc<wgpu::Buffer>>,
+        ) -> wgpu::BindingResource<'a> {
+            let buffer = buffers.get(&self.buffer).expect("Buffer does not exist");
+            let binding = wgpu::BufferBinding {
+                buffer,
+                offset: self.offset,
+                size: Some(
+                    NonZeroU64::new(self.size).expect("0 size resources are not yet supported."),
+                ),
+            };
+            wgpu::BindingResource::Buffer(binding)
+        }
+
+        /// Return the buffer size.
+        pub fn size(&self) -> u64 {
+            self.size
+        }
+
+        /// Return the buffer offset.
+        pub fn offset(&self) -> u64 {
+            self.offset
+        }
     }
 }
+
+pub use _impl::*;

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -20,6 +20,18 @@ pub use runtime::*;
 #[cfg(feature = "spirv")]
 pub use compiler::spirv;
 
+/// Platform dependent reference counting. Uses [`alloc::sync::Arc`] on all platforms except
+/// `wasm32` when the feature `atomics` is enabled. Uses [`alloc::rc::Rc`] instead when on
+/// `wasm32` and with the `atomics` feature enabled.
+#[cfg(not(all(target_arch = "wasm32", target_feature = "atomics")))]
+type Pdrc<T> = alloc::sync::Arc<T>;
+
+/// Platform dependent reference counting. Uses [`alloc::sync::Arc`] on all platforms except
+/// `wasm32` when the feature `atomics` is enabled. Uses [`alloc::rc::Rc`] instead when on
+/// `wasm32` and with the `atomics` feature enabled.
+#[cfg(all(target_arch = "wasm32", target_feature = "atomics"))]
+type Pdrc<T> = alloc::rc::Rc<T>;
+
 #[cfg(test)]
 mod tests {
     pub type TestRuntime = crate::WgpuRuntime<crate::WgslCompiler>;


### PR DESCRIPTION
The target_feature atomics enabled multithreading on the wasm32. The devices in wgpu are not Send or Sync when the target_feature atmoics is enabled as they cannot be shared across threads.

This PR enables cubecl to run wgpu on a dedicated thread and then communicate to this thread using channels.

We are trying to use burn to run inference on wasm32 but we need atomics support to do multi threaded CPU bound compute as well.