### PR TITLE
Hint users towards the possibilty of deriving CubeType and CubeLaunch…

### DIFF
--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -23,6 +23,7 @@ use std::{marker::PhantomData, num::NonZero};
 /// This allows Cube code to not necessitate cloning, which is cumbersome
 /// in algorithmic code. The necessary cloning will automatically appear in
 /// the generated code.
+#[diagnostic::on_unimplemented(note = "Consider using `#[derive(CubeType)]` on `{Self}`")]
 pub trait CubeType {
     type ExpandType: Clone + Init;
 
@@ -57,6 +58,7 @@ pub trait Init: Sized {
 /// Once for the reference and the other for the mutable reference. Often time, the reference
 /// should expand the argument as an input while the mutable reference should expand the argument
 /// as an output.
+#[diagnostic::on_unimplemented(note = "Consider using `#[derive(CubeLaunch)]` on `{Self}`")]
 pub trait LaunchArgExpand: CubeType {
     /// Compilation argument.
     type CompilationArg: Clone


### PR DESCRIPTION
… if missing.

For example, if a user tries to use a struct within a kernel which doesn't impl `CubeType`:

```rust
struct NotCubeType {
  v: u32,
}

#[cube(launch_unchecked)]
fn foo<F: Float>(_input: &Array<F>) {
    let _a = NotCubeType { v: 0 };
}
```

the diag then adds a note for the user to consider deriving `CubeType`:

![image](https://github.com/user-attachments/assets/bc69279a-c549-4320-bd75-d382823e9086)

The diag for `CubeLaunch` is a bit awkwardly placed on `LaunchArgExpand` instead of on `LaunchArg`. This is because for types used as args in kernels the usage of traits in the macro expansion appear in the order

1. `<Arg as CubeType>::ExpandType`
2. `<Arg as LaunchArgExpand>::CompilationArg`
3. `<Arg as LaunchArg>::compilation_arg(..)`

So the user will be poked to first impl `CubeType` for such an arg, then they will afterward be poked to derive `CubeLaunch` via the diag.
If the expansion was re-ordered this would be better. But not sure it's worth relying on.

Imo. these diags will help users anyway so I think they're fine.

Lastly if you care about MSRV the diagnostic feature is quite recent, 1.78.0