### PR TITLE
Fix some path issues with arch linux

### DIFF
--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -473,10 +473,10 @@ fn cuda_path() -> Option<PathBuf> {
         return if std::fs::exists("/usr/local/cuda").is_ok_and(|exists| exists) {
             Some(PathBuf::from("/usr/local/cuda"))
         } else if std::fs::exists("/opt/cuda").is_ok_and(|exists| exists) {
-            Some(PathBuf::from("/opt/cuda")) 
+            Some(PathBuf::from("/opt/cuda"))
         } else if std::fs::exists("/usr/bin/nvcc").is_ok_and(|exists| exists) {
             // Maybe the compiler was installed within the user path.
-            Some(PathBuf::from("/usr")) 
+            Some(PathBuf::from("/usr"))
         } else {
             None
         };

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -470,10 +470,16 @@ fn cuda_path() -> Option<PathBuf> {
     #[cfg(target_os = "linux")]
     {
         // If it is installed as part of the distribution
-        if std::fs::metadata("/usr/bin/nvcc").is_ok() {
-            return Some(PathBuf::from("/usr"));
-        }
-        return Some(PathBuf::from("/usr/local/cuda"));
+        return if std::fs::exists("/usr/local/cuda").is_ok_and(|exists| exists) {
+            Some(PathBuf::from("/usr/local/cuda"))
+        } else if std::fs::exists("/opt/cuda").is_ok_and(|exists| exists) {
+            Some(PathBuf::from("/opt/cuda")) 
+        } else if std::fs::exists("/usr/bin/nvcc").is_ok_and(|exists| exists) {
+            // Maybe the compiler was installed within the user path.
+            Some(PathBuf::from("/usr")) 
+        } else {
+            None
+        };
     }
 
     #[cfg(target_os = "windows")]

--- a/xtask/src/commands/profile.rs
+++ b/xtask/src/commands/profile.rs
@@ -78,12 +78,17 @@ impl Profile {
         let bins = get_benches(&options.bench);
         let bin = bins.first().unwrap().as_path().to_str().unwrap();
         let file = format!("target/{}", options.bench);
-
+        let ncu_bin_path = std::process::Command::new("which")
+            .arg(&options.ncu_path)
+            .output()
+            .map_err(|_| ())
+            .and_then(|output| String::from_utf8(output.stdout).map_err(|_| ()))
+            .expect("Can't find ncu. Verified that it is installed.");
         run_process(
             "sudo",
             &[
                 "BENCH_NUM_SAMPLES=1",
-                &options.ncu_path,
+                ncu_bin_path.trim(),
                 "--nvtx",
                 "--set=full",
                 "--call-stack",

--- a/xtask/src/commands/profile.rs
+++ b/xtask/src/commands/profile.rs
@@ -78,12 +78,14 @@ impl Profile {
         let bins = get_benches(&options.bench);
         let bin = bins.first().unwrap().as_path().to_str().unwrap();
         let file = format!("target/{}", options.bench);
+
         let ncu_bin_path = std::process::Command::new("which")
             .arg(&options.ncu_path)
             .output()
             .map_err(|_| ())
             .and_then(|output| String::from_utf8(output.stdout).map_err(|_| ()))
-            .expect("Can't find ncu. Verified that it is installed.");
+            .expect("Can't find ncu. Make sure it is installed and in your PATH.");
+
         run_process(
             "sudo",
             &[


### PR DESCRIPTION
I had issue with the default cuda and cuda-tools installation on arch linux using the package manager (pacman). I made some path more flexible. Would be great if some users could try it on their own machine with a different setup.