### PR TITLE
Kernel names with float suffix

### DIFF
--- a/crates/cubecl-core/src/codegen/integrator.rs
+++ b/crates/cubecl-core/src/codegen/integrator.rs
@@ -198,8 +198,8 @@ impl KernelSettings {
 
     /// Set kernel name.
     #[allow(dead_code)]
-    pub fn kernel_name(mut self, name: &'static str) -> Self {
-        self.kernel_name = name.to_string();
+    pub fn kernel_name<S: AsRef<str>>(mut self, name: S) -> Self {
+        self.kernel_name = name.as_ref().to_string();
         self
     }
 }

--- a/crates/cubecl-core/src/compute/kernel.rs
+++ b/crates/cubecl-core/src/compute/kernel.rs
@@ -226,20 +226,19 @@ impl<C: Compiler, K: Kernel> CubeTask<C> for KernelTask<C, K> {
         mode: ExecutionMode,
     ) -> CompiledKernel<C> {
         let gpu_ir = self.kernel_definition.define();
-        let kernel_name = gpu_ir.kernel_name.clone();
+        let entrypoint_name = gpu_ir.kernel_name.clone();
         let cube_dim = gpu_ir.cube_dim;
         let lower_level_ir = C::compile(gpu_ir, compilation_options, mode);
         let shared_mem_bytes = lower_level_ir.shared_memory_size();
 
         CompiledKernel {
-            entrypoint_name: kernel_name,
+            entrypoint_name,
             debug_name: Some(core::any::type_name::<K>()),
             source: lower_level_ir.to_string(),
             repr: Some(lower_level_ir),
             cube_dim,
             shared_mem_bytes,
             debug_info: None,
-            kernel_name,
         }
     }
 

--- a/crates/cubecl-core/src/compute/kernel.rs
+++ b/crates/cubecl-core/src/compute/kernel.rs
@@ -239,6 +239,7 @@ impl<C: Compiler, K: Kernel> CubeTask<C> for KernelTask<C, K> {
             cube_dim,
             shared_mem_bytes,
             debug_info: None,
+            kernel_name,
         }
     }
 

--- a/crates/cubecl-cuda/tests/main.rs
+++ b/crates/cubecl-cuda/tests/main.rs
@@ -4,7 +4,9 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_cuda::CudaRuntime;
 use execute_unary_kernel::ExecuteUnaryKernel;
+use half::bf16;
 use kernel_sum::KernelSum;
+use naming_kernel::NamingKernel;
 use pretty_assertions::assert_eq;
 use sequence_for_loop_kernel::SequenceForLoopKernel;
 use slice_assign_kernel::SliceAssignKernel;
@@ -92,6 +94,7 @@ pub fn unary_bench() {
     );
     let expected = include_str!("unary_bench.cu").replace("\r\n", "\n");
     let expected = expected.trim();
+
     assert_eq!(compile(kernel), expected);
 }
 
@@ -110,5 +113,21 @@ pub fn constant_array() {
 
     let kernel = ConstantArrayKernel::<f32, CudaRuntime>::new(settings(), tensor(), data);
     let expected = include_str!("constant_array.cu").replace("\r\n", "\n");
+    assert_eq!(compile(kernel), expected);
+}
+
+// This kernel just exists to have a few generics in order to observe
+// that the generics get propagated into the WGSL kernel name
+#[cube(launch, create_dummy_kernel)]
+fn naming_kernel<F1: Float, N1: Numeric, F2: Float, N2: Numeric>(out: &mut Array<F1>) {
+    if ABSOLUTE_POS < out.len() {
+        out[ABSOLUTE_POS] = F1::from_int(0);
+    }
+}
+
+#[test]
+pub fn naming() {
+    let kernel = NamingKernel::<f32, u8, bf16, i64, CudaRuntime>::new(settings(), array());
+    let expected = include_str!("naming.cu").replace("\r\n", "\n");
     assert_eq!(compile(kernel), expected);
 }

