### PR TITLE
Remove arcs

### DIFF
--- a/crates/cubecl-wgpu/src/compute/poll.rs
+++ b/crates/cubecl-wgpu/src/compute/poll.rs
@@ -10,7 +10,7 @@ mod _impl {
     }
 
     impl WgpuPoll {
-        pub fn new(device: std::sync::Arc<wgpu::Device>) -> Self {
+        pub fn new(device: wgpu::Device) -> Self {
             let active_handle = std::sync::Arc::new(());
             let thread_check = active_handle.clone();
 
@@ -61,7 +61,7 @@ mod _impl {
     #[derive(Debug)]
     pub struct WgpuPoll {}
     impl WgpuPoll {
-        pub fn new(_device: alloc::sync::Arc<wgpu::Device>) -> Self {
+        pub fn new(_device: wgpu::Device) -> Self {
             Self {}
         }
         pub fn start_polling(&self) -> alloc::sync::Arc<()> {

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -27,7 +27,7 @@ use wgpu::ComputePipeline;
 /// Wgpu compute server.
 #[derive(Debug)]
 pub struct WgpuServer<C: WgpuCompiler> {
-    pub(crate) device: Arc<wgpu::Device>,
+    pub(crate) device: wgpu::Device,
     pipelines: HashMap<KernelId, Arc<ComputePipeline>>,
     logger: DebugLogger,
     duration_profiled: Option<Duration>,
@@ -42,8 +42,8 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         memory_properties: MemoryDeviceProperties,
         memory_config: MemoryConfiguration,
         compilation_options: C::CompilationOptions,
-        device: Arc<wgpu::Device>,
-        queue: Arc<wgpu::Queue>,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
         tasks_max: usize,
     ) -> Self {
         let logger = DebugLogger::default();
@@ -64,7 +64,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
 
         Self {
             compilation_options,
-            device: device.clone(),
+            device,
             pipelines: HashMap::new(),
             logger,
             duration_profiled: None,

--- a/crates/cubecl-wgpu/src/compute/storage.rs
+++ b/crates/cubecl-wgpu/src/compute/storage.rs
@@ -1,13 +1,13 @@
 use cubecl_runtime::storage::{ComputeStorage, StorageHandle, StorageId, StorageUtilization};
 use hashbrown::HashMap;
-use std::{num::NonZeroU64, sync::Arc};
+use std::num::NonZeroU64;
 use wgpu::BufferUsages;
 
 /// Buffer storage for wgpu.
 pub struct WgpuStorage {
-    memory: HashMap<StorageId, Arc<wgpu::Buffer>>,
+    memory: HashMap<StorageId, wgpu::Buffer>,
     deallocations: Vec<StorageId>,
-    device: Arc<wgpu::Device>,
+    device: wgpu::Device,
     buffer_usages: BufferUsages,
 }
 
@@ -21,7 +21,7 @@ impl core::fmt::Debug for WgpuStorage {
 #[derive(new)]
 pub struct WgpuResource {
     /// The wgpu buffer.
-    pub buffer: Arc<wgpu::Buffer>,
+    pub buffer: wgpu::Buffer,
 
     offset: u64,
     size: u64,
@@ -54,7 +54,7 @@ impl WgpuResource {
 /// Keeps actual wgpu buffer references in a hashmap with ids as key.
 impl WgpuStorage {
     /// Create a new storage on the given [device](wgpu::Device).
-    pub fn new(device: Arc<wgpu::Device>, usages: BufferUsages) -> Self {
+    pub fn new(device: wgpu::Device, usages: BufferUsages) -> Self {
         Self {
             memory: HashMap::new(),
             deallocations: Vec::new(),
@@ -90,12 +90,12 @@ impl ComputeStorage for WgpuStorage {
     fn alloc(&mut self, size: u64) -> StorageHandle {
         let id = StorageId::new();
 
-        let buffer = Arc::new(self.device.create_buffer(&wgpu::BufferDescriptor {
+        let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size,
             usage: self.buffer_usages,
             mapped_at_creation: false,
-        }));
+        });
 
         self.memory.insert(id, buffer);
         StorageHandle::new(id, StorageUtilization { offset: 0, size })

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -33,10 +33,10 @@ pub struct WgpuStream {
     pub timestamps: KernelTimestamps,
     tasks_count: usize,
     tasks_max: usize,
-    device: Arc<wgpu::Device>,
-    queue: Arc<wgpu::Queue>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
     poll: WgpuPoll,
-    sync_buffer: Option<Arc<wgpu::Buffer>>,
+    sync_buffer: Option<wgpu::Buffer>,
     submission_load: SubmissionLoad,
 }
 
@@ -47,8 +47,8 @@ pub enum PipelineDispatch {
 
 impl WgpuStream {
     pub fn new(
-        device: Arc<wgpu::Device>,
-        queue: Arc<wgpu::Queue>,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
         memory_properties: MemoryDeviceProperties,
         memory_config: MemoryConfiguration,
         timestamps: KernelTimestamps,
@@ -206,7 +206,7 @@ impl WgpuStream {
 
     pub fn read_buffers(
         &mut self,
-        buffers: Vec<(Arc<wgpu::Buffer>, u64, u64)>,
+        buffers: Vec<(wgpu::Buffer, u64, u64)>,
     ) -> impl Future<Output = Vec<Vec<u8>>> + 'static {
         self.compute_pass = None;
         let mut staging_buffers = Vec::with_capacity(buffers.len());
@@ -283,7 +283,7 @@ impl WgpuStream {
 
     pub fn read_buffer(
         &mut self,
-        buffer: Arc<wgpu::Buffer>,
+        buffer: wgpu::Buffer,
         offset: u64,
         size: u64,
     ) -> impl Future<Output = Vec<u8>> + 'static {
@@ -343,7 +343,7 @@ impl WgpuStream {
         match method {
             TimestampMethod::Buffer(resolved, size) => {
                 let period = self.queue.get_timestamp_period() as f64 * 1e-9;
-                let fut = self.read_buffer(Arc::new(resolved), 0, size);
+                let fut = self.read_buffer(resolved, 0, size);
 
                 Box::pin(async move {
                     let data = fut

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -5,7 +5,6 @@ use crate::{
     compute::{WgpuServer, WgpuStorage},
     AutoGraphicsApi, GraphicsApi, WgpuDevice,
 };
-use alloc::sync::Arc;
 use cubecl_common::future;
 use cubecl_core::{
     ir::{Elem, FloatKind},
@@ -103,13 +102,13 @@ impl Default for RuntimeOptions {
 #[derive(Clone, Debug)]
 pub struct WgpuSetup {
     /// The underlying wgpu instance.
-    pub instance: Arc<wgpu::Instance>,
+    pub instance: wgpu::Instance,
     /// The selected 'adapter'. This corresponds to a physical device.
-    pub adapter: Arc<wgpu::Adapter>,
+    pub adapter: wgpu::Adapter,
     /// The wgpu device Burn will use. Nb: There can only be one device per adapter.
-    pub device: Arc<wgpu::Device>,
+    pub device: wgpu::Device,
     /// The queue Burn commands will be submitted to.
-    pub queue: Arc<wgpu::Queue>,
+    pub queue: wgpu::Queue,
 }
 
 /// Create a [`WgpuDevice`] on an existing [`WgpuSetup`].
@@ -239,10 +238,10 @@ pub(crate) async fn create_setup_for_device<G: GraphicsApi, C: WgpuCompiler>(
     );
 
     WgpuSetup {
-        instance: Arc::new(instance),
-        adapter: Arc::new(adapter),
-        device: Arc::new(device),
-        queue: Arc::new(queue),
+        instance,
+        adapter,
+        device,
+        queue,
     }
 }
 


### PR DESCRIPTION
wgpu 24 has made their resources use arcs internally and are now cloneable, so no need to keep arcs ourselves anymore.