### PR TITLE
Import reduce shared

### DIFF
--- a/crates/cubecl-reduce/Cargo.toml
+++ b/crates/cubecl-reduce/Cargo.toml
@@ -21,10 +21,11 @@ default = [
   "cubecl-core/default"
 ]
 std = ["cubecl-runtime/std", "cubecl-core/std"]
-export_tests = ["pretty_assertions"]
+export_tests = ["pretty_assertions", "rand"]
 
 [dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.4.0", default-features = false }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.4.0", default-features = false }
 num-traits = "0.2.19"
 pretty_assertions = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }

--- a/crates/cubecl-reduce/src/instructions.rs
+++ b/crates/cubecl-reduce/src/instructions.rs
@@ -1,5 +1,9 @@
+/// Compute the coordinate of the maximum item returning the smallest coordinate in case of equality.
 pub struct ReduceArgMax;
+
+/// Compute the coordinate of the minimum item returning the smallest coordinate in case of equality.
 pub struct ReduceArgMin;
+
 pub struct ReduceMean;
 pub struct ReduceSum;
 pub struct ReduceProd;

--- a/crates/cubecl-reduce/src/instructions.rs
+++ b/crates/cubecl-reduce/src/instructions.rs
@@ -1,8 +1,55 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
 /// Compute the coordinate of the maximum item returning the smallest coordinate in case of equality.
 pub struct ReduceArgMax;
 
+#[cube]
+impl ReduceArgMax {
+    /// Compare two pairs of items and coordinates and return a new pair 
+    /// where each element in the lines is the maximal item with its coordinate.
+    /// In case of equality, the lowest coordinate is selected.
+    pub fn choose_argmax<N: Numeric>(
+        items0: Line<N>,
+        coordinates0: Line<u32>,
+        items1: Line<N>,
+        coordinates1: Line<u32>,
+    ) -> (Line<N>, Line<u32>) {
+        let to_keep = select_many(
+            items0.equal(items1),
+            coordinates0.less_than(coordinates1),
+            items0.greater_than(items1),
+        );
+        let items = select_many(to_keep, items0, items1);
+        let coordinates = select_many(to_keep, coordinates0, coordinates1);
+        (items, coordinates)
+    }
+}
+
 /// Compute the coordinate of the minimum item returning the smallest coordinate in case of equality.
 pub struct ReduceArgMin;
+
+#[cube]
+impl ReduceArgMin {
+    /// Compare two pairs of items and coordinates and return a new pair 
+    /// where each element in the lines is the minimal item with its coordinate.
+    /// In case of equality, the lowest coordinate is selected.
+    pub fn choose_argmin<N: Numeric>(
+        items0: Line<N>,
+        coordinates0: Line<u32>,
+        items1: Line<N>,
+        coordinates1: Line<u32>,
+    ) -> (Line<N>, Line<u32>) {
+        let to_keep = select_many(
+            items0.equal(items1),
+            coordinates0.less_than(coordinates1),
+            items0.less_than(items1),
+        );
+        let items = select_many(to_keep, items0, items1);
+        let coordinates = select_many(to_keep, coordinates0, coordinates1);
+        (items, coordinates)
+    }
+}
 
 pub struct ReduceMean;
 pub struct ReduceSum;

