### PR TITLE
patch: extending the int trait with not ops

### DIFF
--- a/crates/cubecl-core/src/frontend/element/int.rs
+++ b/crates/cubecl-core/src/frontend/element/int.rs
@@ -28,6 +28,7 @@ pub trait Int:
     + core::ops::BitXor<Output = Self>
     + core::ops::Shl<Output = Self>
     + core::ops::Shr<Output = Self>
+    + core::ops::Not<Output = Self>
     + std::ops::RemAssign
     + std::ops::AddAssign
     + std::ops::SubAssign


### PR DESCRIPTION
Patch for #270. 

Necessary for implementing the Not operation in burn [here](https://github.com/tracel-ai/burn/issues/2234)

Somehow missed it in the initial PR