### PR TITLE
Fix errors on system with multiple AMD CDNA GPUs 

### DIFF
--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -69,6 +69,11 @@ fn create_client<M: WmmaCompiler<HipDialect<M>>>(
     assert_eq!(prop_warp_size as u32, arch.warp_size());
 
     unsafe {
+        let status = cubecl_hip_sys::hipSetDevice(device.index as cubecl_hip_sys::hipDevice_t);
+        assert_eq!(status, HIP_SUCCESS, "Should set the default device for the current thread");
+    }
+
+    unsafe {
         let status =
             cubecl_hip_sys::hipCtxCreate(&mut ctx, 0, device.index as cubecl_hip_sys::hipDevice_t);
         assert_eq!(status, HIP_SUCCESS, "Should create the HIP context");

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -64,7 +64,8 @@ fn create_client<M: WmmaCompiler<HipDialect<M>>>(
             .to_str()
             .unwrap();
     };
-    let arch = M::Architecture::from_str(prop_arch_name).unwrap();
+    let normalized_arch_name = prop_arch_name.split(':').next().unwrap_or(prop_arch_name);
+    let arch = M::Architecture::from_str(normalized_arch_name).unwrap();
     assert_eq!(prop_warp_size as u32, arch.warp_size());
 
     unsafe {

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -70,7 +70,10 @@ fn create_client<M: WmmaCompiler<HipDialect<M>>>(
 
     unsafe {
         let status = cubecl_hip_sys::hipSetDevice(device.index as cubecl_hip_sys::hipDevice_t);
-        assert_eq!(status, HIP_SUCCESS, "Should set the default device for the current thread");
+        assert_eq!(
+            status, HIP_SUCCESS,
+            "Should set the default device for the current thread"
+        );
     }
 
     unsafe {


### PR DESCRIPTION
- Normalize HIP architecture from device properties

On some hardware the architecture name can be composed on several parts.
For instance `gfx908:sramecc+:xnack-` on CDNA GPUs.

For now, we just take the firs part of the architecture name to identify the correct
architecture.

- Fix HIP error "DeviceID out of range" on systems with multiple GPUs