### PR TITLE
Matmul/auto

### DIFF
--- a/crates/cubecl-cpp/src/shared/mma.rs
+++ b/crates/cubecl-cpp/src/shared/mma.rs
@@ -293,9 +293,13 @@ pub mod wmma_api_base {
                 }
             }
             WmmaInstruction::Cast { input, output } => {
+                let ty = match output {
+                    Variable::WmmaFragment { frag, .. } => frag.elem,
+                    _ => panic!("Should be a fragment"),
+                };
                 writeln!(
                     f,
-                    "for(int t=0; t<{input}.num_elements; t++) {{ {output}.x[t] = {input}.x[t]; }}"
+                    "for(int t=0; t<{input}.num_elements; t++) {{ {output}.x[t] = {ty}({input}.x[t]); }}"
                 )
             }
         }

--- a/crates/cubecl-linalg/src/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/base.rs
@@ -59,8 +59,19 @@ pub fn launch_ref<R: Runtime, EG: Float>(
         }
         Strategy::Simple => simple::launch_ref::<R, EG>(client, lhs, rhs, out),
         Strategy::Auto => {
-            if matmul::launch_ref::<R, EG>(client, lhs, rhs, out, false).is_err() {
-                tiling2d::launch_ref::<R, EG>(client, lhs, rhs, out, Tiling2dConfig::default())
+            if let Err(err) = matmul::launch_ref::<R, EG>(client, lhs, rhs, out, false) {
+                match err {
+                    super::kernels::MatmulLaunchError::Unavailable(_) => {
+                        tiling2d::launch_ref::<R, EG>(
+                            client,
+                            lhs,
+                            rhs,
+                            out,
+                            Tiling2dConfig::default(),
+                        )
+                    }
+                    _ => panic!("{err:?}"),
+                }
             }
         }
     };

