### PR TITLE
Some cleaning in matmul tiles

### DIFF
--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -160,8 +160,8 @@ where
 
     fn init_tile_inputs(#[comptime] config: Self::Config) -> (TMM::Lhs, TMM::Rhs) {
         (
-            TMM::init_lhs(config.to_tmm_config()),
-            TMM::init_rhs(config.to_tmm_config()),
+            TMM::allocate_lhs(config.to_tmm_config()),
+            TMM::allocate_rhs(config.to_tmm_config()),
         )
     }
 
@@ -201,7 +201,7 @@ where
 
         #[unroll]
         for _ in 0..config.num_stage.n {
-            acc.push(TMM::init_accumulator(config.to_tmm_config()));
+            acc.push(TMM::allocate_accumulator(config.to_tmm_config()));
         }
 
         acc

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -149,8 +149,8 @@ where
 
     fn init_tile_inputs(#[comptime] config: Self::Config) -> (TMM::Lhs, TMM::Rhs) {
         (
-            TMM::init_lhs(config.to_tmm_config()),
-            TMM::init_rhs(config.to_tmm_config()),
+            TMM::allocate_lhs(config.to_tmm_config()),
+            TMM::allocate_rhs(config.to_tmm_config()),
         )
     }
 
@@ -159,7 +159,7 @@ where
 
         #[unroll]
         for _ in 0..config.num_stage.n {
-            accumulators.push(TMM::init_accumulator(config.to_tmm_config()));
+            accumulators.push(TMM::allocate_accumulator(config.to_tmm_config()));
         }
 
         accumulators

--- a/crates/cubecl-linalg/src/matmul/components/tile/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/base.rs
@@ -48,16 +48,16 @@ pub trait TileMatmul<I: Numeric, O: Numeric>: 'static + Send + Sync {
     /// # Safety
     ///
     /// This may point towards uninitialized memory.
-    /// Make sure to call fill_lhs prior to execute.
-    fn init_lhs(#[comptime] config: Self::Config) -> Self::Lhs;
+    /// Make sure to call [fill_lhs](TileMatmul::fill_lhs) prior to [execute](TileMatmul::execute).
+    fn allocate_lhs(#[comptime] config: Self::Config) -> Self::Lhs;
 
     /// Create the container for RHS data
     ///
     /// # Safety
     ///
     /// This may point towards uninitialized memory.
-    /// Make sure to call fill_rhs prior to execute.
-    fn init_rhs(#[comptime] config: Self::Config) -> Self::Rhs;
+    /// Make sure to call [fill_rhs](TileMatmul::fill_lhs) prior to [execute](TileMatmul::execute).
+    fn allocate_rhs(#[comptime] config: Self::Config) -> Self::Rhs;
 
     /// Fill the container of LHS with data
     fn fill_lhs(slice: &Slice<Line<I>>, lhs: &mut Self::Lhs, #[comptime] config: Self::Config);
@@ -80,15 +80,17 @@ pub trait TileMatmul<I: Numeric, O: Numeric>: 'static + Send + Sync {
         #[comptime] config: Self::Config,
     );
 
-    /// Create the container to receive the execution output.
+    /// Allocate the container to receive the execution output.
     ///
     /// # Safety
     ///
     /// The output container must be initialized to some value (typically 0),
     /// because the execution adds to the already present value.
-    fn init_accumulator(#[comptime] config: Self::Config) -> Self::Accumulator;
+    /// Make sure to call either [fill_accumulator](TileMatmul::fill_accumulator)
+    /// or [zero_accumulator](TileMatmul::zero_accumulator).
+    fn allocate_accumulator(#[comptime] config: Self::Config) -> Self::Accumulator;
 
-    /// Set the accumulator to zeros
+    /// Fill the accumulator with zeros.
     fn zero_accumulator(acc: &mut Self::Accumulator, #[comptime] config: Self::Config);
 }
 

--- a/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
@@ -76,11 +76,11 @@ impl<I: Numeric, O: Numeric> TileMatmul<I, O> for PlaneMma {
         }
     }
 
-    fn init_lhs(#[comptime] config: Config) -> Self::Lhs {
+    fn allocate_lhs(#[comptime] config: Config) -> Self::Lhs {
         Array::new(config.size.k)
     }
 
-    fn init_rhs(#[comptime] config: Config) -> Self::Rhs {
+    fn allocate_rhs(#[comptime] config: Config) -> Self::Rhs {
         Array::new(config.size.k * config.size.n / config.plane_dim())
     }
 
@@ -220,7 +220,7 @@ impl<I: Numeric, O: Numeric> TileMatmul<I, O> for PlaneMma {
         }
     }
 
-    fn init_accumulator(#[comptime] config: Config) -> Self::Accumulator {
+    fn allocate_accumulator(#[comptime] config: Config) -> Self::Accumulator {
         let len = config.size.m * config.size.n / (config.plane_dim());
         Array::new(len)
     }


### PR DESCRIPTION
- Rename `init_lhs` to `allocate_lhs` and similar for `rhs` and `accumulator`.
- Remove simple helper functions in accelerated that were only wrapper in top level functions.