### PR TITLE
Fix find_vectorization broadcasting forline size 1

### DIFF
--- a/crates/cubecl-core/src/frontend/operation/base.rs
+++ b/crates/cubecl-core/src/frontend/operation/base.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU8;
+
 use crate::ir::{
     BinaryOperator, Elem, Instruction, Item, Operation, Operator, UnaryOperator, Variable,
     Vectorization,
@@ -204,13 +206,18 @@ fn find_vectorization(lhs: Vectorization, rhs: Vectorization) -> Vectorization {
         (None, None) => None,
         (None, Some(rhs)) => Some(rhs),
         (Some(lhs), None) => Some(lhs),
-        (Some(lhs), Some(rhs)) if lhs == rhs => Some(lhs),
         (Some(lhs), Some(rhs)) => {
-            panic!(
-                "Left and right have different vectorizations.
-                Left: {lhs}, right: {rhs}.
-                Auto-matching fixed vectorization currently unsupported."
-            );
+            if lhs == rhs {
+                Some(lhs)
+            } else if lhs == NonZeroU8::new(1).unwrap() || rhs == NonZeroU8::new(1).unwrap() {
+                Some(core::cmp::max(lhs, rhs))
+            } else {
+                panic!(
+                    "Left and right have different vectorizations.
+                    Left: {lhs}, right: {rhs}.
+                    Auto-matching fixed vectorization currently unsupported."
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Expand operators would fail for different lhs and rhs line sizes.

In my specific use-case, this was panicking:

```rust
Line::round(value / Line::cast_from(scale))
```
for `value: Line<F>` where `F: Float` and `scale: f32` (so a line size of 1).

When a line size is 1, we can broadcast.