### PR TITLE
Fix default hip feature flag

### DIFF
--- a/crates/cubecl-hip/Cargo.toml
+++ b/crates/cubecl-hip/Cargo.toml
@@ -15,6 +15,7 @@ default = [
   "cubecl-runtime/default",
   "cubecl-common/default",
   "cubecl-core/default",
+  "cubecl-hip-sys/rocm__6_3_1",
   "is_hip",
 ]
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
@@ -28,7 +29,7 @@ cubecl-cpp = { path = "../cubecl-cpp", version = "0.5.0", default-features = fal
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.5.0", default-features = false, features = [
   "channel-mutex",
 ] }
-cubecl-hip-sys = { version = "6.3.1000", default-features = false, features = ["rocm__6_3_1"] }
+cubecl-hip-sys = { version = "6.3.1000", default-features = false }
 
 bytemuck = { workspace = true }
 

--- a/crates/cubecl-runtime/src/lib.rs
+++ b/crates/cubecl-runtime/src/lib.rs
@@ -16,7 +16,6 @@ pub mod channel;
 pub mod client;
 
 /// Autotune module
-#[cfg(feature = "channel-mpsc")]
 pub mod tune;
 
 /// Memory management module.

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -6,7 +6,7 @@ use core::{fmt::Display, hash::Hash};
 use hashbrown::HashMap;
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::ToString};
+use alloc::string::ToString;
 
 /// A local tuner allows to create a tuner for a specific key that can be different from the server
 /// key.

--- a/crates/cubecl-runtime/src/tune/mod.rs
+++ b/crates/cubecl-runtime/src/tune/mod.rs
@@ -61,7 +61,6 @@ mod local;
 mod operation;
 mod tune_benchmark;
 mod tune_cache;
-#[cfg(feature = "channel-mpsc")]
 mod tuner;
 mod util;
 
@@ -73,6 +72,5 @@ pub use local::*;
 pub use operation::*;
 pub use tune_benchmark::*;
 pub use tune_cache::*;
-#[cfg(feature = "channel-mpsc")]
 pub use tuner::*;
 pub use util::*;

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -1,5 +1,6 @@
 use alloc::string::String;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -1,9 +1,9 @@
+use alloc::vec::Vec;
 use std::sync::Arc;
 
 use crate::channel::ComputeChannel;
 use crate::client::ComputeClient;
 use crate::server::ComputeServer;
-#[cfg(feature = "std")]
 use cubecl_common::benchmark::{BenchmarkDurations, TimingMethod};
 
 use super::{AutotuneError, Tunable};
@@ -24,7 +24,6 @@ impl<
     > TuneBenchmark<S, C, In, Out>
 {
     /// Benchmark how long this operation takes for a number of samples.
-    #[cfg(feature = "std")]
     pub async fn sample_durations(self) -> Result<BenchmarkDurations, AutotuneError> {
         let operation = self.operation;
 

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -1,5 +1,5 @@
+use alloc::sync::Arc;
 use alloc::vec::Vec;
-use std::sync::Arc;
 
 use crate::channel::ComputeChannel;
 use crate::client::ComputeClient;

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -9,7 +9,8 @@ use cubecl_common::stub::Duration;
 #[cfg(all(not(target_family = "wasm"), feature = "std"))]
 use std::panic::resume_unwind;
 
-use alloc::string::ToString;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use cubecl_common::benchmark::BenchmarkComputations;
 


### PR DESCRIPTION
Originates from [this discussion](https://github.com/tracel-ai/burn/discussions/2709), linked to [cubecl-hip-sys PR](https://github.com/tracel-ai/cubecl-hip/pull/13).

As it is, `cubecl-hip-sys` feature flags are not additive, so forcing the "rocm__6_3_1" version causes issues when trying to specify another version. I've removed it from the forced feature and moved it to the default for `cubecl-hip`.

I also removed the "channel-mpsc" check (previously required for the `async-channel` dep, which is no longer optional) and "std" check in the autotune module (which was causing issues for burn with no default features - seems to be unnecessary but correct me if I am wrong).

