### PR TITLE
Write enable subgroups on the web

### DIFF
--- a/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
@@ -92,6 +92,11 @@ pub struct ComputeShader {
 
 impl Display for ComputeShader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // On wasm, writeout what extensions we're using. This is standard wgsl but not yet
+        // supported by wgpu.
+        #[cfg(target_family = "wasm")]
+        f.write_str("enable subgroups;")?;
+
         Self::format_bindings(f, "input", &self.inputs, 0)?;
         Self::format_bindings(f, "output", &self.outputs, self.inputs.len())?;
 


### PR DESCRIPTION
On WebGPU, to use subgroups, `enable subgroups;` needs to be added to the wgsl shader.

This is appearantly standard wgsl, coming to wgpu 23+ as well. Atm this is Chrome only, but only Chrome really properly supports WebGPU currently anyway, so probably best to just follow standards and let others catch up.