### PR TITLE
Check for CUDA distribution installation.

### DIFF
--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -469,6 +469,10 @@ fn cuda_path() -> Option<PathBuf> {
 
     #[cfg(target_os = "linux")]
     {
+        // If it is installed as part of the distribution
+        if std::fs::metadata("/usr/bin/nvcc").is_ok() {
+            return Some(PathBuf::from("/usr"));
+        }
         return Some(PathBuf::from("/usr/local/cuda"));
     }
 


### PR DESCRIPTION
In case CUDA is installed by distro packages in the installation check the path of CUDA compiler and return /usr/include path.