--- a/crates/cubecl-cuda/tests/naming.cu
+++ b/crates/cubecl-cuda/tests/naming.cu
@@ -5,8 +5,8 @@ typedef unsigned int uint;
 typedef unsigned long long int uint64;
 typedef long long int int64;
 
-extern "C" __global__ void constant_array_kernel_f32(float output_0[],
-                                                     uint info[]) {
+extern "C" __global__ void naming_kernel_f32_u8_bf16_i64(float output_0[],
+                                                         uint info[]) {
 
   int3 absoluteIdx = make_int3(blockIdx.x * blockDim.x + threadIdx.x,
                                blockIdx.y * blockDim.y + threadIdx.y,
@@ -15,24 +15,17 @@ extern "C" __global__ void constant_array_kernel_f32(float output_0[],
   uint idxGlobal =
       (absoluteIdx.z * gridDim.x * blockDim.x * gridDim.y * blockDim.y) +
       (absoluteIdx.y * gridDim.x * blockDim.x) + absoluteIdx.x;
-  const float arrays_0[3] = {
-      float(3),
-      float(5),
-      float(1),
-  };
   uint l_0_0;
   bool l_0_1;
-  float l_0_2;
   l_0_0 = info[uint(1)];
   l_0_1 = idxGlobal < l_0_0;
   if (l_0_1) {
-    l_0_2 = arrays_0[idxGlobal];
     uint l_1_0;
     bool l_1_1;
     l_1_0 = info[uint(0)];
     l_1_1 = idxGlobal < l_1_0;
     if (l_1_1) {
-      output_0[idxGlobal] = l_0_2;
+      output_0[idxGlobal] = float(0.0);
     }
   }
 }

--- a/crates/cubecl-cuda/tests/plane_sum.cu
+++ b/crates/cubecl-cuda/tests/plane_sum.cu
@@ -1,10 +1,11 @@
+#include <mma.h>
 typedef unsigned char uint8;
 typedef unsigned short uint16;
 typedef unsigned int uint;
 typedef unsigned long long int uint64;
 typedef long long int int64;
 
-extern "C" __global__ void kernel(float output_0[], uint info[]) {
+extern "C" __global__ void kernel_sum(float output_0[], uint info[]) {
 
   int threadIdxGlobal = threadIdx.x + threadIdx.y * blockDim.x +
                         threadIdx.z * (blockDim.x * blockDim.y);
@@ -18,6 +19,7 @@ extern "C" __global__ void kernel(float output_0[], uint info[]) {
   l_0_0 = (threadIdxGlobal < l_0_3) ? output_0[threadIdxGlobal] : float(0);
 
   l_0_1 = l_0_0;
+
   {
     for (int offset = 1; offset < warpSizeChecked; offset *= 2) {
       l_0_1 += __shfl_xor_sync(-1, l_0_1, offset);

--- a/crates/cubecl-cuda/tests/sequence_for_loop.cu
+++ b/crates/cubecl-cuda/tests/sequence_for_loop.cu
@@ -1,10 +1,12 @@
+#include <mma.h>
 typedef unsigned char uint8;
 typedef unsigned short uint16;
 typedef unsigned int uint;
 typedef unsigned long long int uint64;
 typedef long long int int64;
 
-extern "C" __global__ void kernel(float output_0[], uint info[]) {
+extern "C" __global__ void sequence_for_loop_kernel(float output_0[], 
+                                                    uint info[]) { 
 
   int threadIdxGlobal = threadIdx.x + threadIdx.y * blockDim.x +
                         threadIdx.z * (blockDim.x * blockDim.y);

--- a/crates/cubecl-cuda/tests/slice_assign.cu
+++ b/crates/cubecl-cuda/tests/slice_assign.cu
@@ -1,11 +1,12 @@
+#include <mma.h>
 typedef unsigned char uint8;
 typedef unsigned short uint16;
 typedef unsigned int uint;
 typedef unsigned long long int uint64;
 typedef long long int int64;
 
-extern "C" __global__ void kernel(float input_0[], float output_0[],
-                                  uint info[]) {
+extern "C" __global__ void slice_assign_kernel(float input_0[],
+                                               float output_0[], uint info[]) {
 
   int threadIdxGlobal = threadIdx.x + threadIdx.y * blockDim.x +
                         threadIdx.z * (blockDim.x * blockDim.y);

--- a/crates/cubecl-cuda/tests/unary_bench.cu
+++ b/crates/cubecl-cuda/tests/unary_bench.cu
@@ -1,3 +1,4 @@
+#include <mma.h>
 typedef unsigned char uint8;
 typedef unsigned short uint16;
 typedef unsigned int uint;
@@ -11,8 +12,10 @@ struct __align__(16) float_4 {
   float i_3;
 };
 
-extern "C" __global__ void kernel(float_4 input_0[], float_4 input_1[],
-                                  float_4 output_0[], uint info[]) {
+extern "C" __global__ void execute_unary_kernel_f32(float_4 input_0[],
+                                                    float_4 input_1[],
+                                                    float_4 output_0[],
+                                                    uint info[]) {
 
   int3 absoluteIdx = make_int3(blockIdx.x * blockDim.x + threadIdx.x,
                                blockIdx.y * blockDim.y + threadIdx.y,

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -1,7 +1,7 @@
 use darling::usage::{CollectLifetimes as _, CollectTypeParams as _, GenericsExt as _, Purpose};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
-use syn::Ident;
+use syn::{Ident, TypeParamBound};
 
 use crate::{
     parse::kernel::{KernelBody, KernelFn, KernelParam, KernelReturns, KernelSignature, Launch},
@@ -213,6 +213,76 @@ impl Launch {
         }
     }
 
+    /// Returns the kernel source name.
+    /// Appropriate for usage in source code such as CUDA kernel naming.
+    ///
+    /// For example a kernel:
+    /// ```text
+    /// #[cube(launch)]
+    /// fn my_kernel(input: &Array<f32>, output: &mut Array<f32>) { }
+    /// ```
+    /// would produce the name `my_kernel`.
+    ///
+    /// If a generic has the bound `Float`, the kernel also has a suffix
+    /// with the name of the float type in use:
+    /// ```text
+    /// use cubecl_macros::cube;
+    /// fn my_kernel<F: Float>(input: &Array<F>, output: &mut Array<F>) { }
+    /// ```
+    /// now produces the name `my_kernel_f16` or `my_kernel_f32` etc. depending
+    /// on which variant of the kernel is launched by the user.
+    fn kernel_source_name(&self) -> TokenStream {
+        // This is always used
+        let base_name = self.func.sig.name.to_string();
+
+        let generics = &self.kernel_generics;
+        let target = format_ident!("Float");
+
+        // Inspect all generics for the `Float` bound in order to
+        // determine if a suffix should be used
+        for typ in generics.type_params() {
+            for bound in &typ.bounds {
+                let TypeParamBound::Trait(t) = bound else {
+                    continue;
+                };
+
+                // Using last should account for the bound `Float` but also `some::prefix::Float`
+                let Some(last_segment) = t.path.segments.last() else {
+                    continue;
+                };
+
+                let type_param_ident = typ.ident.clone();
+
+                if last_segment.ident == target {
+                    // We found some type parameter with `Float` as a bound,
+                    // add a suffix based on a shortened version of the
+                    // type name
+                    return quote! (
+                        {
+                            // Go from type names such as `half::f16` to `f16` etc.
+                            let shorten = |p: &'static str| {
+                                if let Some((_, last)) = p.rsplit_once("::") {
+                                    last
+                                } else {
+                                    p
+                                }
+                            };
+
+                            let type_name = std::any::type_name::< #type_param_ident >();
+                            let type_name = shorten(type_name);
+
+                            format!("{}_{type_name}", #base_name)
+                        }
+                    );
+                }
+            }
+        }
+
+        quote! {
+            #base_name
+        }
+    }
+
     pub fn kernel_definition(&self) -> TokenStream {
         if self.args.is_launch() {
             let kernel = core_type("Kernel");
@@ -236,7 +306,8 @@ impl Launch {
                 .map(|_| quote![__ty: ::core::marker::PhantomData]);
             let (compilation_args, args) = self.compilation_args_def();
             let info = param_names.clone().into_iter().chain(args.clone());
-            let sig_name = self.func.sig.name.to_string();
+
+            let kernel_source_name = self.kernel_source_name();
 
             quote! {
                 #[doc = #kernel_doc]
@@ -251,7 +322,7 @@ impl Launch {
                 impl #generics #kernel_name #generic_names #where_clause {
                     pub fn new(settings: #kernel_settings, #(#compilation_args,)* #(#const_params),*) -> Self {
                         Self {
-                            settings: settings.kernel_name(#sig_name),
+                            settings: settings.kernel_name(#kernel_source_name),
                             #(#args,)*
                             #(#param_names,)*
                             #phantom_data_init

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -223,30 +223,34 @@ impl Launch {
     /// ```
     /// would produce the name `my_kernel`.
     ///
-    /// If a generic has the `Float` bound the kernel also has a suffix
-    /// with the name of the float type in use:
+    /// If a generic has the `Float` or `Numeric` bound the kernel also has a suffix
+    /// with the name of that type in use:
     /// ```text
     /// fn my_kernel<F: Float>(input: &Array<F>, output: &mut Array<F>) {}
     /// ```
     /// now produces the name `my_kernel_f16` or `my_kernel_f32` etc. depending
     /// on which variant of the kernel is launched by the user.
+    ///
+    /// If a kernel has several matching bounds they are appended as suffixes in order.
     fn kernel_entrypoint_name(&self) -> TokenStream {
         // This base name is always used; a suffix might be added
         // based on generics.
         let base_name = self.func.sig.name.to_string();
 
         let generics = &self.kernel_generics;
-        let ident_float = format_ident!("Float");
+        let suffix_producing_bounds = [format_ident!("Float"), format_ident!("Numeric")];
 
-        // Inspect all generics for the `Float` bound in order to
-        // determine if a suffix should be used
+        let mut matching_generics = vec![];
+
+        // Inspect all generics for the bounds of interest in order to
+        // determine if a suffix should be added
         for typ in generics.type_params() {
             for bound in &typ.bounds {
                 let TypeParamBound::Trait(t) = bound else {
                     continue;
                 };
 
-                // Using last should account for the bound `Float` but also `some::prefix::Float`
+                // Using last should account for the bounds such as `Float` but also `some::prefix::Float`
                 let Some(generic_trailing) = t.path.segments.last() else {
                     continue;
                 };
@@ -254,33 +258,40 @@ impl Launch {
                 // If we find some type parameter with `Float` as a bound,
                 // add a suffix based on a shortened version of the
                 // type name
-                if generic_trailing.ident == ident_float {
-                    // E.g. the `F` in `F: Float`
-                    let type_param_ident = typ.ident.clone();
-
-                    return quote! (
-                        {
-                            // Go from type names such as `half::f16` to `f16` etc.
-                            let shorten = |p: &'static str| {
-                                if let Some((_, last)) = p.rsplit_once("::") {
-                                    last
-                                } else {
-                                    p
-                                }
-                            };
-
-                            let type_name = core::any::type_name::< #type_param_ident >();
-                            let type_name = shorten(type_name);
-
-                            format!("{}_{type_name}", #base_name)
-                        }
-                    );
+                if suffix_producing_bounds.contains(&generic_trailing.ident) {
+                    // E.g. the `F` in `F: Float` or `N` in `N: Numeric`
+                    matching_generics.push(typ.ident.clone());
+                    continue;
                 }
             }
         }
 
-        quote! {
-            #base_name
+        if matching_generics.is_empty() {
+            quote! {
+                #base_name
+            }
+        } else {
+            quote! (
+                {
+                    // Go from type names such as `half::f16` to `f16` etc.
+                    let shorten = |p: &'static str| {
+                        if let Some((_, last)) = p.rsplit_once("::") {
+                            last
+                        } else {
+                            p
+                        }
+                    };
+
+                    let mut name = format!("{}", #base_name);
+
+                    #( {
+                        let type_name = shorten(core::any::type_name::< #matching_generics >());
+                        name.push_str(&format!("_{type_name}"));
+                    })*
+
+                    name
+                }
+            )
         }
     }
 

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -214,7 +214,7 @@ impl Launch {
     }
 
     /// Returns the kernel entrypoint name.
-    /// Appropriate for usage in source code such as namiing the CUDA or WGSL entrypoint.
+    /// Appropriate for usage in source code such as naming the CUDA or WGSL entrypoint.
     ///
     /// For example a kernel:
     /// ```text

--- a/crates/cubecl-wgpu/tests/constant_array.wgsl
+++ b/crates/cubecl-wgpu/tests/constant_array.wgsl
@@ -14,7 +14,7 @@ const WORKGROUP_SIZE_Z = 1u;
 
 @compute
 @workgroup_size(16, 16, 1)
-fn constant_array_kernel(
+fn constant_array_kernel_f32(
     @builtin(global_invocation_id) global_id: vec3<u32>,
     @builtin(num_workgroups) num_workgroups: vec3<u32>,
 ) {

--- a/crates/cubecl-wgpu/tests/naming.wgsl
+++ b/crates/cubecl-wgpu/tests/naming.wgsl
@@ -1,0 +1,25 @@
+@group(0)
+@binding(0)
+var<storage, read_write> output_0_global: array<f32>;
+
+@group(0)
+@binding(1)
+var<storage, read_write> info: array<u32>;
+
+const WORKGROUP_SIZE_X = 16u;
+const WORKGROUP_SIZE_Y = 16u;
+const WORKGROUP_SIZE_Z = 1u;
+
+@compute
+@workgroup_size(16, 16, 1)
+fn naming_kernel_f32_u8_bf16_i64(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
+) {
+let id = (global_id.z * num_workgroups.x * WORKGROUP_SIZE_X * num_workgroups.y * WORKGROUP_SIZE_Y) + (global_id.y * num_workgroups.x * WORKGROUP_SIZE_X) + global_id.x;
+let _0 = info[1u];
+let _1 = id < _0;
+if _1 {
+output_0_global[id] = 0f;
+}
+}

--- a/crates/cubecl-wgpu/tests/naming.wgsl
+++ b/crates/cubecl-wgpu/tests/naming.wgsl
@@ -20,6 +20,12 @@ let id = (global_id.z * num_workgroups.x * WORKGROUP_SIZE_X * num_workgroups.y *
 let _0 = info[1u];
 let _1 = id < _0;
 if _1 {
+var l_1_0: u32;
+var l_1_1: bool;
+l_1_0 = info[0u];
+l_1_1 = id < l_1_0;
+if l_1_1 {
 output_0_global[id] = 0f;
+}
 }
 }

--- a/crates/cubecl-wgpu/tests/unary_bench.wgsl
+++ b/crates/cubecl-wgpu/tests/unary_bench.wgsl
@@ -20,7 +20,7 @@ const WORKGROUP_SIZE_Z = 1u;
 
 @compute
 @workgroup_size(16, 16, 1)
-fn execute_unary_kernel(
+fn execute_unary_kernel_f32(
     @builtin(global_invocation_id) global_id: vec3<u32>,
     @builtin(num_workgroups) num_workgroups: vec3<u32>,
 ) {


### PR DESCRIPTION
Makes kernel entrypoint naming more powerful:

![image](https://github.com/user-attachments/assets/f14dfe88-6d99-4af5-b7ad-b5ffa625576e)

A suffix is added to the kernel name if the kernel has a `X: Float` bound (the generic name is irrelevant, only the bound is important).

Strategy:

- When parsing the kernel, inspect all generics
- Look for a generic type with the Float bound
- Use `core::any::type_name::<X>` where X is the generic type with the correct bound
- Clean up that string in order to have a short suffix e.g. `_f16` or `_f32`
- If no generic had the Float bound, use the base name with no suffix

This allows very clean reporting in tools such as Nsight Compute when testing kernels which are float generic.

I intentionally did not attempt to inspect generics in the `where X: Float` position as I don't foresee myself using that- let me know if this is important.