--- a/crates/cubecl-linalg/src/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/base.rs
@@ -59,7 +59,7 @@ pub fn launch_ref<R: Runtime, EG: Float>(
         }
         Strategy::Simple => simple::launch_ref::<R, EG>(client, lhs, rhs, out),
         Strategy::Auto => {
-            if let Err(_) = matmul::launch_ref::<R, EG>(client, lhs, rhs, out, false) {
+            if matmul::launch_ref::<R, EG>(client, lhs, rhs, out, false).is_err() {
                 tiling2d::launch_ref::<R, EG>(client, lhs, rhs, out, Tiling2dConfig::default())
             }
         }

--- a/crates/cubecl-linalg/src/matmul/components/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/base.rs
@@ -1,6 +1,6 @@
 use cubecl_core::prelude::*;
 
-use crate::matmul::kernels::matmul::AdvancedConfig;
+use crate::matmul::kernels::{matmul::AdvancedConfig, MatmulAvailabilityError};
 
 use super::{config::MatmulConfig, MatmulProblem};
 
@@ -15,7 +15,7 @@ pub trait MatmulKernel<I: Numeric, O: Numeric> {
     /// Checks if the client can handle the features used in this computation
     fn check_availability<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
-    ) -> Result<(), String>;
+    ) -> Result<(), MatmulAvailabilityError>;
 
     /// Create config for this matmul, given launch information
     fn make_config(

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -6,6 +6,7 @@ use crate::matmul::components::{
     batch, config::MatmulConfig, global, Ident, MatmulKernel, MatmulLaunch, StageDim,
 };
 use crate::matmul::kernels::matmul::AdvancedConfig;
+use crate::matmul::kernels::MatmulAvailabilityError;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
@@ -85,7 +86,7 @@ impl<EG: Numeric, ES: Numeric, GMM: global::Matmul<EG, ES>, S: SpanMatmul, C: Cu
 
     fn check_availability<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
-    ) -> Result<(), String> {
+    ) -> Result<(), MatmulAvailabilityError> {
         GMM::check_availability::<R>(client)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -6,6 +6,7 @@ use crate::matmul::components::{
     batch, config::MatmulConfig, global, Ident, MatmulKernel, MatmulLaunch, StageDim,
 };
 use crate::matmul::kernels::matmul::AdvancedConfig;
+use crate::matmul::kernels::MatmulAvailabilityError;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
@@ -65,7 +66,7 @@ impl<EG: Numeric, ES: Numeric, GMM: global::Matmul<EG, ES>, C: CubeDispatch> Mat
 
     fn check_availability<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
-    ) -> Result<(), String> {
+    ) -> Result<(), MatmulAvailabilityError> {
         GMM::check_availability::<R>(client)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/homogeneous/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/homogeneous/base.rs
@@ -9,6 +9,7 @@ use crate::matmul::components::{config::MatmulConfig, global::ZeroAccumulatorLoa
 use crate::matmul::components::{global, MatmulProblem};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::kernels::matmul::AdvancedConfig;
+use crate::matmul::kernels::MatmulAvailabilityError;
 
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -152,7 +153,7 @@ where
 
     fn check_availability<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
-    ) -> Result<(), String> {
+    ) -> Result<(), MatmulAvailabilityError> {
         SMM::check_availability::<R>(client)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/producer_consumer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/producer_consumer/base.rs
@@ -9,6 +9,7 @@ use crate::matmul::components::{config::MatmulConfig, global::ZeroAccumulatorLoa
 use crate::matmul::components::{global, MatmulProblem};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::kernels::matmul::AdvancedConfig;
+use crate::matmul::kernels::MatmulAvailabilityError;
 
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -182,7 +183,7 @@ where
 
     fn check_availability<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
-    ) -> Result<(), String> {
+    ) -> Result<(), MatmulAvailabilityError> {
         SMM::check_availability::<R>(client)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/problem.rs
+++ b/crates/cubecl-linalg/src/matmul/components/problem.rs
@@ -98,7 +98,7 @@ impl MatmulProblem {
             }
         }
 
-        if self.n % self.out_line_size as usize == 1 {
+        if self.n % self.out_line_size as usize != 0 {
             return Err(MatmulInvalidProblem::InvalidLineSizeOut {
                 size: self.n as u32,
                 line_size: self.out_line_size,

--- a/crates/cubecl-linalg/src/matmul/components/problem.rs
+++ b/crates/cubecl-linalg/src/matmul/components/problem.rs
@@ -1,3 +1,5 @@
+use crate::matmul::kernels::MatmulInvalidProblem;
+
 use super::{batch, MatrixLayout};
 
 #[derive(Clone)]
@@ -36,36 +38,73 @@ impl MatmulProblem {
     ///
     ///  - If dimensions of the problem are larger than allowed by the config
     ///  - If line sizes do not divide well the dimension in which they are aligned
-    pub fn check_config<B: batch::Config>(&self, config: &B) {
-        assert!(
-            self.m <= config.max_m() as usize,
-            "Problem has m={} but these configs can only have m<={}",
-            self.m,
-            config.max_m()
-        );
-        assert!(
-            self.n <= config.max_n() as usize,
-            "Problem has n={} but these configs can only have n<={}",
-            self.n,
-            config.max_n()
-        );
-        assert!(
-            self.num_batches() <= config.max_batches() as usize,
-            "Problem has {} batches but these configs can only have batches<={}",
-            self.num_batches(),
-            config.max_batches()
-        );
+    pub fn check_config<B: batch::Config>(&self, config: &B) -> Result<(), MatmulInvalidProblem> {
+        if self.m > config.max_m() as usize {
+            return Err(MatmulInvalidProblem::ExceededMSize {
+                m: self.m as u32,
+                max_m: config.max_m(),
+            });
+        }
 
-        assert!(match self.lhs_layout {
-            MatrixLayout::RowMajor => self.k % self.lhs_line_size as usize == 0,
-            MatrixLayout::ColMajor => self.m % self.lhs_line_size as usize == 0,
-        });
+        if self.n > config.max_n() as usize {
+            return Err(MatmulInvalidProblem::ExceededNSize {
+                n: self.n as u32,
+                max_n: config.max_n(),
+            });
+        }
 
-        assert!(match self.rhs_layout {
-            MatrixLayout::RowMajor => self.n % self.rhs_line_size as usize == 0,
-            MatrixLayout::ColMajor => self.k % self.rhs_line_size as usize == 0,
-        });
+        if self.num_batches() > config.max_batches() as usize {
+            return Err(MatmulInvalidProblem::ExceededBatchSize {
+                b: self.num_batches() as u32,
+                max_b: config.max_batches(),
+            });
+        }
 
-        assert!(self.n % self.out_line_size as usize == 0);
+        match self.lhs_layout {
+            MatrixLayout::RowMajor => {
+                if self.k % self.lhs_line_size as usize != 0 {
+                    return Err(MatmulInvalidProblem::InvalidLineSizeLhs {
+                        size: self.k as u32,
+                        line_size: self.lhs_line_size,
+                    });
+                }
+            }
+            MatrixLayout::ColMajor => {
+                if self.m % self.lhs_line_size as usize != 0 {
+                    return Err(MatmulInvalidProblem::InvalidLineSizeLhs {
+                        size: self.m as u32,
+                        line_size: self.lhs_line_size,
+                    });
+                }
+            }
+        }
+
+        match self.rhs_layout {
+            MatrixLayout::RowMajor => {
+                if self.n % self.rhs_line_size as usize != 0 {
+                    return Err(MatmulInvalidProblem::InvalidLineSizeRhs {
+                        size: self.n as u32,
+                        line_size: self.rhs_line_size,
+                    });
+                }
+            }
+            MatrixLayout::ColMajor => {
+                if self.k % self.rhs_line_size as usize != 0 {
+                    return Err(MatmulInvalidProblem::InvalidLineSizeRhs {
+                        size: self.k as u32,
+                        line_size: self.lhs_line_size,
+                    });
+                }
+            }
+        }
+
+        if self.n % self.out_line_size as usize == 1 {
+            return Err(MatmulInvalidProblem::InvalidLineSizeOut {
+                size: self.n as u32,
+                line_size: self.out_line_size,
+            });
+        }
+
+        Ok(())
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -7,6 +7,7 @@ use crate::matmul::components::config::InputIdent;
 use crate::matmul::components::stage::{StageSize, TilingOrderConfig};
 use crate::matmul::components::{global::AccumulatorLoader, stage::base::Matmul as _};
 use crate::matmul::components::{LhsStageDim, OutStageDim, RhsStageDim};
+use crate::matmul::kernels::MatmulAvailabilityError;
 use crate::matmul::{
     components::{
         config::MatmulConfig,
@@ -170,7 +171,7 @@ where
 
     fn check_availability<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
-    ) -> Result<(), String> {
+    ) -> Result<(), MatmulAvailabilityError> {
         TMM::check_availability::<R>(client)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -7,6 +7,7 @@ use crate::matmul::components::config::InputIdent;
 use crate::matmul::components::stage::base::Matmul as _;
 use crate::matmul::components::stage::{StageSize, TilingOrderConfig};
 use crate::matmul::components::{LhsStageDim, OutStageDim, RhsStageDim};
+use crate::matmul::kernels::MatmulAvailabilityError;
 use crate::matmul::{
     components::{
         config::MatmulConfig,
@@ -160,7 +161,7 @@ where
 
     fn check_availability<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
-    ) -> Result<(), String> {
+    ) -> Result<(), MatmulAvailabilityError> {
         TMM::check_availability::<R>(client)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/tile/accelerated.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/accelerated.rs
@@ -5,6 +5,7 @@ use crate::matmul::components::{
     as_cmma_layout, tile, Ident, MatmulKernel, MatmulProblem, MatrixLayout,
 };
 use crate::matmul::kernels::matmul::AdvancedConfig;
+use crate::matmul::kernels::MatmulAvailabilityError;
 use cubecl_core::{self as cubecl, Feature};
 use cubecl_core::{cmma, prelude::*};
 use half::{bf16, f16};
@@ -100,7 +101,7 @@ macro_rules! instruction {
 
             fn check_availability<R: Runtime>(
                 client: &ComputeClient<R::Server, R::Channel>,
-            ) -> Result<(), String> {
+            ) -> Result<(), MatmulAvailabilityError> {
                 check_availability::<I, O, R>(Self::M, Self::N, Self::K, client)
             }
 
@@ -232,7 +233,7 @@ fn check_availability<I: Numeric, O: Numeric, R: Runtime>(
     n: u32,
     k: u32,
     client: &ComputeClient<R::Server, R::Channel>,
-) -> Result<(), String> {
+) -> Result<(), MatmulAvailabilityError> {
     if !client.properties().feature_enabled(Feature::Cmma {
         a: I::as_elem(),
         b: I::as_elem(),
@@ -241,14 +242,13 @@ fn check_availability<I: Numeric, O: Numeric, R: Runtime>(
         k: k as u8,
         n: n as u8,
     }) {
-        return Err(format!(
-            "Cmma on inputs {:?} and outputs {:?} with shape m={:?}, n={:?}, k={:?} not supported.",
-            I::as_elem(),
-            O::as_elem(),
+        return Err(MatmulAvailabilityError::CmmaInstructionUnavailable {
+            input: I::as_elem(),
+            output: O::as_elem(),
             m,
             n,
-            k
-        ));
+            k,
+        });
     }
 
     if !(client
@@ -258,11 +258,10 @@ fn check_availability<I: Numeric, O: Numeric, R: Runtime>(
             .properties()
             .feature_enabled(Feature::Type(O::as_elem())))
     {
-        return Err(format!(
-            "Types {:?} and/or {:?} not supported.",
-            I::as_elem(),
-            O::as_elem()
-        ));
+        return Err(MatmulAvailabilityError::TypesUnavailable {
+            input: I::as_elem(),
+            output: O::as_elem(),
+        });
     }
 
     Ok(())

--- a/crates/cubecl-linalg/src/matmul/kernels/cmma_old/launch.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/cmma_old/launch.rs
@@ -45,8 +45,8 @@ pub fn matmul_cmma_ref<R: Runtime, F: Float>(
         MatrixLayout::HighlyPermuted => false,
     };
 
-    let lhs_correct_layout = check_layout(&lhs);
-    let rhs_correct_layout = check_layout(&rhs);
+    let lhs_correct_layout = check_layout(lhs);
+    let rhs_correct_layout = check_layout(rhs);
 
     match (lhs_correct_layout, rhs_correct_layout) {
         (true, true) => matmul_cmma_ref_no_check::<R, F>(client, lhs, rhs, out, cmma_config),

--- a/crates/cubecl-linalg/src/matmul/kernels/cmma_old/launch.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/cmma_old/launch.rs
@@ -20,9 +20,9 @@ pub fn matmul_cmma<R: Runtime, F: Float>(
 ) -> TensorHandle<R, F> {
     matmul_cmma_ref::<R, F>(
         client,
-        lhs.as_ref(),
-        rhs.as_ref(),
-        out.as_ref(),
+        &lhs.as_ref(),
+        &rhs.as_ref(),
+        &out.as_ref(),
         cmma_config,
     );
     out
@@ -31,9 +31,9 @@ pub fn matmul_cmma<R: Runtime, F: Float>(
 /// Matrix multiplication using [cooperative matrix-multiply and accumulate operations](cubecl_core::cmma).
 pub fn matmul_cmma_ref<R: Runtime, F: Float>(
     client: &ComputeClient<R::Server, R::Channel>,
-    lhs: TensorHandleRef<'_, R>,
-    rhs: TensorHandleRef<'_, R>,
-    out: TensorHandleRef<'_, R>,
+    lhs: &TensorHandleRef<'_, R>,
+    rhs: &TensorHandleRef<'_, R>,
+    out: &TensorHandleRef<'_, R>,
     cmma_config: CmmaConfig,
 ) {
     let check_layout = |tensor: &TensorHandleRef<'_, R>| match matrix_layout(tensor.strides) {
@@ -53,21 +53,21 @@ pub fn matmul_cmma_ref<R: Runtime, F: Float>(
         (true, false) => matmul_cmma_ref_no_check::<R, F>(
             client,
             lhs,
-            into_contiguous::<R, F>(client, rhs).as_ref(),
+            &into_contiguous::<R, F>(client, rhs).as_ref(),
             out,
             cmma_config,
         ),
         (false, true) => matmul_cmma_ref_no_check::<R, F>(
             client,
-            into_contiguous::<R, F>(client, lhs).as_ref(),
+            &into_contiguous::<R, F>(client, lhs).as_ref(),
             rhs,
             out,
             cmma_config,
         ),
         (false, false) => matmul_cmma_ref_no_check::<R, F>(
             client,
-            into_contiguous::<R, F>(client, lhs).as_ref(),
-            into_contiguous::<R, F>(client, rhs).as_ref(),
+            &into_contiguous::<R, F>(client, lhs).as_ref(),
+            &into_contiguous::<R, F>(client, rhs).as_ref(),
             out,
             cmma_config,
         ),
@@ -76,9 +76,9 @@ pub fn matmul_cmma_ref<R: Runtime, F: Float>(
 
 fn matmul_cmma_ref_no_check<R: Runtime, F: Float>(
     client: &ComputeClient<R::Server, R::Channel>,
-    lhs: TensorHandleRef<'_, R>,
-    rhs: TensorHandleRef<'_, R>,
-    out: TensorHandleRef<'_, R>,
+    lhs: &TensorHandleRef<'_, R>,
+    rhs: &TensorHandleRef<'_, R>,
+    out: &TensorHandleRef<'_, R>,
     cmma_config: CmmaConfig,
 ) {
     let rank = lhs.strides.len();

--- a/crates/cubecl-linalg/src/matmul/kernels/error.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/error.rs
@@ -1,0 +1,127 @@
+use cubecl_core::ir::Elem;
+use std::fmt::Debug;
+
+pub enum MatmulLaunchError {
+    Unavailable(MatmulAvailabilityError),
+    InvalidProblem(MatmulInvalidProblem),
+}
+
+pub enum MatmulAvailabilityError {
+    PlaneOperationsUnavailable,
+    TypesUnavailable {
+        input: Elem,
+        output: Elem,
+    },
+    CmmaInstructionUnavailable {
+        input: Elem,
+        output: Elem,
+        m: u32,
+        n: u32,
+        k: u32,
+    },
+}
+
+pub enum MatmulInvalidProblem {
+    ExceededMSize { m: u32, max_m: u32 },
+    ExceededNSize { n: u32, max_n: u32 },
+    ExceededBatchSize { b: u32, max_b: u32 },
+    InvalidLineSizeLhs { size: u32, line_size: u8 },
+    InvalidLineSizeRhs { size: u32, line_size: u8 },
+    InvalidLineSizeOut { size: u32, line_size: u8 },
+}
+
+impl From<MatmulInvalidProblem> for MatmulLaunchError {
+    fn from(value: MatmulInvalidProblem) -> Self {
+        Self::InvalidProblem(value)
+    }
+}
+
+impl From<MatmulAvailabilityError> for MatmulLaunchError {
+    fn from(value: MatmulAvailabilityError) -> Self {
+        Self::Unavailable(value)
+    }
+}
+
+impl Debug for MatmulLaunchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MatmulLaunchError::Unavailable(err) => {
+                writeln!(
+                    f,
+                    "Unable to launch matmul because a required feature is unavailable: {:?}",
+                    err
+                )
+            }
+            MatmulLaunchError::InvalidProblem(err) => {
+                writeln!(
+                    f,
+                    "Unable to launch matmul because the problem isn't correctly defined: {:?}",
+                    err
+                )
+            }
+        }
+    }
+}
+
+impl Debug for MatmulInvalidProblem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MatmulInvalidProblem::ExceededMSize { m, max_m } => write!(
+                f,
+                "Problem has m={} but these configs can only have m<={}",
+                m, max_m
+            ),
+            MatmulInvalidProblem::ExceededNSize { n, max_n } => write!(
+                f,
+                "Problem has n={} but these configs can only have n<={}",
+                n, max_n,
+            ),
+            MatmulInvalidProblem::ExceededBatchSize { b, max_b } => write!(
+                f,
+                "Problem has {} batches but these configs can only have batches<={}",
+                b, max_b,
+            ),
+            MatmulInvalidProblem::InvalidLineSizeLhs { size, line_size } => write!(
+                f,
+                "the lhs tensor can't be read with line size={line_size} and dimension={size}"
+            ),
+            MatmulInvalidProblem::InvalidLineSizeRhs { size, line_size } => write!(
+                f,
+                "The rhs tensor can't be read with line size={line_size} and dimension={size}"
+            ),
+            MatmulInvalidProblem::InvalidLineSizeOut { size, line_size } => write!(
+                f,
+                "The out tensor can't be read with line size={line_size} and dimension={size}"
+            ),
+        }
+    }
+}
+
+impl Debug for MatmulAvailabilityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MatmulAvailabilityError::PlaneOperationsUnavailable => {
+                writeln!(f, "Plane operations not supported.")
+            }
+            MatmulAvailabilityError::TypesUnavailable { input, output } => {
+                writeln!(
+                    f,
+                    "Types input={:?} and/or output={:?} not supported.",
+                    input, output,
+                )
+            }
+            MatmulAvailabilityError::CmmaInstructionUnavailable {
+                input,
+                output,
+                m,
+                n,
+                k,
+            } => writeln!(
+                f,
+                "Cmma on inputs {:?} and outputs {:?} with shape m={:?}, n={:?}, k={:?} not supported.",
+                input,
+                output, m, n, k
+            ),
+        }
+    }
+}

--- a/crates/cubecl-linalg/src/matmul/kernels/error.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/error.rs
@@ -91,7 +91,7 @@ impl Debug for MatmulInvalidProblem {
             ),
             MatmulInvalidProblem::InvalidLineSizeOut { size, line_size } => write!(
                 f,
-                "The out tensor can't be read with line size={line_size} and dimension={size}"
+                "The out tensor can't be written with line size={line_size} and dimension={size}"
             ),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
@@ -41,7 +41,7 @@ pub trait Algorithm<EG: Numeric> {
 
     fn cube_dim() -> CubeDim;
     fn cube_count(problem: &MatmulProblem) -> CubeCount;
-
+    #[allow(clippy::type_complexity)]
     fn make_config(
         problem: &MatmulProblem,
         cube_dim: &CubeDim,

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
@@ -13,7 +13,7 @@ use crate::matmul::{
         },
         MatmulProblem,
     },
-    kernels::matmul::base::matmul_cube_preparation,
+    kernels::{matmul::base::matmul_cube_preparation, MatmulLaunchError},
 };
 
 use super::standard::StandardAlgorithm;
@@ -26,11 +26,11 @@ pub struct CmmaSelector;
 impl CmmaSelector {
     pub fn select_kernel<R: Runtime, EG: Numeric>(
         client: &ComputeClient<R::Server, R::Channel>,
-        lhs: TensorHandleRef<'_, R>,
-        rhs: TensorHandleRef<'_, R>,
-        out: TensorHandleRef<'_, R>,
+        lhs: &TensorHandleRef<'_, R>,
+        rhs: &TensorHandleRef<'_, R>,
+        out: &TensorHandleRef<'_, R>,
         problem: MatmulProblem,
-    ) -> Result<(), String> {
+    ) -> Result<(), MatmulLaunchError> {
         type ES = half::f16;
         type EA = f32;
 
@@ -190,11 +190,11 @@ pub struct PlaneMmaSelector;
 impl PlaneMmaSelector {
     pub fn select_kernel<R: Runtime, EG: Numeric>(
         client: &ComputeClient<R::Server, R::Channel>,
-        lhs: TensorHandleRef<'_, R>,
-        rhs: TensorHandleRef<'_, R>,
-        out: TensorHandleRef<'_, R>,
+        lhs: &TensorHandleRef<'_, R>,
+        rhs: &TensorHandleRef<'_, R>,
+        out: &TensorHandleRef<'_, R>,
         problem: MatmulProblem,
-    ) -> Result<(), String> {
+    ) -> Result<(), MatmulLaunchError> {
         type ES = f32;
         type EA = f32;
 

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/base.rs
@@ -60,8 +60,8 @@ pub fn launch_ref<R: Runtime, EG: Numeric>(
         MatrixLayout::HighlyPermuted => (true, false),
     };
 
-    let (lhs_make_contiguous, lhs_transposed) = check_layout(&lhs);
-    let (rhs_make_contiguous, rhs_transposed) = check_layout(&rhs);
+    let (lhs_make_contiguous, lhs_transposed) = check_layout(lhs);
+    let (rhs_make_contiguous, rhs_transposed) = check_layout(rhs);
 
     match (lhs_make_contiguous, rhs_make_contiguous) {
         (false, false) => matmul_cmma_ref_no_check::<R, EG>(

--- a/crates/cubecl-linalg/src/matmul/kernels/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/mod.rs
@@ -6,3 +6,7 @@ pub mod matmul;
 pub mod simple;
 /// Non-cooperative Matmul
 pub mod tiling2d;
+
+mod error;
+
+pub use error::*;

--- a/crates/cubecl-linalg/src/matmul/kernels/simple.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/simple.rs
@@ -80,9 +80,9 @@ fn matmul_kernel<F: Float>(
 /// Matrix multiplication using memory coalescing algorithm with custom cube dimensions
 pub fn launch_ref<R: Runtime, E: Float>(
     client: &ComputeClient<R::Server, R::Channel>,
-    lhs: TensorHandleRef<'_, R>,
-    rhs: TensorHandleRef<'_, R>,
-    out: TensorHandleRef<'_, R>,
+    lhs: &TensorHandleRef<'_, R>,
+    rhs: &TensorHandleRef<'_, R>,
+    out: &TensorHandleRef<'_, R>,
 ) {
     let lhs =
         TensorHandle::<R, E>::new(lhs.shape.to_vec(), lhs.strides.to_vec(), lhs.handle.clone());
@@ -96,7 +96,7 @@ fn launch<R: Runtime, E: Float>(
     client: &ComputeClient<R::Server, R::Channel>,
     lhs: TensorHandle<R, E>,
     rhs: TensorHandle<R, E>,
-    out: TensorHandleRef<'_, R>,
+    out: &TensorHandleRef<'_, R>,
 ) {
     let (cube_dim_x, cube_dim_y) = (32, 8);
     let ndims = lhs.shape.len();
@@ -107,7 +107,7 @@ fn launch<R: Runtime, E: Float>(
     let rhs_layout = matrix_layout(&rhs.strides);
 
     let lhs = if !matches!(lhs_layout, MatrixLayout::Contiguous) {
-        into_contiguous::<R, E>(client, lhs.as_ref())
+        into_contiguous::<R, E>(client, &lhs.as_ref())
     } else {
         lhs
     };
@@ -120,7 +120,7 @@ fn launch<R: Runtime, E: Float>(
         rhs.strides.swap(dim1, dim2);
         rhs.shape.swap(dim1, dim2);
 
-        let rhs = into_contiguous::<R, E>(client, rhs.as_ref());
+        let rhs = into_contiguous::<R, E>(client, &rhs.as_ref());
 
         (rhs_original_shape, rhs)
     };

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/launch.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/launch.rs
@@ -20,7 +20,7 @@ pub fn matmul_tiling_2d<R: Runtime, F: Float>(
     out: TensorHandle<R, F>,
     config: Tiling2dConfig,
 ) -> TensorHandle<R, F> {
-    matmul_tiling_2d_ref::<R, F>(client, lhs.as_ref(), rhs.as_ref(), out.as_ref(), config);
+    matmul_tiling_2d_ref::<R, F>(client, &lhs.as_ref(), &rhs.as_ref(), &out.as_ref(), config);
 
     out
 }
@@ -28,9 +28,9 @@ pub fn matmul_tiling_2d<R: Runtime, F: Float>(
 /// Matrix multiplication using tiling 2d algorithm.
 pub fn matmul_tiling_2d_ref<R: Runtime, F: Float>(
     client: &ComputeClient<R::Server, R::Channel>,
-    lhs: TensorHandleRef<'_, R>,
-    rhs: TensorHandleRef<'_, R>,
-    out: TensorHandleRef<'_, R>,
+    lhs: &TensorHandleRef<'_, R>,
+    rhs: &TensorHandleRef<'_, R>,
+    out: &TensorHandleRef<'_, R>,
     config: Tiling2dConfig,
 ) {
     assert!(
@@ -54,21 +54,21 @@ pub fn matmul_tiling_2d_ref<R: Runtime, F: Float>(
         (true, false) => matmul_tiling_2d_ref_no_check::<R, F>(
             client,
             lhs,
-            into_contiguous::<R, F>(client, rhs).as_ref(),
+            &into_contiguous::<R, F>(client, rhs).as_ref(),
             out,
             config,
         ),
         (false, true) => matmul_tiling_2d_ref_no_check::<R, F>(
             client,
-            into_contiguous::<R, F>(client, lhs).as_ref(),
+            &into_contiguous::<R, F>(client, lhs).as_ref(),
             rhs,
             out,
             config,
         ),
         (false, false) => matmul_tiling_2d_ref_no_check::<R, F>(
             client,
-            into_contiguous::<R, F>(client, lhs).as_ref(),
-            into_contiguous::<R, F>(client, rhs).as_ref(),
+            &into_contiguous::<R, F>(client, lhs).as_ref(),
+            &into_contiguous::<R, F>(client, rhs).as_ref(),
             out,
             config,
         ),
@@ -78,9 +78,9 @@ pub fn matmul_tiling_2d_ref<R: Runtime, F: Float>(
 /// Matrix multiplication using tiling 2d algorithm.
 fn matmul_tiling_2d_ref_no_check<R: Runtime, F: Float>(
     client: &ComputeClient<R::Server, R::Channel>,
-    lhs: TensorHandleRef<'_, R>,
-    rhs: TensorHandleRef<'_, R>,
-    out: TensorHandleRef<'_, R>,
+    lhs: &TensorHandleRef<'_, R>,
+    rhs: &TensorHandleRef<'_, R>,
+    out: &TensorHandleRef<'_, R>,
     config: Tiling2dConfig,
 ) {
     let rank = lhs.strides.len();

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/launch.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/launch.rs
@@ -46,8 +46,8 @@ pub fn matmul_tiling_2d_ref<R: Runtime, F: Float>(
         } => true,
         MatrixLayout::HighlyPermuted => false,
     };
-    let lhs_correct_layout = check_layout(&lhs);
-    let rhs_correct_layout = check_layout(&rhs);
+    let lhs_correct_layout = check_layout(lhs);
+    let rhs_correct_layout = check_layout(rhs);
 
     match (lhs_correct_layout, rhs_correct_layout) {
         (true, true) => matmul_tiling_2d_ref_no_check::<R, F>(client, lhs, rhs, out, config),

--- a/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
@@ -47,7 +47,7 @@ where
 
     let cube_dim = A::cube_dim();
     let cube_count = A::cube_count(&problem);
-    let config = A::make_config(&problem, &cube_dim, &cube_count, &A::advanced_config());
+    let config = A::make_config(&problem, &cube_dim, &cube_count, &A::advanced_config()).unwrap();
 
     unsafe {
         A::BatchMatmul::launch_unchecked(

--- a/crates/cubecl-linalg/src/tensor/contiguous.rs
+++ b/crates/cubecl-linalg/src/tensor/contiguous.rs
@@ -59,7 +59,7 @@ fn into_contiguous_kernel<N: CubePrimitive>(
 /// Make a jit tensor contiguous.
 pub fn into_contiguous<R: Runtime, E: CubePrimitive>(
     client: &ComputeClient<R::Server, R::Channel>,
-    input: TensorHandleRef<'_, R>,
+    input: &TensorHandleRef<'_, R>,
 ) -> TensorHandle<R, E> {
     let num_elems: usize = input.shape.iter().product();
     // Vectorization is only enabled when the last dimension is contiguous.
@@ -87,7 +87,7 @@ pub fn into_contiguous<R: Runtime, E: CubePrimitive>(
 /// Make a jit tensor contiguous.
 pub fn into_contiguous_prefetch<R: Runtime, E: CubePrimitive>(
     client: &ComputeClient<R::Server, R::Channel>,
-    input: TensorHandleRef<'_, R>,
+    input: &TensorHandleRef<'_, R>,
     elems_per_unit: u32,
 ) -> TensorHandle<R, E> {
     // Vectorization is only enabled when the last dimension is contiguous.


### PR DESCRIPTION
Revisited the matmul error handling to allow changes in the implementation based on errors. This enables the `auto` strategy, which first tries `accelerate` and then falls back to `tiling2d`.