### PR TITLE
Bump tracel-xtask version to ~1.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ cfg-if = "1.0.0"
 
 ### For xtask crate ###
 strum = { version = "0.26.3", features = ["derive"] }
-tracel-xtask = { version = "~1.1" }
+tracel-xtask = { version = "~1.1.6" }
 
 portable-atomic = { version = "1.9" }
 pretty_assertions = "1.4"


### PR DESCRIPTION
The xtask dependency in the workspace depends on an API "custom_crates_check" which was introduced in 1.1.6.