--- a/crates/cubecl-reduce/src/instructions.rs
+++ b/crates/cubecl-reduce/src/instructions.rs
@@ -6,7 +6,7 @@ pub struct ReduceArgMax;
 
 #[cube]
 impl ReduceArgMax {
-    /// Compare two pairs of items and coordinates and return a new pair 
+    /// Compare two pairs of items and coordinates and return a new pair
     /// where each element in the lines is the maximal item with its coordinate.
     /// In case of equality, the lowest coordinate is selected.
     pub fn choose_argmax<N: Numeric>(
@@ -31,7 +31,7 @@ pub struct ReduceArgMin;
 
 #[cube]
 impl ReduceArgMin {
-    /// Compare two pairs of items and coordinates and return a new pair 
+    /// Compare two pairs of items and coordinates and return a new pair
     /// where each element in the lines is the minimal item with its coordinate.
     /// In case of equality, the lowest coordinate is selected.
     pub fn choose_argmin<N: Numeric>(

--- a/crates/cubecl-reduce/src/lib.rs
+++ b/crates/cubecl-reduce/src/lib.rs
@@ -1,8 +1,10 @@
 mod instructions;
 mod naive;
+mod shared;
 
 #[cfg(feature = "export_tests")]
 pub mod test;
 
 pub use instructions::*;
 pub use naive::*;
+pub use shared::*;

--- a/crates/cubecl-reduce/src/shared.rs
+++ b/crates/cubecl-reduce/src/shared.rs
@@ -1,0 +1,386 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+use crate::{ReduceArgMax, ReduceArgMin, ReduceMean, ReduceProd, ReduceSum};
+
+/// An instruction for the [reduce_shared](reduce_shared) algorithm.
+#[cube]
+pub trait ReduceSharedInstruction<EI: Numeric>: Send + Sync + 'static {
+    /// The reduction accumulator.
+    type Accumulator: CubeType;
+
+    fn create_accumulator(#[comptime] length: u32, #[comptime] line_size: u32)
+        -> Self::Accumulator;
+
+    fn init_accumulator(
+        accumulator: &mut Self::Accumulator,
+        index: u32,
+        #[comptime] line_size: u32,
+    );
+
+    fn accumulate(
+        accumulator: &mut Self::Accumulator,
+        destination: u32,
+        item: Line<EI>,
+        coordinate: u32,
+    );
+
+    fn merge(accumulator: &mut Self::Accumulator, destination: u32, origin: u32);
+
+    fn write_first<EO: Numeric>(
+        output: &mut Tensor<Line<EO>>,
+        accumulator: &Self::Accumulator,
+        index: u32,
+        shape_reduce_dim: u32,
+    );
+}
+
+#[cube]
+pub fn reduce_shared<RD: ReduceSharedInstruction<EI>, EI: Numeric, EO: Numeric>(
+    input: &Tensor<Line<EI>>,
+    output: &mut Tensor<Line<EO>>,
+    reduce_dim: u32,
+    #[comptime] cube_dim: u32,
+    #[comptime] exact_shape: bool,
+) {
+    let line_size = input.line_size();
+    let mut accumulator = RD::create_accumulator(cube_dim, line_size);
+    RD::init_accumulator(&mut accumulator, UNIT_POS, line_size);
+
+    // Compute the first index where to start the reduction for the current cube.
+    // First, compute the coordinate corresponding to the CUBE_POS element of the output tensor
+    // Then, use the strides of the input tensor to find the index of the same coordinate
+    // in the input tensor.
+    let mut offset = 0;
+    for axis in 0..input.rank() {
+        let coordinate = output.coordinate(CUBE_POS, axis);
+        offset += coordinate * input.stride(axis);
+    }
+
+    let num_items_per_unit = div_ceil(input.shape(reduce_dim), cube_dim, exact_shape);
+    // TODO: Change ordering of reduce within cube.
+    offset += UNIT_POS * num_items_per_unit * input.stride(reduce_dim);
+
+    for i in 0..num_items_per_unit {
+        let index = offset + i * input.stride(reduce_dim);
+        let coordinate = i + num_items_per_unit * UNIT_POS;
+        #[allow(clippy::collapsible_else_if)]
+        if exact_shape {
+            RD::accumulate(&mut accumulator, UNIT_POS, input[index], coordinate);
+        } else {
+            if coordinate < input.shape(reduce_dim) {
+                RD::accumulate(&mut accumulator, UNIT_POS, input[index], coordinate);
+            }
+        }
+    }
+
+    sync_units();
+
+    // Merge the accumulator like this with some padding if CUBE_DIM is not a power of 2.
+    //
+    // 0   1   2   3   4   5   6   7
+    // |   |   |   |   |   |   |   |
+    // +-+-+   +-+-+   +-+-+   +-+-+
+    //   |       |       |       |
+    //   +---+---+       +---+---+
+    //       |               |
+    //       +-------+-------+
+    //               |
+    //               *
+    //
+    // Be careful if you want to change the ordering as some reduction algorithms
+    // like ArgMax relies on that to be associative without being commutative.
+    // In that case, it allows ArgMax to always return the smallest coordinate when there are
+    // multiple items with the maximum value without having to explicitely check the coordinates
+    // within each call to RD::merge.
+    if comptime!(cube_dim.is_power_of_two()) {
+        let mut num_active_units = cube_dim;
+        let mut jump = 1;
+        while num_active_units > 1 {
+            num_active_units /= 2;
+            let destination = jump * 2 * UNIT_POS;
+            let origin = jump * (2 * UNIT_POS + 1);
+            if UNIT_POS < num_active_units {
+                RD::merge(&mut accumulator, destination, origin);
+            }
+            jump *= 2;
+            sync_units();
+        }
+    } else {
+        let mut num_remaining_items = cube_dim;
+        let mut jump = 1;
+        while num_remaining_items > 1 {
+            let num_active_units = div_ceil(num_remaining_items, 2, false);
+            let destination = jump * 2 * UNIT_POS;
+            let origin = jump * (2 * UNIT_POS + 1);
+            if origin < num_remaining_items {
+                RD::merge(&mut accumulator, destination, origin);
+            }
+            num_remaining_items = num_active_units;
+            jump *= 2;
+            sync_units();
+        }
+    }
+
+    if UNIT_POS == 0 {
+        RD::write_first(output, &accumulator, CUBE_POS, input.shape(reduce_dim));
+    }
+}
+
+#[cube]
+fn div_ceil(a: u32, b: u32, #[comptime] exact: bool) -> u32 {
+    if exact {
+        a / b
+    } else {
+        (a + b - 1) / b
+    }
+}
+
+// Implementations for common instructions.
+
+#[cube]
+impl<EI: Numeric> ReduceSharedInstruction<EI> for ReduceSum {
+    type Accumulator = SharedMemory<Line<EI>>;
+
+    fn create_accumulator(
+        #[comptime] length: u32,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator {
+        SharedMemory::new_lined(length, line_size)
+    }
+
+    fn init_accumulator(
+        accumulator: &mut Self::Accumulator,
+        index: u32,
+        #[comptime] line_size: u32,
+    ) {
+        accumulator[index] = Line::empty(line_size).fill(EI::from_int(0));
+    }
+
+    fn accumulate(
+        accumulator: &mut Self::Accumulator,
+        destination: u32,
+        item: Line<EI>,
+        _coordinate: u32,
+    ) {
+        accumulator[destination] += item;
+    }
+
+    fn merge(accumulator: &mut Self::Accumulator, destination: u32, origin: u32) {
+        let item = accumulator[origin];
+        accumulator[destination] += item;
+    }
+
+    /// Write the result of the reduction stored in `accumulator` into `output[index]`.
+    fn write_first<EO: Numeric>(
+        output: &mut Tensor<Line<EO>>,
+        accumulator: &Self::Accumulator,
+        index: u32,
+        _shape_reduce_dim: u32,
+    ) {
+        output[index] = Line::cast_from(accumulator[0]);
+    }
+}
+
+#[cube]
+impl<EI: Numeric> ReduceSharedInstruction<EI> for ReduceProd {
+    type Accumulator = SharedMemory<Line<EI>>;
+
+    fn create_accumulator(
+        #[comptime] length: u32,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator {
+        SharedMemory::new_lined(length, line_size)
+    }
+
+    fn init_accumulator(
+        accumulator: &mut Self::Accumulator,
+        index: u32,
+        #[comptime] line_size: u32,
+    ) {
+        accumulator[index] = Line::empty(line_size).fill(EI::from_int(1));
+    }
+
+    fn accumulate(
+        accumulator: &mut Self::Accumulator,
+        destination: u32,
+        item: Line<EI>,
+        _coordinate: u32,
+    ) {
+        accumulator[destination] *= item;
+    }
+
+    fn merge(accumulator: &mut Self::Accumulator, destination: u32, origin: u32) {
+        let item = accumulator[origin];
+        accumulator[destination] *= item;
+    }
+
+    /// Write the result of the reduction stored in `accumulator` into `output[index]`.
+    fn write_first<EO: Numeric>(
+        output: &mut Tensor<Line<EO>>,
+        accumulator: &Self::Accumulator,
+        index: u32,
+        _shape_reduce_dim: u32,
+    ) {
+        output[index] = Line::cast_from(accumulator[0]);
+    }
+}
+
+#[cube]
+impl<EI: Numeric> ReduceSharedInstruction<EI> for ReduceMean {
+    type Accumulator = SharedMemory<Line<EI>>;
+
+    fn create_accumulator(
+        #[comptime] length: u32,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator {
+        SharedMemory::new_lined(length, line_size)
+    }
+
+    fn init_accumulator(
+        accumulator: &mut Self::Accumulator,
+        index: u32,
+        #[comptime] line_size: u32,
+    ) {
+        accumulator[index] = Line::empty(line_size).fill(EI::from_int(0));
+    }
+
+    fn accumulate(
+        accumulator: &mut Self::Accumulator,
+        destination: u32,
+        item: Line<EI>,
+        _coordinate: u32,
+    ) {
+        accumulator[destination] += item;
+    }
+
+    fn merge(accumulator: &mut Self::Accumulator, destination: u32, origin: u32) {
+        let item = accumulator[origin];
+        accumulator[destination] += item;
+    }
+
+    /// Write the result of the reduction stored in `accumulator` into `output[index]`.
+    fn write_first<EO: Numeric>(
+        output: &mut Tensor<Line<EO>>,
+        accumulator: &Self::Accumulator,
+        index: u32,
+        shape_reduce_dim: u32,
+    ) {
+        output[index] = Line::cast_from(accumulator[0])
+            / Line::empty(output.line_size()).fill(EO::cast_from(shape_reduce_dim));
+    }
+}
+
+#[cube]
+impl<EI: Numeric> ReduceSharedInstruction<EI> for ReduceArgMax {
+    type Accumulator = (SharedMemory<Line<EI>>, SharedMemory<Line<u32>>);
+
+    fn create_accumulator(
+        #[comptime] length: u32,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator {
+        (
+            SharedMemory::new_lined(length, line_size),
+            SharedMemory::new_lined(length, line_size),
+        )
+    }
+
+    fn init_accumulator(
+        accumulator: &mut Self::Accumulator,
+        index: u32,
+        #[comptime] line_size: u32,
+    ) {
+        let (items, indices) = accumulator;
+        items[index] = Line::empty(line_size).fill(EI::MIN);
+        indices[index] = Line::empty(line_size).fill(0);
+    }
+
+    fn accumulate(
+        accumulator: &mut Self::Accumulator,
+        destination: u32,
+        item: Line<EI>,
+        coordinate: u32,
+    ) {
+        let (currents, indices) = accumulator;
+        let to_replace = item.greater_than(currents[destination]);
+        currents[destination] = select_many(to_replace, item, currents[destination]);
+        indices[destination] = select_many(
+            to_replace,
+            Line::empty(indices[destination].size()).fill(coordinate),
+            indices[destination],
+        );
+    }
+
+    fn merge(accumulator: &mut Self::Accumulator, destination: u32, origin: u32) {
+        let (items, indices) = accumulator;
+        let to_replace = items[origin].greater_than(items[destination]);
+        items[destination] = select_many(to_replace, items[origin], items[destination]);
+        indices[destination] = select_many(to_replace, indices[origin], indices[destination]);
+    }
+
+    fn write_first<EO: Numeric>(
+        output: &mut Tensor<Line<EO>>,
+        accumulator: &Self::Accumulator,
+        index: u32,
+        _shape_reduce_dim: u32,
+    ) {
+        output[index] = Line::cast_from(accumulator.1[0]);
+    }
+}
+
+#[cube]
+impl<EI: Numeric> ReduceSharedInstruction<EI> for ReduceArgMin {
+    type Accumulator = (SharedMemory<Line<EI>>, SharedMemory<Line<u32>>);
+
+    fn create_accumulator(
+        #[comptime] length: u32,
+        #[comptime] line_size: u32,
+    ) -> Self::Accumulator {
+        (
+            SharedMemory::new_lined(length, line_size),
+            SharedMemory::new_lined(length, line_size),
+        )
+    }
+
+    fn init_accumulator(
+        accumulator: &mut Self::Accumulator,
+        index: u32,
+        #[comptime] line_size: u32,
+    ) {
+        let (items, indices) = accumulator;
+        items[index] = Line::empty(line_size).fill(EI::MAX);
+        indices[index] = Line::empty(line_size).fill(0);
+    }
+
+    fn accumulate(
+        accumulator: &mut Self::Accumulator,
+        destination: u32,
+        item: Line<EI>,
+        coordinate: u32,
+    ) {
+        let (currents, indices) = accumulator;
+        let to_replace = item.less_than(currents[destination]);
+        currents[destination] = select_many(to_replace, item, currents[destination]);
+        indices[destination] = select_many(
+            to_replace,
+            Line::empty(indices[destination].size()).fill(coordinate),
+            indices[destination],
+        );
+    }
+
+    fn merge(accumulator: &mut Self::Accumulator, destination: u32, origin: u32) {
+        let (items, indices) = accumulator;
+        let to_replace = items[origin].less_than(items[destination]);
+        items[destination] = select_many(to_replace, items[origin], items[destination]);
+        indices[destination] = select_many(to_replace, indices[origin], indices[destination]);
+    }
+
+    fn write_first<EO: Numeric>(
+        output: &mut Tensor<Line<EO>>,
+        accumulator: &Self::Accumulator,
+        index: u32,
+        _shape_reduce_dim: u32,
+    ) {
+        output[index] = Line::cast_from(accumulator.1[0]);
+    }
+}

--- a/crates/cubecl-reduce/src/shared.rs
+++ b/crates/cubecl-reduce/src/shared.rs
@@ -131,6 +131,7 @@ pub fn reduce_shared<RD: ReduceSharedInstruction<EI>, EI: Numeric, EO: Numeric>(
 }
 
 #[cube]
+#[allow(clippy::manual_div_ceil)]
 fn div_ceil(a: u32, b: u32) -> u32 {
     (a + b - 1) / b
 }

--- a/crates/cubecl-reduce/src/shared.rs
+++ b/crates/cubecl-reduce/src/shared.rs
@@ -111,12 +111,11 @@ pub fn reduce_shared<RD: ReduceSharedInstruction<EI>, EI: Numeric, EO: Numeric>(
             sync_units();
         }
     } else {
-        // 25
-        let mut num_remaining_items = cube_dim; // 25
+        let mut num_remaining_items = cube_dim;
         let mut jump = 1;
         while num_remaining_items > 1 {
-            let destination = jump * 2 * UNIT_POS; // 2 * UP
-            let origin = jump * (2 * UNIT_POS + 1); // (2 * UP + 1)
+            let destination = jump * 2 * UNIT_POS;
+            let origin = jump * (2 * UNIT_POS + 1);
             if UNIT_POS < num_remaining_items / 2 {
                 RD::merge(&mut accumulator, destination, origin);
             }

--- a/crates/cubecl-reduce/src/test.rs
+++ b/crates/cubecl-reduce/src/test.rs
@@ -2,20 +2,37 @@
 
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
+use rand::{
+    distributions::{Distribution, Uniform},
+    rngs::StdRng,
+    SeedableRng,
+};
 
 use crate::{
-    reduce_naive, ReduceArgMax, ReduceArgMin, ReduceMean, ReduceNaiveInstruction, ReduceProd,
-    ReduceSum,
+    reduce_naive, reduce_shared, ReduceArgMax, ReduceArgMin, ReduceMean, ReduceNaiveInstruction,
+    ReduceProd, ReduceSharedInstruction, ReduceSum,
 };
 
 // Simple kernel to launch tests.
 #[cube(launch_unchecked)]
-pub fn naive_reduce_dim_kernel<I: Numeric, O: Numeric, R: ReduceNaiveInstruction<I>>(
+pub fn kernel_reduce_naive<I: Numeric, O: Numeric, R: ReduceNaiveInstruction<I>>(
     input: &Tensor<Line<I>>,
     output: &mut Tensor<Line<O>>,
     dim: u32,
 ) {
     reduce_naive::<R, I, O>(input, output, dim)
+}
+
+// Simple kernel to launch tests.
+#[cube(launch_unchecked)]
+pub fn kernel_reduce_shared<I: Numeric, O: Numeric, R: ReduceSharedInstruction<I>>(
+    input: &Tensor<Line<I>>,
+    output: &mut Tensor<Line<O>>,
+    reduce_dim: u32,
+    #[comptime] cube_dim: u32,
+    #[comptime] exact_shape: bool,
+) {
+    reduce_shared::<R, I, O>(input, output, reduce_dim, cube_dim, exact_shape)
 }
 
 // This macro generate all the tests.
@@ -41,6 +58,7 @@ macro_rules! testgen_reduce {
         use cubecl_core::prelude::CubeCount;
 
         $crate::impl_test_reduce!(
+            naive,
             $float,
             [
                 {
@@ -99,6 +117,67 @@ macro_rules! testgen_reduce {
                 }
             ]
         );
+
+        $crate::impl_test_reduce!(
+            shared,
+            $float,
+            [
+                {
+                    id: "reduce_columns_small_matrix_row_major",
+                    shape: [4, 8],
+                    stride: [8, 1],
+                    reduce_dim: 0,
+                    cube_count: CubeCount::Static(8, 1, 1),
+                    cube_dim: CubeDim::new(2, 1, 1),
+                    line_size: 1,
+                },
+                {
+                    id: "reduce_columns_large_matrix_row_major",
+                    shape: [8, 256],
+                    stride: [256, 1],
+                    reduce_dim: 1,
+                    cube_count: CubeCount::Static(8, 1, 1),
+                    cube_dim: CubeDim::new(16, 1, 1),
+                    line_size: 1,
+                },
+                {
+                    id: "reduce_rows_large_matrix_row_major_non_power_two_cube_dim",
+                    shape: [16, 256],
+                    stride: [256, 1],
+                    reduce_dim: 0,
+                    cube_count: CubeCount::Static(256, 1, 1),
+                    cube_dim: CubeDim::new(5, 1, 1),
+                    line_size: 1,
+                },
+                {
+                    id: "rank_three_tensor",
+                    shape: [16, 16, 16],
+                    stride: [1, 256, 16],
+                    reduce_dim: 2,
+                    cube_count: CubeCount::Static(16, 16, 1),
+                    cube_dim: CubeDim::new(4, 1, 1),
+                    line_size: 1,
+                },
+                {
+                    id: "rank_three_tensor_unexact_shape",
+                    shape: [11, 12, 13],
+                    stride: [156, 13, 1],
+                    reduce_dim: 1,
+                    cube_count: CubeCount::Static(11, 1, 13),
+                    cube_dim: CubeDim::new(2, 1, 1),
+                    line_size: 1,
+                },
+                {
+                    id: "reduce_rows_large_matrix_row_major_line_size_four",
+                    shape: [32, 64],
+                    stride: [64, 1],
+                    reduce_dim: 0,
+                    cube_count: CubeCount::Static(64, 1, 1),
+                    cube_dim: CubeDim::new(8, 1, 1),
+                    line_size: 4,
+                }
+            ]
+        );
     };
 }
 
@@ -109,6 +188,7 @@ macro_rules! testgen_reduce {
 #[macro_export]
 macro_rules! impl_test_reduce {
     (
+        $kind:ident,
         $float:ident,
         [
             $(
@@ -126,7 +206,7 @@ macro_rules! impl_test_reduce {
         ::paste::paste! {
             $(
                 #[test]
-                pub fn [< reduce_sum_dim_naive_ $id >]() {
+                pub fn [< reduce_sum_dim_ $kind _ $id >]() {
                     let test = TestCase {
                         shape: $shape.into(),
                         stride: $stride.into(),
@@ -135,11 +215,11 @@ macro_rules! impl_test_reduce {
                         cube_dim: $cube_dim,
                         line_size:$line_size
                     };
-                    test.test_sum_dim_naive::<$float, TestRuntime>(&Default::default());
+                    test.[< test_sum_dim_ $kind >]::<$float, TestRuntime>(&Default::default());
                 }
 
                 #[test]
-                pub fn [< reduce_prod_dim_naive_ $id >]() {
+                pub fn [< reduce_prod_dim_ $kind _ $id >]() {
                     let test = TestCase {
                         shape: $shape.into(),
                         stride: $stride.into(),
@@ -148,11 +228,11 @@ macro_rules! impl_test_reduce {
                         cube_dim: $cube_dim,
                         line_size:$line_size
                     };
-                    test.test_prod_dim_naive::<$float, TestRuntime>(&Default::default());
+                    test.[< test_prod_dim_ $kind >]::<$float, TestRuntime>(&Default::default());
                 }
 
                 #[test]
-                pub fn [< reduce_mean_dim_naive_ $id >]() {
+                pub fn [< reduce_mean_dim_ $kind _ $id >]() {
                     let test = TestCase {
                         shape: $shape.into(),
                         stride: $stride.into(),
@@ -161,11 +241,11 @@ macro_rules! impl_test_reduce {
                         cube_dim: $cube_dim,
                         line_size:$line_size
                     };
-                    test.test_mean_dim_naive::<$float, TestRuntime>(&Default::default());
+                    test.[< test_mean_dim_ $kind >]::<$float, TestRuntime>(&Default::default());
                 }
 
                 #[test]
-                pub fn [< reduce_argmax_dim_naive_ $id >]() {
+                pub fn [< reduce_argmax_dim_ $kind _ $id >]() {
                     let test = TestCase {
                         shape: $shape.into(),
                         stride: $stride.into(),
@@ -174,11 +254,11 @@ macro_rules! impl_test_reduce {
                         cube_dim: $cube_dim,
                         line_size:$line_size
                     };
-                    test.test_argmax_dim_naive::<$float, TestRuntime>(&Default::default());
+                    test.[< test_argmax_dim_ $kind >]::<$float, TestRuntime>(&Default::default());
                 }
 
                 #[test]
-                pub fn [< reduce_argmin_dim_naive_ $id >]() {
+                pub fn [< reduce_argmin_dim_ $kind _ $id >]() {
                     let test = TestCase {
                         shape: $shape.into(),
                         stride: $stride.into(),
@@ -187,7 +267,7 @@ macro_rules! impl_test_reduce {
                         cube_dim: $cube_dim,
                         line_size:$line_size
                     };
-                    test.test_argmin_dim_naive::<$float, TestRuntime>(&Default::default());
+                    test.[< test_argmin_dim_ $kind >]::<$float, TestRuntime>(&Default::default());
                 }
             )*
         }
@@ -212,7 +292,7 @@ impl TestCase {
     {
         let input_values: Vec<F> = self.random_input_values();
         let expected_values = self.cpu_sum_dim(&input_values);
-        self.run_test::<F, F, R, ReduceSum>(device, input_values, expected_values)
+        self.run_test_naive::<F, F, R, ReduceSum>(device, input_values, expected_values)
     }
 
     pub fn test_prod_dim_naive<F, R>(&self, device: &R::Device)
@@ -222,7 +302,7 @@ impl TestCase {
     {
         let input_values: Vec<F> = self.random_input_values();
         let expected_values = self.cpu_prod_dim(&input_values);
-        self.run_test::<F, F, R, ReduceProd>(device, input_values, expected_values)
+        self.run_test_naive::<F, F, R, ReduceProd>(device, input_values, expected_values)
     }
 
     pub fn test_mean_dim_naive<F, R>(&self, device: &R::Device)
@@ -232,7 +312,7 @@ impl TestCase {
     {
         let input_values: Vec<F> = self.random_input_values();
         let expected_values = self.cpu_mean_dim(&input_values);
-        self.run_test::<F, F, R, ReduceMean>(device, input_values, expected_values)
+        self.run_test_naive::<F, F, R, ReduceMean>(device, input_values, expected_values)
     }
 
     pub fn test_argmax_dim_naive<F, R>(&self, device: &R::Device)
@@ -242,7 +322,7 @@ impl TestCase {
     {
         let input_values: Vec<F> = self.random_input_values();
         let expected_values = self.cpu_argmax_dim(&input_values);
-        self.run_test::<F, u32, R, ReduceArgMax>(device, input_values, expected_values)
+        self.run_test_naive::<F, u32, R, ReduceArgMax>(device, input_values, expected_values)
     }
 
     pub fn test_argmin_dim_naive<F, R>(&self, device: &R::Device)
@@ -252,10 +332,10 @@ impl TestCase {
     {
         let input_values: Vec<F> = self.random_input_values();
         let expected_values = self.cpu_argmin_dim(&input_values);
-        self.run_test::<F, u32, R, ReduceArgMin>(device, input_values, expected_values)
+        self.run_test_naive::<F, u32, R, ReduceArgMin>(device, input_values, expected_values)
     }
 
-    pub fn run_test<I, O, R, K>(
+    pub fn run_test_naive<I, O, R, K>(
         &self,
         device: &R::Device,
         input_values: Vec<I>,
@@ -292,7 +372,7 @@ impl TestCase {
                 self.line_size,
             );
 
-            naive_reduce_dim_kernel::launch_unchecked::<I, O, K, R>(
+            kernel_reduce_naive::launch_unchecked::<I, O, K, R>(
                 &client,
                 self.cube_count.clone(),
                 self.cube_dim,
@@ -306,7 +386,115 @@ impl TestCase {
         let bytes = client.read_one(binding);
         let output_values = O::from_bytes(&bytes);
 
-        assert_approx_equal_abs(output_values, &expected_values, 1e-7);
+        assert_approx_equal_abs(output_values, &expected_values, 1e-6);
+    }
+
+    pub fn test_sum_dim_shared<F, R>(&self, device: &R::Device)
+    where
+        F: Float + CubeElement + std::fmt::Display,
+        R: Runtime,
+    {
+        let input_values: Vec<F> = self.random_input_values();
+        let expected_values = self.cpu_sum_dim(&input_values);
+        self.run_test_shared::<F, F, R, ReduceSum>(device, input_values, expected_values)
+    }
+
+    pub fn test_prod_dim_shared<F, R>(&self, device: &R::Device)
+    where
+        F: Float + CubeElement + std::fmt::Display,
+        R: Runtime,
+    {
+        let input_values: Vec<F> = self.random_input_values();
+        let expected_values = self.cpu_prod_dim(&input_values);
+        self.run_test_shared::<F, F, R, ReduceProd>(device, input_values, expected_values)
+    }
+
+    pub fn test_mean_dim_shared<F, R>(&self, device: &R::Device)
+    where
+        F: Float + CubeElement + std::fmt::Display,
+        R: Runtime,
+    {
+        let input_values: Vec<F> = self.random_input_values();
+        let expected_values = self.cpu_mean_dim(&input_values);
+        self.run_test_shared::<F, F, R, ReduceMean>(device, input_values, expected_values)
+    }
+
+    pub fn test_argmax_dim_shared<F, R>(&self, device: &R::Device)
+    where
+        F: Float + CubeElement + std::fmt::Display,
+        R: Runtime,
+    {
+        let input_values: Vec<F> = self.random_input_values();
+        let expected_values = self.cpu_argmax_dim(&input_values);
+        self.run_test_shared::<F, u32, R, ReduceArgMax>(device, input_values, expected_values)
+    }
+
+    pub fn test_argmin_dim_shared<F, R>(&self, device: &R::Device)
+    where
+        F: Float + CubeElement + std::fmt::Display,
+        R: Runtime,
+    {
+        let input_values: Vec<F> = self.random_input_values();
+        let expected_values = self.cpu_argmin_dim(&input_values);
+        self.run_test_shared::<F, u32, R, ReduceArgMin>(device, input_values, expected_values)
+    }
+
+    pub fn run_test_shared<I, O, R, K>(
+        &self,
+        device: &R::Device,
+        input_values: Vec<I>,
+        expected_values: Vec<O>,
+    ) where
+        I: Numeric + CubeElement + std::fmt::Display,
+        O: Numeric + CubeElement + std::fmt::Display,
+        R: Runtime,
+        K: ReduceSharedInstruction<I>,
+    {
+        let client = R::client(device);
+        let input_handle = client.create(I::as_bytes(&input_values));
+
+        // Zero initialize a tensor with the same shape as input
+        // except for the `self.reduce_dim` axis where the shape is 1.
+        let output_handle =
+            client.create(O::as_bytes(&vec![O::from_int(0); expected_values.len()]));
+        let mut output_shape = self.shape.clone();
+        output_shape[self.reduce_dim as usize] = 1;
+        let output_stride = self.output_stride();
+
+        let exact_shape =
+            self.shape[self.reduce_dim as usize] % self.cube_dim.num_elems() as usize == 0;
+
+        unsafe {
+            let input_tensor = TensorArg::from_raw_parts::<I>(
+                &input_handle,
+                &self.stride,
+                &self.shape,
+                self.line_size,
+            );
+            let output_tensor = TensorArg::from_raw_parts::<O>(
+                &output_handle,
+                &output_stride,
+                &output_shape,
+                self.line_size,
+            );
+
+            kernel_reduce_shared::launch_unchecked::<I, O, K, R>(
+                &client,
+                self.cube_count.clone(),
+                self.cube_dim,
+                input_tensor,
+                output_tensor,
+                ScalarArg::new(self.reduce_dim),
+                self.cube_dim.num_elems(),
+                exact_shape,
+            );
+        }
+
+        let binding = output_handle.binding();
+        let bytes = client.read_one(binding);
+        let output_values = O::from_bytes(&bytes);
+
+        assert_approx_equal_abs(output_values, &expected_values, 1.0 / 4.0);
     }
 
     fn cpu_sum_dim<F: Float>(&self, values: &[F]) -> Vec<F> {
@@ -410,18 +598,19 @@ impl TestCase {
 
     fn random_input_values<F: Float>(&self) -> Vec<F> {
         let size = self.shape.iter().product::<usize>() * self.line_size as usize;
+        let rng = StdRng::seed_from_u64(self.pseudo_random_seed());
+        let distribution = Uniform::new_inclusive(-8, 8);
+        let factor = 1.0 / 8.0;
+        distribution
+            .sample_iter(rng)
+            .take(size)
+            .map(|r| F::new(r as f32 * factor))
+            .collect()
+    }
 
-        fn lcg(seed: &mut u64) -> f32 {
-            const A: u64 = 1664525;
-            const C: u64 = 1013904223;
-            const M: f64 = 2u64.pow(32) as f64;
-
-            *seed = (A.wrapping_mul(*seed).wrapping_add(C)) % (1u64 << 32);
-            (*seed as f64 / M * 2.0 - 1.0) as f32
-        }
-
-        let mut seed = 123456789; // Not really important for testing.
-        (0..size).map(|_| F::new(lcg(&mut seed))).collect()
+    // We don't need a fancy crypto-secure seed as this is only for testing.
+    fn pseudo_random_seed(&self) -> u64 {
+        (self.stride.len() * self.shape[0]) as u64 ^ self.cube_dim.num_elems() as u64
     }
 }
 


### PR DESCRIPTION
- Import the shared reduction from Burn.
- Add support for Line operation.
- Implement a bunch of tests (also update the test framework to be robust against the small precision of bf16 and f16)
- Impose that ArgMax and ArgMin always returns the smallest coordinate in case of item equality.