### PR TITLE
Add support for 64 wavefront size in HIP compiler

### DIFF
--- a/crates/cubecl-core/src/codegen/compiler.rs
+++ b/crates/cubecl-core/src/codegen/compiler.rs
@@ -12,9 +12,14 @@ pub trait CompilerRepresentation: Display {
 pub trait Compiler: Sync + Send + 'static + Clone + Default + core::fmt::Debug {
     /// The representation for the compiled code.
     type Representation: CompilerRepresentation;
+    type CompilationOptions: Send + Default + core::fmt::Debug;
 
     /// Compiles the [kernel definition](KernelDefinition) into the compiler's representation.
-    fn compile(kernel: KernelDefinition, mode: ExecutionMode) -> Self::Representation;
+    fn compile(
+        kernel: KernelDefinition,
+        compilation_options: &Self::CompilationOptions,
+        mode: ExecutionMode,
+    ) -> Self::Representation;
     /// The size of the given element in bytes.
     fn elem_size(elem: Elem) -> usize;
     fn local_allocator() -> impl LocalAllocator;

--- a/crates/cubecl-cpp/src/hip/wmma/intrinsic_compiler.rs
+++ b/crates/cubecl-cpp/src/hip/wmma/intrinsic_compiler.rs
@@ -118,6 +118,7 @@ for (uint i = 0; i < uint(8); ++i) {{
                 frag_b,
                 frag_c,
                 frag_d,
+                warp_size,
             } => {
                 let ab_format = if let Variable::WmmaFragment { frag: inner_a, .. } = frag_a {
                     if let Variable::WmmaFragment { frag: inner_b, .. } = frag_b {
@@ -158,10 +159,9 @@ for (uint i = 0; i < uint(8); ++i) {{
                 } else {
                     panic!("{frag_c} is not a WMMA fragment!")
                 };
-                // TODO: support wavefront size of 64
                 writeln!(
                     f,
-                    "{frag_d} = __builtin_amdgcn_wmma_{cd_format}_16x16x16_{ab_format}_w32({frag_a}, {frag_b}, {frag_c});"
+                    "{frag_d} = __builtin_amdgcn_wmma_{cd_format}_16x16x16_{ab_format}_w{warp_size}({frag_a}, {frag_b}, {frag_c});"
                 )
             }
             WmmaInstruction::Store {

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -36,9 +36,15 @@ pub trait Dialect:
     fn warp_any(out: &IndexedVariable<Self>) -> String;
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct CompilationOptions {
     pub warp_size: u32,
+}
+
+impl Default for CompilationOptions {
+    fn default() -> Self {
+        Self { warp_size: 32 }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cubecl-cpp/src/shared/mma.rs
+++ b/crates/cubecl-cpp/src/shared/mma.rs
@@ -51,8 +51,6 @@ pub fn register_wmma_features(
     supported_combinations: SupportedWmmaCombinations,
     properties: &mut DeviceProperties<Feature>,
 ) {
-    // TODO: move this commented line to register explicitly at the runtime level
-    // properties.register_feature(Feature::CmmaWarpSize(self.warp_size()));
     for (i, o, c, tdims) in supported_combinations {
         for (m, n, k) in tdims {
             properties.register_feature(Feature::Cmma {
@@ -115,6 +113,7 @@ pub enum WmmaInstruction<D: Dialect> {
         frag_b: Variable<D>,
         frag_c: Variable<D>,
         frag_d: Variable<D>,
+        warp_size: u32,
     },
     /// Store the fragment in an output variable following the stride and the layout.
     Store {
@@ -256,6 +255,7 @@ pub mod wmma_api_base {
                 frag_b,
                 frag_c,
                 frag_d,
+                ..
             } => writeln!(
                 f,
                 "{namespace}::mma_sync({frag_d}, {frag_a}, {frag_b}, {frag_c});"

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -99,14 +99,14 @@ fn create_client(device: &CudaDevice, options: RuntimeOptions) -> ComputeClient<
         options.memory_config,
     );
 
-    // register device props
     let mut device_props = DeviceProperties::new(&[Feature::Plane], mem_properties, hardware_props);
     register_supported_types(&mut device_props);
     device_props.register_feature(Feature::Type(Elem::Float(FloatKind::TF32)));
     let supported_wmma_combinations = CudaWmmaCompiler::supported_wmma_combinations(&arch);
     register_wmma_features(supported_wmma_combinations, &mut device_props);
 
-    let cuda_ctx = CudaContext::new(memory_management, stream, ctx, arch);
+    let comp_opts = Default::default();
+    let cuda_ctx = CudaContext::new(memory_management, comp_opts, stream, ctx, arch);
     let server = CudaServer::new(cuda_ctx);
     ComputeClient::new(MutexComputeChannel::new(server), device_props)
 }

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -1,4 +1,5 @@
 use cubecl_cpp::formatter::format_cpp;
+use cubecl_cpp::shared::CompilationOptions;
 
 use crate::runtime::HipCompiler;
 
@@ -37,6 +38,7 @@ pub(crate) struct HipContext {
     memory_management: MemoryManagement<HipStorage>,
     module_names: HashMap<KernelId, HipCompiledKernel>,
     timestamps: KernelTimestamps,
+    compilation_options: CompilationOptions,
 }
 
 #[derive(Debug)]
@@ -276,6 +278,7 @@ impl ComputeServer for HipServer {
 impl HipContext {
     pub fn new(
         memory_management: MemoryManagement<HipStorage>,
+        compilation_options: CompilationOptions,
         stream: cubecl_hip_sys::hipStream_t,
         context: cubecl_hip_sys::hipCtx_t,
     ) -> Self {
@@ -285,6 +288,7 @@ impl HipContext {
             stream,
             context,
             timestamps: KernelTimestamps::Disabled,
+            compilation_options,
         }
     }
 
@@ -313,7 +317,7 @@ impl HipContext {
         let func_name = CString::new("kernel".to_string()).unwrap();
         // CubeCL compilation
         // jitc = just-in-time compiled
-        let mut jitc_kernel = cube_kernel.compile(mode);
+        let mut jitc_kernel = cube_kernel.compile(&self.compilation_options, mode);
 
         if logger.is_activated() {
             jitc_kernel.debug_info = Some(DebugInformation::new("cpp", kernel_id.clone()));

--- a/crates/cubecl-hip/src/lib.rs
+++ b/crates/cubecl-hip/src/lib.rs
@@ -13,8 +13,10 @@ pub mod runtime;
 pub use device::*;
 #[cfg(target_os = "linux")]
 pub use runtime::HipRuntime;
+#[cfg(target_os = "linux")]
 #[cfg(feature = "rocwmma")]
 pub(crate) type HipWmmaCompiler = cubecl_cpp::hip::wmma::RocWmmaCompiler;
+#[cfg(target_os = "linux")]
 #[cfg(not(feature = "rocwmma"))]
 pub(crate) type HipWmmaCompiler = cubecl_cpp::hip::wmma::WmmaIntrinsicCompiler;
 

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -24,6 +24,9 @@ use crate::{
     SpirvKernel,
 };
 
+#[derive(Clone, Debug, Default)]
+pub struct CompilationOptions {}
+
 pub struct SpirvCompiler<Target: SpirvTarget = GLCompute> {
     pub target: Target,
     builder: Builder,
@@ -41,6 +44,7 @@ pub struct SpirvCompiler<Target: SpirvTarget = GLCompute> {
     pub state: LookupTables,
     pub ext_meta_pos: Vec<u32>,
     pub metadata: Metadata,
+    compilation_options: CompilationOptions,
 }
 
 unsafe impl<T: SpirvTarget> Send for SpirvCompiler<T> {}
@@ -64,6 +68,7 @@ impl<T: SpirvTarget> Clone for SpirvCompiler<T> {
             visited: self.visited.clone(),
             metadata: self.metadata.clone(),
             ext_meta_pos: self.ext_meta_pos.clone(),
+            compilation_options: self.compilation_options.clone(),
         }
     }
 }
@@ -85,6 +90,7 @@ impl<T: SpirvTarget> Default for SpirvCompiler<T> {
             visited: Default::default(),
             metadata: Default::default(),
             ext_meta_pos: Default::default(),
+            compilation_options: Default::default(),
         }
     }
 }
@@ -105,8 +111,13 @@ impl<T: SpirvTarget> DerefMut for SpirvCompiler<T> {
 
 impl<T: SpirvTarget> Compiler for SpirvCompiler<T> {
     type Representation = SpirvKernel;
+    type CompilationOptions = CompilationOptions;
 
-    fn compile(value: KernelDefinition, mode: ExecutionMode) -> Self::Representation {
+    fn compile(
+        value: KernelDefinition,
+        compilation_options: &Self::CompilationOptions,
+        mode: ExecutionMode,
+    ) -> Self::Representation {
         let bindings = value
             .inputs
             .clone()
@@ -128,6 +139,7 @@ impl<T: SpirvTarget> Compiler for SpirvCompiler<T> {
         let (module, optimizer) = Self {
             mode,
             metadata: Metadata::new(num_meta as u32, num_ext),
+            compilation_options: compilation_options.clone(),
             ext_meta_pos,
             ..Default::default()
         }

--- a/crates/cubecl-wgpu/src/compiler/spirv.rs
+++ b/crates/cubecl-wgpu/src/compiler/spirv.rs
@@ -153,7 +153,7 @@ impl WgpuCompiler for SpirvCompiler<GLCompute> {
             mode
         };
         log::debug!("Compiling {}", kernel.name());
-        let compiled = kernel.compile(mode);
+        let compiled = kernel.compile(&server.compilation_options, mode);
         #[cfg(feature = "spirv-dump")]
         dump_spirv(&compiled, kernel.name(), kernel.id());
         compiled

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -30,6 +30,7 @@ pub struct WgpuServer<C: WgpuCompiler> {
     storage_locked: MemoryLock,
     duration_profiled: Option<Duration>,
     stream: WgpuStream,
+    pub compilation_options: C::CompilationOptions,
     _compiler: PhantomData<C>,
 }
 
@@ -37,6 +38,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
     /// Create a new server.
     pub fn new(
         memory_management: MemoryManagement<WgpuStorage>,
+        compilation_options: C::CompilationOptions,
         device: Arc<wgpu::Device>,
         queue: Arc<wgpu::Queue>,
         tasks_max: usize,
@@ -52,6 +54,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
 
         Self {
             memory_management,
+            compilation_options,
             device: device.clone(),
             queue: queue.clone(),
             storage_locked: MemoryLock::default(),

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -159,8 +159,10 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
         let storage = WgpuStorage::new(device.clone());
         MemoryManagement::from_configuration(storage, mem_props, config)
     };
+    let compilation_options = Default::default();
     let server = WgpuServer::new(
         memory_management,
+        compilation_options,
         setup.device.clone(),
         setup.queue,
         options.tasks_max,

--- a/crates/cubecl-wgpu/tests/common.rs
+++ b/crates/cubecl-wgpu/tests/common.rs
@@ -37,8 +37,10 @@ pub fn array() -> ArrayCompilationArg {
 }
 
 pub fn compile(kernel: impl Kernel) -> String {
+    let comp_opts = Default::default();
     <<TestRuntime as Runtime>::Compiler as Compiler>::compile(
         kernel.define(),
+        &comp_opts,
         ExecutionMode::Checked,
     )
     .to_string()


### PR DESCRIPTION
Update CubeTask trait to allow passing compilation options to the compile phase.

Added compilation options support to all compilers even if they are empty for now.