### PR TITLE
Fix enabling exclusive-memory-only

### DIFF
--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -16,7 +16,7 @@ default = [
     "cubecl-common/default",
     "cubecl-core/default",
 ]
-exclusive-memory-only = []
+exclusive-memory-only = ["cubecl-runtime/exclusive-memory-only"]
 spirv = ["cubecl-spirv", "ash", "spirv-dump"]
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 

--- a/crates/cubecl/Cargo.toml
+++ b/crates/cubecl/Cargo.toml
@@ -20,10 +20,7 @@ default = [
     "cubecl-hip?/default",
     "cubecl-wgpu?/default",
 ]
-exclusive-memory-only = [
-    "cubecl-wgpu?/exclusive-memory-only",
-    "cubecl-runtime/exclusive-memory-only",
-]
+exclusive-memory-only = ["cubecl-wgpu?/exclusive-memory-only"]
 linalg = ["dep:cubecl-linalg"]
 std = ["cubecl-core/std", "cubecl-wgpu?/std", "cubecl-cuda?/std"]
 template = ["cubecl-core/template"]


### PR DESCRIPTION
Cube exclusive-pages-only enabled it on both cubecl-wgpu and cubecl-runtime. This doesn't work when isolating cubecl-wgpo in isolation. Instead cubecl-wgpu needs to enable it on cubecl-runtime.