### PR TITLE
Fix for optimizer panic in some matmul kernels

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/index.rs
+++ b/crates/cubecl-core/src/runtime_tests/index.rs
@@ -1,4 +1,4 @@
-use crate as cubecl;
+use crate::{self as cubecl, as_type};
 
 use cubecl::prelude::*;
 
@@ -10,18 +10,18 @@ pub fn kernel_assign<F: Float>(output: &mut Array<F>) {
         output[0] = item;
 
         // out of bounds write should not show up in the array.
-        output[2] = F::new(10.0);
+        output[3] = F::new(10.0);
 
         // out of bounds read should be read as 0.
-        output[1] = output[2];
+        output[1] = output[3];
     }
 }
 
 pub fn test_kernel_index_scalar<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    let handle = client.create(F::as_bytes(&[F::new(0.0), F::new(1.0), F::new(123.0)]));
-    let handle_slice = handle.clone().offset_end(1);
+    let handle = client.create(F::as_bytes(as_type![F: 0.0, 1.0, 123.0, 6.0]));
+    let handle_slice = handle.clone().offset_end(F::as_elem().size() as u64);
     let vectorization = 1;
 
     kernel_assign::launch::<F, R>(

--- a/crates/cubecl-opt/src/gvn/base.rs
+++ b/crates/cubecl-opt/src/gvn/base.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use cubecl_core::{
     ir::{Builtin, ConstantScalarValue, Elem, FloatKind, IntKind, Item, UIntKind},
@@ -8,6 +8,7 @@ use float_ord::FloatOrd;
 use petgraph::{
     algo::dominators::{self, Dominators},
     graph::NodeIndex,
+    visit::{DfsPostOrder, Walker as _},
 };
 use smallvec::SmallVec;
 
@@ -44,7 +45,16 @@ impl GvnPass {
         self.eliminate(opt, changes);
     }
 
-    fn build_dominators(&mut self, opt: &Optimizer) {
+    fn build_dominators(&mut self, opt: &mut Optimizer) {
+        let post_order = DfsPostOrder::new(&opt.program.graph, opt.entry())
+            .iter(&opt.program.graph)
+            .collect::<Vec<_>>();
+        for node in opt.node_ids() {
+            if !post_order.contains(&node) {
+                opt.program.remove_node(node);
+            }
+        }
+
         self.dominators = dominators::simple_fast(&opt.program.graph, opt.entry());
         let mut rev_graph = opt.program.graph.clone();
         rev_graph.reverse();

--- a/crates/cubecl-opt/src/gvn/base.rs
+++ b/crates/cubecl-opt/src/gvn/base.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use cubecl_core::{
     ir::{Builtin, ConstantScalarValue, Elem, FloatKind, IntKind, Item, UIntKind},

--- a/crates/cubecl-spirv/src/debug.rs
+++ b/crates/cubecl-spirv/src/debug.rs
@@ -437,23 +437,23 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             for inlined_at in &debug_info.definitions.inlined_at {
                 self.declare_inlined_at(inlined_at);
             }
-        }
 
-        // Declare entry
-        let entry_name = self.debug_info().name_str.clone();
-        let entry_def = self.definitions().functions[&entry_name];
-        let args = self.debug_string("");
-        let signature = self.debug_string(SIGNATURE);
-        self.void_debug(
-            None,
-            Instructions::DebugEntryPoint,
-            [
-                entry_def.id,
-                entry_def.source.compilation_unit,
-                signature,
-                args,
-            ],
-        );
+            // Declare entry
+            let entry_name = self.debug_info().name_str.clone();
+            let entry_def = self.definitions().functions[&entry_name];
+            let args = self.debug_string("");
+            let signature = self.debug_string(SIGNATURE);
+            self.void_debug(
+                None,
+                Instructions::DebugEntryPoint,
+                [
+                    entry_def.id,
+                    entry_def.source.compilation_unit,
+                    signature,
+                    args,
+                ],
+            );
+        }
     }
 
     fn declare_debug_function(&mut self, function: &FunctionDefinition) {


### PR DESCRIPTION
Fixes an optimizer panic in one of the variants of tiling matmul. This was caused by unreachable loops (after eliminating a constant branch) incorrectly being treated as reachable because every node had a predecessor (from the end of the loop). It's a very quick and dirty fix while I work on refactoring the optimizer to be more maintainable.