### PR TITLE
Fix `spirv-dump` and feature registration for mixed kernels

### DIFF
--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -10,6 +10,7 @@ mod element;
 mod graphics;
 mod runtime;
 
+pub use compiler::base::*;
 pub use compiler::wgsl::WgslCompiler;
 pub use compute::*;
 pub use device::*;


### PR DESCRIPTION
Enabling `spirv-dump` would crash when it encounters a custom wgsl shader, and atomics or f16 would crash because they're removed from the WGPU device features.
This ensures the kernel only gets saved if `repr` is `Some`, and ensures the WGPU device is created with the full feature set, not the trimmed down one that is used for enabling Vulkan extensions.
Also reexports `WgpuCompiler`, which should've been done before.