### PR TITLE
Pin xtask version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ cfg-if = "1.0.0"
 
 ### For xtask crate ###
 strum = { version = "0.26.3", features = ["derive"] }
-tracel-xtask = { version = "~1.1.6" }
+tracel-xtask = { version = "=1.1.8" }
 
 portable-atomic = { version = "1.9" }
 pretty_assertions = "1.4"


### PR DESCRIPTION
Turns out that maintenance is way better by pining our xtask crate rather than allowing auto-update.