### PR TITLE
Bump cubecl-hip dependency to 0.0.7

### DIFF
--- a/crates/cubecl-hip/Cargo.toml
+++ b/crates/cubecl-hip/Cargo.toml
@@ -28,7 +28,7 @@ cubecl-cpp = { path = "../cubecl-cpp", version = "0.4.0", default-features = fal
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.4.0", default-features = false, features = [
   "channel-mutex",
 ] }
-cubecl-hip-sys = { version = "0.0.5", default-features = false, features = ["rocm_622"] }
+cubecl-hip-sys = { version = "0.0.7", default-features = false, features = ["rocm_622"] }
 
 bytemuck = { workspace = true }
 


### PR DESCRIPTION
This new version of `cubecl-hip` adds a default search path for ROCm installation (`/opt/rocm`) so that defining `CUBECL_ROCM_PATH` is not necessary if ROCm is installed to the default path.