### PR TITLE
Upgrade to wgpu 24

### DIFF
--- a/crates/cubecl-core/src/compute/launcher.rs
+++ b/crates/cubecl-core/src/compute/launcher.rs
@@ -133,7 +133,10 @@ impl<R: Runtime> KernelLauncher<R> {
     ///
     /// # Safety
     ///
-    /// Out-of-bounds reads and writes can happen.
+    /// The kernel must not:
+    /// - Contain any out of bounds reads or writes. Doing so is immediate UB.
+    /// - Contain any loops that never terminate. These may be optimized away entirely or cause
+    ///   other unpredictable behaviour.
     pub unsafe fn launch_unchecked<K: Kernel>(
         self,
         cube_count: CubeCount,

--- a/crates/cubecl-runtime/src/base.rs
+++ b/crates/cubecl-runtime/src/base.rs
@@ -14,7 +14,8 @@ pub enum ExecutionMode {
     /// Checked kernels are safe.
     #[default]
     Checked,
-    /// Unchecked kernels are unsafe.
+    /// Unchecked kernels are unsafe - it's up to the user to uphold indexing & infinite loop invariants
+    /// in their kernel.
     Unchecked,
 }
 

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -46,11 +46,14 @@ cfg-if = { workspace = true }
 
 # wgpu dependency for platforms other than macOS
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-wgpu = { version = "23.0.0", features = ["fragile-send-sync-non-atomic-wasm"] }
+wgpu = { version = "24.0.0", features = ["fragile-send-sync-non-atomic-wasm"] }
 # On macOS, the `vulkan-portability` feature is required due to the MoltenVK translation layer.
 # To install MoltenVK, install the VulkanSDK: https://vulkan.lunarg.com/sdk/home#mac
 [target.'cfg(target_os = "macos")'.dependencies]
-wgpu = { version = "23.0.0", features = ["vulkan-portability", "fragile-send-sync-non-atomic-wasm"] }
+wgpu = { version = "24.0.0", features = [
+    "vulkan-portability",
+    "fragile-send-sync-non-atomic-wasm",
+] }
 
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.5.0", features = [

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -18,6 +18,7 @@ pub trait WgpuCompiler: Compiler {
     fn create_pipeline(
         server: &mut WgpuServer<Self>,
         kernel: CompiledKernel<Self>,
+        mode: ExecutionMode,
     ) -> Arc<ComputePipeline>;
 
     #[allow(async_fn_in_trait)]

--- a/crates/cubecl-wgpu/src/compiler/spirv.rs
+++ b/crates/cubecl-wgpu/src/compiler/spirv.rs
@@ -108,11 +108,11 @@ impl WgpuCompiler for SpirvCompiler<GLCompute> {
             })
             .unwrap_or_else(|| {
                 let source = &kernel.source;
-                // Cube always in principle uses unchecked modules. Certain operations like
-                // indexing are instead checked by cube. The WebGPU specification only makes
-                // incredibly loose guarantees that Cube can't rely on. Additionally, kernels
-                // can opt in/out per operation whether checks should be performed which can be faster.
+
                 let checks = wgpu::ShaderRuntimeChecks {
+                    // Cube does not need wgpu bounds checks - OOB behaviour is instead
+                    // checked by cube (if enabled).
+                    // This is because the WebGPU specification only makes loose guarantees that Cube can't rely on.
                     bounds_checks: false,
                     // Loop bounds are only checked in checked mode.
                     force_loop_bounding: mode == ExecutionMode::Checked,

--- a/crates/cubecl-wgpu/src/compiler/spirv.rs
+++ b/crates/cubecl-wgpu/src/compiler/spirv.rs
@@ -112,7 +112,7 @@ impl WgpuCompiler for SpirvCompiler<GLCompute> {
                 // indexing are instead checked by cube. The WebGPU specification only makes
                 // incredibly loose guarantees that Cube can't rely on. Additionally, kernels
                 // can opt in/out per operation whether checks should be performed which can be faster.
-                let checks = ShaderRuntimeChecks {
+                let checks = wgpu::ShaderRuntimeChecks {
                     bounds_checks: false,
                     // Loop bounds are only checked in checked mode.
                     force_loop_bounding: mode == ExecutionMode::Checked,
@@ -122,7 +122,7 @@ impl WgpuCompiler for SpirvCompiler<GLCompute> {
                 // is only available through the use of unsafe code.
                 let module = unsafe {
                     server.device.create_shader_module_trusted(
-                        ShaderModuleDescriptor {
+                        wgpu::ShaderModuleDescriptor {
                             label: None,
                             source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(source)),
                         },
@@ -421,9 +421,7 @@ fn is_robust(device: &wgpu::Device) -> bool {
             .contains(&EXT_ROBUSTNESS2_NAME)
     }
     unsafe {
-        device
-            .as_hal::<hal::api::Vulkan, _, _>(|device| device.map(is_robust).unwrap_or(false))
-            .unwrap_or(false)
+        device.as_hal::<hal::api::Vulkan, _, _>(|device| device.map(is_robust).unwrap_or(false))
     }
 }
 

--- a/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
@@ -233,7 +233,7 @@ impl Elem {
     }
 
     pub fn is_atomic(&self) -> bool {
-        matches!(self, Self::AtomicI32 | Self::AtomicU32)
+        matches!(self, Self::AtomicI32 | Self::AtomicU32 | Self::AtomicF32)
     }
 }
 

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -19,7 +19,7 @@ use cubecl_runtime::{DeviceProperties, ExecutionMode};
 use wgpu::{
     BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BufferBindingType,
     ComputePipeline, DeviceDescriptor, PipelineLayoutDescriptor, ShaderModuleDescriptor,
-    ShaderStages,
+    ShaderRuntimeChecks, ShaderStages,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -87,22 +87,29 @@ impl WgpuCompiler for WgslCompiler {
     fn create_pipeline(
         server: &mut WgpuServer<Self>,
         kernel: CompiledKernel<Self>,
+        mode: ExecutionMode,
     ) -> Arc<ComputePipeline> {
         let source = &kernel.source;
         // Cube always in principle uses unchecked modules. Certain operations like
         // indexing are instead checked by cube. The WebGPU specification only makes
         // incredibly loose guarantees that Cube can't rely on. Additionally, kernels
         // can opt in/out per operation whether checks should be performed which can be faster.
-        //
+        let checks = ShaderRuntimeChecks {
+            bounds_checks: false,
+            // Loop bounds are only checked in checked mode.
+            force_loop_bounding: mode == ExecutionMode::Checked,
+        };
+
         // SAFETY: Cube guarantees OOB safety when launching in checked mode. Launching in unchecked mode
         // is only available through the use of unsafe code.
         let module = unsafe {
-            server
-                .device
-                .create_shader_module_unchecked(ShaderModuleDescriptor {
+            server.device.create_shader_module_trusted(
+                ShaderModuleDescriptor {
                     label: None,
                     source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(source)),
-                })
+                },
+                checks,
+            )
         };
 
         let layout = kernel.repr.map(|repr| {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -19,7 +19,7 @@ use cubecl_runtime::{DeviceProperties, ExecutionMode};
 use wgpu::{
     BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BufferBindingType,
     ComputePipeline, DeviceDescriptor, PipelineLayoutDescriptor, ShaderModuleDescriptor,
-    ShaderRuntimeChecks, ShaderStages,
+    ShaderStages,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -90,11 +90,11 @@ impl WgpuCompiler for WgslCompiler {
         mode: ExecutionMode,
     ) -> Arc<ComputePipeline> {
         let source = &kernel.source;
-        // Cube always in principle uses unchecked modules. Certain operations like
-        // indexing are instead checked by cube. The WebGPU specification only makes
-        // incredibly loose guarantees that Cube can't rely on. Additionally, kernels
-        // can opt in/out per operation whether checks should be performed which can be faster.
-        let checks = ShaderRuntimeChecks {
+
+        let checks = wgpu::ShaderRuntimeChecks {
+            // Cube does not need wgpu bounds checks - OOB behaviour is instead
+            // checked by cube (if enabled).
+            // This is because the WebGPU specification only makes loose guarantees that Cube can't rely on.
             bounds_checks: false,
             // Loop bounds are only checked in checked mode.
             force_loop_bounding: mode == ExecutionMode::Checked,

--- a/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
@@ -880,10 +880,7 @@ for (var {i}: {i_ty} = {start}; {i} {cmp} {end}; {increment}) {{
             }
             Instruction::AtomicSub { lhs, rhs, out } => {
                 let out = out.fmt_left();
-                match rhs.elem() {
-                    Elem::F32 => write!(f, "{out} = atomicAdd({lhs}, -{rhs});"),
-                    _ => write!(f, "{out} = atomicSub({lhs}, {rhs});"),
-                }
+                write!(f, "{out} = atomicSub({lhs}, {rhs});")
             }
             Instruction::AtomicMax { lhs, rhs, out } => {
                 let out = out.fmt_left();

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -92,7 +92,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         }
 
         let compile = self.logger.debug(compile);
-        let pipeline = C::create_pipeline(self, compile);
+        let pipeline = C::create_pipeline(self, compile, mode);
 
         self.pipelines.insert(kernel_id.clone(), pipeline.clone());
 

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -212,7 +212,6 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
     );
     let channel = MutexComputeChannel::new(server);
 
-
     // The wgpu float32-atomic feature guarantees both add and min/max. It does only guarantee float32 support,
     // but since f16 and others aren't supported anyway there is not much to it.
     if features.contains(wgpu::Features::SHADER_FLOAT32_ATOMIC) {
@@ -221,7 +220,6 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
         device_props.register_feature(Feature::AtomicFloat(AtomicFeature::MinMax));
     }
 
-    C::register_features(&setup.adapter, &setup.device, &mut device_props);
     ComputeClient::new(channel, device_props)
 }
 

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 use alloc::sync::Arc;
 use cubecl_common::future;
-use cubecl_core::{AtomicFeature, Feature, Runtime};
+use cubecl_core::{
+    ir::{Elem, FloatKind},
+    AtomicFeature, Feature, Runtime,
+};
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
 use cubecl_runtime::{
     channel::MutexComputeChannel,

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -212,12 +212,11 @@ pub(crate) fn create_client_on_setup<C: WgpuCompiler>(
     );
     let channel = MutexComputeChannel::new(server);
 
-    // The wgpu float32-atomic feature guarantees both add and min/max. It does only guarantee float32 support,
-    // but since f16 and others aren't supported anyway there is not much to it.
     if features.contains(wgpu::Features::SHADER_FLOAT32_ATOMIC) {
+        device_props.register_feature(Feature::Type(Elem::AtomicFloat(FloatKind::F32)));
+
         device_props.register_feature(Feature::AtomicFloat(AtomicFeature::LoadStore));
         device_props.register_feature(Feature::AtomicFloat(AtomicFeature::Add));
-        device_props.register_feature(Feature::AtomicFloat(AtomicFeature::MinMax));
     }
 
     ComputeClient::new(channel, device_props)


### PR DESCRIPTION
- Add atomic floats feature matrix to wgpu. In the future when f16 etc. are supported on wgpu this feature matrix might need to be more granular.
- Change checked execution - infinite loops are now again checked in checked mode as they can cause UB. It might make sense to make more granular options for this later.