### PR TITLE
Add topology properties to client

### DIFF
--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -7,7 +7,7 @@ use cubecl_core::{
 use cubecl_runtime::{
     channel::MutexComputeChannel,
     client::ComputeClient,
-    memory_management::{MemoryDeviceProperties, MemoryManagement},
+    memory_management::{MemoryDeviceProperties, MemoryManagement, TopologyProperties},
     storage::ComputeStorage,
     ComputeRuntime, DeviceProperties,
 };
@@ -72,14 +72,27 @@ fn create_client(device: &CudaDevice, options: RuntimeOptions) -> ComputeClient<
         alignment: CudaStorage::ALIGNMENT,
     };
 
+    let warp_size = unsafe {
+        cudarc::driver::result::device::get_attribute(
+            device_ptr,
+            cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_WARP_SIZE,
+        )
+        .unwrap()
+    };
+    let topology = TopologyProperties {
+        subcube_size_min: warp_size as u32,
+        subcube_size_max: warp_size as u32,
+    };
+
     let memory_management = MemoryManagement::from_configuration(
         storage,
         mem_properties.clone(),
         options.memory_config,
     );
+
     let cuda_ctx = CudaContext::new(memory_management, stream, ctx, arch);
     let mut server = CudaServer::new(cuda_ctx);
-    let mut device_props = DeviceProperties::new(&[Feature::Subcube], mem_properties);
+    let mut device_props = DeviceProperties::new(&[Feature::Subcube], mem_properties, topology);
     register_supported_types(&mut device_props);
     device_props.register_feature(Feature::Type(Elem::Float(FloatKind::TF32)));
     register_wmma_features(&mut device_props, server.arch_version());

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -89,6 +89,10 @@ fn create_client(device: &HipDevice, options: RuntimeOptions) -> ComputeClient<S
         max_page_size: max_memory as u64 / 4,
         alignment: MEMORY_OFFSET_ALIGNMENT,
     };
+    let topology = TopologyProperties {
+        subcube_size_min: prop_warp_size as u32,
+        subcube_size_max: prop_warp_size as u32,
+    };
     let memory_management = MemoryManagement::from_configuration(
         storage,
         mem_properties.clone(),
@@ -96,7 +100,7 @@ fn create_client(device: &HipDevice, options: RuntimeOptions) -> ComputeClient<S
     );
     let hip_ctx = HipContext::new(memory_management, stream, ctx);
     let server = HipServer::new(hip_ctx);
-    let mut device_props = DeviceProperties::new(&[Feature::Subcube], mem_properties);
+    let mut device_props = DeviceProperties::new(&[Feature::Subcube], mem_properties, topology);
     register_supported_types(&mut device_props);
     arch.register_wmma_features(&mut device_props);
 

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -7,7 +7,7 @@ use cubecl_hip_sys::HIP_SUCCESS;
 use cubecl_runtime::{
     channel::MutexComputeChannel,
     client::ComputeClient,
-    memory_management::{MemoryDeviceProperties, MemoryManagement},
+    memory_management::{MemoryDeviceProperties, MemoryManagement, TopologyProperties},
     ComputeRuntime, DeviceProperties,
 };
 

--- a/crates/cubecl-runtime/src/feature_set.rs
+++ b/crates/cubecl-runtime/src/feature_set.rs
@@ -1,4 +1,4 @@
-use crate::memory_management::MemoryDeviceProperties;
+use crate::memory_management::{MemoryDeviceProperties, TopologyProperties};
 use alloc::collections::BTreeSet;
 
 /// Properties of what the device can do, like what [features](Feature) are
