### PR TITLE
More improvements to ExclusivePages memory allocator

### DIFF
--- a/crates/cubecl-core/src/lib.rs
+++ b/crates/cubecl-core/src/lib.rs
@@ -33,7 +33,9 @@ pub use cubecl_runtime::memory_management::MemoryUsage;
 use crate::compute::KernelDefinition;
 use frontend::LaunchArg;
 
+pub use cubecl_common::ExecutionMode;
 pub use cubecl_common::{flex32, tf32};
+
 pub use prelude::CubeCount;
 pub use prelude::CubeDim;
 

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -3,6 +3,8 @@ use super::{
     MemoryConfiguration, MemoryDeviceProperties, MemoryPoolOptions, MemoryUsage, PoolType,
 };
 use crate::storage::{ComputeStorage, StorageHandle};
+use alloc::vec;
+use alloc::vec::Vec;
 
 pub use super::memory_pool::{SliceBinding, SliceHandle};
 

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -178,7 +178,7 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> {
                         const SCALE_MB: u64 = 1024 * 1024 * 1024;
 
                         let dealloc_period =
-                            (500.0 * (1.0 + size as f64 / (SCALE_MB as f64)).round()) as u64;
+                            (1000.0 * (1.0 + size as f64 / (SCALE_MB as f64)).round()) as u64;
 
                         MemoryPoolOptions {
                             pool_type: PoolType::ExclusivePages {

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
@@ -35,7 +35,7 @@ pub(crate) fn calculate_padding(size: u64, buffer_alignment: u64) -> u64 {
 }
 
 pub trait MemoryPool {
-    fn handles_alloc(&self, size: u64) -> bool;
+    fn max_alloc_size(&self) -> u64;
 
     fn get(&self, binding: &SliceBinding) -> Option<&StorageHandle>;
 

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
@@ -61,7 +61,9 @@ impl ExclusiveMemoryPool {
         storage: &mut Storage,
         size: u64,
     ) -> &mut MemoryPage {
-        let alloc_size = (self.cur_avg_size as u64).max(size);
+        let alloc_size = (self.cur_avg_size as u64)
+            .max(size)
+            .next_multiple_of(self.alignment);
 
         let storage = storage.alloc(alloc_size);
 

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
@@ -34,7 +34,6 @@ impl ExclusiveMemoryPool {
     pub(crate) fn new(max_alloc_size: u64, alignment: u64, dealloc_period: u64) -> Self {
         // Pages should be allocated to be aligned.
         assert_eq!(max_alloc_size % alignment, 0);
-        log::info!("Adding pool with size {max_alloc_size}");
 
         Self {
             pages: Vec::new(),

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
@@ -19,7 +19,6 @@ pub(crate) struct SlicedPool {
     recently_allocated_size: u64,
     page_size: u64,
     max_alloc_size: u64,
-    min_alloc_size: u64,
     alignment: u64,
 }
 
@@ -82,8 +81,8 @@ impl MemoryPage {
 }
 
 impl MemoryPool for SlicedPool {
-    fn handles_alloc(&self, size: u64) -> bool {
-        size >= self.min_alloc_size && size <= self.max_alloc_size
+    fn max_alloc_size(&self) -> u64 {
+        self.max_alloc_size
     }
 
     /// Returns the resource from the storage, for the specified handle.
@@ -154,12 +153,7 @@ impl MemoryPool for SlicedPool {
 }
 
 impl SlicedPool {
-    pub(crate) fn new(
-        page_size: u64,
-        min_alloc_size: u64,
-        max_alloc_size: u64,
-        alignment: u64,
-    ) -> Self {
+    pub(crate) fn new(page_size: u64, max_alloc_size: u64, alignment: u64) -> Self {
         // Pages should be allocated to be aligned.
         assert_eq!(page_size % alignment, 0);
         Self {
@@ -171,7 +165,6 @@ impl SlicedPool {
             recently_allocated_size: 0,
             alignment,
             page_size,
-            min_alloc_size,
             max_alloc_size,
         }
     }

--- a/crates/cubecl-runtime/src/memory_management/mod.rs
+++ b/crates/cubecl-runtime/src/memory_management/mod.rs
@@ -17,14 +17,12 @@ pub enum PoolType {
     /// Use a memory where every allocation is a separate page.
     ExclusivePages {
         /// The minimum number of bytes to allocate in this pool.
-        min_alloc_size: u64,
+        max_alloc_size: u64,
     },
     /// Use a memory where each allocation is a slice of a bigger allocation.
     SlicedPages {
         /// The page size to allocate.
         page_size: u64,
-        /// The minimum size of a slice to allocate in the pool.
-        min_slice_size: u64,
         /// The maximum size of a slice to allocate in the pool.
         max_slice_size: u64,
     },

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -97,8 +97,10 @@ impl WgpuStream {
             &memory_properties,
             MemoryConfiguration::Custom {
                 pool_options: vec![MemoryPoolOptions {
-                    pool_type: memory_management::PoolType::ExclusivePages { min_alloc_size: 0 },
-                    dealloc_period: None,
+                    pool_type: memory_management::PoolType::ExclusivePages {
+                        max_alloc_size: SMALL_UNIFORMS_BUFFER_SIZE,
+                    },
+                    dealloc_period: Some(100),
                 }],
             },
         );

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -100,7 +100,7 @@ impl WgpuStream {
                     pool_type: memory_management::PoolType::ExclusivePages {
                         max_alloc_size: SMALL_UNIFORMS_BUFFER_SIZE,
                     },
-                    dealloc_period: Some(100),
+                    dealloc_period: Some(5000),
                 }],
             },
         );


### PR DESCRIPTION
Follow up to #419 as I was still seeing some bad memory behiavour:

- Prefer picking slices that aren't about to be freed
- Get rid of neighbour search again, too unpredictable
  - As part of that, use simpler max_alloc_size again instead of can_handle_alloc & brute force search. "minumum" allocation was a bit confusing.
- Instead of hardcoded over allocation keep a moving average of the *expected* alloc size. If smaller, alloc the average, if bigger, allocate that size exactly.
- Tweak pool sizes / counts / dealloc frequencies a bit