### PR TITLE
Add a macro to insert comments into kernels

### DIFF
--- a/crates/cubecl-core/src/frontend/comment.rs
+++ b/crates/cubecl-core/src/frontend/comment.rs
@@ -1,0 +1,9 @@
+pub mod cube_comment {
+    use crate::{ir::Comment, prelude::CubeContext};
+
+    pub fn expand(context: &mut CubeContext, content: &str) {
+        context.register(Comment {
+            content: content.to_string(),
+        })
+    }
+}

--- a/crates/cubecl-core/src/frontend/mod.rs
+++ b/crates/cubecl-core/src/frontend/mod.rs
@@ -3,6 +3,7 @@ pub mod cmma;
 pub mod synchronization;
 
 mod base;
+mod comment;
 mod const_expand;
 mod container;
 mod context;
@@ -14,6 +15,7 @@ mod plane;
 mod topology;
 
 pub use branch::{range, range_stepped, RangeExpand, SteppedRangeExpand};
+pub use comment::*;
 pub use const_expand::*;
 pub use container::*;
 pub use context::*;

--- a/crates/cubecl-core/src/ir/comment.rs
+++ b/crates/cubecl-core/src/ir/comment.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+
+/// A comment
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[allow(missing_docs)]
+pub struct Comment {
+    pub content: String,
+}
+
+impl Display for Comment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "comment({})", self.content)
+    }
+}

--- a/crates/cubecl-core/src/ir/mod.rs
+++ b/crates/cubecl-core/src/ir/mod.rs
@@ -1,5 +1,6 @@
 mod branch;
 mod cmma;
+mod comment;
 mod debug;
 mod kernel;
 mod local_allocator;
@@ -14,6 +15,7 @@ mod variable;
 pub use super::frontend::AtomicOp;
 pub use branch::*;
 pub use cmma::*;
+pub use comment::*;
 pub use debug::*;
 pub use kernel::*;
 pub use local_allocator::*;

--- a/crates/cubecl-core/src/ir/operation.rs
+++ b/crates/cubecl-core/src/ir/operation.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
-use super::{Branch, CoopMma, DebugInfo, Item, Plane, Scope, Select, Synchronization, Variable};
+use super::{
+    Branch, Comment, CoopMma, DebugInfo, Item, Plane, Scope, Select, Synchronization, Variable,
+};
 use crate::{
     cpa,
     ir::{Elem, UIntKind},
@@ -26,6 +28,7 @@ pub enum Operation {
     Synchronization(Synchronization),
     Plane(Plane),
     CoopMma(CoopMma),
+    Comment(Comment),
     /// Debug instructions, currently only for SPIR-V
     Debug(DebugInfo),
 }
@@ -108,6 +111,7 @@ impl Display for Operation {
             Operation::Plane(plane) => write!(f, "{plane}"),
             Operation::CoopMma(coop_mma) => write!(f, "{coop_mma}"),
             Operation::Copy(variable) => write!(f, "{variable}"),
+            Operation::Comment(comment) => write!(f, "{comment}"),
             // Debug info has no semantic meaning
             Operation::Debug(_) => Ok(()),
         }
@@ -424,6 +428,21 @@ impl From<Synchronization> for Operation {
 
 impl From<Synchronization> for Instruction {
     fn from(value: Synchronization) -> Self {
+        Instruction {
+            out: None,
+            operation: value.into(),
+        }
+    }
+}
+
+impl From<Comment> for Operation {
+    fn from(value: Comment) -> Self {
+        Self::Comment(value)
+    }
+}
+
+impl From<Comment> for Instruction {
+    fn from(value: Comment) -> Self {
         Instruction {
             out: None,
             operation: value.into(),

--- a/crates/cubecl-core/src/ir/processing.rs
+++ b/crates/cubecl-core/src/ir/processing.rs
@@ -316,6 +316,9 @@ impl ScopeProcessing {
                         // Nothing to do.
                     }
                 },
+                Operation::Comment(_) => {
+                    // Nothing to do
+                }
                 Operation::Debug(_) => {}
             });
         self

--- a/crates/cubecl-core/src/prelude.rs
+++ b/crates/cubecl-core/src/prelude.rs
@@ -19,5 +19,5 @@ pub use crate::frontend::{plane_all, plane_max, plane_min, plane_prod, plane_sum
 pub use cubecl_runtime::client::ComputeClient;
 pub use cubecl_runtime::server::CubeCount;
 
-pub use crate::comptime;
 pub use crate::frontend::*;
+pub use crate::{comment, comptime};

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -230,6 +230,9 @@ impl<D: Dialect> CppCompiler<D> {
                 gpu::Synchronization::SyncUnits => instructions.push(Instruction::SyncThreads),
                 gpu::Synchronization::SyncStorage => instructions.push(Instruction::SyncThreads),
             },
+            gpu::Operation::Comment(val) => instructions.push(Instruction::Comment {
+                content: val.content,
+            }),
             gpu::Operation::Plane(op) => {
                 self.warp_size_checked = true;
                 let out = self.compile_variable(out.unwrap());

--- a/crates/cubecl-cpp/src/shared/instruction.rs
+++ b/crates/cubecl-cpp/src/shared/instruction.rs
@@ -177,6 +177,9 @@ pub enum Instruction<D: Dialect> {
         format_string: String,
         args: Vec<Variable<D>>,
     },
+    Comment {
+        content: String,
+    },
 }
 
 impl<D: Dialect> Display for Instruction<D> {
@@ -536,7 +539,14 @@ for ({i_ty} {i} = {start}; {i} {cmp} {end}; {increment}) {{
                     true => "".to_string(),
                     false => format!(", {}", args.join(",")),
                 };
-                writeln!(f, "printf(\"{format_string}\"{args});",)
+                writeln!(f, "printf(\"{format_string}\"{args});")
+            }
+            Instruction::Comment { content } => {
+                if content.contains('\n') {
+                    writeln!(f, "/* {content} */")
+                } else {
+                    writeln!(f, "// {content}")
+                }
             }
         }
     }

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -1,7 +1,8 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
-    AngleBracketedGenericArguments, Ident, Lit, Member, Pat, Path, PathArguments, PathSegment, Type,
+    AngleBracketedGenericArguments, Ident, Lit, LitStr, Member, Pat, Path, PathArguments,
+    PathSegment, Type,
 };
 
 use crate::{
@@ -141,6 +142,9 @@ pub enum Expression {
         const_expr: syn::Expr,
         arms: Vec<ConstMatchArm>,
     },
+    Comment {
+        content: LitStr,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -191,6 +195,7 @@ impl Expression {
             Expression::Keyword { .. } => None,
             Expression::CompilerIntrinsic { .. } => None,
             Expression::ConstMatch { .. } => None,
+            Expression::Comment { .. } => None,
         }
     }
 

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -470,6 +470,10 @@ impl Expression {
                     }
                 }
             }
