### PR TITLE
Remove HIP context from runtime

### DIFF
--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -34,7 +34,6 @@ pub struct HipServer {
 
 #[derive(Debug)]
 pub(crate) struct HipContext {
-    context: cubecl_hip_sys::hipCtx_t,
     stream: cubecl_hip_sys::hipStream_t,
     memory_management: MemoryManagement<HipStorage>,
     module_names: HashMap<KernelId, HipCompiledKernel>,
@@ -321,13 +320,11 @@ impl HipContext {
         memory_management: MemoryManagement<HipStorage>,
         compilation_options: CompilationOptions,
         stream: cubecl_hip_sys::hipStream_t,
-        context: cubecl_hip_sys::hipCtx_t,
     ) -> Self {
         Self {
             memory_management,
             module_names: HashMap::new(),
             stream,
-            context,
             timestamps: KernelTimestamps::Disabled,
             compilation_options,
         }
@@ -536,9 +533,6 @@ impl HipServer {
     }
 
     fn get_context_with_logger(&mut self) -> (&mut HipContext, &mut DebugLogger) {
-        unsafe {
-            cubecl_hip_sys::hipCtxSetCurrent(self.ctx.context);
-        };
         (&mut self.ctx, &mut self.logger)
     }
 }

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -44,8 +44,6 @@ fn create_client<M: WmmaCompiler<HipDialect<M>>>(
     device: &HipDevice,
     options: RuntimeOptions,
 ) -> ComputeClient<Server, Channel> {
-    let mut ctx: cubecl_hip_sys::hipCtx_t = std::ptr::null_mut();
-
     #[allow(unused_assignments)]
     let mut prop_warp_size = 0;
     #[allow(unused_assignments)]
@@ -74,12 +72,6 @@ fn create_client<M: WmmaCompiler<HipDialect<M>>>(
             "Should set the default device for the current thread"
         );
     }
-
-    unsafe {
-        let status =
-            cubecl_hip_sys::hipCtxCreate(&mut ctx, 0, device.index as cubecl_hip_sys::hipDevice_t);
-        assert_eq!(status, HIP_SUCCESS, "Should create the HIP context");
-    };
 
     let stream = unsafe {
         let mut stream: cubecl_hip_sys::hipStream_t = std::ptr::null_mut();
@@ -126,7 +118,7 @@ fn create_client<M: WmmaCompiler<HipDialect<M>>>(
     let comp_opts = CompilationOptions {
         warp_size: arch.warp_size(),
     };
-    let hip_ctx = HipContext::new(memory_management, comp_opts, stream, ctx);
+    let hip_ctx = HipContext::new(memory_management, comp_opts, stream);
     let server = HipServer::new(hip_ctx);
     ComputeClient::new(MutexComputeChannel::new(server), device_props)
 }


### PR DESCRIPTION
This a deprecated API on AMD platform, just there for CUDA API compatibility.
On AMD platform only set device and stream is necessary.