### PR TITLE
Add max_bindings hardware limit

### DIFF
--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -95,8 +95,7 @@ fn create_client(device: &CudaDevice, options: RuntimeOptions) -> ComputeClient<
 
     let cuda_ctx = CudaContext::new(memory_management, stream, ctx, arch);
     let mut server = CudaServer::new(cuda_ctx);
-    let mut device_props =
-        DeviceProperties::new(&[Feature::Plane], mem_properties, hardware_props);
+    let mut device_props = DeviceProperties::new(&[Feature::Plane], mem_properties, hardware_props);
     register_supported_types(&mut device_props);
     device_props.register_feature(Feature::Type(Elem::Float(FloatKind::TF32)));
     register_wmma_features(&mut device_props, server.arch_version());

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -7,7 +7,7 @@ use cubecl_hip_sys::HIP_SUCCESS;
 use cubecl_runtime::{
     channel::MutexComputeChannel,
     client::ComputeClient,
-    memory_management::{MemoryDeviceProperties, MemoryManagement, TopologyProperties},
+    memory_management::{HardwareProperties, MemoryDeviceProperties, MemoryManagement},
     ComputeRuntime, DeviceProperties,
 };
 
@@ -92,6 +92,9 @@ fn create_client(device: &HipDevice, options: RuntimeOptions) -> ComputeClient<S
     let topology = TopologyProperties {
         plane_size_min: prop_warp_size as u32,
         plane_size_max: prop_warp_size as u32,
+        // This is a guess - not clear if ROCM has a limit on the number of bindings,
+        // but it's dubious it's more than this.
+        max_bindings: 1024,
     };
     let memory_management = MemoryManagement::from_configuration(
         storage,

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -89,7 +89,7 @@ fn create_client(device: &HipDevice, options: RuntimeOptions) -> ComputeClient<S
         max_page_size: max_memory as u64 / 4,
         alignment: MEMORY_OFFSET_ALIGNMENT,
     };
