### PR TITLE
fix: bitwise-not-unary-op-for-cubeprimitive

### DIFF
--- a/crates/cubecl-core/src/frontend/container/line/ops.rs
+++ b/crates/cubecl-core/src/frontend/container/line/ops.rs
@@ -6,7 +6,7 @@ use crate::{
         ExpandElementTyped, Floor, Log, Log1p, Max, Min, Powf, Recip, Remainder, Round, Sin, Sqrt,
         Tanh,
     },
-    prelude::{CountOnes, ReverseBits},
+    prelude::{CountOnes, Not, ReverseBits},
     unexpanded,
 };
 
@@ -262,6 +262,7 @@ impl<P: CubePrimitive + Floor> Floor for Line<P> {}
 impl<P: CubePrimitive + Ceil> Ceil for Line<P> {}
 impl<P: CubePrimitive + CountOnes> CountOnes for Line<P> {}
 impl<P: CubePrimitive + ReverseBits> ReverseBits for Line<P> {}
+impl<P: CubePrimitive + Not> Not for Line<P> {}
 
 impl<P: CubePrimitive + NumCast> NumCast for Line<P> {
     fn from<T: num_traits::ToPrimitive>(n: T) -> Option<Self> {

--- a/crates/cubecl-core/src/frontend/element/int.rs
+++ b/crates/cubecl-core/src/frontend/element/int.rs
@@ -3,6 +3,7 @@ use crate::frontend::{
     Numeric,
 };
 use crate::ir::{Elem, IntKind};
+use crate::prelude::Not;
 use crate::Runtime;
 use crate::{
     compute::{KernelBuilder, KernelLauncher},
@@ -18,6 +19,7 @@ pub trait Int:
     Numeric
     + CountOnes
     + ReverseBits
+    + Not
     + std::ops::Rem<Output = Self>
     + core::ops::Add<Output = Self>
     + core::ops::Sub<Output = Self>


### PR DESCRIPTION
Patch for #270 
- Implement not unary op for CubePrimitive [here](https://github.com/tracel-ai/burn/issues/2234)