### PR TITLE
Fix hardware properties for WebGPU

### DIFF
--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -143,15 +143,18 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
     options: RuntimeOptions,
 ) -> ComputeClient<WgpuServer<C>, MutexComputeChannel<WgpuServer<C>>> {
     let limits = setup.device.limits();
+    let adapter_limits = setup.adapter.limits();
+
     let mem_props = MemoryDeviceProperties {
         max_page_size: limits.max_storage_buffer_binding_size as u64,
         alignment: WgpuStorage::ALIGNMENT.max(limits.min_storage_buffer_offset_alignment as u64),
     };
     let hardware_props = HardwareProperties {
-        plane_size_min: setup.adapter.limits().min_subgroup_size,
-        plane_size_max: setup.adapter.limits().max_subgroup_size,
-        max_bindings: limits.max_bind_groups,
+        plane_size_min: adapter_limits.min_subgroup_size,
+        plane_size_max: adapter_limits.max_subgroup_size,
+        max_bindings: limits.max_storage_buffers_per_shader_stage,
     };
+
     let memory_management = {
         let device = setup.device.clone();
         let mem_props = mem_props.clone();
@@ -172,8 +175,15 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
     let features = setup.adapter.features();
     let mut device_props = DeviceProperties::new(&[], mem_props, hardware_props);
 
+    // Workaround: WebGPU does support subgroups and correctly reports this, but wgpu
+    // doesn't plumb through this info. Instead min/max are just reported as 0, which can cause issues.
+    // For now just disable subgroups on WebGPU, until this information is added.
+    let fake_plane_info =
+        adapter_limits.min_subgroup_size == 0 && adapter_limits.max_subgroup_size == 0;
+
     if features.contains(wgpu::Features::SUBGROUP)
         && setup.adapter.get_info().device_type != wgpu::DeviceType::Cpu
+        && !fake_plane_info
     {
         device_props.register_feature(Feature::Plane);
     }


### PR DESCRIPTION
- max_bindings was reading the wrong thing. That's the number of bind groups, not how many buffers you can have per kernel... On desktop this number was only 8, on WebGPU it's only 4. In reality on desktop it's >>>large, and on Chrome it's currently 10. Should improve fusion a bit on desktop, and a good amount on WebGPU.

- Min/max plane size were reported as dummy 0 values, which was causing issues. For now, disable subgroups until wgpu no longer reports dummy values here.