-    let topology = TopologyProperties {
+    let topology = HardwareProperties {
         plane_size_min: prop_warp_size as u32,
         plane_size_max: prop_warp_size as u32,
         // This is a guess - not clear if ROCM has a limit on the number of bindings,

--- a/crates/cubecl-runtime/src/feature_set.rs
+++ b/crates/cubecl-runtime/src/feature_set.rs
@@ -1,4 +1,4 @@
-use crate::memory_management::{MemoryDeviceProperties, TopologyProperties};
+use crate::memory_management::{HardwareProperties, MemoryDeviceProperties};
 use alloc::collections::BTreeSet;
 
 /// Properties of what the device can do, like what [features](Feature) are
@@ -7,7 +7,7 @@ use alloc::collections::BTreeSet;
 pub struct DeviceProperties<Feature: Ord + Copy> {
     set: alloc::collections::BTreeSet<Feature>,
     memory: MemoryDeviceProperties,
-    topology: TopologyProperties,
+    hardware: HardwareProperties,
 }
 
 impl<Feature: Ord + Copy> DeviceProperties<Feature> {
@@ -15,7 +15,7 @@ impl<Feature: Ord + Copy> DeviceProperties<Feature> {
     pub fn new(
         features: &[Feature],
         memory_props: MemoryDeviceProperties,
-        topology: TopologyProperties,
+        hardware: HardwareProperties,
     ) -> Self {
         let mut set = BTreeSet::new();
         for feature in features {
@@ -25,7 +25,7 @@ impl<Feature: Ord + Copy> DeviceProperties<Feature> {
         DeviceProperties {
             set,
             memory: memory_props,
-            topology,
+            hardware,
         }
     }
 
@@ -47,7 +47,7 @@ impl<Feature: Ord + Copy> DeviceProperties<Feature> {
     }
 
     /// The topology properties of this client.
-    pub fn topology_properties(&self) -> &TopologyProperties {
-        &self.topology
+    pub fn hardware_properties(&self) -> &HardwareProperties {
+        &self.hardware
     }
 }

--- a/crates/cubecl-runtime/src/memory_management/mod.rs
+++ b/crates/cubecl-runtime/src/memory_management/mod.rs
@@ -80,7 +80,7 @@ pub struct MemoryDeviceProperties {
     pub alignment: u64,
 }
 
-/// Properties of the device related to topology.
+/// Properties of the device related to the accelerator hardware.
 ///
 /// # Plane size min/max
 ///
@@ -95,9 +95,11 @@ pub struct MemoryDeviceProperties {
 /// query this at compile time is currently available. As a result, the minimum value should usually
 /// be assumed.
 #[derive(Debug, Clone)]
-pub struct TopologyProperties {
+pub struct HardwareProperties {
     /// The minimum size of a plane on this device
     pub plane_size_min: u32,
     /// The maximum size of a plane on this device
     pub plane_size_max: u32,
+    /// minimum number of bindings for a kernel that can be used at once.
+    pub max_bindings: u32,
 }

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -33,7 +33,7 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
         max_page_size: 1024 * 1024 * 512,
         alignment: 32,
     };
-    let topology = TopologyProperties {
+    let topology = HardwareProperties {
         plane_size_min: 32,
         plane_size_max: 32,
         max_bindings: 32,

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -5,7 +5,7 @@ use cubecl_runtime::memory_management::{
 };
 use cubecl_runtime::storage::BytesStorage;
 use cubecl_runtime::tune::{AutotuneOperationSet, LocalTuner};
-use cubecl_runtime::{channel::MutexComputeChannel, memory_management::TopologyProperties};
+use cubecl_runtime::{channel::MutexComputeChannel, memory_management::HardwareProperties};
 use cubecl_runtime::{ComputeRuntime, DeviceProperties};
 
 /// The dummy device.
@@ -36,6 +36,7 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
     let topology = TopologyProperties {
         plane_size_min: 32,
         plane_size_max: 32,
+        max_bindings: 32,
     };
     let memory_management = MemoryManagement::from_configuration(
         storage,

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -143,13 +143,11 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
         max_page_size: limits.max_storage_buffer_binding_size as u64,
         alignment: WgpuStorage::ALIGNMENT.max(limits.min_storage_buffer_offset_alignment as u64),
     };
-    let topology = TopologyProperties {
+    let hardware_props = HardwareProperties {
         plane_size_min: setup.adapter.limits().min_subgroup_size,
         plane_size_max: setup.adapter.limits().max_subgroup_size,
         max_bindings: limits.max_bind_groups,
-
     };
-
     let memory_management = {
         let device = setup.device.clone();
         let mem_props = mem_props.clone();

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -10,7 +10,7 @@ use cubecl_common::future;
 use cubecl_core::{Feature, Runtime};
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
 use cubecl_runtime::{channel::MutexComputeChannel, client::ComputeClient, ComputeRuntime};
-use cubecl_runtime::{memory_management::TopologyProperties, DeviceProperties};
+use cubecl_runtime::{memory_management::HardwareProperties, DeviceProperties};
 use cubecl_runtime::{
     memory_management::{MemoryDeviceProperties, MemoryManagement},
     storage::ComputeStorage,
@@ -146,6 +146,8 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
     let topology = TopologyProperties {
         plane_size_min: setup.adapter.limits().min_subgroup_size,
         plane_size_max: setup.adapter.limits().max_subgroup_size,
+        max_bindings: limits.max_bind_groups,
+
     };
 
     let memory_management = {
@@ -164,7 +166,7 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
     let channel = MutexComputeChannel::new(server);
 
     let features = setup.adapter.features();
-    let mut device_props = DeviceProperties::new(&[], mem_props, topology);
+    let mut device_props = DeviceProperties::new(&[], mem_props, hardware_props);
 
     if features.contains(wgpu::Features::SUBGROUP)
         && setup.adapter.get_info().device_type != wgpu::DeviceType::Cpu


### PR DESCRIPTION
Keep track of max_bindings in client properties.

Rather than adding something new I've renamed TopologyProperties to HardwareProperties. Maybe a slight misnomer as it's not just hardware but hardware + software that determine some of these limits. It's nice to have a place for this as we need more hardware limits.