### PR TITLE
[Feat] Rework allocator

### DIFF
--- a/crates/cubecl-core/src/codegen/compiler.rs
+++ b/crates/cubecl-core/src/codegen/compiler.rs
@@ -1,4 +1,4 @@
-use crate::ir::{Allocator, Elem, KernelDefinition};
+use crate::ir::{Elem, KernelDefinition};
 use cubecl_runtime::ExecutionMode;
 use std::fmt::Display;
 
@@ -22,7 +22,6 @@ pub trait Compiler: Sync + Send + 'static + Clone + Default + core::fmt::Debug {
     ) -> Self::Representation;
     /// The size of the given element in bytes.
     fn elem_size(elem: Elem) -> usize;
-    fn local_allocator() -> Allocator;
     /// The maximal size of a shared memory, in bytes
     fn max_shared_memory_size() -> usize;
 }

--- a/crates/cubecl-core/src/compute/builder.rs
+++ b/crates/cubecl-core/src/compute/builder.rs
@@ -1,4 +1,4 @@
-use crate::ir::{Allocator, Elem, Item, Visibility};
+use crate::ir::{Elem, Id, Item, Visibility};
 use crate::prelude::KernelDefinition;
 use crate::KernelSettings;
 use crate::{
@@ -14,8 +14,8 @@ pub struct KernelBuilder {
     inputs: Vec<InputInfo>,
     outputs: Vec<OutputInfo>,
     indices: HashMap<Elem, usize>,
-    num_input: u16,
-    num_output: u16,
+    num_input: Id,
+    num_output: Id,
 }
 
 impl KernelBuilder {
@@ -25,7 +25,7 @@ impl KernelBuilder {
             Some(index) => match self.inputs.get_mut(*index).unwrap() {
                 InputInfo::Scalar { elem: _, size } => {
                     *size += 1;
-                    *size as u16 - 1
+                    *size as Id - 1
                 }
                 _ => panic!("Should be a scalar."),
             },
@@ -76,7 +76,7 @@ impl KernelBuilder {
     }
 
     /// Register an output that uses the same resource as the input as the given position.
-    pub fn inplace_output(&mut self, position: u16) -> ExpandElement {
+    pub fn inplace_output(&mut self, position: Id) -> ExpandElement {
         let input = self
             .inputs
             .get_mut(position as usize)
@@ -117,9 +117,9 @@ impl KernelBuilder {
         .integrate(settings)
     }
 
-    pub fn with_local_allocator(allocator: Allocator) -> Self {
+    pub fn new() -> Self {
         Self {
-            context: CubeContext::root(allocator),
+            context: CubeContext::root(),
             inputs: Vec::new(),
             outputs: Vec::new(),
             indices: HashMap::new(),
@@ -131,6 +131,6 @@ impl KernelBuilder {
 
 impl Default for KernelBuilder {
     fn default() -> Self {
-        Self::with_local_allocator(Allocator::new())
+        Self::new()
     }
 }

--- a/crates/cubecl-core/src/frontend/cmma.rs
+++ b/crates/cubecl-core/src/frontend/cmma.rs
@@ -433,7 +433,7 @@ pub mod cast {
         }
         let input = *input.elem;
         let input_mat = match input.kind {
-            ir::VariableKind::Matrix { id, mat, depth } => mat,
+            ir::VariableKind::Matrix { mat, .. } => mat,
             _ => unreachable!(),
         };
 

--- a/crates/cubecl-core/src/frontend/container/array/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/array/launch.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     compute::{KernelBuilder, KernelLauncher},
-    ir::{Item, Vectorization},
+    ir::{Id, Item, Vectorization},
     prelude::{
         ArgSettings, CompilationArg, CubePrimitive, ExpandElementTyped, LaunchArg, LaunchArgExpand,
         TensorHandleRef,
@@ -16,7 +16,7 @@ use super::Array;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub struct ArrayCompilationArg {
-    pub inplace: Option<u16>,
+    pub inplace: Option<Id>,
     pub vectorisation: Vectorization,
 }
 
@@ -166,7 +166,7 @@ impl<C: CubePrimitive> LaunchArg for Array<C> {
                 vectorisation: Vectorization::Some(NonZero::new(*vectorization_factor).unwrap()),
             },
             ArrayArg::Alias { input_pos } => ArrayCompilationArg {
-                inplace: Some(*input_pos as u16),
+                inplace: Some(*input_pos as Id),
                 vectorisation: Vectorization::None,
             },
         }

--- a/crates/cubecl-core/src/frontend/container/tensor/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/launch.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     compute::{KernelBuilder, KernelLauncher},
-    ir::{Item, Vectorization},
+    ir::{Id, Item, Vectorization},
     prelude::{
         ArgSettings, CompilationArg, CubePrimitive, ExpandElementTyped, LaunchArg, LaunchArgExpand,
     },
@@ -59,7 +59,7 @@ impl<R: Runtime> core::fmt::Debug for TensorHandleRef<'_, R> {
 /// Compilation argument for a [tensor](Tensor).
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub struct TensorCompilationArg {
-    pub inplace: Option<u16>,
+    pub inplace: Option<Id>,
     pub vectorisation: Vectorization,
 }
 
@@ -108,7 +108,7 @@ impl<C: CubePrimitive> LaunchArg for Tensor<C> {
                 vectorisation: Vectorization::Some(NonZero::new(*vectorization_factor).unwrap()),
             },
             TensorArg::Alias { input_pos } => TensorCompilationArg {
-                inplace: Some(*input_pos as u16),
+                inplace: Some(*input_pos as Id),
                 vectorisation: Vectorization::None,
             },
         }

--- a/crates/cubecl-core/src/frontend/operation/base.rs
+++ b/crates/cubecl-core/src/frontend/operation/base.rs
@@ -252,7 +252,7 @@ pub fn array_assign_binary_op_expand<
         *array_value,
     );
     let array_value = array_value.consume();
-    let op_out = context.create_local(array.item);
+    let op_out = context.create_local(array_item);
     let calculate = Instruction::new(
         func(BinaryOperator {
             lhs: array_value,

--- a/crates/cubecl-core/src/ir/allocator.rs
+++ b/crates/cubecl-core/src/ir/allocator.rs
@@ -41,15 +41,15 @@ impl PartialEq for Allocator {
 }
 
 impl Allocator {
-    /// Create a new immutable local variable of type specified by `item` for the given `scope`.
+    /// Create a new immutable local variable of type specified by `item`.
     pub fn create_local(&self, item: Item) -> ExpandElement {
         let id = self.new_local_index();
         let local = VariableKind::LocalConst { id };
         ExpandElement::Plain(Variable::new(local, item))
     }
 
-    /// Create a new mutable local variable of type specified by `item` for the given `scope`.
-    /// Try to reuse a previously defined but unused mutable variable in the current scope if possible.
+    /// Create a new mutable local variable of type specified by `item`.
+    /// Try to reuse a previously defined but unused mutable variable if possible.
     /// Else, this define a new variable.
     pub fn create_local_mut(&self, item: Item) -> ExpandElement {
         if item.elem.is_atomic() {
@@ -60,7 +60,7 @@ impl Allocator {
         }
     }
 
-    /// Create a new mutable restricted local variable of type specified by `item` into the given `scope`.
+    /// Create a new mutable restricted local variable of type specified by `item`.
     pub fn create_local_restricted(&self, item: Item) -> ExpandElement {
         let id = self.new_local_index();
         let local = VariableKind::LocalMut { id };
@@ -122,14 +122,5 @@ impl Allocator {
 
     pub fn new_local_index(&self) -> u32 {
         self.next_id.fetch_add(1, Ordering::Release)
-    }
-
-    pub fn managed_locals(&self) -> Vec<Variable> {
-        self.local_mut_pool
-            .borrow()
-            .values()
-            .flatten()
-            .map(|it| **it)
-            .collect()
     }
 }

--- a/crates/cubecl-core/src/ir/allocator.rs
+++ b/crates/cubecl-core/src/ir/allocator.rs
@@ -1,8 +1,13 @@
-use std::{collections::HashMap, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    rc::Rc,
+    sync::atomic::{AtomicU32, Ordering},
+};
 
 use crate::prelude::ExpandElement;
 
-use super::{Item, Scope, Variable};
+use super::{Item, Matrix, Variable, VariableKind};
 
 /// An allocator for local variables of a kernel.
 ///
@@ -22,52 +27,80 @@ use super::{Item, Scope, Variable};
 /// That is, each variable must be declared and used exactly once.
 ///
 /// [static single-assignment](https://en.wikipedia.org/wiki/Static_single-assignment_form)
-#[derive(Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct Allocator {
-    local_mut_pool: HashMap<Item, Vec<ExpandElement>>,
+    local_mut_pool: Rc<RefCell<HashMap<Item, Vec<ExpandElement>>>>,
+    next_id: Rc<AtomicU32>,
 }
 
-impl Default for Allocator {
-    fn default() -> Self {
-        Self::new()
+impl PartialEq for Allocator {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.local_mut_pool, &other.local_mut_pool)
+            && Rc::ptr_eq(&self.next_id, &other.next_id)
     }
 }
 
 impl Allocator {
-    /// Create a new allocator.
-    pub fn new() -> Self {
-        Self {
-            local_mut_pool: HashMap::new(),
-        }
-    }
-
     /// Create a new immutable local variable of type specified by `item` for the given `scope`.
-    pub fn create_local(&self, scope: &mut Scope, item: Item) -> ExpandElement {
-        ExpandElement::Plain(scope.create_local(item))
+    pub fn create_local(&self, item: Item) -> ExpandElement {
+        let id = self.new_local_index();
+        let local = VariableKind::LocalConst { id };
+        ExpandElement::Plain(Variable::new(local, item))
     }
 
     /// Create a new mutable local variable of type specified by `item` for the given `scope`.
     /// Try to reuse a previously defined but unused mutable variable in the current scope if possible.
     /// Else, this define a new variable.
-    pub fn create_local_mut(&mut self, scope: &mut Scope, item: Item) -> ExpandElement {
+    pub fn create_local_mut(&self, item: Item) -> ExpandElement {
         if item.elem.is_atomic() {
-            ExpandElement::Plain(scope.create_local_restricted(item))
+            self.create_local_restricted(item)
         } else {
             self.reuse_local_mut(item)
-                .unwrap_or_else(|| ExpandElement::Managed(self.add_local_mut(scope, item)))
+                .unwrap_or_else(|| ExpandElement::Managed(self.add_local_mut(item)))
         }
     }
 
     /// Create a new mutable restricted local variable of type specified by `item` into the given `scope`.
-    pub fn create_local_restricted(&self, scope: &mut Scope, item: Item) -> ExpandElement {
-        ExpandElement::Plain(scope.create_local_restricted(item))
+    pub fn create_local_restricted(&self, item: Item) -> ExpandElement {
+        let id = self.new_local_index();
+        let local = VariableKind::LocalMut { id };
+        ExpandElement::Plain(Variable::new(local, item))
+    }
+
+    pub fn create_local_array(&self, item: Item, array_size: u32) -> ExpandElement {
+        let id = self.new_local_index();
+        let local_array = Variable::new(
+            VariableKind::LocalArray {
+                id,
+                length: array_size,
+            },
+            item,
+        );
+        ExpandElement::Plain(local_array)
+    }
+
+    /// Create a slice variable
+    pub fn create_slice(&self, item: Item) -> ExpandElement {
+        let id = self.new_local_index();
+        let variable = Variable::new(VariableKind::Slice { id }, item);
+        ExpandElement::Plain(variable)
+    }
+
+    /// Create a matrix variable
+    pub fn create_matrix(&self, matrix: Matrix) -> ExpandElement {
+        let id = self.new_local_index();
+        let variable = Variable::new(
+            VariableKind::Matrix { id, mat: matrix },
+            Item::new(matrix.elem),
+        );
+        ExpandElement::Plain(variable)
     }
 
     // Try to return a reusable mutable variable for the given `item` or `None` otherwise.
     fn reuse_local_mut(&self, item: Item) -> Option<ExpandElement> {
         // Among the candidates, take a variable if it's only referenced by the pool.
         // Arbitrarily takes the first it finds in reversed order.
-        self.local_mut_pool.get(&item).and_then(|vars| {
+        self.local_mut_pool.borrow().get(&item).and_then(|vars| {
             vars.iter()
                 .rev()
                 .find(|var| matches!(var, ExpandElement::Managed(v) if Rc::strong_count(v) == 1))
@@ -76,14 +109,27 @@ impl Allocator {
     }
 
     /// Add a new variable to the pool with type specified by `item` for the given `scope`.
-    fn add_local_mut(&mut self, scope: &mut Scope, item: Item) -> Rc<Variable> {
-        let var = Rc::new(scope.create_local_mut(item));
+    pub fn add_local_mut(&self, item: Item) -> Rc<Variable> {
+        let id = self.new_local_index();
+        let local = Variable::new(VariableKind::LocalMut { id }, item);
+        let var = Rc::new(local);
         let expand = ExpandElement::Managed(var.clone());
-        if let Some(variables) = self.local_mut_pool.get_mut(&item) {
-            variables.push(expand);
-        } else {
-            self.local_mut_pool.insert(var.item, vec![expand]);
-        }
+        let mut pool = self.local_mut_pool.borrow_mut();
+        let variables = pool.entry(item).or_default();
+        variables.push(expand);
         var
+    }
+
+    pub fn new_local_index(&self) -> u32 {
+        self.next_id.fetch_add(1, Ordering::Release)
+    }
+
+    pub fn managed_locals(&self) -> Vec<Variable> {
+        self.local_mut_pool
+            .borrow()
+            .values()
+            .flatten()
+            .map(|it| **it)
+            .collect()
     }
 }

--- a/crates/cubecl-core/src/ir/kernel.rs
+++ b/crates/cubecl-core/src/ir/kernel.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::num::NonZero;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct KernelDefinition {
     pub inputs: Vec<Binding>,

--- a/crates/cubecl-core/src/ir/kernel.rs
+++ b/crates/cubecl-core/src/ir/kernel.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::num::NonZero;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[allow(missing_docs)]
 pub struct KernelDefinition {
     pub inputs: Vec<Binding>,

--- a/crates/cubecl-core/src/ir/scope.rs
+++ b/crates/cubecl-core/src/ir/scope.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use crate::ir::ConstantScalarValue;
 
 use super::{
-    cpa, processing::ScopeProcessing, Allocator, Elem, Id, Instruction, Item, Matrix, Operation,
-    UIntKind, Variable, VariableKind,
+    cpa, processing::ScopeProcessing, Allocator, Elem, Id, Instruction, Item, Operation, UIntKind,
+    Variable, VariableKind,
 };
 
 /// The scope is the main [operation](Operation) and [variable](Variable) container that simplify
@@ -96,22 +96,8 @@ impl Scope {
         local
     }
 
-    /// Create a matrix variable
-    pub fn create_matrix(&mut self, matrix: Matrix) -> Variable {
-        let variable = *self.allocator.create_matrix(matrix);
-        self.add_matrix(variable);
-        variable
-    }
-
     pub fn add_matrix(&mut self, variable: Variable) {
         self.matrices.push(variable);
-    }
-
-    /// Create a slice variable
-    pub fn create_slice(&mut self, item: Item) -> Variable {
-        let variable = *self.allocator.create_slice(item);
-        self.add_slice(variable);
-        variable
     }
 
     pub fn add_slice(&mut self, slice: Variable) {

--- a/crates/cubecl-core/src/ir/variable.rs
+++ b/crates/cubecl-core/src/ir/variable.rs
@@ -34,22 +34,22 @@ impl Variable {
     }
 }
 
-type Id = u16;
+pub type Id = u32;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum VariableKind {
     GlobalInputArray(Id),
     GlobalOutputArray(Id),
     GlobalScalar(Id),
-    LocalArray { id: Id, depth: u8, length: u32 },
-    LocalMut { id: Id, depth: u8 },
-    LocalConst { id: Id, depth: u8 },
-    Versioned { id: Id, depth: u8, version: u16 },
+    LocalArray { id: Id, length: u32 },
+    LocalMut { id: Id },
+    LocalConst { id: Id },
+    Versioned { id: Id, version: u16 },
     ConstantScalar(ConstantScalarValue),
     ConstantArray { id: Id, length: u32 },
     SharedMemory { id: Id, length: u32 },
-    Matrix { id: Id, mat: Matrix, depth: u8 },
-    Slice { id: Id, depth: u8 },
+    Matrix { id: Id, mat: Matrix },
+    Slice { id: Id },
     Builtin(Builtin),
 }
 
@@ -387,18 +387,6 @@ impl Variable {
         }
     }
 
-    pub fn depth(&self) -> Option<u8> {
-        match self.kind {
-            VariableKind::LocalMut { depth, .. }
-            | VariableKind::Versioned { depth, .. }
-            | VariableKind::LocalConst { depth, .. }
-            | VariableKind::LocalArray { depth, .. }
-            | VariableKind::Matrix { depth, .. }
-            | VariableKind::Slice { depth, .. } => Some(depth),
-            _ => None,
-        }
-    }
-
     pub fn as_const(&self) -> Option<ConstantScalarValue> {
         match self.kind {
             VariableKind::ConstantScalar(constant) => Some(constant),
@@ -414,16 +402,16 @@ impl Display for Variable {
             VariableKind::GlobalOutputArray(id) => write!(f, "output({id})"),
             VariableKind::GlobalScalar(id) => write!(f, "scalar({id})"),
             VariableKind::ConstantScalar(constant) => write!(f, "{constant}"),
-            VariableKind::LocalMut { id, depth } => write!(f, "local({id}, {depth})"),
-            VariableKind::Versioned { id, depth, version } => {
-                write!(f, "local({id}, {depth}).v{version}")
+            VariableKind::LocalMut { id } => write!(f, "local({id})"),
+            VariableKind::Versioned { id, version } => {
+                write!(f, "local({id}).v{version}")
             }
-            VariableKind::LocalConst { id, depth } => write!(f, "binding({id}, {depth})"),
+            VariableKind::LocalConst { id } => write!(f, "binding({id})"),
             VariableKind::ConstantArray { id, .. } => write!(f, "const_array({id})"),
             VariableKind::SharedMemory { id, .. } => write!(f, "shared({id})"),
             VariableKind::LocalArray { id, .. } => write!(f, "array({id})"),
-            VariableKind::Matrix { id, depth, .. } => write!(f, "matrix({id}, {depth})"),
-            VariableKind::Slice { id, depth } => write!(f, "slice({id}, {depth})"),
+            VariableKind::Matrix { id, .. } => write!(f, "matrix({id})"),
+            VariableKind::Slice { id } => write!(f, "slice({id})"),
             VariableKind::Builtin(builtin) => write!(f, "{builtin:?}"),
         }
     }

--- a/crates/cubecl-cpp/src/shared/body.rs
+++ b/crates/cubecl-cpp/src/shared/body.rs
@@ -116,8 +116,8 @@ impl<D: Dialect> Display for Body<D> {
         for array in self.local_arrays.iter() {
             write!(
                 f,
-                "{} l_arr_{}_{}[{}];\n\n",
-                array.item, array.index, array.depth, array.size
+                "{} l_arr_{}[{}];\n\n",
+                array.item, array.index, array.size
             )?;
         }
 

--- a/crates/cubecl-cpp/src/shared/kernel.rs
+++ b/crates/cubecl-cpp/src/shared/kernel.rs
@@ -1,6 +1,6 @@
 use super::{Body, Dialect, Item, Variable};
 use cubecl_core::{
-    ir::{CubeDim, Visibility},
+    ir::{CubeDim, Id, Visibility},
     CompilerRepresentation,
 };
 use std::{collections::HashSet, fmt::Display};
@@ -14,14 +14,14 @@ pub struct Binding<D: Dialect> {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SharedMemory<D: Dialect> {
-    pub index: u16,
+    pub index: Id,
     pub item: Item<D>,
     pub size: u32,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ConstArray<D: Dialect> {
-    pub index: u16,
+    pub index: Id,
     pub item: Item<D>,
     pub size: u32,
     pub values: Vec<Variable<D>>,
@@ -29,25 +29,19 @@ pub struct ConstArray<D: Dialect> {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct LocalArray<D: Dialect> {
-    pub index: u16,
+    pub index: Id,
     pub item: Item<D>,
-    pub depth: u8,
     pub size: u32,
 }
 
 impl<D: Dialect> LocalArray<D> {
-    pub fn new(index: u16, item: Item<D>, depth: u8, size: u32) -> Self {
-        Self {
-            index,
-            item,
-            depth,
-            size,
-        }
+    pub fn new(index: Id, item: Item<D>, size: u32) -> Self {
+        Self { index, item, size }
     }
 }
 
 impl<D: Dialect> SharedMemory<D> {
-    pub fn new(index: u16, item: Item<D>, size: u32) -> Self {
+    pub fn new(index: Id, item: Item<D>, size: u32) -> Self {
         Self { index, item, size }
     }
 }

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -202,20 +202,14 @@ impl Launch {
 
     fn define_body(&self) -> TokenStream {
         let kernel_builder = prelude_type("KernelBuilder");
-        let runtime = prelude_type("Runtime");
-        let compiler = core_type("Compiler");
         let io_map = self.io_mappings();
         let register_type = self.analysis.register_elems();
         let runtime_args = self.runtime_params().map(|it| &it.name);
         let comptime_args = self.comptime_params().map(|it| &it.name);
         let generics = self.analysis.process_generics(&self.func.sig.generics);
-        let allocator = self.args.local_allocator.as_ref();
-        let allocator = allocator.map(|it| it.to_token_stream()).unwrap_or_else(
-            || quote![<<__R as #runtime>::Compiler as #compiler>::local_allocator()],
-        );
 
         quote! {
-            let mut builder = #kernel_builder::with_local_allocator(#allocator);
+            let mut builder = #kernel_builder::default();
             #register_type
             #io_map
             expand #generics(&mut builder.context, #(#runtime_args.clone(),)* #(self.#comptime_args.clone()),*);

--- a/crates/cubecl-macros/src/parse/kernel.rs
+++ b/crates/cubecl-macros/src/parse/kernel.rs
@@ -4,8 +4,8 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::{collections::HashMap, iter};
 use syn::{
-    parse_quote, punctuated::Punctuated, spanned::Spanned, visit_mut::VisitMut, Expr, FnArg,
-    Generics, Ident, ItemFn, ReturnType, Signature, TraitItemFn, Type, Visibility,
+    parse_quote, punctuated::Punctuated, spanned::Spanned, visit_mut::VisitMut, FnArg, Generics,
+    Ident, ItemFn, ReturnType, Signature, TraitItemFn, Type, Visibility,
 };
 
 use super::{desugar::Desugar, helpers::is_comptime_attr, statement::parse_pat};
@@ -16,7 +16,6 @@ pub(crate) struct KernelArgs {
     pub launch_unchecked: Flag,
     pub debug: Flag,
     pub create_dummy_kernel: Flag,
-    pub local_allocator: Option<Expr>,
 }
 
 pub fn from_tokens<T: FromMeta>(tokens: TokenStream) -> syn::Result<T> {

--- a/crates/cubecl-opt/src/block.rs
+++ b/crates/cubecl-opt/src/block.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
-use cubecl_core::ir::{Instruction, Variable};
+use cubecl_core::ir::{Id, Instruction, Variable};
 use petgraph::graph::NodeIndex;
 use stable_vec::StableVec;
 
@@ -20,9 +20,9 @@ pub struct BasicBlock {
     /// The phi nodes that are required to be generated at the start of this block.
     pub phi_nodes: Rc<RefCell<Vec<PhiInstruction>>>,
     /// The variables written to by this block. Only set during the SSA transformation.
-    pub(crate) writes: HashSet<(u16, u8)>,
+    pub(crate) writes: HashSet<Id>,
     /// The live variables at the start of this block. Used for pruning phi nodes.
-    pub(crate) live_vars: HashSet<(u16, u8)>,
+    pub(crate) live_vars: HashSet<Id>,
     /// The dominance frontiers of this block (where phi nodes must be inserted).
     pub(crate) dom_frontiers: HashSet<NodeIndex>,
     /// A stable list of operations performed in this block.
@@ -66,7 +66,7 @@ impl Program {
     /// Check whether a variable is dead at the start of this block. Note that `false` does not mean
     /// the variable is definitely live - just that it *may* be live and must be treated as such.
     #[track_caller]
-    pub fn is_dead(&self, node: NodeIndex, var: (u16, u8)) -> bool {
+    pub fn is_dead(&self, node: NodeIndex, var: Id) -> bool {
         !self[node].live_vars.contains(&var)
     }
 }

--- a/crates/cubecl-opt/src/control_flow.rs
+++ b/crates/cubecl-opt/src/control_flow.rs
@@ -253,7 +253,7 @@ impl Optimizer {
         let step = range_loop.step.unwrap_or(1.into());
 
         let i_id = match range_loop.i.kind {
-            VariableKind::LocalMut { id, depth, .. } => (id, depth),
+            VariableKind::LocalMut { id, .. } => id,
             _ => unreachable!(),
         };
         let i = range_loop.i;
@@ -308,7 +308,9 @@ impl Optimizer {
                 true => Operator::LowerEqual,
                 false => Operator::Lower,
             };
-            let tmp = self.create_temporary(Item::new(Elem::Bool));
+            let tmp = *self
+                .allocator
+                .create_local_restricted(Item::new(Elem::Bool));
             self.program[header].ops.borrow_mut().push(Instruction::new(
                 op(BinaryOperator {
                     lhs: i,

--- a/crates/cubecl-opt/src/debug.rs
+++ b/crates/cubecl-opt/src/debug.rs
@@ -58,7 +58,7 @@ impl Display for Optimizer {
                 writeln!(f, "    Uses: {:?}", bb.block_use)?;
             }
             let live_vars = bb.live_vars.iter();
-            let live_vars = live_vars.map(|it| format!("local({}, {})", it.0, it.1));
+            let live_vars = live_vars.map(|it| format!("local({})", it));
             let live_vars = live_vars.collect::<Vec<_>>();
             writeln!(f, "    Live variables: [{}]\n", live_vars.join(", "))?;
 
@@ -229,7 +229,7 @@ impl Display for Value {
             Value::ConstArray(id, _, _) => write!(f, "const_array({id})"),
             Value::Builtin(builtin) => write!(f, "{builtin:?}"),
             Value::Output(id, _) => write!(f, "output({id})"),
-            Value::Slice(id, depth, _) => write!(f, "slice({id}, {depth})"),
+            Value::Slice(id, _) => write!(f, "slice({id})"),
         }
     }
 }
@@ -237,8 +237,8 @@ impl Display for Value {
 impl Display for Local {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.version {
-            0 => write!(f, "binding({}, {})", self.id, self.depth),
-            v => write!(f, "local({}, {}).v{v}", self.id, self.depth),
+            0 => write!(f, "binding({})", self.id),
+            v => write!(f, "local({}).v{v}", self.id),
         }
     }
 }

--- a/crates/cubecl-opt/src/gvn/apply.rs
+++ b/crates/cubecl-opt/src/gvn/apply.rs
@@ -81,7 +81,7 @@ impl GvnPass {
                     }
                     let leaders = &mut self.block_sets.get_mut(&pred).unwrap().leaders;
                     if !leaders.contains_key(&val) {
-                        let new_temp = opt.create_temporary(expr.item());
+                        let new_temp = *opt.allocator.create_local_restricted(expr.item());
                         let new_op = ir::Instruction::new(expr.to_operation(leaders), new_temp);
                         opt.program[pred].ops.borrow_mut().push(new_op);
                         leaders.insert(val, value_of_var(&new_temp).unwrap());
@@ -100,7 +100,7 @@ impl GvnPass {
             let new_phis = new_phis
                 .into_iter()
                 .map(|entries| PhiInstruction {
-                    out: opt.create_temporary(entries[0].value.item),
+                    out: *opt.allocator.create_local_restricted(entries[0].value.item),
                     entries,
                 })
                 .collect::<Vec<_>>();

--- a/crates/cubecl-opt/src/gvn/base.rs
+++ b/crates/cubecl-opt/src/gvn/base.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cubecl_core::ir::{Builtin, ConstantScalarValue, Elem, FloatKind, IntKind, Item, UIntKind};
+use cubecl_core::ir::{Builtin, ConstantScalarValue, Elem, FloatKind, Id, IntKind, Item, UIntKind};
 use float_ord::FloatOrd;
 use petgraph::{
     algo::dominators::{self, Dominators},
@@ -95,8 +95,7 @@ impl Default for ValueTable {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub struct Local {
-    pub id: u16,
-    pub depth: u8,
+    pub id: Id,
     pub version: u16,
     pub item: Item,
 }
@@ -113,13 +112,13 @@ pub enum Constant {
 pub enum Value {
     Constant(Constant),
     Local(Local),
-    Input(u16, Item),
-    Scalar(u16, Elem),
-    ConstArray(u16, Item, u32),
+    Input(Id, Item),
+    Scalar(Id, Elem),
+    ConstArray(Id, Item, u32),
     Builtin(Builtin),
     // Metadata only
-    Output(u16, Item),
-    Slice(u16, u8, Item),
+    Output(Id, Item),
+    Slice(Id, Item),
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
@@ -166,7 +165,7 @@ impl Value {
             Value::ConstArray(_, item, _) => *item,
             Value::Builtin(_) => Item::new(Elem::UInt(UIntKind::U32)),
             Value::Output(_, item) => *item,
-            Value::Slice(_, _, item) => *item,
+            Value::Slice(_, item) => *item,
         }
     }
 }

--- a/crates/cubecl-opt/src/gvn/convert.rs
+++ b/crates/cubecl-opt/src/gvn/convert.rs
@@ -217,25 +217,12 @@ impl Value {
             Value::Constant(val) => Variable::constant((*val).into()),
             Value::Local(Local {
                 id,
-                depth,
                 version: 0,
                 item,
-            }) => Variable::new(
-                VariableKind::LocalConst {
-                    id: *id,
-                    depth: *depth,
-                },
-                *item,
-            ),
-            Value::Local(Local {
-                id,
-                depth,
-                version,
-                item,
-            }) => Variable::new(
+            }) => Variable::new(VariableKind::LocalConst { id: *id }, *item),
+            Value::Local(Local { id, version, item }) => Variable::new(
                 VariableKind::Versioned {
                     id: *id,
-                    depth: *depth,
                     version: *version,
                 },
                 *item,
@@ -253,13 +240,7 @@ impl Value {
             ),
             Value::Builtin(builtin) => Variable::builtin(*builtin),
             Value::Output(id, item) => Variable::new(VariableKind::GlobalOutputArray(*id), *item),
-            Value::Slice(id, depth, item) => Variable::new(
-                VariableKind::Slice {
-                    id: *id,
-                    depth: *depth,
-                },
-                *item,
-            ),
+            Value::Slice(id, item) => Variable::new(VariableKind::Slice { id: *id }, *item),
         }
     }
 }
@@ -270,15 +251,10 @@ pub fn value_of_var(var: &Variable) -> Option<Value> {
         VariableKind::GlobalInputArray(id) => Value::Input(id, item),
         VariableKind::GlobalOutputArray(id) => Value::Output(id, item),
         VariableKind::GlobalScalar(id) => Value::Scalar(id, item.elem),
-        VariableKind::Versioned { id, depth, version } => Value::Local(Local {
+        VariableKind::Versioned { id, version } => Value::Local(Local { id, version, item }),
+        VariableKind::LocalConst { id } => Value::Local(Local {
             id,
-            depth,
-            version,
-            item,
-        }),
-        VariableKind::LocalConst { id, depth } => Value::Local(Local {
-            id,
-            depth,
+
             version: 0,
             item,
         }),
@@ -288,7 +264,7 @@ pub fn value_of_var(var: &Variable) -> Option<Value> {
         | VariableKind::SharedMemory { .. }
         | VariableKind::LocalArray { .. }
         | VariableKind::Matrix { .. } => None?,
-        VariableKind::Slice { id, depth } => Value::Slice(id, depth, item),
+        VariableKind::Slice { id } => Value::Slice(id, item),
         VariableKind::Builtin(builtin) => Value::Builtin(builtin),
     };
     Some(val)

--- a/crates/cubecl-opt/src/passes/constant_prop.rs
+++ b/crates/cubecl-opt/src/passes/constant_prop.rs
@@ -122,8 +122,8 @@ impl OptimizerPass for ConstOperandSimplify {
                             op.operation = Operation::Copy(length.into());
                             changes.inc();
                         }
-                        VariableKind::Slice { id, depth } => {
-                            let slice = opt.program.slices.get(&(id, depth));
+                        VariableKind::Slice { id } => {
+                            let slice = opt.program.slices.get(&id);
                             if let Some(Slice {
                                 const_len: Some(len),
                                 ..

--- a/crates/cubecl-opt/src/passes/in_bounds_analysis.rs
+++ b/crates/cubecl-opt/src/passes/in_bounds_analysis.rs
@@ -86,11 +86,7 @@ fn const_len(opt: &Optimizer, var: &Variable) -> Option<u32> {
         VariableKind::ConstantArray { length, .. } => Some(length),
         VariableKind::SharedMemory { length, .. } => Some(length),
         VariableKind::LocalArray { length, .. } => Some(length),
-        VariableKind::Slice { id, depth } => opt
-            .program
-            .slices
-            .get(&(id, depth))
-            .and_then(|it| it.const_len),
+        VariableKind::Slice { id } => opt.program.slices.get(&id).and_then(|it| it.const_len),
         _ => None,
     }
 }

--- a/crates/cubecl-opt/src/passes/index_merge.rs
+++ b/crates/cubecl-opt/src/passes/index_merge.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use cubecl_core::ir::{
-    CopyMemoryOperator, Instruction, Operation, Operator, Variable, VariableKind,
+    CopyMemoryOperator, Id, Instruction, Operation, Operator, Variable, VariableKind,
 };
 
 use crate::{AtomicCounter, Optimizer};
@@ -60,10 +60,10 @@ impl OptimizerPass for CopyTransform {
     }
 }
 
-fn as_versioned(var: &Variable) -> Option<(u16, u8, u16)> {
+fn as_versioned(var: &Variable) -> Option<(Id, u16)> {
     match var.kind {
-        VariableKind::LocalConst { id, depth } => Some((id, depth, 0)),
-        VariableKind::Versioned { id, depth, version } => Some((id, depth, version)),
+        VariableKind::LocalConst { id } => Some((id, 0)),
+        VariableKind::Versioned { id, version } => Some((id, version)),
         _ => None,
     }
 }

--- a/crates/cubecl-opt/src/passes/liveness.rs
+++ b/crates/cubecl-opt/src/passes/liveness.rs
@@ -1,13 +1,14 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use cubecl_core::ir::Id;
 use petgraph::graph::NodeIndex;
 
 use crate::Optimizer;
 
 #[derive(Clone)]
 struct BlockSets {
-    gen: HashSet<(u16, u8)>,
-    kill: HashSet<(u16, u8)>,
+    gen: HashSet<Id>,
+    kill: HashSet<Id>,
 }
 
 struct State {

--- a/crates/cubecl-opt/src/passes/reduce_strength.rs
+++ b/crates/cubecl-opt/src/passes/reduce_strength.rs
@@ -56,7 +56,7 @@ impl OptimizerPass for ReduceStrength {
                                 changes.inc();
                             }
                             val if (val + 1).is_power_of_two() => {
-                                let temp = opt.create_temporary(inst.item());
+                                let temp = *opt.allocator.create_local_restricted(inst.item());
                                 new_ops.push(Instruction::new(
                                     Operator::ShiftLeft(BinaryOperator {
                                         lhs: dyn_val,
@@ -74,7 +74,7 @@ impl OptimizerPass for ReduceStrength {
                                 changes.inc();
                             }
                             val if (val - 1).is_power_of_two() => {
-                                let temp = opt.create_temporary(inst.item());
+                                let temp = *opt.allocator.create_local_restricted(inst.item());
                                 new_ops.push(Instruction::new(
                                     Operator::ShiftLeft(BinaryOperator {
                                         lhs: dyn_val,

--- a/crates/cubecl-opt/src/phi_frontiers.rs
+++ b/crates/cubecl-opt/src/phi_frontiers.rs
@@ -1,4 +1,4 @@
-use cubecl_core::ir::{Item, Variable, VariableKind};
+use cubecl_core::ir::{Id, Item, Variable, VariableKind};
 use petgraph::{algo::dominators::simple_fast, graph::NodeIndex, visit::EdgeRef, Direction};
 
 use super::{
@@ -55,15 +55,8 @@ impl Program {
     }
 
     /// Insert a phi node for variable `id` at `block`
-    pub fn insert_phi(&mut self, block: NodeIndex, id: (u16, u8), item: Item) {
-        let var = Variable::new(
-            VariableKind::Versioned {
-                id: id.0,
-                depth: id.1,
-                version: 0,
-            },
-            item,
-        );
+    pub fn insert_phi(&mut self, block: NodeIndex, id: Id, item: Item) {
+        let var = Variable::new(VariableKind::Versioned { id, version: 0 }, item);
         let entries = self
             .edges_directed(block, Direction::Incoming)
             .map(|edge| edge.source())

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -8,10 +8,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use cubecl_core::{
-    ir::{Allocator, KernelDefinition},
-    Compiler, ExecutionMode,
-};
+use cubecl_core::{ir::KernelDefinition, Compiler, ExecutionMode};
 use rspirv::{
     dr::{Builder, InsertPoint, Instruction, Module, Operand},
     spirv::{BuiltIn, Capability, Decoration, Op, StorageClass, Word},
@@ -157,10 +154,6 @@ impl<T: SpirvTarget> Compiler for SpirvCompiler<T> {
 
     fn elem_size(elem: core::Elem) -> usize {
         elem.size()
-    }
-
-    fn local_allocator() -> Allocator {
-        Allocator::new()
     }
 
     fn max_shared_memory_size() -> usize {

--- a/crates/cubecl-spirv/src/instruction.rs
+++ b/crates/cubecl-spirv/src/instruction.rs
@@ -90,7 +90,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                 let start = self.compile_variable(op.start);
                 let end = self.compile_variable(op.end);
                 let out = match out.kind {
-                    core::VariableKind::Slice { id, depth } => (id, depth),
+                    core::VariableKind::Slice { id } => id,
                     _ => unreachable!(),
                 };
 

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use cubecl_core::ir::expand_checked_index_assign;
 use cubecl_core::{
-    ir::{self as cube, Allocator, UIntKind},
+    ir::{self as cube, UIntKind},
     prelude::CompiledKernel,
     server::ComputeServer,
     Feature, Metadata,
@@ -79,10 +79,6 @@ impl cubecl_core::Compiler for WgslCompiler {
 
     fn max_shared_memory_size() -> usize {
         32768
-    }
-
-    fn local_allocator() -> Allocator {
-        Allocator::new()
     }
 }
 
@@ -357,21 +353,19 @@ impl WgslCompiler {
             cube::VariableKind::GlobalScalar(id) => {
                 wgsl::Variable::GlobalScalar(id, Self::compile_elem(item.elem), item.elem)
             }
-            cube::VariableKind::LocalMut { id, depth }
-            | cube::VariableKind::Versioned { id, depth, .. } => wgsl::Variable::LocalMut {
+            cube::VariableKind::LocalMut { id } | cube::VariableKind::Versioned { id, .. } => {
+                wgsl::Variable::LocalMut {
+                    id,
+                    item: Self::compile_item(item),
+                }
+            }
+            cube::VariableKind::LocalConst { id } => wgsl::Variable::LocalConst {
                 id,
                 item: Self::compile_item(item),
-                depth,
             },
-            cube::VariableKind::LocalConst { id, depth } => wgsl::Variable::LocalConst {
+            cube::VariableKind::Slice { id } => wgsl::Variable::Slice {
                 id,
                 item: Self::compile_item(item),
-                depth,
-            },
-            cube::VariableKind::Slice { id, depth } => wgsl::Variable::Slice {
-                id,
-                item: Self::compile_item(item),
-                depth,
             },
             cube::VariableKind::GlobalOutputArray(id) => {
                 wgsl::Variable::GlobalOutputArray(id, Self::compile_item(item))
@@ -391,13 +385,12 @@ impl WgslCompiler {
                 let item = Self::compile_item(item);
                 wgsl::Variable::ConstantArray(id, item, length)
             }
-            cube::VariableKind::LocalArray { id, depth, length } => {
+            cube::VariableKind::LocalArray { id, length } => {
                 let item = Self::compile_item(item);
                 if !self.local_arrays.iter().any(|s| s.index == id) {
-                    self.local_arrays
-                        .push(LocalArray::new(id, item, depth, length));
+                    self.local_arrays.push(LocalArray::new(id, item, length));
                 }
-                wgsl::Variable::LocalArray(id, item, depth, length)
+                wgsl::Variable::LocalArray(id, item, length)
             }
             cube::VariableKind::Builtin(builtin) => match builtin {
                 cube::Builtin::AbsolutePos => {
@@ -695,14 +688,14 @@ impl WgslCompiler {
             }
             cube::Metadata::Length { var } => match var.kind {
                 cube::VariableKind::GlobalInputArray(id) => {
-                    let offset = self.metadata.len_index(id as u32);
+                    let offset = self.metadata.len_index(id);
                     wgsl::Instruction::Metadata {
                         out: self.compile_variable(out),
                         info_offset: self.compile_variable(offset.into()),
                     }
                 }
                 cube::VariableKind::GlobalOutputArray(id) => {
-                    let offset = self.metadata.len_index(self.num_inputs as u32 + id as u32);
+                    let offset = self.metadata.len_index(self.num_inputs as u32 + id);
                     wgsl::Instruction::Metadata {
                         out: self.compile_variable(out),
                         info_offset: self.compile_variable(offset.into()),
@@ -715,14 +708,14 @@ impl WgslCompiler {
             },
             cube::Metadata::BufferLength { var } => match var.kind {
                 cube::VariableKind::GlobalInputArray(id) => {
-                    let offset = self.metadata.buffer_len_index(id as u32);
+                    let offset = self.metadata.buffer_len_index(id);
                     wgsl::Instruction::Metadata {
                         out: self.compile_variable(out),
                         info_offset: self.compile_variable(offset.into()),
                     }
                 }
                 cube::VariableKind::GlobalOutputArray(id) => {
-                    let id = self.num_inputs as u32 + id as u32;
+                    let id = self.num_inputs as u32 + id;
                     let offset = self.metadata.buffer_len_index(id);
                     wgsl::Instruction::Metadata {
                         out: self.compile_variable(out),

--- a/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
@@ -1170,7 +1170,7 @@ fn index_assign(
                 | Variable::GlobalOutputArray(_, _)
                 | Variable::SharedMemory(_, _, _)
                 | Variable::Slice { .. }
-                | Variable::LocalArray(_, _, _, _) => true,
+                | Variable::LocalArray(_, _, _) => true,
                 Variable::Named { is_array, .. } => *is_array,
                 _ => false,
             };

--- a/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
@@ -1,5 +1,8 @@
 use super::{Body, Extension, Item, Variable};
-use cubecl_core::{ir::CubeDim, CompilerRepresentation};
+use cubecl_core::{
+    ir::{CubeDim, Id},
+    CompilerRepresentation,
+};
 use std::fmt::Display;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -25,13 +28,13 @@ pub struct Binding {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SharedMemory {
     location: Location,
-    pub index: u16,
+    pub index: Id,
     item: Item,
     size: u32,
 }
 
 impl SharedMemory {
-    pub fn new(index: u16, item: Item, size: u32) -> Self {
+    pub fn new(index: Id, item: Item, size: u32) -> Self {
         Self {
             location: Location::Workgroup,
             index,
@@ -43,7 +46,7 @@ impl SharedMemory {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ConstantArray {
-    pub index: u16,
+    pub index: Id,
     pub item: Item,
     pub size: u32,
     pub values: Vec<Variable>,
@@ -51,20 +54,14 @@ pub struct ConstantArray {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct LocalArray {
-    pub index: u16,
+    pub index: Id,
     item: Item,
-    name: u8,
     size: u32,
 }
 
 impl LocalArray {
-    pub fn new(index: u16, item: Item, name: u8, size: u32) -> Self {
-        Self {
-            index,
-            item,
-            name,
-            size,
-        }
+    pub fn new(index: Id, item: Item, size: u32) -> Self {
+        Self { index, item, size }
     }
 }
 
@@ -183,8 +180,8 @@ fn {}(
         for array in self.local_arrays.iter() {
             writeln!(
                 f,
-                "var a_{}_{}: array<{}, {}>;\n",
-                array.name, array.index, array.item, array.size
+                "var a_{}: array<{}, {}>;\n",
+                array.index, array.item, array.size
             )?;
         }
 


### PR DESCRIPTION
Reworks allocator to carry a global state, with a reference owned by each scope. This allows for globally incrementing indices, preventing any potential name collisions entirely.
Removes `depth` from variables now that indices are already globally unique, which simplifies a lot of code in the optimizer.
Changes IDs to `u32` because there's no actual performance benefit to using `u16`, and `u32` gives a lot more headroom now that `depth` is gone. `u16` + `u8` would've gotten aligned to 32 bits regardless with the old IDs.
Replaces all of the uses for `u16` for IDs with the `Id` type alias that I introduced in the `Variable` refactor to make potential refactors easier in the future.

I currently don't change how variables are declared,  which leads to some slightly awkward code in `CubeContext` and `Scope`. I think eventually declaration should move out of each scope to the global allocator, but that would require larger changes to the backends that I wanted to avoid  for now.

## Testing
All tests pass now (except for the 16 CUDA tests that are expected to fail).