### PR TITLE
Different seeds for lhs/rhs

### DIFF
--- a/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
@@ -138,7 +138,8 @@ fn tensor_raw_parts<EG: Float + CubeElement, R: Runtime>(
 ) -> TensorRawParts<EG> {
     match ident {
         Ident::Lhs => {
-            let original_data: Vec<EG> = generate_random_data(tensor_size(problem, Ident::Lhs));
+            let original_data: Vec<EG> =
+                generate_random_data(tensor_size(problem, Ident::Lhs), 1234);
             let data = match problem.lhs_layout {
                 MatrixLayout::RowMajor => original_data.clone(),
                 MatrixLayout::ColMajor => {
@@ -154,7 +155,8 @@ fn tensor_raw_parts<EG: Float + CubeElement, R: Runtime>(
             }
         }
         Ident::Rhs => {
-            let original_data: Vec<EG> = generate_random_data(tensor_size(problem, Ident::Rhs));
+            let original_data: Vec<EG> =
+                generate_random_data(tensor_size(problem, Ident::Rhs), 5678);
             let data = match problem.rhs_layout {
                 MatrixLayout::RowMajor => original_data.clone(),
                 MatrixLayout::ColMajor => {

--- a/crates/cubecl-linalg/src/matmul/tests/test_utils.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_utils.rs
@@ -116,7 +116,10 @@ impl CastInto<flex32> for f32 {
 ///
 /// This is a naive CPU implementation with fixed seed,
 /// not designed to be used for other purposes than testing.
-pub(crate) fn generate_random_data<F: Float + CubeElement>(num_elements: usize) -> Vec<F> {
+pub(crate) fn generate_random_data<F: Float + CubeElement>(
+    num_elements: usize,
+    mut seed: u64,
+) -> Vec<F> {
     fn lcg(seed: &mut u64) -> f32 {
         const A: u64 = 1664525;
         const C: u64 = 1013904223;
@@ -125,8 +128,6 @@ pub(crate) fn generate_random_data<F: Float + CubeElement>(num_elements: usize) 
         *seed = (A.wrapping_mul(*seed).wrapping_add(C)) % (1u64 << 32);
         (*seed as f64 / M * 2.0 - 1.0) as f32
     }
-
-    let mut seed = 12345;
 
     (0..num_elements).map(|_| F::new(lcg(&mut seed))).collect()
 }
@@ -251,7 +252,7 @@ impl MatmulTestCase {
         client: &ComputeClient<R::Server, R::Channel>,
         shape: Vec<usize>,
     ) -> TensorHandle<R, F> {
-        let data = generate_random_data::<F>(shape.iter().product());
+        let data = generate_random_data::<F>(shape.iter().product(), 999);
         let handle = client.create(bytemuck::cast_slice(&data));
         TensorHandle::new_contiguous(shape, handle)
     }


### PR DESCRIPTION
Using the same seed for lhs and rhs could be error prone, because we could have lhs and rhs exactly the same. 