### PR TITLE
Elem::Bool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pub fn launch<R: Runtime>(device: &R::Device) {
     let input = &[-1., 0., 1., 5.];
     let vectorization = 4;
     let output_handle = client.empty(input.len() * core::mem::size_of::<f32>());
-    let input_handle = client.create(f32::as_bytes(input));
+    let input_handle = client.create(f32::to_elem_data(input));
 
     unsafe {
         gelu_array::launch_unchecked::<f32, R>(

--- a/crates/cubecl-core/Cargo.toml
+++ b/crates/cubecl-core/Cargo.toml
@@ -22,7 +22,7 @@ template = []
 [dependencies]
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.4.0", default-features = false }
 
-bytemuck = { workspace = true }
+bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 cubecl-common = { path = "../cubecl-common", version = "0.4.0", default-features = false }
 cubecl-macros = { path = "../cubecl-macros", version = "0.4.0", default-features = false }
 derive-new = { workspace = true }

--- a/crates/cubecl-core/src/codegen/execution.rs
+++ b/crates/cubecl-core/src/codegen/execution.rs
@@ -289,7 +289,7 @@ fn execute_settings<'a, R: Runtime, E1: CubeElement, E2: CubeElement, E3: CubeEl
         }
     }
 
-    let info = client.create(bytemuck::cast_slice(&info));
+    let info = client.create(&u32::to_elem_data(&info));
 
     // Finally we finish with the named bindings.
     let handles_scalars =
@@ -334,16 +334,16 @@ fn create_scalar_handles<R: Runtime, E1: CubeElement, E2: CubeElement, E3: CubeE
         for (j, scalar_priority) in scalar_priorities.iter().enumerate() {
             if scalar_priority == &i {
                 if j == 0 {
-                    if let Some(values) = &scalars_0 {
-                        handles_scalars.push(client.create(bytemuck::cast_slice(values)));
+                    if let Some(values) = scalars_0 {
+                        handles_scalars.push(client.create(&E1::to_elem_data(values)));
                     }
                 } else if j == 1 {
-                    if let Some(values) = &scalars_1 {
-                        handles_scalars.push(client.create(bytemuck::cast_slice(values)));
+                    if let Some(values) = scalars_1 {
+                        handles_scalars.push(client.create(&E2::to_elem_data(values)));
                     }
                 } else if j == 2 {
-                    if let Some(values) = &scalars_2 {
-                        handles_scalars.push(client.create(bytemuck::cast_slice(values)));
+                    if let Some(values) = scalars_2 {
+                        handles_scalars.push(client.create(&E3::to_elem_data(values)));
                     }
                 }
             }

--- a/crates/cubecl-core/src/compute/launcher.rs
+++ b/crates/cubecl-core/src/compute/launcher.rs
@@ -1,14 +1,13 @@
 use std::marker::PhantomData;
 
 use crate::prelude::{ArrayArg, TensorArg};
-use crate::KernelSettings;
 use crate::{compute::KernelTask, ir::UIntKind};
 use crate::{
     ir::{Elem, FloatKind, IntKind},
     MetadataBuilder,
 };
+use crate::{CubeElement, KernelSettings};
 use crate::{Kernel, Runtime};
-use bytemuck::NoUninit;
 use cubecl_runtime::client::ComputeClient;
 use cubecl_runtime::server::{Binding, CubeCount};
 
@@ -314,12 +313,12 @@ impl<R: Runtime> TensorState<R> {
             let metadata = metadata.finish();
 
             bindings_global.extend(bindings);
-            bindings_global.push(client.create(bytemuck::cast_slice(&metadata)).binding());
+            bindings_global.push(client.create(&u32::to_elem_data(&metadata)).binding());
         }
     }
 }
 
-impl<T: NoUninit> ScalarState<T> {
+impl<T: CubeElement> ScalarState<T> {
     /// Add a new scalar value to the state.
     pub fn push(&mut self, val: T) {
         match self {
@@ -336,7 +335,7 @@ impl<T: NoUninit> ScalarState<T> {
         match self {
             ScalarState::Empty => (),
             ScalarState::Some(values) => {
-                let handle = client.create(bytemuck::cast_slice(values));
+                let handle = client.create(&T::to_elem_data(values));
                 bindings.push(handle.binding());
             }
         }

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -1,4 +1,4 @@
-use super::{flex32, CubePrimitive, Numeric, Vectorized};
+use super::{flex32, Algebraic, CubePrimitive, Vectorized};
 use crate::tf32;
 use crate::{
     ir::{ConstantScalarValue, Elem, Item, Operation, Variable, VariableKind},
@@ -424,7 +424,7 @@ impl<T: Init> Init for Vec<T> {
 }
 
 /// Create a constant element of the correct type during expansion.
-pub(crate) fn __expand_new<C: Numeric, Out: Numeric>(
+pub(crate) fn __expand_new<C: Algebraic, Out: Algebraic>(
     _context: &mut CubeContext,
     val: C,
 ) -> ExpandElementTyped<Out> {
@@ -433,7 +433,7 @@ pub(crate) fn __expand_new<C: Numeric, Out: Numeric>(
 }
 
 /// Create a vectorized constant element of the correct type during expansion.
-pub(crate) fn __expand_vectorized<C: Numeric + CubeIndex<u32>, Out: Numeric>(
+pub(crate) fn __expand_vectorized<C: Algebraic + CubeIndex<u32>, Out: Algebraic>(
     context: &mut CubeContext,
     val: C,
     vectorization: u32,

--- a/crates/cubecl-core/src/frontend/element/float.rs
+++ b/crates/cubecl-core/src/frontend/element/float.rs
@@ -1,6 +1,7 @@
 use std::num::NonZero;
 
 use half::{bf16, f16};
+use num_traits::NumCast;
 
 use crate::{
     ir::{Elem, FloatKind, Item},
@@ -8,7 +9,7 @@ use crate::{
     unexpanded,
 };
 
-use super::Numeric;
+use super::Algebraic;
 
 mod relaxed;
 mod tensor_float;
@@ -18,7 +19,7 @@ pub use tensor_float::*;
 
 /// Floating point numbers. Used as input in float kernels
 pub trait Float:
-    Numeric
+    Algebraic
     + Exp
     + Log
     + Log1p
@@ -112,7 +113,13 @@ macro_rules! impl_float {
         impl Numeric for $primitive {
             const MAX: Self = $primitive::MAX;
             const MIN: Self = $primitive::MIN;
+
+            fn from_int(val: i64) -> Self {
+                <Self as NumCast>::from(val).unwrap()
+            }
         }
+
+        impl Algebraic for $primitive {}
 
         impl Vectorized for $primitive {
             fn vectorization_factor(&self) -> u32 {

--- a/crates/cubecl-core/src/frontend/element/float/relaxed.rs
+++ b/crates/cubecl-core/src/frontend/element/float/relaxed.rs
@@ -14,14 +14,13 @@ use serde::Serialize;
 
 use crate::{
     ir::{Elem, FloatKind, Item},
-    prelude::Numeric,
     unexpanded,
 };
 
 use super::{
-    init_expand_element, CubeContext, CubePrimitive, CubeType, ExpandElement,
+    init_expand_element, Algebraic, CubeContext, CubePrimitive, CubeType, ExpandElement,
     ExpandElementBaseInit, ExpandElementTyped, Float, Init, IntoRuntime, KernelBuilder,
-    KernelLauncher, LaunchArgExpand, Runtime, ScalarArgSettings, Vectorized,
+    KernelLauncher, LaunchArgExpand, Numeric, Runtime, ScalarArgSettings, Vectorized,
 };
 
 /// A floating point type with relaxed precision, minimum [`f16`], max [`f32`].
@@ -180,7 +179,13 @@ impl IntoRuntime for flex32 {
 impl Numeric for flex32 {
     const MAX: Self = flex32::from_f32(f32::MAX);
     const MIN: Self = flex32::from_f32(f32::MIN);
+
+    fn from_int(val: i64) -> Self {
+        <Self as NumCast>::from(val).unwrap()
+    }
 }
+
+impl Algebraic for flex32 {}
 
 impl Vectorized for flex32 {
     fn vectorization_factor(&self) -> u32 {

--- a/crates/cubecl-core/src/frontend/element/float/tensor_float.rs
+++ b/crates/cubecl-core/src/frontend/element/float/tensor_float.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{
-    init_expand_element, CubeContext, CubePrimitive, CubeType, ExpandElement,
+    init_expand_element, Algebraic, CubeContext, CubePrimitive, CubeType, ExpandElement,
     ExpandElementBaseInit, ExpandElementTyped, Float, Init, IntoRuntime, KernelBuilder,
     KernelLauncher, LaunchArgExpand, Runtime, ScalarArgSettings, Vectorized,
 };
@@ -187,7 +187,13 @@ impl IntoRuntime for tf32 {
 impl Numeric for tf32 {
     const MAX: Self = tf32::from_f32(f32::MAX);
     const MIN: Self = tf32::from_f32(f32::MIN);
+
+    fn from_int(val: i64) -> Self {
+        <Self as NumCast>::from(val).unwrap()
+    }
 }
+
+impl Algebraic for tf32 {}
 
 impl Vectorized for tf32 {
     fn vectorization_factor(&self) -> u32 {

--- a/crates/cubecl-core/src/frontend/element/int.rs
+++ b/crates/cubecl-core/src/frontend/element/int.rs
@@ -1,6 +1,6 @@
 use crate::frontend::{
-    CubeContext, CubePrimitive, CubeType, ExpandElement, ExpandElementBaseInit, ExpandElementTyped,
-    Numeric,
+    Algebraic, CubeContext, CubePrimitive, CubeType, ExpandElement, ExpandElementBaseInit,
+    ExpandElementTyped, Numeric,
 };
 use crate::ir::{Elem, IntKind};
 use crate::Runtime;
@@ -8,6 +8,7 @@ use crate::{
     compute::{KernelBuilder, KernelLauncher},
     unexpanded,
 };
+use num_traits::NumCast;
 
 use super::{
     init_expand_element, Init, IntoRuntime, LaunchArgExpand, ScalarArgSettings, Vectorized,
@@ -16,7 +17,7 @@ use super::{
 
 /// Signed or unsigned integer. Used as input in int kernels
 pub trait Int:
-    Numeric
+    Algebraic
     + std::ops::Rem<Output = Self>
     + core::ops::Add<Output = Self>
     + core::ops::Sub<Output = Self>
@@ -81,7 +82,13 @@ macro_rules! impl_int {
         impl Numeric for $type {
             const MAX: Self = $type::MAX;
             const MIN: Self = $type::MIN;
+
+            fn from_int(val: i64) -> Self {
+                <Self as NumCast>::from(val).unwrap()
+            }
         }
+
+        impl Algebraic for $type {}
 
         impl Vectorized for $type {
             fn vectorization_factor(&self) -> u32 {

--- a/crates/cubecl-core/src/frontend/element/uint.rs
+++ b/crates/cubecl-core/src/frontend/element/uint.rs
@@ -1,10 +1,11 @@
 use crate::prelude::{KernelBuilder, KernelLauncher};
 use crate::Runtime;
 use crate::{
-    frontend::{CubeContext, CubePrimitive, CubeType, ExpandElement, Numeric},
+    frontend::{Algebraic, CubeContext, CubePrimitive, CubeType, ExpandElement, Numeric},
     ir::UIntKind,
 };
 use crate::{ir::Elem, unexpanded};
+use num_traits::NumCast;
 
 use super::{
     init_expand_element, ExpandElementBaseInit, ExpandElementTyped, Init, Int, IntoRuntime,
@@ -53,7 +54,13 @@ macro_rules! declare_uint {
         impl Numeric for $primitive {
             const MAX: Self = $primitive::MAX;
             const MIN: Self = $primitive::MIN;
+
+            fn from_int(val: i64) -> Self {
+                <Self as NumCast>::from(val).unwrap()
+            }
         }
+
+        impl Algebraic for $primitive {}
 
         impl Int for $primitive {
             const BITS: u32 = $primitive::BITS;

--- a/crates/cubecl-core/src/frontend/operation/assignation.rs
+++ b/crates/cubecl-core/src/frontend/operation/assignation.rs
@@ -102,7 +102,7 @@ pub mod index_assign {
     impl_index!(Array);
     impl_index!(Tensor);
     impl_index!(SharedMemory);
-    impl_index_vec!(i64, i32, i16, i8, f16, bf16, flex32, tf32, f32, f64, u64, u32, u16, u8);
+    impl_index_vec!(i64, i32, i16, i8, f16, bf16, flex32, tf32, f32, f64, u64, u32, u16, u8, bool);
 
     impl<E: CubeType, I: Index> CubeIndexMut<I> for SliceMut<E> {}
 }
@@ -172,7 +172,7 @@ pub mod index {
     impl_index!(Array);
     impl_index!(Tensor);
     impl_index!(SharedMemory);
-    impl_index_vec!(i64, i32, i16, i8, f16, flex32, tf32, bf16, f32, f64, u64, u32, u16, u8);
+    impl_index_vec!(i64, i32, i16, i8, f16, flex32, tf32, bf16, f32, f64, u64, u32, u16, u8, bool);
 
     impl<E: CubeType, I: Index> CubeIndex<I> for Slice<E> {
         type Output = E;

--- a/crates/cubecl-core/src/ir/kernel.rs
+++ b/crates/cubecl-core/src/ir/kernel.rs
@@ -171,7 +171,8 @@ impl Elem {
                 UIntKind::U32 => core::mem::size_of::<u32>(),
                 UIntKind::U64 => core::mem::size_of::<u64>(),
             },
-            Elem::Bool => core::mem::size_of::<bool>(),
+            // Currently, bools are represented as u32 in the backend.
+            Elem::Bool => core::mem::size_of::<u32>(),
         }
     }
 

--- a/crates/cubecl-core/src/pod.rs
+++ b/crates/cubecl-core/src/pod.rs
@@ -1,3 +1,5 @@
+use bytemuck::NoUninit;
+
 use crate::{
     flex32,
     ir::{Elem, FloatKind, IntKind, UIntKind},
@@ -5,13 +7,15 @@ use crate::{
 };
 
 /// The base element trait for the jit backend.
-pub trait CubeElement: core::fmt::Debug + Send + Sync + 'static + Clone + bytemuck::Pod {
+pub trait CubeElement: core::fmt::Debug + Send + Sync + 'static + Clone + NoUninit {
     /// Returns the name of the type.
     fn type_name() -> &'static str;
     /// Convert a slice of elements to a slice of bytes.
-    fn as_bytes(slice: &[Self]) -> &[u8];
+    fn to_elem_data(slice: &[Self]) -> Vec<u8> {
+        bytemuck::cast_slice(slice).to_vec()
+    }
     /// Convert a slice of bytes to a slice of elements.
-    fn from_bytes(bytes: &[u8]) -> &[Self];
+    fn from_elem_data(element_data: Vec<u8>) -> Vec<Self>;
     /// Element representation for `cubecl`.
     fn cube_elem() -> Elem;
     /// Highest possible value
@@ -24,11 +28,8 @@ impl CubeElement for u64 {
     fn type_name() -> &'static str {
         "u64"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::UInt(UIntKind::U64)
@@ -45,11 +46,8 @@ impl CubeElement for u32 {
     fn type_name() -> &'static str {
         "u32"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::UInt(UIntKind::U32)
@@ -66,11 +64,8 @@ impl CubeElement for u16 {
     fn type_name() -> &'static str {
         "u16"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::UInt(UIntKind::U16)
@@ -87,11 +82,8 @@ impl CubeElement for u8 {
     fn type_name() -> &'static str {
         "u8"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::UInt(UIntKind::U8)
@@ -108,11 +100,8 @@ impl CubeElement for i64 {
     fn type_name() -> &'static str {
         "i64"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Int(IntKind::I64)
@@ -131,11 +120,8 @@ impl CubeElement for i32 {
     fn type_name() -> &'static str {
         "i32"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Int(IntKind::I32)
@@ -154,11 +140,8 @@ impl CubeElement for i16 {
     fn type_name() -> &'static str {
         "i16"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Int(IntKind::I16)
@@ -177,11 +160,8 @@ impl CubeElement for i8 {
     fn type_name() -> &'static str {
         "i8"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Int(IntKind::I8)
@@ -200,11 +180,8 @@ impl CubeElement for f64 {
     fn type_name() -> &'static str {
         "f64"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Float(FloatKind::F64)
@@ -221,11 +198,8 @@ impl CubeElement for f32 {
     fn type_name() -> &'static str {
         "f32"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Float(FloatKind::F32)
@@ -242,11 +216,8 @@ impl CubeElement for half::f16 {
     fn type_name() -> &'static str {
         "f16"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Float(FloatKind::F16)
@@ -263,11 +234,8 @@ impl CubeElement for half::bf16 {
     fn type_name() -> &'static str {
         "bf16"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Float(FloatKind::BF16)
@@ -284,11 +252,8 @@ impl CubeElement for flex32 {
     fn type_name() -> &'static str {
         "flex32"
     }
-    fn as_bytes(slice: &[Self]) -> &[u8] {
-        bytemuck::cast_slice(slice)
-    }
-    fn from_bytes(bytes: &[u8]) -> &[Self] {
-        bytemuck::cast_slice(bytes)
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytemuck::cast_slice(bytes.as_slice()).to_vec()
     }
     fn cube_elem() -> Elem {
         Elem::Float(FloatKind::Flex32)
@@ -298,5 +263,38 @@ impl CubeElement for flex32 {
     }
     fn minimum_value() -> Self {
         flex32::MIN
+    }
+}
+
+impl CubeElement for bool {
+    fn type_name() -> &'static str {
+        "bool"
+    }
+    fn to_elem_data(slice: &[Self]) -> Vec<u8> {
+        slice
+            .iter()
+            .flat_map(|&x| {
+                if x {
+                    1u32.to_le_bytes()
+                } else {
+                    0u32.to_le_bytes()
+                }
+            })
+            .collect()
+    }
+    fn from_elem_data(bytes: Vec<u8>) -> Vec<Self> {
+        bytes
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes(c.try_into().unwrap()) != 0)
+            .collect()
+    }
+    fn cube_elem() -> Elem {
+        Elem::Bool
+    }
+    fn maximum_value() -> Self {
+        true
+    }
+    fn minimum_value() -> Self {
+        false
     }
 }

--- a/crates/cubecl-core/src/runtime_tests/assign.rs
+++ b/crates/cubecl-core/src/runtime_tests/assign.rs
@@ -13,7 +13,7 @@ pub fn kernel_assign<F: Float>(output: &mut Array<F>) {
 pub fn test_kernel_assign_scalar<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(F::as_bytes(&[F::new(0.0), F::new(1.0)]));
+    let handle = client.create(&F::to_elem_data(&[F::new(0.0), F::new(1.0)]));
 
     let vectorization = 2;
 
@@ -25,7 +25,7 @@ pub fn test_kernel_assign_scalar<R: Runtime, F: Float + CubeElement>(
     );
 
     let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(actual);
 
     assert_eq!(actual[0], F::new(5.0));
 }

--- a/crates/cubecl-core/src/runtime_tests/binary.rs
+++ b/crates/cubecl-core/src/runtime_tests/binary.rs
@@ -14,8 +14,7 @@ pub(crate) fn assert_equals_approx<
     expected: &[F],
     epsilon: f32,
 ) {
-    let actual = client.read_one(output.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(output.binding()));
 
     // normalize to type epsilon
     let epsilon = (epsilon / f32::EPSILON * F::EPSILON.to_f32().unwrap()).max(epsilon);
@@ -69,8 +68,8 @@ macro_rules! test_binary_impl {
                 let lhs = $lhs;
                 let rhs = $rhs;
                 let output_handle = client.empty($expected.len() * core::mem::size_of::<$float_type>());
-                let lhs_handle = client.create($float_type::as_bytes(lhs));
-                let rhs_handle = client.create($float_type::as_bytes(rhs));
+                let lhs_handle = client.create(&$float_type::to_elem_data(lhs));
+                let rhs_handle = client.create(&$float_type::to_elem_data(rhs));
 
                 unsafe {
                     test_function::launch_unchecked::<$float_type, R>(

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -1,4 +1,4 @@
-use crate::{self as cubecl, as_bytes};
+use crate::{self as cubecl, to_elem_data};
 
 use cubecl::prelude::*;
 
@@ -53,7 +53,7 @@ pub fn kernel_select<F: Float>(output: &mut Array<F>, cond: u32) {
 pub fn test_switch_statement<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(as_bytes![F: 0.0, 1.0]);
+    let handle = client.create(to_elem_data![F: 0.0, 1.0]);
 
     let vectorization = 2;
 
@@ -65,8 +65,7 @@ pub fn test_switch_statement<R: Runtime, F: Float + CubeElement>(
         ScalarArg::new(0),
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], F::new(1.0));
 }
@@ -74,7 +73,7 @@ pub fn test_switch_statement<R: Runtime, F: Float + CubeElement>(
 pub fn test_switch_used_as_value<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(as_bytes![F: 0.0, 1.0]);
+    let handle = client.create(to_elem_data![F: 0.0, 1.0]);
 
     let vectorization = 2;
 
@@ -86,8 +85,7 @@ pub fn test_switch_used_as_value<R: Runtime, F: Float + CubeElement>(
         ScalarArg::new(1),
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], F::new(3.0));
 }
@@ -95,7 +93,7 @@ pub fn test_switch_used_as_value<R: Runtime, F: Float + CubeElement>(
 pub fn test_switch_default<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(as_bytes![F: 0.0, 1.0]);
+    let handle = client.create(to_elem_data![F: 0.0, 1.0]);
 
     let vectorization = 2;
 
@@ -107,8 +105,7 @@ pub fn test_switch_default<R: Runtime, F: Float + CubeElement>(
         ScalarArg::new(5),
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], F::new(5.0));
 }
@@ -116,7 +113,7 @@ pub fn test_switch_default<R: Runtime, F: Float + CubeElement>(
 pub fn test_switch_or_branch<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(as_bytes![F: 0.0, 1.0]);
+    let handle = client.create(to_elem_data![F: 0.0, 1.0]);
 
     let vectorization = 2;
 
@@ -128,8 +125,7 @@ pub fn test_switch_or_branch<R: Runtime, F: Float + CubeElement>(
         ScalarArg::new(2),
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], F::new(3.0));
 }
@@ -138,7 +134,7 @@ pub fn test_select<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
     cond: bool,
 ) {
-    let handle = client.create(as_bytes![F: 0.0]);
+    let handle = client.create(to_elem_data![F: 0.0]);
 
     let vectorization = 1;
 
@@ -152,8 +148,7 @@ pub fn test_select<R: Runtime, F: Float + CubeElement>(
         ScalarArg::new(cond_u32),
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     if cond {
         assert_eq!(actual[0], F::new(3.0));

--- a/crates/cubecl-core/src/runtime_tests/cmma.rs
+++ b/crates/cubecl-core/src/runtime_tests/cmma.rs
@@ -106,8 +106,8 @@ pub fn test_simple_1<R: Runtime>(
     let lhs: Vec<f16> = (0..256).map(|i| f16::from_f32(i as f32)).collect();
     let rhs: Vec<f16> = (0..256).map(|i| f16::from_f32((i % 8) as f32)).collect();
 
-    let lhs = client.create(f16::as_bytes(&lhs));
-    let rhs = client.create(f16::as_bytes(&rhs));
+    let lhs = client.create(&f16::to_elem_data(&lhs));
+    let rhs = client.create(&f16::to_elem_data(&rhs));
     let out = client.empty(core::mem::size_of::<f32>() * 256);
 
     unsafe {
@@ -121,8 +121,7 @@ pub fn test_simple_1<R: Runtime>(
         )
     };
 
-    let actual = client.read_one(out.binding());
-    let actual = f32::from_bytes(&actual);
+    let actual = f32::from_elem_data(client.read_one(out.binding()));
 
     let expected = [
         504., 504., 504., 504., 504., 504., 504., 504., 504., 504., 504., 504., 504., 504., 504.,
@@ -148,7 +147,7 @@ pub fn test_simple_1<R: Runtime>(
         13944., 13944., 13944., 13944., 13944., 13944., 13944.,
     ];
 
-    assert_eq!(expected, actual);
+    assert_eq!(expected, actual.as_slice());
 }
 
 pub fn test_simple_tf32<R: Runtime>(
@@ -170,8 +169,8 @@ pub fn test_simple_tf32<R: Runtime>(
     let lhs: Vec<f32> = (0..128).map(|i| (i as f32)).collect();
     let rhs: Vec<f32> = (0..128).map(|i| ((i % 8) as f32)).collect();
 
-    let lhs = client.create(f32::as_bytes(&lhs));
-    let rhs = client.create(f32::as_bytes(&rhs));
+    let lhs = client.create(&f32::to_elem_data(&lhs));
+    let rhs = client.create(&f32::to_elem_data(&rhs));
     let out = client.empty(core::mem::size_of::<f32>() * 256);
 
     unsafe {
@@ -185,8 +184,7 @@ pub fn test_simple_tf32<R: Runtime>(
         )
     };
 
-    let actual = client.read_one(out.binding());
-    let actual = f32::from_bytes(&actual);
+    let actual = f32::from_elem_data(client.read_one(out.binding()));
 
     let expected = [
         0., 28., 56., 84., 112., 140., 168., 196., 0., 28., 56., 84., 112., 140., 168., 196., 0.,
@@ -209,7 +207,7 @@ pub fn test_simple_tf32<R: Runtime>(
         2964., 3952., 4940., 5928., 6916., 0., 988., 1976., 2964., 3952., 4940., 5928., 6916.,
     ];
 
-    assert_eq!(expected, actual);
+    assert_eq!(expected, actual.as_slice());
 }
 
 #[allow(missing_docs)]

--- a/crates/cubecl-core/src/runtime_tests/const_match.rs
+++ b/crates/cubecl-core/src/runtime_tests/const_match.rs
@@ -1,7 +1,7 @@
 use core::hash;
 use std::fmt::Debug;
 
-use crate::{self as cubecl, as_bytes};
+use crate::{self as cubecl, to_elem_data};
 
 use cubecl::prelude::*;
 
@@ -29,7 +29,7 @@ pub fn test_kernel_const_match<
 >(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(as_bytes![F: 0.0, 1.0]);
+    let handle = client.create(to_elem_data![F: 0.0, 1.0]);
 
     let index = 1;
     let value = 5.0;
@@ -42,8 +42,7 @@ pub fn test_kernel_const_match<
         Operation::IndexAssign(index as u32, U::new(value as i64)),
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[index], F::new(value));
 }

--- a/crates/cubecl-core/src/runtime_tests/constants.rs
+++ b/crates/cubecl-core/src/runtime_tests/constants.rs
@@ -11,7 +11,7 @@ fn constant_array_kernel<F: Float>(out: &mut Array<F>, #[comptime] data: Vec<u32
 }
 
 pub fn test_constant_array<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
-    let handle = client.create(f32::as_bytes(&[0.0, 1.0]));
+    let handle = client.create(&f32::to_elem_data(&[0.0, 1.0]));
 
     let vectorization = 1;
 
@@ -23,8 +23,7 @@ pub fn test_constant_array<R: Runtime>(client: ComputeClient<R::Server, R::Chann
         vec![3, 5, 1],
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = f32::from_bytes(&actual);
+    let actual = f32::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], 5.0);
 }

--- a/crates/cubecl-core/src/runtime_tests/different_rank.rs
+++ b/crates/cubecl-core/src/runtime_tests/different_rank.rs
@@ -1,4 +1,4 @@
-use crate::{self as cubecl, as_bytes, as_type};
+use crate::{self as cubecl, as_type, to_elem_data};
 
 use cubecl::prelude::*;
 
@@ -50,9 +50,9 @@ fn test_kernel_different_rank<R: Runtime, F: Float + CubeElement>(
 ) {
     let vectorisation = 2;
 
-    let handle_lhs = client.create(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
-    let handle_rhs = client.create(as_bytes![F: 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]);
-    let handle_out = client.create(as_bytes![F: 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+    let handle_lhs = client.create(to_elem_data![F: 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+    let handle_rhs = client.create(to_elem_data![F: 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]);
+    let handle_out = client.create(to_elem_data![F: 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
 
     let lhs = unsafe {
         TensorArg::from_raw_parts::<F>(&handle_lhs, &strides_lhs, &shape_lhs, vectorisation)
@@ -73,8 +73,7 @@ fn test_kernel_different_rank<R: Runtime, F: Float + CubeElement>(
         out,
     );
 
-    let actual = client.read_one(handle_out.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle_out.binding()));
 
     assert_eq!(
         actual,

--- a/crates/cubecl-core/src/runtime_tests/launch.rs
+++ b/crates/cubecl-core/src/runtime_tests/launch.rs
@@ -1,4 +1,4 @@
-use crate::{self as cubecl, as_bytes};
+use crate::{self as cubecl, to_elem_data};
 use cubecl::prelude::*;
 
 #[cube(launch)]
@@ -18,7 +18,7 @@ pub fn kernel_without_generics(output: &mut Array<f32>) {
 pub fn test_kernel_with_generics<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(as_bytes![F: 0.0, 1.0]);
+    let handle = client.create(to_elem_data![F: 0.0, 1.0]);
 
     kernel_with_generics::launch::<F, R>(
         &client,
@@ -27,14 +27,13 @@ pub fn test_kernel_with_generics<R: Runtime, F: Float + CubeElement>(
         unsafe { ArrayArg::from_raw_parts::<F>(&handle, 2, 1) },
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], F::new(5.0));
 }
 
 pub fn test_kernel_without_generics<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
-    let handle = client.create(f32::as_bytes(&[0.0, 1.0]));
+    let handle = client.create(&f32::to_elem_data(&[0.0, 1.0]));
 
     kernel_without_generics::launch::<R>(
         &client,
@@ -43,8 +42,7 @@ pub fn test_kernel_without_generics<R: Runtime>(client: ComputeClient<R::Server,
         unsafe { ArrayArg::from_raw_parts::<f32>(&handle, 2, 1) },
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = f32::from_bytes(&actual);
+    let actual = f32::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], 5.0);
 }

--- a/crates/cubecl-core/src/runtime_tests/metadata.rs
+++ b/crates/cubecl-core/src/runtime_tests/metadata.rs
@@ -95,11 +95,10 @@ pub fn test_shape_dim_4<R: Runtime>(client: ComputeClient<R::Server, R::Channel>
         )
     };
 
-    let actual = client.read_one(handle3.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(handle3.binding()));
     let expect: Vec<u32> = vec![2, 3, 4, 5, 9, 8, 7, 6, 10, 11, 12, 13];
 
-    assert_eq!(actual, &expect);
+    assert_eq!(actual, expect);
 }
 
 pub fn test_shape_different_ranks<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
@@ -118,11 +117,10 @@ pub fn test_shape_different_ranks<R: Runtime>(client: ComputeClient<R::Server, R
         )
     };
 
-    let actual = client.read_one(handle3.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(handle3.binding()));
     let expect: Vec<u32> = vec![2, 3, 4, 5, 9, 8, 7, 10, 11, 4, 3, 2];
 
-    assert_eq!(actual, &expect);
+    assert_eq!(actual, expect);
 }
 
 pub fn test_stride_different_ranks<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
@@ -141,11 +139,10 @@ pub fn test_stride_different_ranks<R: Runtime>(client: ComputeClient<R::Server, 
         )
     };
 
-    let actual = client.read_one(handle3.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(handle3.binding()));
     let expect: Vec<u32> = vec![1, 2, 3, 4, 4, 5, 6, 3, 2];
 
-    assert_eq!(actual, &expect);
+    assert_eq!(actual, expect);
 }
 
 pub fn test_len_different_ranks<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
@@ -164,11 +161,10 @@ pub fn test_len_different_ranks<R: Runtime>(client: ComputeClient<R::Server, R::
         )
     };
 
-    let actual = client.read_one(handle3.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(handle3.binding()));
     let expect: Vec<u32> = vec![2 * 3 * 4 * 5, 9 * 8 * 7, 10 * 11];
 
-    assert_eq!(actual, &expect);
+    assert_eq!(actual, expect);
 }
 
 pub fn test_buffer_len_discontiguous<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
@@ -183,8 +179,7 @@ pub fn test_buffer_len_discontiguous<R: Runtime>(client: ComputeClient<R::Server
         )
     };
 
-    let actual = client.read_one(handle1.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(handle1.binding()));
 
     assert_eq!(actual[0], 64);
 }
@@ -201,8 +196,7 @@ pub fn test_buffer_len_vectorized<R: Runtime>(client: ComputeClient<R::Server, R
         )
     };
 
-    let actual = client.read_one(handle1.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(handle1.binding()));
 
     assert_eq!(actual[0], 8);
 }
@@ -222,8 +216,7 @@ pub fn test_buffer_len_offset<R: Runtime>(client: ComputeClient<R::Server, R::Ch
         )
     };
 
-    let actual = client.read_one(handle1.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(handle1.binding()));
 
     assert_eq!(actual[0], 32);
 }

--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -106,9 +106,9 @@ macro_rules! testgen_untyped {
 
 #[allow(missing_docs)]
 #[macro_export]
-macro_rules! as_bytes {
+macro_rules! to_elem_data {
     ($ty:ident: $($elem:expr),*) => {
-        F::as_bytes(&[$($ty::new($elem),)*])
+        &F::to_elem_data(&[$($ty::new($elem),)*])
     };
 }
 

--- a/crates/cubecl-core/src/runtime_tests/plane.rs
+++ b/crates/cubecl-core/src/runtime_tests/plane.rs
@@ -370,7 +370,7 @@ fn test_plane_operation<TestRuntime: Runtime, F: Float + CubeElement, Launch>(
         return;
     }
 
-    let handle = client.create(F::as_bytes(input));
+    let handle = client.create(&F::to_elem_data(input));
     let (shape, strides) = ([input.len()], [1]);
 
     unsafe {
@@ -380,8 +380,7 @@ fn test_plane_operation<TestRuntime: Runtime, F: Float + CubeElement, Launch>(
         );
     }
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual, expected);
 }

--- a/crates/cubecl-core/src/runtime_tests/sequence.rs
+++ b/crates/cubecl-core/src/runtime_tests/sequence.rs
@@ -1,4 +1,4 @@
-use crate::{self as cubecl, as_bytes};
+use crate::{self as cubecl, to_elem_data};
 use cubecl::prelude::*;
 
 #[cube(launch)]
@@ -33,7 +33,7 @@ pub fn sequence_index<F: Float>(output: &mut Array<F>) {
 pub fn test_sequence_for_loop<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(as_bytes![F: 0.0]);
+    let handle = client.create(to_elem_data![F: 0.0]);
 
     sequence_for_loop::launch::<F, R>(
         &client,
@@ -42,8 +42,7 @@ pub fn test_sequence_for_loop<R: Runtime, F: Float + CubeElement>(
         unsafe { ArrayArg::from_raw_parts::<F>(&handle, 2, 1) },
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], F::new(5.0));
 }
@@ -51,7 +50,7 @@ pub fn test_sequence_for_loop<R: Runtime, F: Float + CubeElement>(
 pub fn test_sequence_index<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(as_bytes![F: 0.0]);
+    let handle = client.create(to_elem_data![F: 0.0]);
 
     sequence_index::launch::<F, R>(
         &client,
@@ -60,8 +59,7 @@ pub fn test_sequence_index<R: Runtime, F: Float + CubeElement>(
         unsafe { ArrayArg::from_raw_parts::<F>(&handle, 2, 1) },
     );
 
-    let actual = client.read_one(handle.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(handle.binding()));
 
     assert_eq!(actual[0], F::new(6.0));
 }

--- a/crates/cubecl-core/src/runtime_tests/slice.rs
+++ b/crates/cubecl-core/src/runtime_tests/slice.rs
@@ -1,4 +1,4 @@
-use crate::{self as cubecl, as_bytes, as_type};
+use crate::{self as cubecl, as_type, to_elem_data};
 use cubecl::prelude::*;
 
 #[cube(launch)]
@@ -51,7 +51,7 @@ pub fn slice_mut_len(output: &mut Array<u32>) {
 pub fn test_slice_select<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let input = client.create(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
+    let input = client.create(to_elem_data![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
     let output = client.empty(core::mem::size_of::<F>());
 
     unsafe {
@@ -64,8 +64,7 @@ pub fn test_slice_select<R: Runtime, F: Float + CubeElement>(
         )
     };
 
-    let actual = client.read_one(output.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(output.binding()));
 
     assert_eq!(actual[0], F::new(2.0));
 }
@@ -73,7 +72,7 @@ pub fn test_slice_select<R: Runtime, F: Float + CubeElement>(
 pub fn test_slice_len<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let input = client.create(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
+    let input = client.create(to_elem_data![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
     let output = client.empty(core::mem::size_of::<u32>());
 
     unsafe {
@@ -86,8 +85,7 @@ pub fn test_slice_len<R: Runtime, F: Float + CubeElement>(
         )
     };
 
-    let actual = client.read_one(output.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(output.binding()));
 
     assert_eq!(actual, &[2]);
 }
@@ -95,8 +93,8 @@ pub fn test_slice_len<R: Runtime, F: Float + CubeElement>(
 pub fn test_slice_for<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let input = client.create(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
-    let output = client.create(as_bytes![F: 0.0]);
+    let input = client.create(to_elem_data![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
+    let output = client.create(to_elem_data![F: 0.0]);
 
     unsafe {
         slice_for::launch::<F, R>(
@@ -108,17 +106,15 @@ pub fn test_slice_for<R: Runtime, F: Float + CubeElement>(
         )
     };
 
-    let actual = client.read_one(output.binding());
-    let actual = F::from_bytes(&actual);
-
+    let actual = F::from_elem_data(client.read_one(output.binding()));
     assert_eq!(actual[0], F::new(5.0));
 }
 
 pub fn test_slice_mut_assign<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let input = client.create(as_bytes![F: 15.0]);
-    let output = client.create(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
+    let input = client.create(to_elem_data![F: 15.0]);
+    let output = client.create(to_elem_data![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
 
     unsafe {
         slice_mut_assign::launch::<F, R>(
@@ -130,8 +126,7 @@ pub fn test_slice_mut_assign<R: Runtime, F: Float + CubeElement>(
         )
     };
 
-    let actual = client.read_one(output.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(output.binding()));
 
     assert_eq!(&actual[0..5], as_type![F: 0.0, 1.0, 15.0, 3.0, 4.0]);
 }
@@ -148,8 +143,7 @@ pub fn test_slice_mut_len<R: Runtime>(client: ComputeClient<R::Server, R::Channe
         )
     };
 
-    let actual = client.read_one(output.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(output.binding()));
 
     assert_eq!(actual[0], 2);
 }

--- a/crates/cubecl-core/src/runtime_tests/topology.rs
+++ b/crates/cubecl-core/src/runtime_tests/topology.rs
@@ -27,11 +27,10 @@ pub fn test_kernel_topology_absolute_pos<R: Runtime>(client: ComputeClient<R::Se
         )
     };
 
-    let actual = client.read_one(handle1.binding());
-    let actual = u32::from_bytes(&actual);
+    let actual = u32::from_elem_data(client.read_one(handle1.binding()));
     let expect: Vec<u32> = (0..length).collect();
 
-    assert_eq!(actual, &expect);
+    assert_eq!(actual, expect);
 }
 
 #[allow(missing_docs)]

--- a/crates/cubecl-core/src/runtime_tests/unary.rs
+++ b/crates/cubecl-core/src/runtime_tests/unary.rs
@@ -14,8 +14,7 @@ pub(crate) fn assert_equals_approx<
     expected: &[F],
     epsilon: F,
 ) {
-    let actual = client.read_one(output.binding());
-    let actual = F::from_bytes(&actual);
+    let actual = F::from_elem_data(client.read_one(output.binding()));
 
     for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
         assert!(
@@ -58,7 +57,7 @@ macro_rules! test_unary_impl {
             {
                 let input = $input;
                 let output_handle = client.empty(input.len() * core::mem::size_of::<$float_type>());
-                let input_handle = client.create($float_type::as_bytes(input));
+                let input_handle = client.create(&$float_type::to_elem_data(input));
 
                 unsafe {
                     test_function::launch_unchecked::<$float_type, R>(

--- a/crates/cubecl-core/tests/frontend/cast_kind.rs
+++ b/crates/cubecl-core/tests/frontend/cast_kind.rs
@@ -1,7 +1,8 @@
 use cubecl_core as cubecl;
+use cubecl_core::prelude::Algebraic;
 use cubecl_core::{
     cube,
-    frontend::{Cast, Float, Int, Numeric},
+    frontend::{Cast, Float, Int},
 };
 
 #[cube]
@@ -19,14 +20,14 @@ pub fn cast_int_kind<I1: Int, I2: Int>(input: I1) {
 }
 
 #[cube]
-pub fn cast_numeric_to_kind<T: Numeric, I: Int>(input: T) {
+pub fn cast_numeric_to_kind<T: Algebraic, I: Int>(input: T) {
     let x = input + T::from_int(5);
     let y = I::cast_from(x);
     let _ = y + I::from_int(2);
 }
 
 #[cube]
-pub fn cast_int_to_numeric<I: Int, T: Numeric>(input: I) {
+pub fn cast_int_to_numeric<I: Int, T: Algebraic>(input: I) {
     let x = input + I::from_int(5);
     let y = T::cast_from(x);
     let _ = y + T::from_int(2);

--- a/crates/cubecl-core/tests/frontend/comptime.rs
+++ b/crates/cubecl-core/tests/frontend/comptime.rs
@@ -14,7 +14,7 @@ impl Init for State {
 }
 
 #[cube]
-pub fn comptime_if_else<T: Numeric>(lhs: T, #[comptime] cond: bool) {
+pub fn comptime_if_else<T: Algebraic>(lhs: T, #[comptime] cond: bool) {
     if cond {
         let _ = lhs + T::from_int(4);
     } else {
@@ -24,7 +24,11 @@ pub fn comptime_if_else<T: Numeric>(lhs: T, #[comptime] cond: bool) {
 
 #[cube]
 #[allow(clippy::collapsible_else_if)]
-pub fn comptime_else_then_if<T: Numeric>(lhs: T, #[comptime] cond1: bool, #[comptime] cond2: bool) {
+pub fn comptime_else_then_if<T: Algebraic>(
+    lhs: T,
+    #[comptime] cond1: bool,
+    #[comptime] cond2: bool,
+) {
     if cond1 {
         let _ = lhs + T::from_int(4);
     } else {
@@ -43,7 +47,7 @@ pub fn comptime_float() {
 }
 
 #[cube]
-pub fn comptime_elsif<T: Numeric>(lhs: T, #[comptime] cond1: bool, #[comptime] cond2: bool) {
+pub fn comptime_elsif<T: Algebraic>(lhs: T, #[comptime] cond1: bool, #[comptime] cond2: bool) {
     if cond1 {
         let _ = lhs + T::from_int(4);
     } else if cond2 {
@@ -54,7 +58,7 @@ pub fn comptime_elsif<T: Numeric>(lhs: T, #[comptime] cond1: bool, #[comptime] c
 }
 
 #[cube]
-pub fn comptime_elsif_with_runtime1<T: Numeric>(lhs: T, #[comptime] comptime_cond: bool) {
+pub fn comptime_elsif_with_runtime1<T: Algebraic>(lhs: T, #[comptime] comptime_cond: bool) {
     let runtime_cond = lhs >= T::from_int(2);
     if comptime_cond {
         let _ = lhs + T::from_int(4);
@@ -66,7 +70,7 @@ pub fn comptime_elsif_with_runtime1<T: Numeric>(lhs: T, #[comptime] comptime_con
 }
 
 #[cube]
-pub fn comptime_elsif_with_runtime2<T: Numeric>(lhs: T, #[comptime] comptime_cond: bool) {
+pub fn comptime_elsif_with_runtime2<T: Algebraic>(lhs: T, #[comptime] comptime_cond: bool) {
     let runtime_cond = lhs >= T::from_int(2);
     if runtime_cond {
         let _ = lhs + T::from_int(4);
@@ -78,7 +82,7 @@ pub fn comptime_elsif_with_runtime2<T: Numeric>(lhs: T, #[comptime] comptime_con
 }
 
 #[cube]
-pub fn comptime_if_expr<T: Numeric>(lhs: T, #[comptime] x: u32, #[comptime] y: u32) {
+pub fn comptime_if_expr<T: Algebraic>(lhs: T, #[comptime] x: u32, #[comptime] y: u32) {
     let y2 = x + y;
 
     if x < y2 {
@@ -89,7 +93,7 @@ pub fn comptime_if_expr<T: Numeric>(lhs: T, #[comptime] x: u32, #[comptime] y: u
 }
 
 #[cube]
-pub fn comptime_with_map_bool<T: Numeric>(#[comptime] state: State) -> T {
+pub fn comptime_with_map_bool<T: Algebraic>(#[comptime] state: State) -> T {
     let cond = state.cond;
 
     let mut x = T::from_int(3);
@@ -102,7 +106,7 @@ pub fn comptime_with_map_bool<T: Numeric>(#[comptime] state: State) -> T {
 }
 
 #[cube]
-pub fn comptime_with_map_uint<T: Numeric>(#[comptime] state: State) -> T {
+pub fn comptime_with_map_uint<T: Algebraic>(#[comptime] state: State) -> T {
     let bound = state.bound;
 
     let mut x = T::from_int(3);
@@ -119,7 +123,7 @@ fn rust_function(input: u32) -> u32 {
 }
 
 #[cube]
-pub fn comptime_block<T: Numeric>(a: T) -> T {
+pub fn comptime_block<T: Algebraic>(a: T) -> T {
     let comptime_val = comptime! { rust_function(2) as i64 };
 
     a + T::from_int(comptime_val)

--- a/crates/cubecl-core/tests/frontend/cube_impl.rs
+++ b/crates/cubecl-core/tests/frontend/cube_impl.rs
@@ -45,7 +45,7 @@ struct TypeGeneric<C: CubePrimitive> {
 }
 
 #[cube]
-impl<C: Numeric> TypeGeneric<C> {
+impl<C: Algebraic> TypeGeneric<C> {
     #[allow(dead_code)]
     fn value(&self, lhs: u32) -> C {
         self.a * C::cast_from(lhs)
@@ -60,13 +60,13 @@ impl<C: Numeric> TypeGeneric<C> {
 }
 
 #[derive(CubeType)]
-struct ComplexType<C: Numeric, T: Numeric> {
+struct ComplexType<C: Algebraic, T: Algebraic> {
     a: C,
     t: T,
 }
 
 #[cube]
-impl<C: Numeric> ComplexType<C, f32> {
+impl<C: Algebraic> ComplexType<C, f32> {
     #[allow(dead_code)]
     pub fn complex_method(&mut self, lhs: f32, rhs: C) -> f32 {
         let tmp = self.a + (C::cast_from(lhs) / rhs);

--- a/crates/cubecl-core/tests/frontend/function_call.rs
+++ b/crates/cubecl-core/tests/frontend/function_call.rs
@@ -1,4 +1,5 @@
 use cubecl_core as cubecl;
+use cubecl_core::prelude::Algebraic;
 use cubecl_core::{cube, frontend::Numeric};
 
 #[cube]
@@ -32,17 +33,17 @@ pub fn no_call_with_arg(x: u32) {
 }
 
 #[cube]
-pub fn caller_with_generics<T: Numeric>(x: T) {
+pub fn caller_with_generics<T: Algebraic>(x: T) {
     let _ = x + callee_with_generics::<T>(x);
 }
 
 #[cube]
-pub fn callee_with_generics<T: Numeric>(x: T) -> T {
+pub fn callee_with_generics<T: Algebraic>(x: T) -> T {
     x * T::from_int(8)
 }
 
 #[cube]
-pub fn no_call_with_generics<T: Numeric>(x: T) {
+pub fn no_call_with_generics<T: Algebraic>(x: T) {
     let _ = x + x * T::from_int(8);
 }
 

--- a/crates/cubecl-core/tests/frontend/generic_kernel.rs
+++ b/crates/cubecl-core/tests/frontend/generic_kernel.rs
@@ -1,8 +1,8 @@
 use cubecl_core as cubecl;
-use cubecl_core::{cube, frontend::Numeric};
+use cubecl_core::{cube, frontend::Algebraic};
 
 #[cube]
-pub fn generic_kernel<T: Numeric>(lhs: T) {
+pub fn generic_kernel<T: Algebraic>(lhs: T) {
     let _ = lhs + T::from_int(5);
 }
 

--- a/crates/cubecl-core/tests/frontend/if.rs
+++ b/crates/cubecl-core/tests/frontend/if.rs
@@ -2,14 +2,14 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[cube]
-pub fn if_greater<T: Numeric>(lhs: T) {
+pub fn if_greater<T: Algebraic>(lhs: T) {
     if lhs > T::from_int(0) {
         let _ = lhs + T::from_int(4);
     }
 }
 
 #[cube]
-pub fn if_greater_var<T: Numeric>(lhs: T) {
+pub fn if_greater_var<T: Algebraic>(lhs: T) {
     let x = lhs > T::from_int(0);
     if x {
         let _ = lhs + T::from_int(4);

--- a/crates/cubecl-core/tests/frontend/ops.rs
+++ b/crates/cubecl-core/tests/frontend/ops.rs
@@ -2,27 +2,27 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[cube]
-pub fn add_op<T: Numeric>(a: T, b: T) -> T {
+pub fn add_op<T: Algebraic>(a: T, b: T) -> T {
     a + b
 }
 
 #[cube]
-pub fn sub_op<T: Numeric>(a: T, b: T) -> T {
+pub fn sub_op<T: Algebraic>(a: T, b: T) -> T {
     a - b
 }
 
 #[cube]
-pub fn mul_op<T: Numeric>(a: T, b: T) -> T {
+pub fn mul_op<T: Algebraic>(a: T, b: T) -> T {
     a * b
 }
 
 #[cube]
-pub fn div_op<T: Numeric>(a: T, b: T) -> T {
+pub fn div_op<T: Algebraic>(a: T, b: T) -> T {
     a / b
 }
 
 #[cube]
-pub fn abs_op<T: Numeric>(a: T) -> T {
+pub fn abs_op<T: Algebraic>(a: T) -> T {
     T::abs(a)
 }
 
@@ -127,17 +127,17 @@ pub fn modulo_op(a: u32, b: u32) -> u32 {
 }
 
 #[cube]
-pub fn remainder_op<T: Numeric>(a: T, b: T) -> T {
+pub fn remainder_op<T: Algebraic>(a: T, b: T) -> T {
     T::rem(a, b)
 }
 
 #[cube]
-pub fn max_op<T: Numeric>(a: T, b: T) -> T {
+pub fn max_op<T: Algebraic>(a: T, b: T) -> T {
     T::max(a, b)
 }
 
 #[cube]
-pub fn min_op<T: Numeric>(a: T, b: T) -> T {
+pub fn min_op<T: Algebraic>(a: T, b: T) -> T {
     T::min(a, b)
 }
 
@@ -182,22 +182,22 @@ pub fn shr_op(a: u32, b: u32) -> u32 {
 }
 
 #[cube]
-pub fn add_assign_op<T: Numeric>(mut a: T, b: T) {
+pub fn add_assign_op<T: Algebraic>(mut a: T, b: T) {
     a += b;
 }
 
 #[cube]
-pub fn sub_assign_op<T: Numeric>(mut a: T, b: T) {
+pub fn sub_assign_op<T: Algebraic>(mut a: T, b: T) {
     a -= b;
 }
 
 #[cube]
-pub fn mul_assign_op<T: Numeric>(mut a: T, b: T) {
+pub fn mul_assign_op<T: Algebraic>(mut a: T, b: T) {
     a *= b;
 }
 
 #[cube]
-pub fn div_assign_op<T: Numeric>(mut a: T, b: T) {
+pub fn div_assign_op<T: Algebraic>(mut a: T, b: T) {
     a /= b;
 }
 

--- a/crates/cubecl-core/tests/frontend/parenthesis.rs
+++ b/crates/cubecl-core/tests/frontend/parenthesis.rs
@@ -2,7 +2,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[cube]
-pub fn parenthesis<T: Numeric>(x: T, y: T, z: T) -> T {
+pub fn parenthesis<T: Algebraic>(x: T, y: T, z: T) -> T {
     x * (y + z)
 }
 

--- a/crates/cubecl-core/tests/frontend/struct.rs
+++ b/crates/cubecl-core/tests/frontend/struct.rs
@@ -32,7 +32,7 @@ pub struct State<T: Numeric> {
 }
 
 #[cube]
-pub fn state_receiver_with_reuse<T: Numeric>(state: State<T>) -> T {
+pub fn state_receiver_with_reuse<T: Algebraic>(state: State<T>) -> T {
     let x = state.first + state.second;
     state.second + x + state.first
 }

--- a/crates/cubecl-core/tests/frontend/trait.rs
+++ b/crates/cubecl-core/tests/frontend/trait.rs
@@ -14,12 +14,12 @@ struct AddStrategy;
 #[cube]
 /// The actual implementation of AddStrategy's operation
 /// Automatically generated an _expand variant
-pub fn add_strategy_operation<T: Numeric>(input_1: T, input_2: T) -> T {
+pub fn add_strategy_operation<T: Algebraic>(input_1: T, input_2: T) -> T {
     input_1 + input_2
 }
 
 #[cube]
-impl<T: Numeric> Strategy<T> for AddStrategy {
+impl<T: Algebraic> Strategy<T> for AddStrategy {
     fn operation(input_1: T, input_2: T) -> T {
         add_strategy_operation::<T>(input_1, input_2)
     }
@@ -28,7 +28,7 @@ impl<T: Numeric> Strategy<T> for AddStrategy {
 struct SubStrategy;
 
 #[cube]
-impl<T: Numeric> Strategy<T> for SubStrategy {
+impl<T: Algebraic> Strategy<T> for SubStrategy {
     fn operation(input_1: T, input_2: T) -> T {
         input_1 - input_2
     }
@@ -46,8 +46,8 @@ pub fn two_strategy_traits<S1: Strategy<F>, S2: Strategy<F>, F: Float>(x: F, y: 
 }
 
 pub trait MethodTypedStrategy {
-    fn operation<T: Numeric>(input_1: T, input_2: T) -> T;
-    fn __expand_operation<T: Numeric>(
+    fn operation<T: Algebraic>(input_1: T, input_2: T) -> T;
+    fn __expand_operation<T: Algebraic>(
         _context: &mut CubeContext,
         input_1: <T as CubeType>::ExpandType,
         input_2: <T as CubeType>::ExpandType,
@@ -55,11 +55,11 @@ pub trait MethodTypedStrategy {
 }
 
 impl MethodTypedStrategy for AddStrategy {
-    fn operation<T: Numeric>(input_1: T, input_2: T) -> T {
+    fn operation<T: Algebraic>(input_1: T, input_2: T) -> T {
         add_strategy_operation(input_1, input_2)
     }
 
-    fn __expand_operation<T: Numeric>(
+    fn __expand_operation<T: Algebraic>(
         context: &mut CubeContext,
         input_1: <T as CubeType>::ExpandType,
         input_2: <T as CubeType>::ExpandType,
@@ -69,7 +69,7 @@ impl MethodTypedStrategy for AddStrategy {
 }
 
 #[cube]
-pub fn with_trait_generic_method<S: MethodTypedStrategy, T: Numeric>(x: T, y: T) -> T {
+pub fn with_trait_generic_method<S: MethodTypedStrategy, T: Algebraic>(x: T, y: T) -> T {
     S::operation::<T>(x, y)
 }
 

--- a/crates/cubecl-core/tests/frontend/vectorization.rs
+++ b/crates/cubecl-core/tests/frontend/vectorization.rs
@@ -2,7 +2,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[cube]
-pub fn vectorization_binary<T: Numeric>(lhs: T) {
+pub fn vectorization_binary<T: Algebraic>(lhs: T) {
     let _ = lhs + T::from_vec([4, 5]);
 }
 

--- a/crates/cubecl-cpp/src/shared/element.rs
+++ b/crates/cubecl-cpp/src/shared/element.rs
@@ -567,7 +567,8 @@ impl<D: Dialect> Elem<D> {
             Elem::U16 => core::mem::size_of::<u16>(),
             Elem::U32 => core::mem::size_of::<u32>(),
             Elem::U64 => core::mem::size_of::<u64>(),
-            Elem::Bool => core::mem::size_of::<bool>(),
+            // Bools are currently represented as u32s.
+            Elem::Bool => core::mem::size_of::<u32>(),
             Elem::Atomic(AtomicKind::I32) => core::mem::size_of::<i32>(),
             Elem::Atomic(AtomicKind::U32) => core::mem::size_of::<u32>(),
             Elem::_Dialect(_) => 0,

--- a/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
@@ -23,13 +23,13 @@ pub type PlaneMma32x32x32<I, O> = PlaneMma<I, O, 32, 32, 32>;
 ///  - When loading perpendicular to the lines, too much data is loaded from in comparison to what is used.
 ///    A solution could be to always load the stage with lhs in row-major and rhs in col-major, using only parallel fill
 ///  - If not vec4, there are patches in read_output that may harm performance
-pub struct PlaneMma<I: Numeric, O: Numeric, const M: u32, const N: u32, const K: u32> {
+pub struct PlaneMma<I: Algebraic, O: Algebraic, const M: u32, const N: u32, const K: u32> {
     _input: PhantomData<I>,
     _output: PhantomData<O>,
 }
 
 #[cube]
-impl<I: Numeric, O: Numeric, const M: u32, const N: u32, const K: u32> tile::Matmul<I, O>
+impl<I: Algebraic, O: Algebraic, const M: u32, const N: u32, const K: u32> tile::Matmul<I, O>
     for PlaneMma<I, O, M, N, K>
 {
     const M: u32 = M;
@@ -321,7 +321,7 @@ fn fill_parallel_rhs<E: Numeric>(
     }
 }
 
-impl<I: Numeric, O: Numeric, const M: u32, const N: u32, const K: u32> MatmulKernel<I, O>
+impl<I: Algebraic, O: Algebraic, const M: u32, const N: u32, const K: u32> MatmulKernel<I, O>
     for PlaneMma<I, O, M, N, K>
 {
     type Config = Config;

--- a/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
@@ -148,7 +148,7 @@ fn tensor_raw_parts<EG: Float + CubeElement, R: Runtime>(
             };
 
             TensorRawParts {
-                handle: client.create(EG::as_bytes(&data)),
+                handle: client.create(&EG::to_elem_data(&data)),
                 shape: shape(problem, Ident::Lhs),
                 strides: strides(problem, Ident::Lhs),
                 original_data: Some(original_data),
@@ -165,7 +165,7 @@ fn tensor_raw_parts<EG: Float + CubeElement, R: Runtime>(
             };
 
             TensorRawParts {
-                handle: client.create(EG::as_bytes(&data)),
+                handle: client.create(&EG::to_elem_data(&data)),
                 shape: shape(problem, Ident::Rhs),
                 strides: strides(problem, Ident::Rhs),
                 original_data: Some(original_data),

--- a/crates/cubecl-std/src/reduce/sum.rs
+++ b/crates/cubecl-std/src/reduce/sum.rs
@@ -14,7 +14,7 @@ pub struct ReduceConfig {
 ///
 /// This is a work in progress toward a more general multi-dimensional reduce kernel.
 #[cube(launch_unchecked)]
-pub fn reduce_sum<N: Numeric>(
+pub fn reduce_sum<N: Algebraic>(
     input: &Tensor<Line<N>>,
     output: &mut Tensor<Line<N>>,
     #[comptime] config: ReduceConfig,
@@ -28,7 +28,7 @@ pub fn reduce_sum<N: Numeric>(
 ///
 /// This is a work in progress toward a more general multi-dimensional reduce kernel.
 #[cube(launch_unchecked)]
-pub fn reduce_sum_lined<N: Numeric>(
+pub fn reduce_sum_lined<N: Algebraic>(
     input: &Tensor<Line<N>>,
     output: &mut Tensor<N>,
     #[comptime] config: ReduceConfig,
@@ -40,7 +40,7 @@ pub fn reduce_sum_lined<N: Numeric>(
 
 /// Compute the sum of all elements of `input` and write it to the first element of `output`.
 #[cube]
-pub fn reduce_sum_vector<N: Numeric>(
+pub fn reduce_sum_vector<N: Algebraic>(
     input: &Slice<Line<N>>,
     output: &mut SliceMut<Line<N>>,
     #[comptime] config: ReduceConfig,
@@ -86,7 +86,7 @@ pub fn reduce_sum_vector<N: Numeric>(
 
 /// For each line, sum all elements and write the result into the corresponding element of output.
 #[cube]
-pub fn reduce_sum_lines<N: Numeric>(
+pub fn reduce_sum_lines<N: Algebraic>(
     input: &Slice<Line<N>>,
     output: &mut SliceMut<N>,
     #[comptime] length: u32,

--- a/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
@@ -226,7 +226,8 @@ impl Elem {
             Self::AtomicI32 => core::mem::size_of::<i32>(),
             Self::U32 => core::mem::size_of::<u32>(),
             Self::AtomicU32 => core::mem::size_of::<u32>(),
-            Self::Bool => core::mem::size_of::<bool>(),
+            // Bools are defined as 4 bytes in wgsl.
+            Self::Bool => core::mem::size_of::<u32>(),
         }
     }
 

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -195,7 +195,7 @@ impl WgpuStream {
                     .iter()
                     .map(|(staging_buffer, size)| {
                         let data = staging_buffer.slice(..).get_mapped_range();
-                        bytemuck::cast_slice(&data[0..(*size as usize)]).to_vec()
+                        data[0..(*size as usize)].to_vec()
                     })
                     .collect()
             };

--- a/examples/fusing/src/lib.rs
+++ b/examples/fusing/src/lib.rs
@@ -38,7 +38,7 @@ pub fn launch<R: Runtime>(device: &R::Device) {
     let vectorization = 4;
     let output_handle_1 = client.empty(input.len() * core::mem::size_of::<f32>());
     let output_handle_2 = client.empty(input.len() * core::mem::size_of::<f32>());
-    let input_handle = client.create(f32::as_bytes(input));
+    let input_handle = client.create(&f32::to_elem_data(input));
 
     let mut ops = Sequence::new();
     let mut inputs = SequenceArg::new();
@@ -82,12 +82,10 @@ pub fn launch<R: Runtime>(device: &R::Device) {
         )
     };
 
-    let bytes = client.read_one(output_handle_1.binding());
-    let output_1 = f32::from_bytes(&bytes);
+    let output_1 = f32::from_elem_data(client.read_one(output_handle_1.binding()));
 
     println!("Output 1 => {output_1:?}");
 
-    let bytes = client.read_one(output_handle_2.binding());
-    let output_2 = f32::from_bytes(&bytes);
+    let output_2 = f32::from_elem_data(client.read_one(output_handle_2.binding()));
     println!("Output 2 => {output_2:?}");
 }

--- a/examples/gelu/src/lib.rs
+++ b/examples/gelu/src/lib.rs
@@ -23,7 +23,7 @@ pub fn launch<R: Runtime>(device: &R::Device) {
     let input = &[-1., 0., 1., 5.];
     let vectorization = 4;
     let output_handle = client.empty(input.len() * core::mem::size_of::<f32>());
-    let input_handle = client.create(f32::as_bytes(input));
+    let input_handle = client.create(&f32::to_elem_data(input));
 
     unsafe {
         gelu_array::launch_unchecked::<f32, R>(
@@ -35,8 +35,7 @@ pub fn launch<R: Runtime>(device: &R::Device) {
         )
     };
 
-    let bytes = client.read_one(output_handle.binding());
-    let output = f32::from_bytes(&bytes);
+    let output = f32::from_elem_data(client.read_one(output_handle.binding()));
 
     // Should be [-0.1587,  0.0000,  0.8413,  5.0000]
     println!("Executed gelu with runtime {:?} => {output:?}", R::name());

--- a/examples/normalization/src/lib.rs
+++ b/examples/normalization/src/lib.rs
@@ -11,7 +11,7 @@ fn norm_test<F: Float>(input: &Array<F>, output_a: &mut Array<F>, output_b: &mut
 pub fn launch<R: Runtime>(device: &R::Device) {
     let client = R::client(device);
     let input = &[-1., 0., 1., 5.];
-    let input_handle = client.create(f32::as_bytes(input));
+    let input_handle = client.create(&f32::to_elem_data(input));
     let output_a_handle = client.empty(input.len() * core::mem::size_of::<f32>());
     let output_b_handle = client.empty(input.len() * core::mem::size_of::<f32>());
 
@@ -26,16 +26,14 @@ pub fn launch<R: Runtime>(device: &R::Device) {
         )
     };
 
-    let bytes = client.read_one(output_a_handle.binding());
-    let output = f32::from_bytes(&bytes);
+    let output = f32::from_elem_data(client.read_one(output_a_handle.binding()));
 
     println!(
         "Executed normalize with runtime {:?} => {output:?}",
         R::name()
     );
 
-    let bytes = client.read_one(output_b_handle.binding());
-    let output = f32::from_bytes(&bytes);
+    let output = f32::from_elem_data(client.read_one(output_b_handle.binding()));
 
     println!(
         "Executed normalize using magnitude with runtime {:?} => {output:?}",

--- a/examples/sum_things/src/lib.rs
+++ b/examples/sum_things/src/lib.rs
@@ -188,7 +188,7 @@ pub fn launch<R: Runtime>(device: &R::Device) {
     let len = input.len();
 
     let output = client.empty(input.len() * core::mem::size_of::<f32>());
-    let input = client.create(f32::as_bytes(input));
+    let input = client.create(&f32::to_elem_data(input));
 
     for kind in [
         KernelKind::Basic,
@@ -216,8 +216,7 @@ pub fn launch<R: Runtime>(device: &R::Device) {
                 }
             }
         }
-        let bytes = client.read_one(output.clone().binding());
-        let output = f32::from_bytes(&bytes);
+        let output = f32::from_elem_data(client.read_one(output.clone().binding()));
 
         println!("[{:?} - {kind:?}]\n {output:?}", R::name());
     }

--- a/profiling/matmul-example/README.md
+++ b/profiling/matmul-example/README.md
@@ -35,8 +35,8 @@ mod cube_cuda {
         let tensor_values: Vec<f32> = (0..num_of_batch * height * width)
             .map(|x| x as f32)
             .collect();
-        let tensor_a_handle = client.create(f32::as_bytes(&tensor_values));
-        let tensor_b_handle = client.create(f32::as_bytes(&tensor_values));
+        let tensor_a_handle = client.create(f32::to_elem_data(&tensor_values));
+        let tensor_b_handle = client.create(f32::to_elem_data(&tensor_values));
         let tensor_c_handle = client.empty(12 * 1024 * 1024 * core::mem::size_of::<f32>());
 
         let tensor_a_shape = vec![num_of_batch, height, width];

--- a/profiling/matmul-example/src/main.rs
+++ b/profiling/matmul-example/src/main.rs
@@ -41,8 +41,8 @@ mod cube_cuda {
         let tensor_values: Vec<f32> = (0..num_of_batch * height * width)
             .map(|x| x as f32)
             .collect();
-        let tensor_a_handle = client.create(f32::as_bytes(&tensor_values));
-        let tensor_b_handle = client.create(f32::as_bytes(&tensor_values));
+        let tensor_a_handle = client.create(f32::to_elem_data(&tensor_values));
+        let tensor_b_handle = client.create(f32::to_elem_data(&tensor_values));
         let tensor_c_handle = client.empty(12 * 1024 * 1024 * core::mem::size_of::<f32>());
 
         let tensor_a_shape = vec![num_of_batch, height, width];
@@ -78,8 +78,8 @@ mod cube_wgpu {
         let tensor_values: Vec<f32> = (0..num_of_batch * height * width)
             .map(|x| x as f32)
             .collect();
-        let tensor_a_handle = client.create(f32::as_bytes(&tensor_values));
-        let tensor_b_handle = client.create(f32::as_bytes(&tensor_values));
+        let tensor_a_handle = client.create(f32::to_elem_data(&tensor_values));
+        let tensor_b_handle = client.create(f32::to_elem_data(&tensor_values));
         let tensor_c_handle = client.empty(12 * 1024 * 1024 * core::mem::size_of::<f32>());
 
         let tensor_a_shape = vec![num_of_batch, height, width];


### PR DESCRIPTION
WIP: Use actual Elem::Bool instead of rewriting them to u32 early on.