@@ -7,11 +7,16 @@ use alloc::collections::BTreeSet;
 pub struct DeviceProperties<Feature: Ord + Copy> {
     set: alloc::collections::BTreeSet<Feature>,
     memory: MemoryDeviceProperties,
+    topology: TopologyProperties,
 }
 
 impl<Feature: Ord + Copy> DeviceProperties<Feature> {
     /// Create a new feature set with the given features and memory properties.
-    pub fn new(features: &[Feature], memory_props: MemoryDeviceProperties) -> Self {
+    pub fn new(
+        features: &[Feature],
+        memory_props: MemoryDeviceProperties,
+        topology: TopologyProperties,
+    ) -> Self {
         let mut set = BTreeSet::new();
         for feature in features {
             set.insert(*feature);
@@ -20,6 +25,7 @@ impl<Feature: Ord + Copy> DeviceProperties<Feature> {
         DeviceProperties {
             set,
             memory: memory_props,
+            topology,
         }
     }
 
@@ -38,5 +44,10 @@ impl<Feature: Ord + Copy> DeviceProperties<Feature> {
     /// The memory properties of this client.
     pub fn memory_properties(&self) -> &MemoryDeviceProperties {
         &self.memory
+    }
+
+    /// The topology properties of this client.
+    pub fn topology_properties(&self) -> &TopologyProperties {
+        &self.topology
     }
 }

--- a/crates/cubecl-runtime/src/memory_management/mod.rs
+++ b/crates/cubecl-runtime/src/memory_management/mod.rs
@@ -81,6 +81,19 @@ pub struct MemoryDeviceProperties {
 }
 
 /// Properties of the device related to topology.
+///
+/// # Subcube size min/max
+///
+/// This is a range of possible values for the subcube size.
+///
+/// For Nvidia GPUs and HIP, this is a single fixed value.
+///
+/// For wgpu with AMD GPUs this is a rannge of possible values, but the actual configured value
+/// is undefined and can only be queried at runtime. Should usually be 32, but not guaranteed.
+///
+/// For Intel GPUs, this is variable based on the number of registers used in the kernel. No way to
+/// query this at compile time is currently available. As a result, the minimum value should usually
+/// be assumed.
 #[derive(Debug, Clone)]
 pub struct TopologyProperties {
     /// The minimum size of a subcube on this device

--- a/crates/cubecl-runtime/src/memory_management/mod.rs
+++ b/crates/cubecl-runtime/src/memory_management/mod.rs
@@ -79,3 +79,12 @@ pub struct MemoryDeviceProperties {
     /// The required memory offset alignment in bytes.
     pub alignment: u64,
 }
+
+/// Properties of the device related to topology.
+#[derive(Debug, Clone)]
+pub struct TopologyProperties {
+    /// The minimum size of a subcube on this device
+    pub subcube_size_min: u32,
+    /// The maximum size of a subcube on this device
+    pub subcube_size_max: u32,
+}

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -1,11 +1,11 @@
 use super::DummyServer;
-use cubecl_runtime::channel::MutexComputeChannel;
 use cubecl_runtime::client::ComputeClient;
 use cubecl_runtime::memory_management::{
     MemoryConfiguration, MemoryDeviceProperties, MemoryManagement,
 };
 use cubecl_runtime::storage::BytesStorage;
 use cubecl_runtime::tune::{AutotuneOperationSet, LocalTuner};
+use cubecl_runtime::{channel::MutexComputeChannel, memory_management::TopologyProperties};
 use cubecl_runtime::{ComputeRuntime, DeviceProperties};
 
 /// The dummy device.
@@ -33,6 +33,10 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
         max_page_size: 1024 * 1024 * 512,
         alignment: 32,
     };
+    let topology = TopologyProperties {
+        subcube_size_min: 32,
+        subcube_size_max: 32,
+    };
     let memory_management = MemoryManagement::from_configuration(
         storage,
         mem_properties.clone(),
@@ -40,7 +44,10 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
     );
     let server = DummyServer::new(memory_management);
     let channel = MutexComputeChannel::new(server);
-    ComputeClient::new(channel, DeviceProperties::new(&[], mem_properties))
+    ComputeClient::new(
+        channel,
+        DeviceProperties::new(&[], mem_properties, topology),
+    )
 }
 
 pub fn client(device: &DummyDevice) -> DummyClient {

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -36,6 +36,6 @@ mod tests_spirv {
     use half::f16;
 
     cubecl_core::testgen_all!(f32: [f16, flex32, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
-    cubecl_linalg::testgen_plane_mma!([f16, flex32, f32, f64], f32);
+    cubecl_linalg::testgen_plane_mma!([f16, flex32, f32], f32);
     cubecl_linalg::testgen_tiling2d!([f16, flex32, f32, f64]);
 }


### PR DESCRIPTION
Adds topology properties to the client to directly read out things like subcube size from the device instead of assuming a warp size of 32.