### PR TITLE
Fix include of rocwmma headers when using HIP wmma intrinsic compiler

### DIFF
--- a/crates/cubecl-cpp/src/cuda/dialect.rs
+++ b/crates/cubecl-cpp/src/cuda/dialect.rs
@@ -10,6 +10,10 @@ pub struct CudaDialect<M> {
 impl<M: WmmaCompiler<Self>> WmmaCompiler<Self> for CudaDialect<M> {
     type Architecture = M::Architecture;
 
+    fn wmma_includes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        M::wmma_includes(f)
+    }
+
     fn deftypes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         M::deftypes(f)
     }
@@ -62,10 +66,6 @@ impl<M: WmmaCompiler<Self>> Dialect for CudaDialect<M> {
     }
     fn include_runtime(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("#include <cuda_runtime.h>\n")
-    }
-
-    fn include_wmma(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("#include <mma.h>\n")
     }
 
     fn bfloat16_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/cubecl-cpp/src/cuda/wmma/cuda_compiler.rs
+++ b/crates/cubecl-cpp/src/cuda/wmma/cuda_compiler.rs
@@ -16,6 +16,10 @@ pub struct CudaWmmaCompiler {}
 impl WmmaCompiler<CudaDialect<Self>> for CudaWmmaCompiler {
     type Architecture = CudaArchitecture;
 
+    fn wmma_includes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("#include <mma.h>\n")
+    }
+
     fn deftypes(_f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }

--- a/crates/cubecl-cpp/src/hip/dialect.rs
+++ b/crates/cubecl-cpp/src/hip/dialect.rs
@@ -10,6 +10,10 @@ pub struct HipDialect<M> {
 impl<M: WmmaCompiler<Self>> WmmaCompiler<Self> for HipDialect<M> {
     type Architecture = M::Architecture;
 
+    fn wmma_includes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        M::wmma_includes(f)
+    }
+
     fn deftypes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         M::deftypes(f)
     }
@@ -63,9 +67,6 @@ impl<M: WmmaCompiler<Self>> Dialect for HipDialect<M> {
     }
     fn include_runtime(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("#include <hip/hip_runtime.h>\n")
-    }
-    fn include_wmma(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("#include <rocwmma/rocwmma.hpp>\n")
     }
     fn bfloat16_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("hip_bfloat16")

--- a/crates/cubecl-cpp/src/hip/wmma/intrinsic_compiler.rs
+++ b/crates/cubecl-cpp/src/hip/wmma/intrinsic_compiler.rs
@@ -13,6 +13,11 @@ pub struct WmmaIntrinsicCompiler {}
 impl WmmaCompiler<HipDialect<Self>> for WmmaIntrinsicCompiler {
     type Architecture = AMDArchitecture;
 
+    fn wmma_includes(_f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // nothing to do
+        Ok(())
+    }
+
     fn deftypes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("typedef __bf16 bhalf8_t __attribute__((ext_vector_type(8)));\n")?;
         f.write_str("typedef __bf16 bhalf16_t __attribute__((ext_vector_type(16)));\n")?;

--- a/crates/cubecl-cpp/src/hip/wmma/rocwmma_compiler.rs
+++ b/crates/cubecl-cpp/src/hip/wmma/rocwmma_compiler.rs
@@ -15,6 +15,10 @@ pub struct RocWmmaCompiler {}
 impl WmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
     type Architecture = AMDArchitecture;
 
+    fn wmma_includes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("#include <rocwmma/rocwmma.hpp>\n")
+    }
+
     fn deftypes(_f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Ok(())
     }

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -24,7 +24,6 @@ pub trait Dialect:
     // includes
     fn include_f16(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     fn include_bf16(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
-    fn include_wmma(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     fn include_runtime(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     // types
     fn bfloat16_type_name(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;

--- a/crates/cubecl-cpp/src/shared/kernel.rs
+++ b/crates/cubecl-cpp/src/shared/kernel.rs
@@ -87,7 +87,7 @@ impl<D: Dialect> Display for ComputeKernel<D> {
         }
 
         if self.wmma_activated {
-            D::include_wmma(f)?;
+            D::wmma_includes(f)?;
         }
 
         f.write_str("typedef unsigned char uint8;\n")?;

--- a/crates/cubecl-cpp/src/shared/mma.rs
+++ b/crates/cubecl-cpp/src/shared/mma.rs
@@ -20,6 +20,7 @@ pub trait WmmaCompiler<D: Dialect>:
 {
     type Architecture: Architecture;
 
+    fn wmma_includes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     fn deftypes(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
     fn local_variables(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
 


### PR DESCRIPTION
This reverts commit 6faddf8e04d08a37d2a575d3c2dabfa885e6fcfa and correctly fixes the wmma includes mechanism.