### PR TITLE
Fix constant arrays in SPIR-V

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/constants.rs
+++ b/crates/cubecl-core/src/runtime_tests/constants.rs
@@ -36,7 +36,6 @@ macro_rules! testgen_constants {
         use super::*;
 
         #[test]
-        #[ignore = "Currently fails to compile in wgsl"]
         fn test_constant_array() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::constants::test_constant_array::<TestRuntime>(client);

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/matmul_algorithm.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/matmul_algorithm.rs
@@ -264,8 +264,8 @@ macro_rules! matmul_test_define {
                 fn cube_count(problem: &MatmulProblem) -> CubeCount {
                     let m_stage = S4x4x2::NUM_M * 16;
                     let n_stage = S4x4x2::NUM_N * 16;
-                    let cubes_needed_m = (problem.m as u32 + m_stage - 1) / m_stage;
-                    let cubes_needed_n = (problem.n as u32 + n_stage - 1) / n_stage;
+                    let cubes_needed_m = (problem.m as u32).div_ceil(m_stage);
+                    let cubes_needed_n = (problem.n as u32).div_ceil(n_stage);
 
                     use cubecl_linalg::matmul::components::batch::CubeCountDispatch;
                     batch::TransposedDispatch::cube_count(cubes_needed_m, cubes_needed_n, 1u32)

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -235,6 +235,11 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
 
     fn setup(&mut self, label: Word) -> usize {
         self.begin_block(Some(label)).unwrap();
+
+        for const_arr in self.opt.const_arrays() {
+            self.register_const_array(const_arr);
+        }
+
         let setup_block = self.selected_block().unwrap();
         self.select_block(None).unwrap();
         setup_block

--- a/crates/cubecl-spirv/src/variable.rs
+++ b/crates/cubecl-spirv/src/variable.rs
@@ -563,8 +563,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                 IndexedVariable::Pointer(id, item.clone())
             }
             Variable::ConstantArray(id, item, _) => {
-                let ptr_ty =
-                    Item::Pointer(StorageClass::UniformConstant, Box::new(item.clone())).id(self);
+                let ptr_ty = Item::Pointer(StorageClass::Function, Box::new(item.clone())).id(self);
                 let id = access_chain(self, ptr_ty, None, *id, vec![index_id]).unwrap();
                 IndexedVariable::Pointer(id, item.clone())
             }


### PR DESCRIPTION
Fixes constant arrays for SPIR-V by loading them into a function variable. Uncomments constant array test.