### PR TITLE
Matmul: tilewise loader

### DIFF
--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -53,8 +53,8 @@ impl<EG: Numeric, ES: Numeric, GMM: global::Matmul<EG, ES>, S: SpanMatmul, C: Cu
         let cubes_y = config.cube_count_y();
         let cubes_z = config.cube_count_batch();
 
-        let stage_x = config.stage_dim(Ident::Out).height();
-        let stage_y = config.stage_dim(Ident::Out).width();
+        let stage_x = config.stage_dim(Ident::Out).num_elements_x_dim();
+        let stage_y = config.stage_dim(Ident::Out).num_elements_y_dim();
         let stage_z = 1;
 
         let (x_index, y_index) = C::x_y_indices();

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -34,8 +34,8 @@ impl<EG: Numeric, ES: Numeric, GMM: global::Matmul<EG, ES>, C: CubeDispatch> bat
         #[comptime] config: Self::Config,
     ) {
         let (x_index, y_index) = C::x_y_indices();
-        let x_offset = x_index * config.stage_dim(Ident::Lhs).height();
-        let y_offset = y_index * config.stage_dim(Ident::Rhs).width();
+        let x_offset = x_index * config.stage_dim(Ident::Lhs).num_elements_x_dim();
+        let y_offset = y_index * config.stage_dim(Ident::Rhs).num_elements_y_dim();
         let nth_batch = C::batch_index();
         let k_range = (0, lhs.shape(lhs.rank() - 1));
 
@@ -125,11 +125,11 @@ impl<G: global::Config, C: CubeDispatch> batch::Config for Config<G, C> {
     }
 
     fn max_m(&self) -> u32 {
-        C::max_x(self.cube_count) * self.stage_dim(Ident::Out).height()
+        C::max_x(self.cube_count) * self.stage_dim(Ident::Out).num_elements_x_dim()
     }
 
     fn max_n(&self) -> u32 {
-        C::max_y(self.cube_count) * self.stage_dim(Ident::Out).width()
+        C::max_y(self.cube_count) * self.stage_dim(Ident::Out).num_elements_y_dim()
     }
 
     fn max_batches(&self) -> u32 {

--- a/crates/cubecl-linalg/src/matmul/components/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/config.rs
@@ -64,7 +64,7 @@ pub struct StageDims {
 pub trait StageDim: 'static + Send + Sync {
     /// Returns the total number of elements of the stage
     fn total_elements(&self) -> u32 {
-        self.height() * self.width()
+        self.num_elements_x_dim() * self.num_elements_y_dim()
     }
 
     /// Returns the number of elements within one tile
@@ -72,14 +72,18 @@ pub trait StageDim: 'static + Send + Sync {
         self.tile_size_x_dim() * self.tile_size_y_dim()
     }
 
-    /// Returns the height of the stage, i.e. the number of elements across the x dimension
-    fn height(&self) -> u32 {
+    /// Returns the number of elements across the x dimension
+    fn num_elements_x_dim(&self) -> u32 {
         self.num_tiles_x_dim() * self.tile_size_x_dim()
     }
 
-    /// Returns the width of the stage, i.e. the number of elements across the y dimension
-    fn width(&self) -> u32 {
+    /// Returns the number of elements across the y dimension
+    fn num_elements_y_dim(&self) -> u32 {
         self.num_tiles_y_dim() * self.tile_size_y_dim()
+    }
+
+    fn num_tiles(&self) -> u32 {
+        self.num_tiles_x_dim() * self.num_tiles_y_dim()
     }
 
     /// Number of elements in a buffer

--- a/crates/cubecl-linalg/src/matmul/components/global/homogeneous/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/homogeneous/base.rs
@@ -14,26 +14,36 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
-use super::loader::{LhsLoader, RhsLoader};
+use super::loader::{LhsLoader, LoadingStrategy, RhsLoader};
 
 /// Performs matrix multiplication at the global level, with each plane sharing the same responsibilities
 /// - All planes load data to the stage
 /// - All planes are used in the stage matmul computation
-pub struct Matmul<EG: Numeric, ES: Numeric, SMM: stage::Matmul<ES, EG>> {
+pub struct Matmul<
+    EG: Numeric,
+    ES: Numeric,
+    SMM: stage::Matmul<ES, EG>,
+    LL: LoadingStrategy,
+    RL: LoadingStrategy,
+> {
     _eg: PhantomData<EG>,
     _es: PhantomData<ES>,
     _stage_matmul: PhantomData<SMM>,
+    _lhs_loading: PhantomData<LL>,
+    _rhs_loading: PhantomData<RL>,
 }
 
 #[cube]
-impl<EG, ES, SMM> global::Matmul<EG, ES> for Matmul<EG, ES, SMM>
+impl<EG, ES, SMM, LL, RL> global::Matmul<EG, ES> for Matmul<EG, ES, SMM, LL, RL>
 where
     EG: Numeric,
     ES: Numeric,
     SMM: stage::Matmul<ES, EG, LhsReader = LhsReader<ES>, RhsReader = RhsReader<ES>>,
+    LL: LoadingStrategy,
+    RL: LoadingStrategy,
 {
-    type LhsLoader = LhsLoader<EG, ES, SMM::Config>;
-    type RhsLoader = RhsLoader<EG, ES, SMM::Config>;
+    type LhsLoader = LhsLoader<EG, ES, SMM::Config, LL>;
+    type RhsLoader = RhsLoader<EG, ES, SMM::Config, RL>;
     type Out = Unloader<EG>;
     type Accumulator = SMM::Accumulator;
 
@@ -118,11 +128,13 @@ where
     }
 }
 
-impl<EG, ES, SMM> MatmulKernel<EG, EG> for Matmul<EG, ES, SMM>
+impl<EG, ES, SMM, LL, RL> MatmulKernel<EG, EG> for Matmul<EG, ES, SMM, LL, RL>
 where
     EG: Numeric,
     ES: Numeric,
     SMM: stage::Matmul<ES, EG>,
+    LL: LoadingStrategy,
+    RL: LoadingStrategy,
 {
     type Config = Config<SMM::Config>;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/homogeneous/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/homogeneous/cyclic_loading.rs
@@ -7,14 +7,16 @@ use crate::matmul::components::{Ident, MatrixLayout};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
+use super::loader::LoadingStrategy;
+
 #[derive(CubeType, Clone, Copy)]
 /// Loads the content of all tiles in the tensor view using all planes,
 /// iterating with steps determined by the plane's dimension.
 pub struct CyclicLoading {}
 
 #[cube]
-impl CyclicLoading {
-    pub fn load_to_slice<EG: Numeric, ES: Numeric, G: Config>(
+impl LoadingStrategy for CyclicLoading {
+    fn load_to_slice<EG: Numeric, ES: Numeric, G: Config>(
         read_view: &TensorReader<EG>,
         slice: &mut SliceMut<Line<ES>>,
         #[comptime] ident: Ident,

--- a/crates/cubecl-linalg/src/matmul/components/global/homogeneous/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/homogeneous/loader.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 
 use crate::matmul::components::global::homogeneous;
-use crate::matmul::components::global::homogeneous::cyclic_loading::CyclicLoading;
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::Loader;
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
@@ -11,22 +10,24 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[derive(CubeType)]
-pub struct LhsLoader<EG: Numeric, ES: Numeric, S: stage::Config> {
+pub struct LhsLoader<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy> {
     pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
     _config: PhantomData<S>,
+    _loading: PhantomData<L>,
 }
 
 #[derive(CubeType)]
-pub struct RhsLoader<EG: Numeric, ES: Numeric, S: stage::Config> {
+pub struct RhsLoader<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy> {
     pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
     _config: PhantomData<S>,
+    _loading: PhantomData<L>,
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::Config> Loader<EG, ES, homogeneous::Config<S>>
-    for LhsLoader<EG, ES, S>
+impl<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy>
+    Loader<EG, ES, homogeneous::Config<S>> for LhsLoader<EG, ES, S, L>
 {
     type StageReader = LhsReader<ES>;
 
@@ -34,7 +35,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::Config> Loader<EG, ES, homogeneous::Con
         this: &mut Self,
         #[comptime] config: homogeneous::Config<S>,
     ) -> Self::StageReader {
-        CyclicLoading::load_to_slice::<EG, ES, homogeneous::Config<S>>(
+        L::load_to_slice::<EG, ES, homogeneous::Config<S>>(
             &this.tensor_view,
             &mut this.stage.as_slice_mut(),
             Ident::Lhs,
@@ -49,7 +50,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::Config> Loader<EG, ES, homogeneous::Con
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::Config> LhsLoader<EG, ES, S> {
+impl<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy> LhsLoader<EG, ES, S, L> {
     pub fn new<G: global::Config>(
         tensor: &Tensor<Line<EG>>,
         x_offset: u32,
@@ -60,17 +61,18 @@ impl<EG: Numeric, ES: Numeric, S: stage::Config> LhsLoader<EG, ES, S> {
         let stage = Stage::new::<G::SmmConfig>(Ident::Lhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        LhsLoader::<EG, ES, S> {
+        LhsLoader::<EG, ES, S, L> {
             tensor_view,
             stage,
             _config: PhantomData::<S>.runtime(),
+            _loading: PhantomData::<L>.runtime(),
         }
     }
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::Config> Loader<EG, ES, homogeneous::Config<S>>
-    for RhsLoader<EG, ES, S>
+impl<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy>
+    Loader<EG, ES, homogeneous::Config<S>> for RhsLoader<EG, ES, S, L>
 {
     type StageReader = RhsReader<ES>;
 
@@ -78,7 +80,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::Config> Loader<EG, ES, homogeneous::Con
         this: &mut Self,
         #[comptime] config: homogeneous::Config<S>,
     ) -> Self::StageReader {
-        CyclicLoading::load_to_slice::<EG, ES, homogeneous::Config<S>>(
+        L::load_to_slice::<EG, ES, homogeneous::Config<S>>(
             &this.tensor_view,
             &mut this.stage.as_slice_mut(),
             Ident::Rhs,
@@ -93,7 +95,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::Config> Loader<EG, ES, homogeneous::Con
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::Config> RhsLoader<EG, ES, S> {
+impl<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy> RhsLoader<EG, ES, S, L> {
     pub fn new<G: global::Config>(
         tensor: &Tensor<Line<EG>>,
         x_offset: u32,
@@ -104,10 +106,21 @@ impl<EG: Numeric, ES: Numeric, S: stage::Config> RhsLoader<EG, ES, S> {
         let stage = Stage::new::<G::SmmConfig>(Ident::Rhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        RhsLoader::<EG, ES, S> {
+        RhsLoader::<EG, ES, S, L> {
             tensor_view,
             stage,
             _config: PhantomData::<S>.runtime(),
+            _loading: PhantomData::<L>.runtime(),
         }
     }
+}
+
+#[cube]
+pub trait LoadingStrategy: 'static + Send + Sync + Clone {
+    fn load_to_slice<EG: Numeric, ES: Numeric, G: global::Config>(
+        read_view: &TensorReader<EG>,
+        slice: &mut SliceMut<Line<ES>>,
+        #[comptime] ident: Ident,
+        #[comptime] config: G,
+    );
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/homogeneous/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/homogeneous/mod.rs
@@ -1,5 +1,8 @@
 mod base;
 mod cyclic_loading;
 mod loader;
+mod tilewise_loading;
 
 pub use base::*;
+pub use cyclic_loading::CyclicLoading;
+pub use tilewise_loading::TilewiseLoading;

--- a/crates/cubecl-linalg/src/matmul/components/global/homogeneous/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/homogeneous/tilewise_loading.rs
@@ -25,7 +25,7 @@ impl LoadingStrategy for TilewiseLoading {
         let stage_dim = config.stage_dim(ident);
         let line_size = config.global_line_size(ident);
 
-        #[clippy::allow(all)]
+        #[allow(clippy::all)]
         let _ = comptime! {
             check_num_planes(config.num_planes(), stage_dim.num_tiles());
             check_line_sizes(line_size, config.stage_line_size(ident))
@@ -67,7 +67,7 @@ impl LoadingStrategy for TilewiseLoading {
             match config.transpose_load(ident) {
                 false => slice[offset] = Line::cast_from(line_read),
                 true => {
-                    #[clippy::allow(all)]
+                    #[allow(clippy::all)]
                     let _ = comptime!(unsupported_transpose_load());
                 }
             }

--- a/crates/cubecl-linalg/src/matmul/components/global/homogeneous/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/homogeneous/tilewise_loading.rs
@@ -25,8 +25,11 @@ impl LoadingStrategy for TilewiseLoading {
         let stage_dim = config.stage_dim(ident);
         let line_size = config.global_line_size(ident);
 
-        let _ = comptime!(check_num_planes(config.num_planes(), stage_dim.num_tiles()));
-        let _ = comptime!(check_line_sizes(line_size, config.stage_line_size(ident)));
+        #[clippy::allow(all)]
+        let _ = comptime! {
+            check_num_planes(config.num_planes(), stage_dim.num_tiles());
+            check_line_sizes(line_size, config.stage_line_size(ident))
+        };
 
         let num_lines_per_tile = comptime!(stage_dim.tile_num_elements() / line_size);
 
@@ -64,6 +67,7 @@ impl LoadingStrategy for TilewiseLoading {
             match config.transpose_load(ident) {
                 false => slice[offset] = Line::cast_from(line_read),
                 true => {
+                    #[clippy::allow(all)]
                     let _ = comptime!(unsupported_transpose_load());
                 }
             }

--- a/crates/cubecl-linalg/src/matmul/components/global/homogeneous/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/homogeneous/tilewise_loading.rs
@@ -1,0 +1,92 @@
+use crate::matmul::components::global::tensor_view::TensorReader;
+use crate::matmul::components::global::Config;
+use crate::matmul::components::stage::{
+    ColMajorTiling, RowMajorTiling, TilingOrder, TilingOrderConfig,
+};
+use crate::matmul::components::Ident;
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+use super::loader::LoadingStrategy;
+
+#[derive(CubeType, Clone, Copy)]
+/// Loads the content of all tiles in the tensor view using
+/// one plane per tile.
+pub struct TilewiseLoading {}
+
+#[cube]
+impl LoadingStrategy for TilewiseLoading {
+    fn load_to_slice<EG: Numeric, ES: Numeric, G: Config>(
+        read_view: &TensorReader<EG>,
+        slice: &mut SliceMut<Line<ES>>,
+        #[comptime] ident: Ident,
+        #[comptime] config: G,
+    ) {
+        let stage_dim = config.stage_dim(ident);
+        let line_size = config.global_line_size(ident);
+
+        let _ = comptime!(check_num_planes(config.num_planes(), stage_dim.num_tiles()));
+        let _ = comptime!(check_line_sizes(line_size, config.stage_line_size(ident)));
+
+        let num_lines_per_tile = comptime!(stage_dim.tile_num_elements() / line_size);
+
+        let nth_tile = UNIT_POS_Y;
+        let offset_base = num_lines_per_tile * nth_tile;
+
+        let num_loads_per_unit = num_lines_per_tile / config.plane_dim();
+
+        let (tile_x, tile_y) = match config.tiling_order(ident) {
+            TilingOrderConfig::RowMajor => RowMajorTiling::to_x_y(
+                nth_tile,
+                stage_dim.num_tiles_x_dim(),
+                stage_dim.num_tiles_y_dim(),
+            ),
+            TilingOrderConfig::ColMajor => ColMajorTiling::to_x_y(
+                nth_tile,
+                stage_dim.num_tiles_x_dim(),
+                stage_dim.num_tiles_y_dim(),
+            ),
+        };
+
+        for i in 0..num_loads_per_unit {
+            let pos_within_tile = i * config.plane_dim() + UNIT_POS_X;
+
+            let line_read = read_view.load_coalesced::<G>(
+                tile_x,
+                tile_y,
+                pos_within_tile * line_size,
+                ident,
+                config,
+            );
+
+            let offset = offset_base + pos_within_tile;
+
+            match config.transpose_load(ident) {
+                false => slice[offset] = Line::cast_from(line_read),
+                true => {
+                    let _ = comptime!(unsupported_transpose_load());
+                }
+            }
+        }
+    }
+}
+
+fn check_num_planes(num_planes: u32, num_tiles: u32) {
+    assert!(
+        num_planes == num_tiles,
+        "Number of planes {:?} must equal number of tiles {:?} for tilewise loading.",
+        num_planes,
+        num_tiles
+    );
+}
+
+fn check_line_sizes(global_line_size: u32, stage_line_size: u32) {
+    assert!(
+        global_line_size == stage_line_size,
+        "Global and stage line sizes must match for tilewise loading."
+    );
+}
+
+fn unsupported_transpose_load() {
+    panic!("Transpose load not yet supported in tilewise loading setup")
+}

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/cmma.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/cmma.rs
@@ -29,7 +29,13 @@ impl<EG: Numeric> base::Algorithm<EG> for Cmma<EG> {
     type StageMatmul =
         stage::multi_buffer::Matmul<Self::ES, Self::EG, Self::EA, Self::TileMatmul, Stage>;
 
-    type GlobalMatmul = global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+    type GlobalMatmul = global::homogeneous::Matmul<
+        Self::EG,
+        Self::ES,
+        Self::StageMatmul,
+        global::homogeneous::CyclicLoading,
+        global::homogeneous::CyclicLoading,
+    >;
 
     type BatchMatmul = batch::one_to_one::Matmul<Self::EG, Self::ES, Self::GlobalMatmul, Dispatch>;
 

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/plane_mma.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/plane_mma.rs
@@ -29,7 +29,13 @@ impl<EG: Numeric> base::Algorithm<EG> for PlaneMma<EG> {
     type StageMatmul =
         stage::multi_buffer::Matmul<Self::ES, Self::EG, Self::EA, Self::TileMatmul, Stage>;
 
-    type GlobalMatmul = global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+    type GlobalMatmul = global::homogeneous::Matmul<
+        Self::EG,
+        Self::ES,
+        Self::StageMatmul,
+        global::homogeneous::CyclicLoading,
+        global::homogeneous::CyclicLoading,
+    >;
 
     type BatchMatmul = batch::one_to_one::Matmul<Self::EG, Self::ES, Self::GlobalMatmul, Dispatch>;
 

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/matmul_algorithm.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/matmul_algorithm.rs
@@ -48,8 +48,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -109,8 +114,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -225,8 +235,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -580,8 +595,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -637,8 +657,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -694,8 +719,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -751,8 +781,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -808,8 +843,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -865,8 +905,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -922,8 +967,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -979,8 +1029,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1036,8 +1091,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1093,8 +1153,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1150,8 +1215,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_many::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1207,8 +1277,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1262,8 +1337,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1316,8 +1396,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1370,8 +1455,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1424,8 +1514,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1478,8 +1573,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1532,8 +1632,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1591,8 +1696,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1650,8 +1760,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1704,8 +1819,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1758,8 +1878,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1812,8 +1937,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1866,8 +1996,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1920,8 +2055,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -1974,8 +2114,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2028,8 +2173,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2082,8 +2232,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2136,8 +2291,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2190,8 +2350,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2244,8 +2409,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2298,8 +2468,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2352,8 +2527,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2410,8 +2590,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2467,8 +2652,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2524,8 +2714,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2581,8 +2776,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2638,8 +2838,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2695,8 +2900,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2752,8 +2962,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2809,8 +3024,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2866,8 +3086,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2923,8 +3148,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -2980,8 +3210,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3037,8 +3272,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3091,8 +3331,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3145,8 +3390,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3199,8 +3449,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3253,8 +3508,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3307,8 +3567,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3361,8 +3626,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3415,8 +3685,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3469,8 +3744,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3523,8 +3803,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3577,8 +3862,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x2x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3635,8 +3925,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3689,8 +3984,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3743,8 +4043,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3797,8 +4102,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3851,8 +4161,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x2x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3905,8 +4220,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x2x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -3959,8 +4279,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x2x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4013,8 +4338,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x2x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4067,8 +4397,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x2x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4121,8 +4456,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x2x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4175,8 +4515,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x2x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4229,8 +4574,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S2x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4283,8 +4633,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S1x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4337,8 +4692,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S8x1x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4391,8 +4751,13 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x1,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,
@@ -4445,8 +4810,190 @@ macro_rules! matmul_test_define {
                     Self::TileMatmul,
                     S4x4x2,
                 >;
-                type GlobalMatmul =
-                    global::homogeneous::Matmul<Self::EG, Self::ES, Self::StageMatmul>;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
+                type BatchMatmul = batch::one_to_one::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::GlobalMatmul,
+                    batch::NaturalDispatch,
+                >;
+
+                fn cube_dim() -> CubeDim {
+                    CubeDim::new($plane_dim, 4, 1)
+                }
+                fn cube_count(_problem: &MatmulProblem) -> CubeCount {
+                    CubeCount::Static(1, 1, 1)
+                }
+            }
+
+            let advanced_config = AdvancedConfig::default();
+            test_matmul_algorithm::<Test, $eg, $es, TestRuntime>(
+                problem,
+                advanced_config,
+                &<<TestRuntime as Runtime>::Device>::default(),
+            );
+        }
+
+        #[test]
+        pub fn bo_gh32x16x32_s2x1x2_t16x16x16_rr_ln4_tilewise_load_lhs() {
+            let problem = MatmulProblem {
+                m: 32,
+                n: 16,
+                k: 32,
+                batches: (vec![], vec![]),
+                lhs_layout: MatrixLayout::RowMajor,
+                rhs_layout: MatrixLayout::RowMajor,
+                lhs_line_size: 4,
+                rhs_line_size: 4,
+                out_line_size: 4,
+            };
+            struct Test {}
+
+            impl matmul::Algorithm<$eg> for Test {
+                const PLANE_DIM: u32 = $plane_dim;
+                type EG = $eg;
+                type ES = $es;
+                type EA = $ea;
+
+                type TileMatmul = $t_16x16x16<Self::ES, Self::EA>;
+                type StageMatmul = stage::multi_buffer::Matmul<
+                    Self::ES,
+                    Self::EG,
+                    Self::EA,
+                    Self::TileMatmul,
+                    S2x1x1,
+                >;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::TilewiseLoading,
+                    global::homogeneous::CyclicLoading,
+                >;
+                type BatchMatmul = batch::one_to_one::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::GlobalMatmul,
+                    batch::NaturalDispatch,
+                >;
+
+                fn cube_dim() -> CubeDim {
+                    CubeDim::new($plane_dim, 2, 1)
+                }
+                fn cube_count(_problem: &MatmulProblem) -> CubeCount {
+                    CubeCount::Static(1, 1, 1)
+                }
+            }
+
+            let advanced_config = AdvancedConfig::default();
+            test_matmul_algorithm::<Test, $eg, $es, TestRuntime>(
+                problem,
+                advanced_config,
+                &<<TestRuntime as Runtime>::Device>::default(),
+            );
+        }
+
+        #[test]
+        pub fn bo_gh32x16x32_s2x1x2_t16x16x16_rr_ln4_tilewise_load_rhs() {
+            let problem = MatmulProblem {
+                m: 32,
+                n: 16,
+                k: 32,
+                batches: (vec![], vec![]),
+                lhs_layout: MatrixLayout::RowMajor,
+                rhs_layout: MatrixLayout::RowMajor,
+                lhs_line_size: 4,
+                rhs_line_size: 4,
+                out_line_size: 4,
+            };
+            struct Test {}
+
+            impl matmul::Algorithm<$eg> for Test {
+                const PLANE_DIM: u32 = $plane_dim;
+                type EG = $eg;
+                type ES = $es;
+                type EA = $ea;
+
+                type TileMatmul = $t_16x16x16<Self::ES, Self::EA>;
+                type StageMatmul = stage::multi_buffer::Matmul<
+                    Self::ES,
+                    Self::EG,
+                    Self::EA,
+                    Self::TileMatmul,
+                    S2x1x2,
+                >;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::CyclicLoading,
+                    global::homogeneous::TilewiseLoading,
+                >;
+                type BatchMatmul = batch::one_to_one::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::GlobalMatmul,
+                    batch::NaturalDispatch,
+                >;
+
+                fn cube_dim() -> CubeDim {
+                    CubeDim::new($plane_dim, 2, 1)
+                }
+                fn cube_count(_problem: &MatmulProblem) -> CubeCount {
+                    CubeCount::Static(1, 1, 1)
+                }
+            }
+
+            let advanced_config = AdvancedConfig::default();
+            test_matmul_algorithm::<Test, $eg, $es, TestRuntime>(
+                problem,
+                advanced_config,
+                &<<TestRuntime as Runtime>::Device>::default(),
+            );
+        }
+
+        #[test]
+        pub fn bo_gh64x64x32_s4x4x1_t16x16x16_rr_ln4_tilewise_load_both() {
+            let problem = MatmulProblem {
+                m: 64,
+                n: 64,
+                k: 32,
+                batches: (vec![], vec![]),
+                lhs_layout: MatrixLayout::RowMajor,
+                rhs_layout: MatrixLayout::RowMajor,
+                lhs_line_size: 4,
+                rhs_line_size: 4,
+                out_line_size: 4,
+            };
+            struct Test {}
+
+            impl matmul::Algorithm<$eg> for Test {
+                const PLANE_DIM: u32 = $plane_dim;
+                type EG = $eg;
+                type ES = $es;
+                type EA = $ea;
+
+                type TileMatmul = $t_16x16x16<Self::ES, Self::EA>;
+                type StageMatmul = stage::multi_buffer::Matmul<
+                    Self::ES,
+                    Self::EG,
+                    Self::EA,
+                    Self::TileMatmul,
+                    S4x4x1,
+                >;
+                type GlobalMatmul = global::homogeneous::Matmul<
+                    Self::EG,
+                    Self::ES,
+                    Self::StageMatmul,
+                    global::homogeneous::TilewiseLoading,
+                    global::homogeneous::TilewiseLoading,
+                >;
                 type BatchMatmul = batch::one_to_one::Matmul<
                     Self::EG,
                     Self::ES,


### PR DESCRIPTION
Addition of the tilewise loader, which existed in cmma old but was never ported. It needs the number of planes to be the same as the number of tiles. Possible to have it only on lhs or rhs, or both, or none. 

Combined with renaming of width/height