### PR TITLE
Fix compilation on arm64

### DIFF
--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -399,8 +399,7 @@ impl HipContext {
         let include_option_cstr = CString::new(include_option).unwrap();
         // needed for rocWMMA extension to compile
         let cpp_std_option_cstr = CString::new("--std=c++17").unwrap();
-        let mut options: Vec<*const i8> =
-            vec![cpp_std_option_cstr.as_ptr(), include_option_cstr.as_ptr()];
+        let mut options = vec![cpp_std_option_cstr.as_ptr(), include_option_cstr.as_ptr()];
         unsafe {
             let options_ptr = options.as_mut_ptr();
             let status =
@@ -413,7 +412,7 @@ impl HipContext {
                     status, hiprtcResult_HIPRTC_SUCCESS,
                     "Should retrieve the compilation log size"
                 );
-                let mut log_buffer = vec![0i8; log_size];
+                let mut log_buffer = vec![0; log_size];
                 let status = cubecl_hip_sys::hiprtcGetProgramLog(program, log_buffer.as_mut_ptr());
                 assert_eq!(
                     status, hiprtcResult_HIPRTC_SUCCESS,
@@ -446,7 +445,7 @@ impl HipContext {
                 "Should get size of compiled code"
             );
         }
-        let mut code = vec![0i8; code_size];
+        let mut code = vec![0; code_size];
         unsafe {
             let status = cubecl_hip_sys::hiprtcGetCode(program, code.as_mut_ptr());
             assert_eq!(


### PR DESCRIPTION
Remove explicit type annotations to let the compiler figure out the right type.

While trying to fix something in the burn repo, I tried running `run-checks.sh all` there which pulls in and compiles `cubecl-hip` that fails with errors like:
```
error[E0308]: mismatched types
   --> /home/<user>/.cargo/git/checkouts/cubecl-aa41a28b39b598f9/8244dbb/crates/cubecl-hip/src/compute/server.rs:403:18
    |
403 |             vec![cpp_std_option_cstr.as_ptr(), include_option_cstr.as_ptr()];
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const i8`, found `*const u8`
    |
    = note: expected raw pointer `*const i8`
               found raw pointer `*const u8`
```

I'm compiling it on linux arm64, and [on this platform `c_char` is `u8` instead of `i8`](https://github.com/rust-lang/rust/blob/1.84.0/library/core/src/ffi/mod.rs#L99).
