### PR TITLE
Make spirv feature to compile on macOS

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/metadata.rs
+++ b/crates/cubecl-core/src/runtime_tests/metadata.rs
@@ -256,14 +256,22 @@ macro_rules! testgen_metadata {
         }
 
         #[test]
-        fn test_buffer_len() {
+        fn test_buffer_len_discontiguous() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::metadata::test_buffer_len_discontiguous::<TestRuntime>(
-                client.clone(),
+                client,
             );
-            cubecl_core::runtime_tests::metadata::test_buffer_len_vectorized::<TestRuntime>(
-                client.clone(),
-            );
+        }
+
+        #[test]
+        fn test_buffer_len_vectorized() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::metadata::test_buffer_len_vectorized::<TestRuntime>(client);
+        }
+
+        #[test]
+        fn test_buffer_len_offset() {
+            let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::metadata::test_buffer_len_offset::<TestRuntime>(client);
         }
     };

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -35,7 +35,6 @@ ash = { version = "0.38", optional = true }
 cubecl-spirv = { path = "../cubecl-spirv", version = "0.4.0", optional = true }
 
 bytemuck = { workspace = true }
-wgpu = { version = "22.0.0", features = ["fragile-send-sync-non-atomic-wasm"] }
 
 async-channel = { workspace = true }
 derive-new = { workspace = true }
@@ -44,6 +43,14 @@ log = { workspace = true }
 web-time = { workspace = true }
 
 cfg-if = { workspace = true }
+
+# wgpu dependency for platforms other than macOS
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+wgpu = { version = "22.0.0", features = ["fragile-send-sync-non-atomic-wasm"] }
+# On macOS, the `vulkan-portability` feature is required due to the MoltenVK translation layer.
+# To install MoltenVK, install the VulkanSDK: https://vulkan.lunarg.com/sdk/home#mac
+[target.'cfg(target_os = "macos")'.dependencies]
+wgpu = { version = "22.0.0", features = ["vulkan-portability", "fragile-send-sync-non-atomic-wasm"] }
 
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.4.0", features = [

--- a/crates/cubecl-wgpu/build.rs
+++ b/crates/cubecl-wgpu/build.rs
@@ -1,8 +1,29 @@
 use cfg_aliases::cfg_aliases;
+use std::env;
 
 fn main() {
     // Setup cfg aliases
     cfg_aliases! {
         exclusive_memory_only: { any(feature = "exclusive-memory-only", target_family = "wasm") },
+    }
+
+    // Check if we are on macOS
+    // Errors out on MacOS when the "spirv" feature is enabled and the Vulkan SDK is not installed.
+    // To install Vulkan SDK visit https://vulkan.lunarg.com/sdk/home#mac
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_SPIRV");
+    println!("cargo:rerun-if-env-changed=VULKAN_SDK");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    let is_macos = env::var("CARGO_CFG_TARGET_OS")
+        .map(|os| os == "macos")
+        .unwrap_or(false);
+    if is_macos {
+        println!("cargo:rustc-cfg=feature=\"vulkan-portability\"");
+    }
+    let spirv_feature_enabled = env::var("CARGO_FEATURE_SPIRV").is_ok();
+    let vulkan_sdk_installed = env::var("VULKAN_SDK").is_ok();
+    if is_macos && spirv_feature_enabled && !vulkan_sdk_installed {
+        let msg = "The Vulkan SDK is required on macOS when the 'spirv' feature is enabled. Install the Vulkan SDK and make sure the VULKAN_SDK environment variable is set. Visit https://vulkan.lunarg.com/sdk/home#mac to learn how to install it.";
+        println!("cargo:warning={msg}");
+        panic!("{msg}");
     }
 }

--- a/xtask/src/commands/check.rs
+++ b/xtask/src/commands/check.rs
@@ -18,6 +18,8 @@ pub(crate) fn handle_command(mut args: CubeCLCheckCmdArgs) -> anyhow::Result<()>
     // cubecl-wgpu with SPIR-V
     // cubecl-wgpu with exclusive-memory-only
     // cubecl-runtime without default features
+    // Disabled on MacOS see:
+    #[cfg(not(target_os = "macos"))]
     helpers::custom_crates_check(
         vec!["cubecl-wgpu"],
         vec!["--features", "spirv"],


### PR DESCRIPTION
Added some guidance in the `build.rs` file.

Lots of tests are failling though because of some device feature not present.

Also, not related to spir-v, there is one wgpu test failing `test_buffer_len_offset` with message:

> Buffer offset 5248 does not respect device's requested `min_storage_buffer_offset_alignment` limit 256

The offset 5248 changes each time we execute the test.