### PR TITLE
Flush when too many handles are locked

### DIFF
--- a/crates/cubecl-runtime/src/memory_management/memory_lock.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_lock.rs
@@ -1,18 +1,32 @@
-use alloc::collections::BTreeSet;
-
 use crate::storage::StorageId;
+use alloc::collections::BTreeSet;
 
 /// A set of storage buffers that are 'locked' and cannot be
 /// used for allocations currently.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct MemoryLock {
     locked: BTreeSet<StorageId>,
+    flush_threshold: usize,
 }
 
 impl MemoryLock {
+    /// Create a new memory lock with the given flushing threshold.
+    pub fn new(flush_threshold: usize) -> Self {
+        Self {
+            locked: Default::default(),
+            flush_threshold,
+        }
+    }
     /// Check whether a particular storage ID is locked currently.
     pub fn is_locked(&self, storage: &StorageId) -> bool {
         self.locked.contains(storage)
+    }
+
+    /// Whether the flushing threshold has been reached.
+    pub fn should_flush(&self) -> bool {
+        // For now we only consider the number of handles locked, but we may consider the amount in
+        // bytes at some point.
+        self.locked.len() >= self.flush_threshold
     }
 
     /// Add a storage ID to be locked.

--- a/crates/cubecl-runtime/src/memory_management/memory_lock.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_lock.rs
@@ -23,7 +23,7 @@ impl MemoryLock {
     }
 
     /// Whether the flushing threshold has been reached.
-    pub fn should_flush(&self) -> bool {
+    pub fn has_reached_threshold(&self) -> bool {
         // For now we only consider the number of handles locked, but we may consider the amount in
         // bytes at some point.
         self.locked.len() >= self.flush_threshold

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/ring.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/ring.rs
@@ -300,7 +300,7 @@ mod tests {
             .unwrap();
         assert_eq!(slice, slice_ids[0]);
 
-        let mut locked = MemoryLock::default();
+        let mut locked = MemoryLock::new(32);
         locked.add_locked(storage_id_1);
 
         let slice = ring

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -249,7 +249,10 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
             CubeCount::Static(x, y, z) => PipelineDispatch::Static(x, y, z),
         };
 
-        if self.stream.register(pipeline, resources, dispatch) {
+        if self
+            .stream
+            .register(pipeline, resources, dispatch, &self.storage_locked)
+        {
             self.on_flushed();
         }
 

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -187,7 +187,7 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
                 .copy_from_slice(data);
 
             // If too many handles are locked, we flush.
-            if self.storage_locked.should_flush() {
+            if self.storage_locked.has_reached_threshold() {
                 self.flush();
             }
         }

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -128,7 +128,7 @@ impl WgpuStream {
             }
         }
 
-        if self.tasks_count >= self.tasks_max || memory_lock.should_flush() {
+        if self.tasks_count >= self.tasks_max || memory_lock.has_reached_threshold() {
             self.flush();
             true
         } else {

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -2,7 +2,7 @@ use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 use web_time::Instant;
 
 use super::{poll::WgpuPoll, timestamps::KernelTimestamps, WgpuResource};
-use cubecl_runtime::{TimestampsError, TimestampsResult};
+use cubecl_runtime::{memory_management::MemoryLock, TimestampsError, TimestampsResult};
 use wgpu::ComputePipeline;
 
 #[derive(Debug)]
@@ -66,6 +66,7 @@ impl WgpuStream {
         pipeline: Arc<ComputePipeline>,
         resources: Vec<WgpuResource>,
         dispatch: PipelineDispatch,
+        memory_lock: &MemoryLock,
     ) -> bool {
         // Start a new compute pass if needed. The forget_lifetime allows
         // to store this with a 'static lifetime, but the compute pass must
@@ -127,7 +128,7 @@ impl WgpuStream {
             }
         }
 
-        if self.tasks_count >= self.tasks_max {
+        if self.tasks_count >= self.tasks_max || memory_lock.should_flush() {
             self.flush();
             true
         } else {

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -43,4 +43,5 @@ mod tests_spirv {
     cubecl_linalg::testgen_matmul_tiling2d!([f16, flex32, f32, f64]);
     cubecl_linalg::testgen_matmul_simple!([flex32, f32]);
     cubecl_linalg::testgen_matmul_accelerated!([f16]);
+    cubecl_reduce::testgen_reduce!();
 }


### PR DESCRIPTION
It helps when running wgpu tests or with autotune when tensors are allocated, but the kernel is never executed.