### PR TITLE
Added panic for memory partitioning error

### DIFF
--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -280,6 +280,13 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> {
 
         // Find first pool where size <= p.max_alloc with a binary search.
         let pool_ind = self.pools.partition_point(|p| size > p.max_alloc_size());
+
+        // Ensure the pool index is in bounds, otherwise there isn't any pool that can fit the
+        // requested allocation
+        if pool_ind >= self.pools.len() {
+            panic!("Unable to find valid pool partition point: No memory pool big enough to reserve {size} bytes.");
+        }
+
         let pool = &mut self.pools[pool_ind];
         if pool.max_alloc_size() < size {
             panic!("No memory pool big enough to reserve {size} bytes.");


### PR DESCRIPTION
Currently when the system cannot allocate any more memory to CubeCL the code panics on a cryptic out of bounds error in the memory management system, specifically when the code is unable to find a valid partition of the available memory blocks. This PR adds a panic to better inform the user of the problem.