### PR TITLE
Fix `debug_print` macro so it correctly treats variables

### DIFF
--- a/crates/cubecl-core/src/frontend/debug.rs
+++ b/crates/cubecl-core/src/frontend/debug.rs
@@ -84,9 +84,9 @@ macro_rules! debug_print {
 /// specific, but Vulkan and CUDA both use the C++ conventions. WGSL isn't currently supported.
 #[macro_export]
 macro_rules! debug_print_expand {
-    ($scope:expr, $format:literal, $($args:expr),*) => {
+    ($scope:expr, $format:expr, $($args:expr),*) => {
         {
-            let args = vec![$(*$args.expand),*];
+            let args = vec![$(*$crate::ir::ExpandElement::from($args)),*];
             $crate::frontend::printf_expand($scope, $format, args);
         }
     };

--- a/crates/cubecl-core/src/frontend/mod.rs
+++ b/crates/cubecl-core/src/frontend/mod.rs
@@ -28,3 +28,5 @@ pub use options::*;
 pub use plane::*;
 pub use polyfills::*;
 pub use topology::*;
+
+pub use crate::{debug_print, debug_print_expand};

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -78,6 +78,11 @@ pub enum Expression {
     VerbatimTerminated {
         tokens: TokenStream,
     },
+    #[allow(clippy::enum_variant_names)]
+    ExpressionMacro {
+        ident: Ident,
+        args: Vec<Expression>,
+    },
     Continue(Span),
     Return(Span),
     ForLoop {
@@ -171,6 +176,7 @@ impl Expression {
             Expression::Literal { ty, .. } => Some(ty.clone()),
             Expression::Assignment { ty, .. } => ty.clone(),
             Expression::Verbatim { .. } => None,
+            Expression::ExpressionMacro { .. } => None,
             Expression::Block(block) => block.ty.clone(),
             Expression::FunctionCall { .. } => None,
             Expression::Break { .. } => None,

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -46,6 +46,9 @@ impl Expression {
                     }
                 }
             }
+            Expr::Lit(literal) if matches!(literal.lit, Lit::Str(_)) => Expression::Verbatim {
+                tokens: literal.to_token_stream(),
+            },
             Expr::Lit(literal) => {
                 let ty = lit_ty(&literal.lit)?;
                 Expression::Literal {

--- a/crates/cubecl-macros/src/parse/statement.rs
+++ b/crates/cubecl-macros/src/parse/statement.rs
@@ -1,9 +1,8 @@
-use quote::{format_ident, quote};
-use syn::{LitStr, Pat, Stmt, Type, TypeReference};
+use quote::format_ident;
+use syn::{parse_quote, ExprArray, LitStr, Pat, Stmt, Type, TypeReference};
 
 use crate::{
     expression::Expression,
-    paths::core_type,
     scope::Context,
     statement::{Pattern, Statement},
 };
@@ -46,11 +45,17 @@ impl Statement {
                         terminated: val.semi_token.is_some(),
                     }
                 } else if val.mac.path.is_ident("debug_print") {
-                    let expand = core_type("debug_print_expand");
                     let args = val.mac.tokens;
+                    let arg_exprs: ExprArray = parse_quote!([#args]);
+                    let args = arg_exprs
+                        .elems
+                        .into_iter()
+                        .map(|expr| Expression::from_expr(expr, context))
+                        .collect::<Result<_, _>>()?;
                     Statement::Expression {
-                        expression: Box::new(Expression::Verbatim {
-                            tokens: quote![#expand!(context, #args)],
+                        expression: Box::new(Expression::ExpressionMacro {
+                            ident: val.mac.path.get_ident().cloned().unwrap(),
+                            args,
                         }),
                         terminated: val.semi_token.is_some(),
                     }


### PR DESCRIPTION
The debug_print macro was incorrectly treating variables as plain verbatim paths, so it wasn't updating the scope with a usage (leading to use after move) and wasn't properly expanding globals (leading to things like `UNIT_POS` always printing `2`). This fixes those issues by parsing the argument list as a `Vec<Expression>`.