### PR TITLE
[hip] Fix shuffle intrinsic names for __shfl_xor and __shfl_down

### DIFF
--- a/crates/cubecl-cpp/src/hip/dialect.rs
+++ b/crates/cubecl-cpp/src/hip/dialect.rs
@@ -79,10 +79,10 @@ impl<M: WmmaCompiler<Self>> Dialect for HipDialect<M> {
         format!("__shfl({var}, {source})")
     }
     fn warp_shuffle_xor(var: &str, offset: &str) -> String {
-        format!("__shfl_xor_sync({var}, {offset})")
+        format!("__shfl_xor({var}, {offset})")
     }
     fn warp_shuffle_down(var: &str, offset: &str) -> String {
-        format!("__shfl_down_sync({var}, {offset})")
+        format!("__shfl_down({var}, {offset})")
     }
     fn warp_all(var: &str) -> String {
         format!("__all({var})")


### PR DESCRIPTION
Fixed a bug identified in discussion: https://github.com/tracel-ai/burn/discussions/2709