### PR TITLE
feat: not-trait-impl-for-int-types

### DIFF
--- a/crates/cubecl-core/src/frontend/operation/unary.rs
+++ b/crates/cubecl-core/src/frontend/operation/unary.rs
@@ -309,3 +309,17 @@ impl_unary_func!(
     u64,
     i64
 );
+impl_unary_func!(
+    Not,
+    not,
+    __expand_not,
+    Operator::Not,
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    u64,
+    i64
+);


### PR DESCRIPTION
Patch for #270 

Unary bitwise `Not` trait implementation for int types [here](https://github.com/tracel-ai/burn/issues/2234)