### PR TITLE
Feat/ virtual tensor

### DIFF
--- a/crates/cubecl-cpp/src/shared/kernel.rs
+++ b/crates/cubecl-cpp/src/shared/kernel.rs
@@ -139,7 +139,11 @@ extern \"C\" __global__ void {}(
             binding_index += 1;
             match binding.vis {
                 Visibility::Read => {
-                    write!(f, "const {}* __restrict__ input_{}", binding.item, index)?;
+                    write!(f, "{} input_{}[]", binding.item, index)?;
+                    // TODO: It breaks slices, because we can't easily create pointer to __restrict__,
+                    // we should have multiple pointer types to enable that optimization.
+                    //
+                    // write!(f, "const {}* __restrict__ input_{}", binding.item, index)?;
                 }
                 Visibility::ReadWrite => {
                     write!(f, "{} input_{}[]", binding.item, index)?;
@@ -161,7 +165,11 @@ extern \"C\" __global__ void {}(
 
             match binding.vis {
                 Visibility::Read => {
-                    write!(f, "const {}* __restrict__ {}", binding.item, name)?;
+                    write!(f, "{} {}[]", binding.item, name)?;
+                    // TODO: It breaks slices, because we can't easily create pointer to __restrict__,
+                    // we should have multiple pointer types to enable that optimization.
+                    //
+                    // write!(f, "const {}* __restrict__ {}", binding.item, name)?;
                 }
                 Visibility::ReadWrite => {
                     write!(f, "{} {}[]", binding.item, name)?;

--- a/crates/cubecl-linalg/src/matmul/components/global/args.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/args.rs
@@ -1,5 +1,6 @@
+use crate::tensor::{VirtualTensorOperations, VirtualTensorOperationsExpand};
 use cubecl::prelude::*;
-use cubecl_core as cubecl;
+use cubecl_core::{self as cubecl};
 
 #[cube]
 /// Arguments for the matrix multiplication algorithm.
@@ -58,6 +59,91 @@ pub enum TensorInputIdent {
 pub struct TensorInput<EG: Numeric, GA: MatmulArgs<EG>> {
     state: *const GA::State,
     ident: TensorInputIdent,
+}
+
+impl<EG: Numeric, MA: MatmulArgs<EG>> VirtualTensorOperations<EG> for TensorInput<EG, MA> {}
+impl<EG: Numeric, MA: MatmulArgs<EG>> VirtualTensorOperations<EG> for TensorOutput<EG, MA> {}
+
+impl<EG: Numeric, MA: MatmulArgs<EG>> VirtualTensorOperationsExpand<EG>
+    for TensorOutputExpand<EG, MA>
+{
+    fn __expand_read_method(
+        &self,
+        _context: &mut CubeContext,
+        _index: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<Line<EG>> {
+        panic!("Can't read output tensor");
+    }
+
+    fn __expand_write_method(
+        &self,
+        context: &mut CubeContext,
+        index: ExpandElementTyped<u32>,
+        value: ExpandElementTyped<Line<EG>>,
+    ) {
+        TensorOutputExpand::__expand_write_method(self.clone(), context, index, value)
+    }
+
+    fn __expand_shape_method(
+        &self,
+        context: &mut CubeContext,
+        axis: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<u32> {
+        TensorOutputExpand::__expand_shape_method(self.clone(), context, axis)
+    }
+
+    fn __expand_stride_method(
+        &self,
+        context: &mut CubeContext,
+        axis: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<u32> {
+        TensorOutputExpand::__expand_stride_method(self.clone(), context, axis)
+    }
+
+    fn __expand_rank_method(&self, context: &mut CubeContext) -> ExpandElementTyped<u32> {
+        TensorOutputExpand::__expand_rank_method(self.clone(), context)
+    }
+}
+
+impl<EG: Numeric, MA: MatmulArgs<EG>> VirtualTensorOperationsExpand<EG>
+    for TensorInputExpand<EG, MA>
+{
+    fn __expand_read_method(
+        &self,
+        context: &mut CubeContext,
+        index: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<Line<EG>> {
+        TensorInputExpand::__expand_read_method(self.clone(), context, index)
+    }
+
+    fn __expand_write_method(
+        &self,
+        _context: &mut CubeContext,
+        _index: ExpandElementTyped<u32>,
+        _value: ExpandElementTyped<Line<EG>>,
+    ) {
+        panic!("Can't write to input tensor");
+    }
+
+    fn __expand_shape_method(
+        &self,
+        context: &mut CubeContext,
+        axis: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<u32> {
+        TensorInputExpand::__expand_shape_method(self.clone(), context, axis)
+    }
+
+    fn __expand_stride_method(
+        &self,
+        context: &mut CubeContext,
+        axis: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<u32> {
+        TensorInputExpand::__expand_stride_method(self.clone(), context, axis)
+    }
+
+    fn __expand_rank_method(&self, context: &mut CubeContext) -> ExpandElementTyped<u32> {
+        TensorInputExpand::__expand_rank_method(self.clone(), context)
+    }
 }
 
 /// Tensor output representation.

--- a/crates/cubecl-linalg/src/matmul/components/global/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/base.rs
@@ -6,8 +6,7 @@ use crate::matmul::components::StageDim;
 use crate::matmul::components::{config::MatmulConfig, tile};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::components::{MatmulKernel, MatmulSpec};
-
-use super::args::{TensorInput, TensorOutput};
+use crate::tensor::{ReadWrite, VirtualTensor};
 
 #[cube]
 /// Provides matrix multiplication operations at the global level.
@@ -52,7 +51,7 @@ pub trait Matmul<MS: MatmulSpec>: 'static + Send + Sync + MatmulKernel<Config: C
 
     /// Initialize the loader for Lhs, starting at row m and column k
     fn init_lhs_loader(
-        lhs: TensorInput<MS::EG, MS::Args>,
+        lhs: VirtualTensor<MS::EG>,
         m_offset: u32,
         k_offset: u32,
         batch_offset: u32,
@@ -61,7 +60,7 @@ pub trait Matmul<MS: MatmulSpec>: 'static + Send + Sync + MatmulKernel<Config: C
 
     /// Initialize the loader for Rhs, starting at row k and column n
     fn init_rhs_loader(
-        rhs: TensorInput<MS::EG, MS::Args>,
+        rhs: VirtualTensor<MS::EG>,
         k_offset: u32,
         n_offset: u32,
         batch_offset: u32,
@@ -70,7 +69,7 @@ pub trait Matmul<MS: MatmulSpec>: 'static + Send + Sync + MatmulKernel<Config: C
 
     /// Initialize the unloader at row m and column n
     fn init_unloader(
-        out: TensorOutput<MS::EG, MS::Args>,
+        out: VirtualTensor<MS::EG, ReadWrite>,
         m_offset: u32,
         n_offset: u32,
         batch_offset: u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/buffer_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/buffer_loading.rs
@@ -1,6 +1,5 @@
 use crate::matmul::components::config::InputIdent;
 use crate::matmul::components::global;
-use crate::matmul::components::global::args::MatmulArgs;
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::Ident;
 use cubecl_core as cubecl;
@@ -13,8 +12,8 @@ pub struct BufferLoading {}
 
 #[cube]
 impl BufferLoading {
-    pub fn load_to_slice<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, G: global::Config>(
-        read_view: &TensorReader<GA, EG>,
+    pub fn load_to_slice<EG: Numeric, ES: Numeric, G: global::Config>(
+        read_view: &TensorReader<EG>,
         buffer_slice: &mut SliceMut<Line<ES>>,
         #[comptime] num_producer_planes: u32,
         #[comptime] producer_plane_offset: u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/base.rs
@@ -1,4 +1,3 @@
-use crate::matmul::components::global::args::{TensorInput, TensorOutput};
 use crate::matmul::components::global::unloader::Unloader;
 use crate::matmul::components::global::{Config as _, Loader};
 use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBufferReader};
@@ -11,6 +10,7 @@ use crate::matmul::components::{stage, MatmulSpec};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::kernels::matmul::AdvancedConfig;
 use crate::matmul::kernels::MatmulAvailabilityError;
+use crate::tensor::{ReadWrite, VirtualTensor};
 
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -37,10 +37,10 @@ where
         RhsReader = RhsBufferReader<MS::ES>,
     >,
 {
-    type LhsLoader = LhsBufferLoader<MS::Args, MS::EG, MS::ES, SMM::Config>;
-    type RhsLoader = RhsBufferLoader<MS::Args, MS::EG, MS::ES, SMM::Config>;
+    type LhsLoader = LhsBufferLoader<MS::EG, MS::ES, SMM::Config>;
+    type RhsLoader = RhsBufferLoader<MS::EG, MS::ES, SMM::Config>;
     type AccumulatorLoader = ZeroAccumulatorLoader;
-    type Out = Unloader<MS::Args, MS::EG>;
+    type Out = Unloader<MS::EG>;
     type Accumulator = SMM::Accumulator;
 
     fn execute(
@@ -135,7 +135,7 @@ where
     }
 
     fn init_lhs_loader(
-        lhs: TensorInput<MS::EG, MS::Args>,
+        lhs: VirtualTensor<MS::EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -145,7 +145,7 @@ where
     }
 
     fn init_rhs_loader(
-        rhs: TensorInput<MS::EG, MS::Args>,
+        rhs: VirtualTensor<MS::EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -155,7 +155,7 @@ where
     }
 
     fn init_unloader(
-        out: TensorOutput<MS::EG, MS::Args>,
+        out: VirtualTensor<MS::EG, ReadWrite>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/loader.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 
 use crate::matmul::components::config::InputIdent;
-use crate::matmul::components::global::args::{MatmulArgs, TensorInput};
 use crate::matmul::components::global::base::Config as _;
 use crate::matmul::components::global::buffered::buffer_loading::BufferLoading;
 use crate::matmul::components::global::buffered::pipelined;
@@ -11,12 +10,13 @@ use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBuffer
 use crate::matmul::components::stage::TilingOrderConfig;
 use crate::matmul::components::stage::{self, Stage};
 use crate::matmul::components::{global, Ident};
+use crate::tensor::VirtualTensor;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[derive(CubeType)]
-pub struct LhsBufferLoader<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config> {
-    pub tensor_view: TensorReader<GA, EG>,
+pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::Config> {
+    pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
     buffer_iter: u32,
     num_buffers: u32,
@@ -24,8 +24,8 @@ pub struct LhsBufferLoader<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stag
 }
 
 #[derive(CubeType)]
-pub struct RhsBufferLoader<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config> {
-    pub tensor_view: TensorReader<GA, EG>,
+pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::Config> {
+    pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
     buffer_iter: u32,
     num_buffers: u32,
@@ -33,13 +33,13 @@ pub struct RhsBufferLoader<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stag
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
-    Loader<EG, ES, pipelined::Config<S>> for LhsBufferLoader<GA, EG, ES, S>
+impl<EG: Numeric, ES: Numeric, S: stage::Config> Loader<EG, ES, pipelined::Config<S>>
+    for LhsBufferLoader<EG, ES, S>
 {
     type StageReader = LhsBufferReader<ES>;
 
     fn fill_stage(this: &mut Self, #[comptime] config: pipelined::Config<S>) {
-        load_buffer::<GA, EG, ES, S>(
+        load_buffer::<EG, ES, S>(
             this.buffer_iter,
             &this.tensor_view,
             &mut this.stage,
@@ -62,11 +62,9 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
-    LhsBufferLoader<GA, EG, ES, S>
-{
+impl<EG: Numeric, ES: Numeric, S: stage::Config> LhsBufferLoader<EG, ES, S> {
     pub fn new(
-        tensor: TensorInput<EG, GA>,
+        tensor: VirtualTensor<EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -75,7 +73,7 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
         let stage = Stage::new::<S>(Ident::Lhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        LhsBufferLoader::<GA, EG, ES, S> {
+        LhsBufferLoader::<EG, ES, S> {
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
@@ -86,13 +84,13 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
-    Loader<EG, ES, pipelined::Config<S>> for RhsBufferLoader<GA, EG, ES, S>
+impl<EG: Numeric, ES: Numeric, S: stage::Config> Loader<EG, ES, pipelined::Config<S>>
+    for RhsBufferLoader<EG, ES, S>
 {
     type StageReader = RhsBufferReader<ES>;
 
     fn fill_stage(this: &mut Self, #[comptime] config: pipelined::Config<S>) {
-        load_buffer::<GA, EG, ES, S>(
+        load_buffer::<EG, ES, S>(
             this.buffer_iter,
             &this.tensor_view,
             &mut this.stage,
@@ -115,11 +113,9 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
-    RhsBufferLoader<GA, EG, ES, S>
-{
+impl<EG: Numeric, ES: Numeric, S: stage::Config> RhsBufferLoader<EG, ES, S> {
     pub fn new(
-        tensor: TensorInput<EG, GA>,
+        tensor: VirtualTensor<EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -128,7 +124,7 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
         let stage = Stage::new::<S>(Ident::Rhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        RhsBufferLoader::<GA, EG, ES, S> {
+        RhsBufferLoader::<EG, ES, S> {
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
@@ -139,9 +135,9 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>
 }
 
 #[cube]
-fn load_buffer<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>(
+fn load_buffer<EG: Numeric, ES: Numeric, S: stage::Config>(
     buffer_iter: u32,
-    tensor_view: &TensorReader<GA, EG>,
+    tensor_view: &TensorReader<EG>,
     stage: &mut Stage<ES>,
     #[comptime] ident: Ident,
     #[comptime] config: pipelined::Config<S>,
@@ -157,7 +153,7 @@ fn load_buffer<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config>(
     let end = start + buffer_num_lines;
     let buffer_slice = &mut stage.as_slice_mut().slice_mut(start, end);
 
-    BufferLoading::load_to_slice::<GA, EG, ES, pipelined::Config<S>>(
+    BufferLoading::load_to_slice::<EG, ES, pipelined::Config<S>>(
         tensor_view,
         buffer_slice,
         config.num_planes(),

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
@@ -1,4 +1,3 @@
-use crate::matmul::components::global::args::{TensorInput, TensorOutput};
 use crate::matmul::components::global::unloader::Unloader;
 use crate::matmul::components::global::{Config as _, Loader};
 use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBufferReader};
@@ -11,6 +10,7 @@ use crate::matmul::components::{stage, MatmulSpec};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::kernels::matmul::AdvancedConfig;
 use crate::matmul::kernels::MatmulAvailabilityError;
+use crate::tensor::{ReadWrite, VirtualTensor};
 
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -39,10 +39,10 @@ where
         RhsReader = RhsBufferReader<MS::ES>,
     >,
 {
-    type LhsLoader = LhsBufferLoader<MS::Args, MS::EG, MS::ES, SMM::Config>;
-    type RhsLoader = RhsBufferLoader<MS::Args, MS::EG, MS::ES, SMM::Config>;
+    type LhsLoader = LhsBufferLoader<MS::EG, MS::ES, SMM::Config>;
+    type RhsLoader = RhsBufferLoader<MS::EG, MS::ES, SMM::Config>;
     type AccumulatorLoader = ZeroAccumulatorLoader;
-    type Out = Unloader<MS::Args, MS::EG>;
+    type Out = Unloader<MS::EG>;
     type Accumulator = SMM::Accumulator;
 
     fn execute(
@@ -102,7 +102,7 @@ where
     }
 
     fn init_lhs_loader(
-        lhs: TensorInput<MS::EG, MS::Args>,
+        lhs: VirtualTensor<MS::EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -119,7 +119,7 @@ where
     }
 
     fn init_rhs_loader(
-        rhs: TensorInput<MS::EG, MS::Args>,
+        rhs: VirtualTensor<MS::EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -136,7 +136,7 @@ where
     }
 
     fn init_unloader(
-        out: TensorOutput<MS::EG, MS::Args>,
+        out: VirtualTensor<MS::EG, ReadWrite>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
@@ -1,4 +1,3 @@
-use crate::matmul::components::global::args::{TensorInput, TensorOutput};
 use crate::matmul::components::global::unloader::Unloader;
 use crate::matmul::components::global::{Config as _, Loader};
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
@@ -11,6 +10,7 @@ use crate::matmul::components::{stage, MatmulSpec};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::kernels::matmul::AdvancedConfig;
 use crate::matmul::kernels::MatmulAvailabilityError;
+use crate::tensor::{ReadWrite, VirtualTensor};
 
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -46,10 +46,10 @@ where
     LL: LoadingStrategy,
     RL: LoadingStrategy,
 {
-    type LhsLoader = LhsLoader<MS::Args, MS::EG, MS::ES, SMM::Config, LL>;
-    type RhsLoader = RhsLoader<MS::Args, MS::EG, MS::ES, SMM::Config, RL>;
+    type LhsLoader = LhsLoader<MS::EG, MS::ES, SMM::Config, LL>;
+    type RhsLoader = RhsLoader<MS::EG, MS::ES, SMM::Config, RL>;
     type AccumulatorLoader = ZeroAccumulatorLoader;
-    type Out = Unloader<MS::Args, MS::EG>;
+    type Out = Unloader<MS::EG>;
     type Accumulator = SMM::Accumulator;
 
     fn execute(
@@ -101,7 +101,7 @@ where
     }
 
     fn init_lhs_loader(
-        lhs: TensorInput<MS::EG, MS::Args>,
+        lhs: VirtualTensor<MS::EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -111,7 +111,7 @@ where
     }
 
     fn init_rhs_loader(
-        rhs: TensorInput<MS::EG, MS::Args>,
+        rhs: VirtualTensor<MS::EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -121,7 +121,7 @@ where
     }
 
     fn init_unloader(
-        out: TensorOutput<MS::EG, MS::Args>,
+        out: VirtualTensor<MS::EG, ReadWrite>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/cyclic_loading.rs
@@ -1,4 +1,3 @@
-use crate::matmul::components::global::args::MatmulArgs;
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::Config;
 use crate::matmul::components::stage::{
@@ -17,8 +16,8 @@ pub struct CyclicLoading {}
 
 #[cube]
 impl LoadingStrategy for CyclicLoading {
-    fn load_to_slice<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, G: Config>(
-        read_view: &TensorReader<GA, EG>,
+    fn load_to_slice<EG: Numeric, ES: Numeric, G: Config>(
+        read_view: &TensorReader<EG>,
         slice: &mut SliceMut<Line<ES>>,
         #[comptime] ident: Ident,
         #[comptime] config: G,

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/loader.rs
@@ -1,51 +1,39 @@
 use std::marker::PhantomData;
 
-use crate::matmul::components::global::args::{MatmulArgs, TensorInput};
 use crate::matmul::components::global::full_load;
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::Loader;
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
 use crate::matmul::components::stage::{self, Stage};
 use crate::matmul::components::{global, Ident};
+use crate::tensor::VirtualTensor;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[derive(CubeType)]
-pub struct LhsLoader<
-    GA: MatmulArgs<EG>,
-    EG: Numeric,
-    ES: Numeric,
-    S: stage::Config,
-    L: LoadingStrategy,
-> {
-    pub tensor_view: TensorReader<GA, EG>,
+pub struct LhsLoader<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy> {
+    pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
     _config: PhantomData<S>,
     _loading: PhantomData<L>,
 }
 
 #[derive(CubeType)]
-pub struct RhsLoader<
-    GA: MatmulArgs<EG>,
-    EG: Numeric,
-    ES: Numeric,
-    S: stage::Config,
-    L: LoadingStrategy,
-> {
-    pub tensor_view: TensorReader<GA, EG>,
+pub struct RhsLoader<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy> {
+    pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
     _config: PhantomData<S>,
     _loading: PhantomData<L>,
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy>
-    Loader<EG, ES, full_load::Config<S>> for LhsLoader<GA, EG, ES, S, L>
+impl<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy>
+    Loader<EG, ES, full_load::Config<S>> for LhsLoader<EG, ES, S, L>
 {
     type StageReader = LhsReader<ES>;
 
     fn fill_stage(this: &mut Self, #[comptime] config: full_load::Config<S>) {
-        L::load_to_slice::<GA, EG, ES, full_load::Config<S>>(
+        L::load_to_slice::<EG, ES, full_load::Config<S>>(
             &this.tensor_view,
             &mut this.stage.as_slice_mut(),
             Ident::Lhs,
@@ -63,11 +51,9 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingS
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy>
-    LhsLoader<GA, EG, ES, S, L>
-{
+impl<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy> LhsLoader<EG, ES, S, L> {
     pub fn new<G: global::Config>(
-        tensor: TensorInput<EG, GA>,
+        tensor: VirtualTensor<EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -76,7 +62,7 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingS
         let stage = Stage::new::<G::SmmConfig>(Ident::Lhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        LhsLoader::<GA, EG, ES, S, L> {
+        LhsLoader::<EG, ES, S, L> {
             tensor_view,
             stage,
             _config: PhantomData::<S>.runtime(),
@@ -86,13 +72,13 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingS
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy>
-    Loader<EG, ES, full_load::Config<S>> for RhsLoader<GA, EG, ES, S, L>
+impl<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy>
+    Loader<EG, ES, full_load::Config<S>> for RhsLoader<EG, ES, S, L>
 {
     type StageReader = RhsReader<ES>;
 
     fn fill_stage(this: &mut Self, #[comptime] config: full_load::Config<S>) {
-        L::load_to_slice::<GA, EG, ES, full_load::Config<S>>(
+        L::load_to_slice::<EG, ES, full_load::Config<S>>(
             &this.tensor_view,
             &mut this.stage.as_slice_mut(),
             Ident::Rhs,
@@ -110,11 +96,9 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingS
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy>
-    RhsLoader<GA, EG, ES, S, L>
-{
+impl<EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingStrategy> RhsLoader<EG, ES, S, L> {
     pub fn new<G: global::Config>(
-        tensor: TensorInput<EG, GA>,
+        tensor: VirtualTensor<EG>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
@@ -123,7 +107,7 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingS
         let stage = Stage::new::<G::SmmConfig>(Ident::Rhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        RhsLoader::<GA, EG, ES, S, L> {
+        RhsLoader::<EG, ES, S, L> {
             tensor_view,
             stage,
             _config: PhantomData::<S>.runtime(),
@@ -134,8 +118,8 @@ impl<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, S: stage::Config, L: LoadingS
 
 #[cube]
 pub trait LoadingStrategy: 'static + Send + Sync + Clone {
-    fn load_to_slice<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, G: global::Config>(
-        read_view: &TensorReader<GA, EG>,
+    fn load_to_slice<EG: Numeric, ES: Numeric, G: global::Config>(
+        read_view: &TensorReader<EG>,
         slice: &mut SliceMut<Line<ES>>,
         #[comptime] ident: Ident,
         #[comptime] config: G,

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/tilewise_loading.rs
@@ -1,4 +1,3 @@
-use crate::matmul::components::global::args::MatmulArgs;
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::Config;
 use crate::matmul::components::stage::{
@@ -17,8 +16,8 @@ pub struct TilewiseLoading {}
 
 #[cube]
 impl LoadingStrategy for TilewiseLoading {
-    fn load_to_slice<MA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, G: Config>(
-        read_view: &TensorReader<MA, EG>,
+    fn load_to_slice<EG: Numeric, ES: Numeric, G: Config>(
+        read_view: &TensorReader<EG>,
         slice: &mut SliceMut<Line<ES>>,
         #[comptime] ident: Ident,
         #[comptime] config: G,

--- a/crates/cubecl-linalg/src/matmul/components/global/tilewise_unloading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tilewise_unloading.rs
@@ -4,8 +4,6 @@ use crate::matmul::components::Ident;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use super::args::MatmulArgs;
-
 #[derive(CubeType)]
 /// Writes the contents of a tile to the tensor view using a single plane,
 /// iterating with steps determined by the plane's dimension.
@@ -13,8 +11,8 @@ pub struct TilewiseUnloading {}
 
 #[cube]
 impl TilewiseUnloading {
-    pub fn unload_from_slice<GA: MatmulArgs<EG>, EG: Numeric, ES: Numeric, G: Config>(
-        write_view: &mut TensorWriter<GA, EG>,
+    pub fn unload_from_slice<EG: Numeric, ES: Numeric, G: Config>(
+        write_view: &mut TensorWriter<EG>,
         slice: Slice<Line<ES>>,
         tile_x: u32,
         tile_y: u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/unloader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/unloader.rs
@@ -1,20 +1,19 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use crate::matmul::components::global;
 use crate::matmul::components::global::tensor_view::TensorWriter;
 use crate::matmul::components::global::tilewise_unloading::TilewiseUnloading;
 use crate::matmul::components::stage::StageWriter;
-
-use super::args::{MatmulArgs, TensorOutput};
+use crate::tensor::ReadWrite;
+use crate::{matmul::components::global, tensor::VirtualTensor};
 
 #[derive(CubeType)]
-pub struct Unloader<GA: MatmulArgs<EG>, EG: Numeric> {
-    pub tensor_view: TensorWriter<GA, EG>,
+pub struct Unloader<EG: Numeric> {
+    pub tensor_view: TensorWriter<EG>,
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric> global::Unloader<EG> for Unloader<GA, EG> {
+impl<EG: Numeric> global::Unloader<EG> for Unloader<EG> {
     type StageWriter = Self;
 
     fn as_stage_writer<G: global::Config>(this: Self) -> Self::StageWriter {
@@ -23,21 +22,21 @@ impl<GA: MatmulArgs<EG>, EG: Numeric> global::Unloader<EG> for Unloader<GA, EG> 
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric> Unloader<GA, EG> {
+impl<EG: Numeric> Unloader<EG> {
     pub fn new(
-        tensor: TensorOutput<EG, GA>,
+        tensor: VirtualTensor<EG, ReadWrite>,
         x_offset: u32,
         y_offset: u32,
         batch_offset: u32,
     ) -> Self {
-        Unloader::<GA, EG> {
+        Unloader::<EG> {
             tensor_view: TensorWriter::new(tensor, x_offset, y_offset, batch_offset),
         }
     }
 }
 
 #[cube]
-impl<GA: MatmulArgs<EG>, EG: Numeric> StageWriter<EG> for Unloader<GA, EG> {
+impl<EG: Numeric> StageWriter<EG> for Unloader<EG> {
     fn write<ES: Numeric, G: global::Config>(
         this: &mut Self,
         slice: Slice<Line<ES>>,
@@ -45,7 +44,7 @@ impl<GA: MatmulArgs<EG>, EG: Numeric> StageWriter<EG> for Unloader<GA, EG> {
         accumulator_offset: u32,
         #[comptime] config: G,
     ) {
-        TilewiseUnloading::unload_from_slice::<GA, EG, ES, G>(
+        TilewiseUnloading::unload_from_slice::<EG, ES, G>(
             &mut this.tensor_view,
             slice,
             compute_plane_offset,

--- a/crates/cubecl-linalg/src/tensor/mod.rs
+++ b/crates/cubecl-linalg/src/tensor/mod.rs
@@ -1,7 +1,9 @@
 mod base;
 mod contiguous;
 mod layout;
+mod r#virtual;
 
 pub use base::*;
 pub use contiguous::*;
 pub use layout::*;
+pub use r#virtual::*;

--- a/crates/cubecl-linalg/src/tensor/virtual.rs
+++ b/crates/cubecl-linalg/src/tensor/virtual.rs
@@ -2,23 +2,22 @@ use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, unexpanded};
 use std::{marker::PhantomData, sync::Arc};
 
+/// The read tag for [virtual tensor](VirtualTensor).
 #[derive(Clone)]
 pub struct Read;
+
+/// The read write tag for [virtual tensor](VirtualTensor).
 #[derive(Clone)]
 pub struct ReadWrite;
 
+/// Tensor representation that is decoupled from how the tensor is stored.
 #[derive(Clone)]
 pub struct VirtualTensor<E: Numeric, IO = Read> {
     state: Arc<dyn VirtualTensorOperations<E>>,
     _p: PhantomData<IO>,
 }
 
-impl<E: Numeric, IO: Clone> IntoRuntime for VirtualTensor<E, IO> {
-    fn __expand_runtime_method(self, _context: &mut CubeContext) -> Self::ExpandType {
-        panic!("Virtual tensor don't exist at comptime")
-    }
-}
-
+/// Expand type for [VirtualTensor].
 #[derive(Clone)]
 pub struct VirtualTensorExpand<E: Numeric, IO> {
     state: Arc<dyn VirtualTensorOperationsExpand<E>>,
@@ -27,15 +26,22 @@ pub struct VirtualTensorExpand<E: Numeric, IO> {
 
 #[cube]
 impl<E: Numeric, IO: Clone> VirtualTensor<E, IO> {
+    /// Read the tensor at the given index.
     pub fn read(&self, index: u32) -> Line<E> {
         self.state.read(index)
     }
+
+    /// Get the shape of the tensor at the given axis.
     pub fn shape(&self, axis: u32) -> u32 {
         self.state.shape(axis)
     }
+
+    /// Get the stride of the tensor at the given axis.
     pub fn stride(&self, axis: u32) -> u32 {
         self.state.stride(axis)
     }
+
+    /// Get the rank of the tensor.
     pub fn rank(&self) -> u32 {
         self.state.rank()
     }
@@ -43,17 +49,19 @@ impl<E: Numeric, IO: Clone> VirtualTensor<E, IO> {
 
 #[cube]
 impl<E: Numeric> VirtualTensor<E, ReadWrite> {
-    /// Read the tensor at the given index.
+    /// Write the tensor at the given index.
     pub fn write(&mut self, index: u32, value: Line<E>) {
         self.state.write(index, value)
     }
 }
 
 impl<E: Numeric> VirtualTensor<E, Read> {
+    /// Create a new [read only](Read) [virtual tensor](VirtualTensor).
     pub fn new<V: VirtualTensorOperations<E> + 'static>(_v: &V) -> Self {
         unexpanded!()
     }
 
+    /// Expand function of [Self::new].
     pub fn __expand_new<V>(
         _context: &mut CubeContext,
         v: V::ExpandType,
@@ -70,10 +78,12 @@ impl<E: Numeric> VirtualTensor<E, Read> {
 }
 
 impl<E: Numeric> VirtualTensor<E, ReadWrite> {
+    /// Create a new [read write](ReadWrite) [virtual tensor](VirtualTensor).
     pub fn new<V: VirtualTensorOperations<E> + 'static>(_v: &mut V) -> Self {
         unexpanded!()
     }
 
+    /// Expand function of [Self::new].
     pub fn __expand_new<V>(
         _context: &mut CubeContext,
         v: V::ExpandType,
@@ -89,37 +99,42 @@ impl<E: Numeric> VirtualTensor<E, ReadWrite> {
     }
 }
 
-impl<E: Numeric, IO: Clone> CubeType for VirtualTensor<E, IO> {
-    type ExpandType = VirtualTensorExpand<E, IO>;
-}
-
+/// Trait to be implemented by a type that can become a [virtual tensor](VirtualTensor).
+///
+/// The [expand trait](VirtualTensorOperationsExpand) also need to be implemented for the type's
+/// expand type.
+///
+/// # Warning
+///
+/// This trait is kind of unsafe, [VirtualTensorOperations::write] doesn't follow the mutability
+/// rules, but it won't lead to any undefined behavior.
 pub trait VirtualTensorOperations<E: Numeric> {
     /// Read the tensor at the given index.
     fn read(&self, _index: u32) -> Line<E> {
         unexpanded!()
     }
-
     /// Write the tensor at the given index.
     fn write(&self, _index: u32, _value: Line<E>) {
         unexpanded!()
     }
-
     /// Get the shape of the tensor at the given axis.
     fn shape(&self, _axis: u32) -> u32 {
         unexpanded!()
     }
-
     /// Get the stride of the tensor at the given axis.
     fn stride(&self, _axis: u32) -> u32 {
         unexpanded!()
     }
-
     /// Get the rank of the tensor.
     fn rank(&self) -> u32 {
         unexpanded!()
     }
 }
 
+/// Expand trait for [VirtualTensorOperations].
+///
+/// For now this needs to be manually implemented for any type that needs to become a virtual
+/// tensor.
 pub trait VirtualTensorOperationsExpand<E: Numeric> {
     fn __expand_read_method(
         &self,
@@ -145,49 +160,69 @@ pub trait VirtualTensorOperationsExpand<E: Numeric> {
     fn __expand_rank_method(&self, context: &mut CubeContext) -> ExpandElementTyped<u32>;
 }
 
-impl<E: Numeric, IO> Init for VirtualTensorExpand<E, IO> {
-    fn init(self, _context: &mut CubeContext) -> Self {
-        self
+/// Making [virtual tensors](VirtualTensor) a proper [cube type](CubeType).
+mod __cube_type {
+    use super::*;
+
+    impl<E: Numeric, IO: Clone> CubeType for VirtualTensor<E, IO> {
+        type ExpandType = VirtualTensorExpand<E, IO>;
+    }
+
+    impl<E: Numeric, IO> Init for VirtualTensorExpand<E, IO> {
+        fn init(self, _context: &mut CubeContext) -> Self {
+            self
+        }
+    }
+
+    impl<E: Numeric, IO: Clone> IntoRuntime for VirtualTensor<E, IO> {
+        fn __expand_runtime_method(self, _context: &mut CubeContext) -> Self::ExpandType {
+            panic!("Virtual tensors don't exist at comptime.")
+        }
     }
 }
 
-impl<E: Numeric> VirtualTensorOperations<E> for Tensor<Line<E>> {}
-impl<E: Numeric> VirtualTensorOperationsExpand<E> for ExpandElementTyped<Tensor<Line<E>>> {
-    fn __expand_read_method(
-        &self,
-        context: &mut CubeContext,
-        index: ExpandElementTyped<u32>,
-    ) -> ExpandElementTyped<Line<E>> {
-        self.clone().__expand_index_unchecked_method(context, index)
-    }
+/// Enable tensors to be virtual.
+mod __tensor {
+    use super::*;
 
-    fn __expand_write_method(
-        &self,
-        context: &mut CubeContext,
-        index: ExpandElementTyped<u32>,
-        value: ExpandElementTyped<Line<E>>,
-    ) {
-        self.clone()
-            .__expand_index_assign_unchecked_method(context, index, value)
-    }
+    impl<E: Numeric> VirtualTensorOperations<E> for Tensor<Line<E>> {}
+    impl<E: Numeric> VirtualTensorOperationsExpand<E> for ExpandElementTyped<Tensor<Line<E>>> {
+        fn __expand_read_method(
+            &self,
+            context: &mut CubeContext,
+            index: ExpandElementTyped<u32>,
+        ) -> ExpandElementTyped<Line<E>> {
+            self.clone().__expand_index_unchecked_method(context, index)
+        }
 
-    fn __expand_shape_method(
-        &self,
-        context: &mut CubeContext,
-        axis: ExpandElementTyped<u32>,
-    ) -> ExpandElementTyped<u32> {
-        self.clone().__expand_shape_method(context, axis)
-    }
+        fn __expand_write_method(
+            &self,
+            context: &mut CubeContext,
+            index: ExpandElementTyped<u32>,
+            value: ExpandElementTyped<Line<E>>,
+        ) {
+            self.clone()
+                .__expand_index_assign_unchecked_method(context, index, value)
+        }
 
-    fn __expand_stride_method(
-        &self,
-        context: &mut CubeContext,
-        axis: ExpandElementTyped<u32>,
-    ) -> ExpandElementTyped<u32> {
-        self.clone().__expand_stride_method(context, axis)
-    }
+        fn __expand_shape_method(
+            &self,
+            context: &mut CubeContext,
+            axis: ExpandElementTyped<u32>,
+        ) -> ExpandElementTyped<u32> {
+            self.clone().__expand_shape_method(context, axis)
+        }
 
-    fn __expand_rank_method(&self, context: &mut CubeContext) -> ExpandElementTyped<u32> {
-        self.clone().__expand_rank_method(context)
+        fn __expand_stride_method(
+            &self,
+            context: &mut CubeContext,
+            axis: ExpandElementTyped<u32>,
+        ) -> ExpandElementTyped<u32> {
+            self.clone().__expand_stride_method(context, axis)
+        }
+
+        fn __expand_rank_method(&self, context: &mut CubeContext) -> ExpandElementTyped<u32> {
+            self.clone().__expand_rank_method(context)
+        }
     }
 }

--- a/crates/cubecl-linalg/src/tensor/virtual.rs
+++ b/crates/cubecl-linalg/src/tensor/virtual.rs
@@ -50,7 +50,7 @@ impl<E: Numeric> VirtualTensor<E, ReadWrite> {
 }
 
 impl<E: Numeric> VirtualTensor<E, Read> {
-    pub fn new<V: VirtualTensorOperations<E> + 'static>(v: &V) -> Self {
+    pub fn new<V: VirtualTensorOperations<E> + 'static>(_v: &V) -> Self {
         unexpanded!()
     }
 
@@ -70,7 +70,7 @@ impl<E: Numeric> VirtualTensor<E, Read> {
 }
 
 impl<E: Numeric> VirtualTensor<E, ReadWrite> {
-    pub fn new<V: VirtualTensorOperations<E> + 'static>(v: &mut V) -> Self {
+    pub fn new<V: VirtualTensorOperations<E> + 'static>(_v: &mut V) -> Self {
         unexpanded!()
     }
 

--- a/crates/cubecl-linalg/src/tensor/virtual.rs
+++ b/crates/cubecl-linalg/src/tensor/virtual.rs
@@ -1,0 +1,193 @@
+use cubecl::prelude::*;
+use cubecl_core::{self as cubecl, unexpanded};
+use std::{marker::PhantomData, sync::Arc};
+
+#[derive(Clone)]
+pub struct Read;
+#[derive(Clone)]
+pub struct ReadWrite;
+
+#[derive(Clone)]
+pub struct VirtualTensor<E: Numeric, IO = Read> {
+    state: Arc<dyn VirtualTensorOperations<E>>,
+    _p: PhantomData<IO>,
+}
+
+impl<E: Numeric, IO: Clone> IntoRuntime for VirtualTensor<E, IO> {
+    fn __expand_runtime_method(self, _context: &mut CubeContext) -> Self::ExpandType {
+        panic!("Virtual tensor don't exist at comptime")
+    }
+}
+
+#[derive(Clone)]
+pub struct VirtualTensorExpand<E: Numeric, IO> {
+    state: Arc<dyn VirtualTensorOperationsExpand<E>>,
+    _p: PhantomData<IO>,
+}
+
+#[cube]
+impl<E: Numeric, IO: Clone> VirtualTensor<E, IO> {
+    pub fn read(&self, index: u32) -> Line<E> {
+        self.state.read(index)
+    }
+    pub fn shape(&self, axis: u32) -> u32 {
+        self.state.shape(axis)
+    }
+    pub fn stride(&self, axis: u32) -> u32 {
+        self.state.stride(axis)
+    }
+    pub fn rank(&self) -> u32 {
+        self.state.rank()
+    }
+}
+
+#[cube]
+impl<E: Numeric> VirtualTensor<E, ReadWrite> {
+    /// Read the tensor at the given index.
+    pub fn write(&mut self, index: u32, value: Line<E>) {
+        self.state.write(index, value)
+    }
+}
+
+impl<E: Numeric> VirtualTensor<E, Read> {
+    pub fn new<V: VirtualTensorOperations<E> + 'static>(v: &V) -> Self {
+        unexpanded!()
+    }
+
+    pub fn __expand_new<V>(
+        _context: &mut CubeContext,
+        v: V::ExpandType,
+    ) -> VirtualTensorExpand<E, Read>
+    where
+        V::ExpandType: VirtualTensorOperationsExpand<E>,
+        V: VirtualTensorOperations<E> + CubeType + 'static,
+    {
+        VirtualTensorExpand {
+            state: Arc::new(v),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<E: Numeric> VirtualTensor<E, ReadWrite> {
+    pub fn new<V: VirtualTensorOperations<E> + 'static>(v: &mut V) -> Self {
+        unexpanded!()
+    }
+
+    pub fn __expand_new<V>(
+        _context: &mut CubeContext,
+        v: V::ExpandType,
+    ) -> VirtualTensorExpand<E, ReadWrite>
+    where
+        V::ExpandType: VirtualTensorOperationsExpand<E>,
+        V: VirtualTensorOperations<E> + CubeType + 'static,
+    {
+        VirtualTensorExpand {
+            state: Arc::new(v),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<E: Numeric, IO: Clone> CubeType for VirtualTensor<E, IO> {
+    type ExpandType = VirtualTensorExpand<E, IO>;
+}
+
+pub trait VirtualTensorOperations<E: Numeric> {
+    /// Read the tensor at the given index.
+    fn read(&self, _index: u32) -> Line<E> {
+        unexpanded!()
+    }
+
+    /// Write the tensor at the given index.
+    fn write(&self, _index: u32, _value: Line<E>) {
+        unexpanded!()
+    }
+
+    /// Get the shape of the tensor at the given axis.
+    fn shape(&self, _axis: u32) -> u32 {
+        unexpanded!()
+    }
+
+    /// Get the stride of the tensor at the given axis.
+    fn stride(&self, _axis: u32) -> u32 {
+        unexpanded!()
+    }
+
+    /// Get the rank of the tensor.
+    fn rank(&self) -> u32 {
+        unexpanded!()
+    }
+}
+
+pub trait VirtualTensorOperationsExpand<E: Numeric> {
+    fn __expand_read_method(
+        &self,
+        context: &mut CubeContext,
+        index: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<Line<E>>;
+    fn __expand_write_method(
+        &self,
+        context: &mut CubeContext,
+        index: ExpandElementTyped<u32>,
+        value: ExpandElementTyped<Line<E>>,
+    );
+    fn __expand_shape_method(
+        &self,
+        context: &mut CubeContext,
+        axis: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<u32>;
+    fn __expand_stride_method(
+        &self,
+        context: &mut CubeContext,
+        axis: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<u32>;
+    fn __expand_rank_method(&self, context: &mut CubeContext) -> ExpandElementTyped<u32>;
+}
+
+impl<E: Numeric, IO> Init for VirtualTensorExpand<E, IO> {
+    fn init(self, _context: &mut CubeContext) -> Self {
+        self
+    }
+}
+
+impl<E: Numeric> VirtualTensorOperations<E> for Tensor<Line<E>> {}
+impl<E: Numeric> VirtualTensorOperationsExpand<E> for ExpandElementTyped<Tensor<Line<E>>> {
+    fn __expand_read_method(
+        &self,
+        context: &mut CubeContext,
+        index: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<Line<E>> {
+        self.clone().__expand_index_unchecked_method(context, index)
+    }
+
+    fn __expand_write_method(
+        &self,
+        context: &mut CubeContext,
+        index: ExpandElementTyped<u32>,
+        value: ExpandElementTyped<Line<E>>,
+    ) {
+        self.clone()
+            .__expand_index_assign_unchecked_method(context, index, value)
+    }
+
+    fn __expand_shape_method(
+        &self,
+        context: &mut CubeContext,
+        axis: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<u32> {
+        self.clone().__expand_shape_method(context, axis)
+    }
+
+    fn __expand_stride_method(
+        &self,
+        context: &mut CubeContext,
+        axis: ExpandElementTyped<u32>,
+    ) -> ExpandElementTyped<u32> {
+        self.clone().__expand_stride_method(context, axis)
+    }
+
+    fn __expand_rank_method(&self, context: &mut CubeContext) -> ExpandElementTyped<u32> {
+        self.clone().__expand_rank_method(context)
+    }
+}


### PR DESCRIPTION
Added a virtual tensor type so that we don't have to carry the `MatmulArgs` trait in all matmul components, since it makes it really really hard to reuse those components in other kernels that don't have the same arguments.