### PR TITLE
Fix autotune compilation on WASM

### DIFF
--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -116,7 +116,6 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             TuneCacheResult::Pending => {
                 // We're waiting for results to come in.
             }
-            #[cfg(autotune_persistent_cache)]
             TuneCacheResult::Unchecked => {
                 panic!("Should have checked the cache already.")
             }
@@ -142,7 +141,6 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
                 TuneCacheResult::Miss => {
                     panic!("Should have at least started autotuning");
                 }
-                #[cfg(autotune_persistent_cache)]
                 TuneCacheResult::Unchecked => {
                     panic!("Should have checked the cache.")
                 }

--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -65,7 +65,6 @@ pub enum TuneCacheResult {
         fastest_index: usize,
     },
     /// The operation might be cached, but we don't know yet whether the checksum is valid.
-    #[cfg(autotune_persistent_cache)]
     Unchecked,
     /// We don't know yet what is fastest, but are waiting for a result to come in.
     Pending,


### PR DESCRIPTION
Same problem as https://github.com/tracel-ai/cubecl/pull/239

This fixes it by allowing Unchecked as a type when autotune_persistent_cache is off. Imo it's not worth all this conditional compilation business, fine to leave it to runtime and will break less this way.