+            Expression::Comment { content } => {
+                let frontend_path = frontend_path();
+                quote![#frontend_path::cube_comment::expand(context, #content)]
+            }
         }
     }
 }

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -151,6 +151,23 @@ pub fn comptime(input: TokenStream) -> TokenStream {
     quote![{ #tokens }].into()
 }
 
+/// Insert a literal comment into the kernel source code.
+///
+/// # Example
+/// ```ignored
+/// #use cubecl_macros::cube;
+/// #[cube]
+/// fn do_stuff(input: u32) -> u32 {
+///     comment!("Add five to the input");
+///     input + 5
+/// }
+/// ```
+#[proc_macro]
+pub fn comment(input: TokenStream) -> TokenStream {
+    let tokens: proc_macro2::TokenStream = input.into();
+    quote![{ #tokens }].into()
+}
+
 /// Implements display and initialization for autotune keys.
 ///
 /// # Helper

--- a/crates/cubecl-macros/src/parse/statement.rs
+++ b/crates/cubecl-macros/src/parse/statement.rs
@@ -1,5 +1,5 @@
 use quote::{format_ident, quote};
-use syn::{Pat, Stmt, Type, TypeReference};
+use syn::{LitStr, Pat, Stmt, Type, TypeReference};
 
 use crate::{
     expression::Expression,
@@ -52,6 +52,12 @@ impl Statement {
                         expression: Box::new(Expression::Verbatim {
                             tokens: quote![#expand!(context, #args)],
                         }),
+                        terminated: val.semi_token.is_some(),
+                    }
+                } else if val.mac.path.is_ident("comment") {
+                    let content = syn::parse2::<LitStr>(val.mac.tokens)?;
+                    Statement::Expression {
+                        expression: Box::new(Expression::Comment { content }),
                         terminated: val.semi_token.is_some(),
                     }
                 } else {

--- a/crates/cubecl-opt/src/gvn/numbering.rs
+++ b/crates/cubecl-opt/src/gvn/numbering.rs
@@ -117,9 +117,10 @@ impl ValueTable {
             Operation::Operator(operator) => self.create_expr_op(operator, inst.out()),
             Operation::Metadata(metadata) => self.create_expr_meta(metadata, inst.out()),
             Operation::Plane(_) | Operation::Atomic(_) => Err(value_of_var(&inst.out())),
-            Operation::Branch(_) | Operation::Synchronization(_) | Operation::CoopMma(_) => {
-                Err(None)
-            }
+            Operation::Branch(_)
+            | Operation::Synchronization(_)
+            | Operation::CoopMma(_)
+            | Operation::Comment(_) => Err(None),
             Operation::Debug(_) => Err(None),
         }
     }

--- a/crates/cubecl-opt/src/instructions.rs
+++ b/crates/cubecl-opt/src/instructions.rs
@@ -41,7 +41,7 @@ impl Optimizer {
             Operation::Atomic(atomic) => self.visit_atomic(atomic, visit_read),
             Operation::Metadata(meta) => self.visit_meta(meta, visit_read),
             // Sync has no outputs
-            Operation::Synchronization(_) | Operation::Debug(_) => {}
+            Operation::Synchronization(_) | Operation::Debug(_) | Operation::Comment(_) => {}
             Operation::Plane(plane) => self.visit_plane(plane, visit_read),
             Operation::CoopMma(coop_mma) => self.visit_cmma(coop_mma, visit_read),
             Operation::Branch(_) => unreachable!(),

--- a/crates/cubecl-spirv/src/instruction.rs
+++ b/crates/cubecl-spirv/src/instruction.rs
@@ -32,7 +32,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             Operation::Plane(plane) => self.compile_plane(plane, inst.out),
             Operation::Synchronization(sync) => self.compile_sync(sync),
             Operation::CoopMma(cmma) => self.compile_cmma(cmma, inst.out),
-            Operation::Comment(_) => { /* Comment are not supported on spir-v. */ },
+            Operation::Comment(_) => { /* Comment are not supported on spir-v. */ }
             Operation::Debug(debug) => self.compile_debug(debug),
         }
     }

--- a/crates/cubecl-spirv/src/instruction.rs
+++ b/crates/cubecl-spirv/src/instruction.rs
@@ -32,6 +32,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             Operation::Plane(plane) => self.compile_plane(plane, inst.out),
             Operation::Synchronization(sync) => self.compile_sync(sync),
             Operation::CoopMma(cmma) => self.compile_cmma(cmma, inst.out),
+            Operation::Comment(_) => { /* Comment are not supported on spir-v. */ },
             Operation::Debug(debug) => self.compile_debug(debug),
         }
     }

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -548,6 +548,7 @@ impl WgslCompiler {
             cube::Operation::CoopMma(_) => {
                 panic!("Cooperative matrix-multiply and accumulate isn't supported on wgpu.")
             }
+            cube::Operation::Comment(comment) => self.compile_comment(instructions, comment),
             // No good way to attach debug info
             cube::Operation::Debug(_) => {}
         }
@@ -651,6 +652,16 @@ impl WgslCompiler {
                 instructions.push(wgsl::Instruction::StorageBarrier)
             }
         };
+    }
+
+    fn compile_comment(
+        &mut self,
+        instructions: &mut Vec<wgsl::Instruction>,
+        comment: cube::Comment,
+    ) {
+        instructions.push(wgsl::Instruction::Comment {
+            content: comment.content,
+        })
     }
 
     fn compile_metadata(

--- a/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
@@ -360,6 +360,9 @@ pub enum Instruction {
         out_index: Variable,
         len: u32,
     },
+    Comment {
+        content: String,
+    },
 }
 
 impl Display for Instruction {
@@ -908,6 +911,13 @@ for (var {i}: {i_ty} = {start}; {i} {cmp} {end}; {increment}) {{
                 let inputs = inputs.iter().map(|var| var.to_string()).collect::<Vec<_>>();
                 let out = out.fmt_left();
                 writeln!(f, "{out} = {item}({})", inputs.join(", "))
+            }
+            Instruction::Comment { content } => {
+                if content.contains('\n') {
+                    writeln!(f, "/* {content} */")
+                } else {
+                    writeln!(f, "// {content}")
+                }
             }
         }
     }


### PR DESCRIPTION
For example, the following snippet

```rust
#[cube]
#[allow(clippy::manual_div_ceil)]
fn div_ceil(a: u32, b: u32) -> u32 {
    comment!("Hello from the div_ceil function.");
    (a + b - 1) / b
}
```

renders to the following code for a WebGPU kernel

```wgsl
let _14 = l_0_0 / 1u;
let _15 = info[info[8u] + scalars_u32[0]];
// Hello from the div_ceil function.
let _16 = _15 + 1u;
let _17 = _16 - 1u;
let _18 = _17 / 1u;
let _19 = info[info[6u] + scalars_u32[0]];
// Hello from the div_ceil function.
let _20 = _19 + 1u;
let _21 = _20 - 1u;
```

I also added support for multi-line comments which render with`/* comment */` syntax.


