### PR TITLE
Fix an issue with shared sum test

### DIFF
--- a/crates/cubecl-reduce/src/shared_sum.rs
+++ b/crates/cubecl-reduce/src/shared_sum.rs
@@ -10,6 +10,13 @@ use crate::ReduceError;
 ///
 /// Return an error if atomic addition is not supported for the type `N`.
 ///
+/// # Important
+///
+/// This doesn't set the value of output to 0 before computing the sums.
+/// It is the responsability of the caller to ensure that ouput is set to
+/// the proper value. Basically, the behavior of this kernel is akin to the AddAssign operator
+/// as it update the output instead of overwriting it.
+///
 /// # Example
 ///
 /// This examples show how to sum all the elements of a small `2 x 2` matrix.

--- a/crates/cubecl-reduce/src/test.rs
+++ b/crates/cubecl-reduce/src/test.rs
@@ -504,7 +504,7 @@ impl TestCase {
         let client = R::client(device);
 
         let input_handle = client.create(F::as_bytes(&input_values));
-        let output_handle = client.empty(size_of::<F>());
+        let output_handle = client.create(F::as_bytes(&[F::from_int(0)]));
 
         let input = unsafe {
             TensorHandleRef::<R>::from_raw_parts(


### PR DESCRIPTION
We need to initialize the output tensor to contain 0 before launching the kernel. Else there is a slight chance that the test fail because of a wrong initialization. I also documented this behavior.