### PR TITLE
Replace all Float bound with Numeric for matmul

### DIFF
--- a/crates/cubecl-linalg/src/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/base.rs
@@ -1,6 +1,6 @@
 use cubecl_core::{
     client::ComputeClient,
-    prelude::{Float, TensorHandleRef},
+    prelude::{Float, Numeric, TensorHandleRef},
     Runtime,
 };
 
@@ -46,7 +46,7 @@ pub fn launch<R: Runtime, EG: Float>(
     )
 }
 
-pub fn launch_ref<R: Runtime, EG: Float>(
+pub fn launch_ref<R: Runtime, EG: Numeric>(
     strategy: &Strategy,
     client: &ComputeClient<R::Server, R::Channel>,
     lhs: &TensorHandleRef<R>,

--- a/crates/cubecl-linalg/src/matmul/kernels/simple.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/simple.rs
@@ -9,10 +9,10 @@ use crate::tensor::{into_contiguous, matrix_layout, MatrixLayout, TensorHandle};
 use super::MatmulLaunchError;
 
 #[cube(launch_unchecked)]
-fn matmul_kernel<F: Float>(
-    lhs: &Tensor<Line<F>>,
-    rhs: &Tensor<Line<F>>,
-    out: &mut Tensor<F>,
+fn matmul_kernel<N: Numeric>(
+    lhs: &Tensor<Line<N>>,
+    rhs: &Tensor<Line<N>>,
+    out: &mut Tensor<N>,
     // number of dimensions not involved in the matmul
     #[comptime] num_batches: Option<u32>,
 ) {
@@ -49,7 +49,7 @@ fn matmul_kernel<F: Float>(
     offset_lhs /= line_size.runtime();
     offset_rhs /= line_size.runtime();
 
-    let mut sum = Line::empty(line_size).fill(F::from_int(0));
+    let mut sum = Line::empty(line_size).fill(N::from_int(0));
 
     k /= line_size.runtime();
 
@@ -65,7 +65,7 @@ fn matmul_kernel<F: Float>(
 
     let unroll_sum = line_size != 1;
     if unroll_sum {
-        let mut accum = F::new(0.);
+        let mut accum = N::from_int(0);
         // we unroll the loop to sum `vectorization_factor` elements at once, which lets us
         // use SIMD instructions to speed up the computation
         #[unroll]
@@ -80,7 +80,7 @@ fn matmul_kernel<F: Float>(
 }
 
 /// Matrix multiplication using memory coalescing algorithm with custom cube dimensions
-pub fn launch_ref<R: Runtime, E: Float>(
+pub fn launch_ref<R: Runtime, E: Numeric>(
     client: &ComputeClient<R::Server, R::Channel>,
     lhs: &TensorHandleRef<'_, R>,
     rhs: &TensorHandleRef<'_, R>,
@@ -94,7 +94,7 @@ pub fn launch_ref<R: Runtime, E: Float>(
     launch(client, lhs, rhs, out)
 }
 
-pub fn launch<R: Runtime, E: Float>(
+pub fn launch<R: Runtime, E: Numeric>(
     client: &ComputeClient<R::Server, R::Channel>,
     lhs: TensorHandle<R, E>,
     rhs: TensorHandle<R, E>,

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/compute_loop.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/compute_loop.rs
@@ -5,11 +5,11 @@ use super::{base::Coordinates, config::CubeTiling2dConfig, outer_product::tile_o
 
 #[cube]
 #[allow(unused_mut)]
-pub(crate) fn compute_loop<F: Float>(
+pub(crate) fn compute_loop<N: Numeric>(
     coordinates: Coordinates,
-    shared_lhs: SharedMemory<Line<F>>,
-    shared_rhs: SharedMemory<Line<F>>,
-    results: &mut Array<F>,
+    shared_lhs: SharedMemory<Line<N>>,
+    shared_rhs: SharedMemory<Line<N>>,
+    results: &mut Array<N>,
     #[comptime] config: CubeTiling2dConfig,
 ) {
     let tile_size = config.tile_size;
@@ -26,6 +26,6 @@ pub(crate) fn compute_loop<F: Float>(
         let register_m = shared_lhs[(unit_row + dot_index * block_size_m) / tile_size];
         let register_n = shared_rhs[(unit_col + dot_index * block_size_n) / tile_size];
 
-        tile_outer_product::<F>(register_m, register_n, results, config);
+        tile_outer_product::<N>(register_m, register_n, results, config);
     }
 }

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/load_shared_memory.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/load_shared_memory.rs
@@ -13,60 +13,60 @@ use super::{
 
 #[derive(CubeType)]
 #[allow(dead_code)]
-pub(crate) struct LoadInfo<F: Float> {
+pub(crate) struct LoadInfo<N: Numeric> {
     pub coordinates: Coordinates,
     pub k: u32,
     pub batch_offset: u32,
-    pub shared_memory: SharedMemory<Line<F>>,
+    pub shared_memory: SharedMemory<Line<N>>,
     pub dims: Dimensions,
 }
 
 #[cube]
-pub(crate) trait Loader<F: Float>: Sync + Send + 'static {
-    fn load_lhs_plain<B: BlockLoader<F>>(
-        lhs: &Tensor<Line<F>>,
-        load_info: LoadInfo<F>,
+pub(crate) trait Loader<N: Numeric>: Sync + Send + 'static {
+    fn load_lhs_plain<B: BlockLoader<N>>(
+        lhs: &Tensor<Line<N>>,
+        load_info: LoadInfo<N>,
         #[comptime] config: CubeTiling2dConfig,
     );
-    fn load_lhs_transposed<B: BlockLoader<F>>(
-        lhs: &Tensor<Line<F>>,
-        load_info: LoadInfo<F>,
+    fn load_lhs_transposed<B: BlockLoader<N>>(
+        lhs: &Tensor<Line<N>>,
+        load_info: LoadInfo<N>,
         #[comptime] config: CubeTiling2dConfig,
     );
-    fn load_rhs_plain<B: BlockLoader<F>>(
-        rhs: &Tensor<Line<F>>,
-        load_info: LoadInfo<F>,
+    fn load_rhs_plain<B: BlockLoader<N>>(
+        rhs: &Tensor<Line<N>>,
+        load_info: LoadInfo<N>,
         #[comptime] config: CubeTiling2dConfig,
     );
-    fn load_rhs_transposed<B: BlockLoader<F>>(
-        rhs: &Tensor<Line<F>>,
-        load_info: LoadInfo<F>,
+    fn load_rhs_transposed<B: BlockLoader<N>>(
+        rhs: &Tensor<Line<N>>,
+        load_info: LoadInfo<N>,
         #[comptime] config: CubeTiling2dConfig,
     );
 }
 
 #[cube]
-pub(crate) fn load_to_shared_memories<F: Float, L: Loader<F>>(
-    lhs: &Tensor<Line<F>>,
-    rhs: &Tensor<Line<F>>,
+pub(crate) fn load_to_shared_memories<N: Numeric, L: Loader<N>>(
+    lhs: &Tensor<Line<N>>,
+    rhs: &Tensor<Line<N>>,
     coordinates: Coordinates,
     k: u32,
     offsets: BatchOffsets,
-    shared: SharedMemories<F>,
+    shared: SharedMemories<N>,
     #[comptime] config: CubeTiling2dConfig,
     dims: Dimensions,
 ) {
     let lhs_transposed = config.lhs_transposed;
     let rhs_transposed = config.rhs_transposed;
 
-    let lhs_load_info = LoadInfo::<F> {
+    let lhs_load_info = LoadInfo::<N> {
         coordinates,
         k,
         batch_offset: offsets.lhs,
         shared_memory: shared.lhs,
         dims,
     };
-    let rhs_load_info = LoadInfo::<F> {
+    let rhs_load_info = LoadInfo::<N> {
         coordinates,
         k,
         batch_offset: offsets.rhs,
@@ -76,23 +76,23 @@ pub(crate) fn load_to_shared_memories<F: Float, L: Loader<F>>(
 
     // Lhs must be loaded as transposed. If it already is transposed in global memory, we load as plain.
     if lhs_transposed {
-        load_lhs_plain::<F, L>(lhs, lhs_load_info, config);
+        load_lhs_plain::<N, L>(lhs, lhs_load_info, config);
     } else {
-        load_lhs_transposed::<F, L>(lhs, lhs_load_info, config);
+        load_lhs_transposed::<N, L>(lhs, lhs_load_info, config);
     }
 
     // Rhs must be loaded as plain. If it is transposed in global memory, we transpose it back.
     if rhs_transposed {
-        load_rhs_transposed::<F, L>(rhs, rhs_load_info, config);
+        load_rhs_transposed::<N, L>(rhs, rhs_load_info, config);
     } else {
-        load_rhs_plain::<F, L>(rhs, rhs_load_info, config);
+        load_rhs_plain::<N, L>(rhs, rhs_load_info, config);
     }
 }
 
 #[cube]
-pub(crate) fn load_lhs_transposed<F: Float, L: Loader<F>>(
-    lhs: &Tensor<Line<F>>,
-    load_info: LoadInfo<F>,
+pub(crate) fn load_lhs_transposed<N: Numeric, L: Loader<N>>(
+    lhs: &Tensor<Line<N>>,
+    load_info: LoadInfo<N>,
     #[comptime] config: CubeTiling2dConfig,
 ) {
     let check_m_bounds = config.check_m_bounds;
@@ -112,9 +112,9 @@ pub(crate) fn load_lhs_transposed<F: Float, L: Loader<F>>(
 }
 
 #[cube]
-pub(crate) fn load_lhs_plain<F: Float, L: Loader<F>>(
-    lhs: &Tensor<Line<F>>,
-    load_info: LoadInfo<F>,
+pub(crate) fn load_lhs_plain<N: Numeric, L: Loader<N>>(
+    lhs: &Tensor<Line<N>>,
+    load_info: LoadInfo<N>,
     #[comptime] config: CubeTiling2dConfig,
 ) {
     let check_m_bounds = config.check_m_bounds;
@@ -134,9 +134,9 @@ pub(crate) fn load_lhs_plain<F: Float, L: Loader<F>>(
 }
 
 #[cube]
-pub(crate) fn load_rhs_transposed<F: Float, L: Loader<F>>(
-    rhs: &Tensor<Line<F>>,
-    load_info: LoadInfo<F>,
+pub(crate) fn load_rhs_transposed<N: Numeric, L: Loader<N>>(
+    rhs: &Tensor<Line<N>>,
+    load_info: LoadInfo<N>,
     #[comptime] config: CubeTiling2dConfig,
 ) {
     let check_k_bounds = config.check_k_bounds;
@@ -156,9 +156,9 @@ pub(crate) fn load_rhs_transposed<F: Float, L: Loader<F>>(
 }
 
 #[cube]
-pub(crate) fn load_rhs_plain<F: Float, L: Loader<F>>(
-    rhs: &Tensor<Line<F>>,
-    load_info: LoadInfo<F>,
+pub(crate) fn load_rhs_plain<N: Numeric, L: Loader<N>>(
+    rhs: &Tensor<Line<N>>,
+    load_info: LoadInfo<N>,
     #[comptime] config: CubeTiling2dConfig,
 ) {
     let check_k_bounds = config.check_k_bounds;

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/outer_product.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/outer_product.rs
@@ -4,10 +4,10 @@ use cubecl_core::prelude::*;
 use super::config::CubeTiling2dConfig;
 
 #[cube]
-pub(crate) fn tile_outer_product<F: Float>(
-    register_m: Line<F>,
-    register_n: Line<F>,
-    results: &mut Array<F>,
+pub(crate) fn tile_outer_product<N: Numeric>(
+    register_m: Line<N>,
+    register_n: Line<N>,
+    results: &mut Array<N>,
     #[comptime] config: CubeTiling2dConfig,
 ) {
     let tile_size = config.tile_size;
@@ -18,7 +18,7 @@ pub(crate) fn tile_outer_product<F: Float>(
         let res_pos_base = res_idx_m * tile_size;
         #[unroll(unroll)]
         for res_idx_n in 0..register_n.size() {
-            let mul: F = register_m[res_idx_m] * register_n[res_idx_n];
+            let mul: N = register_m[res_idx_m] * register_n[res_idx_n];
             results[res_pos_base + res_idx_n] += mul;
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/base.rs
@@ -7,18 +7,18 @@ use crate::matmul::kernels::tiling2d::tile::memory_access::ContiguousAccess;
 use crate::matmul::kernels::tiling2d::write_output::WriteTileInfo;
 
 #[cube]
-pub(crate) trait BlockLoader<F: Float>: Send + Sync + 'static {
-    fn load_tile_plain<A: ContiguousAccess<F>>(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+pub(crate) trait BlockLoader<N: Numeric>: Send + Sync + 'static {
+    fn load_tile_plain<A: ContiguousAccess<N>>(
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         read_tile_info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
     );
 
     fn load_tile_transposed(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         read_tile_info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
@@ -26,10 +26,10 @@ pub(crate) trait BlockLoader<F: Float>: Send + Sync + 'static {
 }
 
 #[cube]
-pub(crate) trait BlockWriter<F: Float>: Send + Sync + 'static {
-    fn write_output<A: ContiguousAccess<F>>(
-        out: &mut Tensor<Line<F>>,
-        results: &Array<F>,
+pub(crate) trait BlockWriter<N: Numeric>: Send + Sync + 'static {
+    fn write_output<A: ContiguousAccess<N>>(
+        out: &mut Tensor<Line<N>>,
+        results: &Array<N>,
         write_tile_info: WriteTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
@@ -37,15 +37,15 @@ pub(crate) trait BlockWriter<F: Float>: Send + Sync + 'static {
 }
 
 #[cube]
-pub(crate) fn all_zeros_runtime<F: Float>(
-    shared_memory: &mut SharedMemory<Line<F>>,
+pub(crate) fn all_zeros_runtime<N: Numeric>(
+    shared_memory: &mut SharedMemory<Line<N>>,
     start: u32,
     sm_position_base: u32,
     sm_stride: u32,
     #[comptime] config: CubeTiling2dConfig,
 ) {
     let tile_size = config.tile_size;
-    let zeros = Line::empty(tile_size).fill(F::new(0.));
+    let zeros = Line::empty(tile_size).fill(N::from_int(0));
 
     for i in start..tile_size {
         let sm_position = (sm_position_base + i * sm_stride) / tile_size;
@@ -55,15 +55,15 @@ pub(crate) fn all_zeros_runtime<F: Float>(
 }
 
 #[cube]
-pub(crate) fn all_zeros_comptime<F: Float>(
-    shared_memory: &mut SharedMemory<Line<F>>,
+pub(crate) fn all_zeros_comptime<N: Numeric>(
+    shared_memory: &mut SharedMemory<Line<N>>,
     sm_position_base: u32,
     sm_stride: u32,
     #[comptime] config: CubeTiling2dConfig,
 ) {
     let tile_size = config.tile_size;
     let unroll = config.unroll_tile;
-    let zeros = Line::empty(tile_size).fill(F::new(0.));
+    let zeros = Line::empty(tile_size).fill(N::from_int(0));
 
     #[unroll(unroll)]
     for i in 0..tile_size {

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/horizontal_block_check.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/horizontal_block_check.rs
@@ -15,10 +15,10 @@ use super::base::{all_zeros_comptime, all_zeros_runtime, BlockLoader, BlockWrite
 pub(crate) struct HorizontalCheckBlockIO;
 
 #[cube]
-impl<F: Float> BlockLoader<F> for HorizontalCheckBlockIO {
-    fn load_tile_plain<A: ContiguousAccess<F>>(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+impl<N: Numeric> BlockLoader<N> for HorizontalCheckBlockIO {
+    fn load_tile_plain<A: ContiguousAccess<N>>(
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
@@ -43,8 +43,8 @@ impl<F: Float> BlockLoader<F> for HorizontalCheckBlockIO {
     }
 
     fn load_tile_transposed(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
@@ -81,10 +81,10 @@ impl<F: Float> BlockLoader<F> for HorizontalCheckBlockIO {
 }
 
 #[cube]
-impl<F: Float> BlockWriter<F> for HorizontalCheckBlockIO {
-    fn write_output<A: ContiguousAccess<F>>(
-        out: &mut Tensor<Line<F>>,
-        results: &Array<F>,
+impl<N: Numeric> BlockWriter<N> for HorizontalCheckBlockIO {
+    fn write_output<A: ContiguousAccess<N>>(
+        out: &mut Tensor<Line<N>>,
+        results: &Array<N>,
         info: WriteTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/unchecked_block.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/unchecked_block.rs
@@ -16,10 +16,10 @@ use super::base::{BlockLoader, BlockWriter};
 pub(crate) struct UncheckedBlockIO;
 
 #[cube]
-impl<F: Float> BlockLoader<F> for UncheckedBlockIO {
-    fn load_tile_plain<A: ContiguousAccess<F>>(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+impl<N: Numeric> BlockLoader<N> for UncheckedBlockIO {
+    fn load_tile_plain<A: ContiguousAccess<N>>(
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         _check_bounds: CheckBounds,
@@ -38,8 +38,8 @@ impl<F: Float> BlockLoader<F> for UncheckedBlockIO {
     }
 
     fn load_tile_transposed(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         _check_bounds: CheckBounds,
@@ -63,10 +63,10 @@ impl<F: Float> BlockLoader<F> for UncheckedBlockIO {
 }
 
 #[cube]
-impl<F: Float> BlockWriter<F> for UncheckedBlockIO {
-    fn write_output<A: ContiguousAccess<F>>(
-        out: &mut Tensor<Line<F>>,
-        results: &Array<F>,
+impl<N: Numeric> BlockWriter<N> for UncheckedBlockIO {
+    fn write_output<A: ContiguousAccess<N>>(
+        out: &mut Tensor<Line<N>>,
+        results: &Array<N>,
         info: WriteTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         _check_bounds: CheckBounds,

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/vertical_block_check.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/vertical_block_check.rs
@@ -15,10 +15,10 @@ use super::base::{all_zeros_runtime, BlockLoader, BlockWriter};
 pub(crate) struct VerticalCheckBlockIO;
 
 #[cube]
-impl<F: Float> BlockLoader<F> for VerticalCheckBlockIO {
-    fn load_tile_plain<A: ContiguousAccess<F>>(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+impl<N: Numeric> BlockLoader<N> for VerticalCheckBlockIO {
+    fn load_tile_plain<A: ContiguousAccess<N>>(
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
@@ -49,8 +49,8 @@ impl<F: Float> BlockLoader<F> for VerticalCheckBlockIO {
     }
 
     fn load_tile_transposed(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
@@ -76,10 +76,10 @@ impl<F: Float> BlockLoader<F> for VerticalCheckBlockIO {
 }
 
 #[cube]
-impl<F: Float> BlockWriter<F> for VerticalCheckBlockIO {
-    fn write_output<A: ContiguousAccess<F>>(
-        out: &mut Tensor<Line<F>>,
-        results: &Array<F>,
+impl<N: Numeric> BlockWriter<N> for VerticalCheckBlockIO {
+    fn write_output<A: ContiguousAccess<N>>(
+        out: &mut Tensor<Line<N>>,
+        results: &Array<N>,
         info: WriteTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/whole_block_check.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/block_io/whole_block_check.rs
@@ -15,10 +15,10 @@ use super::base::{all_zeros_comptime, all_zeros_runtime, BlockLoader, BlockWrite
 pub(crate) struct WholeCheckBlockIO;
 
 #[cube]
-impl<F: Float> BlockLoader<F> for WholeCheckBlockIO {
-    fn load_tile_plain<A: ContiguousAccess<F>>(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+impl<N: Numeric> BlockLoader<N> for WholeCheckBlockIO {
+    fn load_tile_plain<A: ContiguousAccess<N>>(
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
@@ -54,8 +54,8 @@ impl<F: Float> BlockLoader<F> for WholeCheckBlockIO {
         }
     }
     fn load_tile_transposed(
-        tensor: &Tensor<Line<F>>,
-        shared_memory: &mut SharedMemory<Line<F>>,
+        tensor: &Tensor<Line<N>>,
+        shared_memory: &mut SharedMemory<Line<N>>,
         info: ReadTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,
@@ -94,10 +94,10 @@ impl<F: Float> BlockLoader<F> for WholeCheckBlockIO {
 }
 
 #[cube]
-impl<F: Float> BlockWriter<F> for WholeCheckBlockIO {
-    fn write_output<A: ContiguousAccess<F>>(
-        out: &mut Tensor<Line<F>>,
-        results: &Array<F>,
+impl<N: Numeric> BlockWriter<N> for WholeCheckBlockIO {
+    fn write_output<A: ContiguousAccess<N>>(
+        out: &mut Tensor<Line<N>>,
+        results: &Array<N>,
         info: WriteTileInfo,
         #[comptime] config: CubeTiling2dConfig,
         check_bounds: CheckBounds,

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/loader.rs
@@ -14,8 +14,8 @@ use super::{
 
 // Transposed tensor's vectorization must be 1
 // Plain tensor's vectorization must equal tile size
-pub(crate) struct TileLoader<F: Float> {
-    _f: PhantomData<F>,
+pub(crate) struct TileLoader<N: Numeric> {
+    _f: PhantomData<N>,
 }
 
 #[derive(CubeType)]
@@ -44,10 +44,10 @@ pub(crate) struct ReadTileInfo {
 }
 
 #[cube]
-impl<F: Float> Loader<F> for TileLoader<F> {
-    fn load_lhs_plain<B: BlockLoader<F>>(
-        lhs: &Tensor<Line<F>>,
-        load_info: LoadInfo<F>,
+impl<N: Numeric> Loader<N> for TileLoader<N> {
+    fn load_lhs_plain<B: BlockLoader<N>>(
+        lhs: &Tensor<Line<N>>,
+        load_info: LoadInfo<N>,
         #[comptime] config: CubeTiling2dConfig,
     ) {
         let dims = load_info.dims;
@@ -66,12 +66,12 @@ impl<F: Float> Loader<F> for TileLoader<F> {
             skip_col: coordinates.skip_row,
         };
 
-        load_plain::<F, B>(lhs, load_info, load_indices, check_bounds, config);
+        load_plain::<N, B>(lhs, load_info, load_indices, check_bounds, config);
     }
 
-    fn load_lhs_transposed<B: BlockLoader<F>>(
-        lhs: &Tensor<Line<F>>,
-        load_info: LoadInfo<F>,
+    fn load_lhs_transposed<B: BlockLoader<N>>(
+        lhs: &Tensor<Line<N>>,
+        load_info: LoadInfo<N>,
         #[comptime] config: CubeTiling2dConfig,
     ) {
         let dims = load_info.dims;
@@ -90,12 +90,12 @@ impl<F: Float> Loader<F> for TileLoader<F> {
             skip_col: load_info.k,
         };
 
-        load_transposed::<F, B>(lhs, load_info, load_indices, check_bounds, config);
+        load_transposed::<N, B>(lhs, load_info, load_indices, check_bounds, config);
     }
 
-    fn load_rhs_plain<B: BlockLoader<F>>(
-        rhs: &Tensor<Line<F>>,
-        load_info: LoadInfo<F>,
+    fn load_rhs_plain<B: BlockLoader<N>>(
+        rhs: &Tensor<Line<N>>,
+        load_info: LoadInfo<N>,
         #[comptime] config: CubeTiling2dConfig,
     ) {
         let coordinates = load_info.coordinates;
@@ -114,12 +114,12 @@ impl<F: Float> Loader<F> for TileLoader<F> {
             skip_col: coordinates.skip_col,
         };
 
-        load_plain::<F, B>(rhs, load_info, load_indices, check_bounds, config);
+        load_plain::<N, B>(rhs, load_info, load_indices, check_bounds, config);
     }
 
-    fn load_rhs_transposed<B: BlockLoader<F>>(
-        rhs: &Tensor<Line<F>>,
-        load_info: LoadInfo<F>,
+    fn load_rhs_transposed<B: BlockLoader<N>>(
+        rhs: &Tensor<Line<N>>,
+        load_info: LoadInfo<N>,
         #[comptime] config: CubeTiling2dConfig,
     ) {
         let dims = load_info.dims;
@@ -138,14 +138,14 @@ impl<F: Float> Loader<F> for TileLoader<F> {
             skip_col: load_info.k,
         };
 
-        load_transposed::<F, B>(rhs, load_info, load_indices, check_bounds, config);
+        load_transposed::<N, B>(rhs, load_info, load_indices, check_bounds, config);
     }
 }
 
 #[cube]
-pub(crate) fn load_plain<F: Float, L: BlockLoader<F>>(
-    tensor: &Tensor<Line<F>>,
-    load_info: LoadInfo<F>,
+pub(crate) fn load_plain<N: Numeric, L: BlockLoader<N>>(
+    tensor: &Tensor<Line<N>>,
+    load_info: LoadInfo<N>,
     load_indices: LoadIndices,
     check_bounds: CheckBounds,
     #[comptime] config: CubeTiling2dConfig,
@@ -196,9 +196,9 @@ pub(crate) fn load_plain<F: Float, L: BlockLoader<F>>(
 }
 
 #[cube]
-pub(crate) fn load_transposed<F: Float, L: BlockLoader<F>>(
-    tensor: &Tensor<Line<F>>,
-    load_info: LoadInfo<F>,
+pub(crate) fn load_transposed<N: Numeric, L: BlockLoader<N>>(
+    tensor: &Tensor<Line<N>>,
+    load_info: LoadInfo<N>,
     load_indices: LoadIndices,
     check_bounds: CheckBounds,
     #[comptime] config: CubeTiling2dConfig,

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/writer.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/writer.rs
@@ -15,15 +15,15 @@ use super::{
     memory_access::{MatchingVectorization, UnmatchingVectorization},
 };
 
-pub(crate) struct TileWriter<F: Float> {
-    _f: PhantomData<F>,
+pub(crate) struct TileWriter<N: Numeric> {
+    _f: PhantomData<N>,
 }
 
 #[cube]
-impl<F: Float> OutputWriter<F> for TileWriter<F> {
-    fn write_output<B: BlockWriter<F>>(
-        out: &mut Tensor<Line<F>>,
-        results: &Array<F>,
+impl<N: Numeric> OutputWriter<N> for TileWriter<N> {
+    fn write_output<B: BlockWriter<N>>(
+        out: &mut Tensor<Line<N>>,
+        results: &Array<N>,
         write_info: WriteTileInfo,
         dims: Dimensions,
         #[comptime] config: CubeTiling2dConfig,

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/write_output.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/write_output.rs
@@ -19,10 +19,10 @@ pub(crate) struct WriteTileInfo {
 }
 
 #[cube]
-pub(crate) trait OutputWriter<F: Float>: Sync + Send + 'static {
-    fn write_output<B: BlockWriter<F>>(
-        out: &mut Tensor<Line<F>>,
-        results: &Array<F>,
+pub(crate) trait OutputWriter<N: Numeric>: Sync + Send + 'static {
+    fn write_output<B: BlockWriter<N>>(
+        out: &mut Tensor<Line<N>>,
+        results: &Array<N>,
         write_tile_info: WriteTileInfo,
         dims: Dimensions,
         #[comptime] config: CubeTiling2dConfig,
@@ -30,9 +30,9 @@ pub(crate) trait OutputWriter<F: Float>: Sync + Send + 'static {
 }
 
 #[cube]
-pub(crate) fn write_to_output<F: Float, W: OutputWriter<F>>(
-    out: &mut Tensor<Line<F>>,
-    results: &Array<F>,
+pub(crate) fn write_to_output<N: Numeric, W: OutputWriter<N>>(
+    out: &mut Tensor<Line<N>>,
+    results: &Array<N>,
     coordinates: Coordinates,
     offset_output: u32,
     dims: Dimensions,


### PR DESCRIPTION
I replaced most bound from `<F: Float>` to `<N: Numeric>`. I believe this will be useful for quantization where we want to support matmul between `u8` elements. Since `Float: Numeric`, one can still perform matmul with float as before. So I don't see a reason not to do it anyway as it won't break any of the existing code.