### PR TITLE
Add lineinfo flag to CUDA source compilation options

### DIFF
--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -360,7 +360,7 @@ impl CudaContext {
 
         let include_path = include_path();
         let include_option = format!("--include-path={}", include_path.to_str().unwrap());
-        let options = &[arch.as_str(), include_option.as_str()];
+        let options = &[arch.as_str(), include_option.as_str(), "-lineinfo"];
 
         let kernel_compiled = logger.debug(kernel_compiled);
 


### PR DESCRIPTION
Allows viewing PTX in Nsight Compute:

![image](https://github.com/user-attachments/assets/d99837a8-8056-4cb1-a66d-4e108451dfb9)

In fact it opens up this menu with several options: 

![image](https://github.com/user-attachments/assets/43a30596-1a76-453b-b20e-ad27898a69f2)


Without `-lineinfo` the only option is SASS.

This does not affect optimizations/perf at all to the best of my knowledge.

One source of that is here: https://developer.nvidia.com/blog/debugging-cuda-more-efficiently-with-nvidia-compute-sanitizer/#compiling_for_compute_sanitizer

> ... -lineinfo to generate line number information without impacting your code on an optimization level.