### PR TITLE
Add Runtime trait method to get default kernel/shader extension

### DIFF
--- a/crates/cubecl-core/src/runtime.rs
+++ b/crates/cubecl-core/src/runtime.rs
@@ -24,6 +24,10 @@ pub trait Runtime: Send + Sync + 'static + core::fmt::Debug {
     /// The runtime name.
     fn name() -> &'static str;
 
+    /// The default extension for the runtime's kernel/shader code.
+    /// Might change based on which compiler is used.
+    fn extension() -> &'static str;
+
     /// Return true if global input array lengths should be added to kernel info.
     fn require_array_lengths() -> bool {
         false

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -127,6 +127,10 @@ impl Runtime for CudaRuntime {
     fn supported_line_sizes() -> &'static [u8] {
         &[8, 4, 2]
     }
+
+    fn extension() -> &'static str {
+        "cu"
+    }
 }
 
 fn register_wmma_features(properties: &mut DeviceProperties<Feature>, arch: u32) {

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -133,4 +133,8 @@ impl Runtime for HipRuntime {
     fn supported_line_sizes() -> &'static [u8] {
         &[8, 4, 2]
     }
+
+    fn extension() -> &'static str {
+        "hip"
+    }
 }

--- a/crates/cubecl-wgpu/src/compiler/spirv.rs
+++ b/crates/cubecl-wgpu/src/compiler/spirv.rs
@@ -391,6 +391,10 @@ impl Runtime for WgpuRuntime<VkSpirvCompiler> {
     fn supported_line_sizes() -> &'static [u8] {
         &[4, 2]
     }
+
+    fn extension() -> &'static str {
+        "spv"
+    }
 }
 
 #[cfg(feature = "spirv-dump")]

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -52,6 +52,10 @@ impl Runtime for WgpuRuntime<WgslCompiler> {
     fn supported_line_sizes() -> &'static [u8] {
         &[4, 2]
     }
+
+    fn extension() -> &'static str {
+        "wgsl"
+    }
 }
 
 /// The values that control how a WGPU Runtime will perform its calculations.


### PR DESCRIPTION
Useful in cases where kernels are compiled and written to files in a generic setting.