### PR TITLE
Simplify matmul config

### DIFF
--- a/crates/cubecl-linalg/src/matmul/components/batch/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/base.rs
@@ -2,8 +2,8 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::matmul::components::global::args::{self, MatmulArgs, TensorInput, TensorOutput};
-use crate::matmul::components::MatmulPrecision;
-use crate::matmul::components::{config::MatmulConfig, global, Ident, MatmulLaunch, StageDim};
+use crate::matmul::components::{MatmulPrecision, StageDim};
+use crate::matmul::components::{config::MatmulConfig, global, Ident, MatmulLaunch};
 use crate::tensor::{ReadWrite, VirtualTensor};
 
 /// A family of [matmuls](BatchMatmul) working with any [precision](MatmulPrecision).
@@ -50,7 +50,7 @@ pub trait BatchConfig: MatmulConfig {
     fn to_gmm_config(&self) -> Self::GmmConfig;
 
     /// Returns the [StageDim] for the given ident
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim>;
+    fn stage_dim(&self, ident: Ident) -> StageDim;
 
     /// Returns the largest m dimension supported with these configs
     fn max_m(&self) -> u32;

--- a/crates/cubecl-linalg/src/matmul/components/batch/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/base.rs
@@ -2,8 +2,8 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::matmul::components::global::args::{self, MatmulArgs, TensorInput, TensorOutput};
-use crate::matmul::components::{MatmulPrecision, StageDim};
 use crate::matmul::components::{config::MatmulConfig, global, Ident, MatmulLaunch};
+use crate::matmul::components::{MatmulPrecision, StageDim};
 use crate::tensor::{ReadWrite, VirtualTensor};
 
 /// A family of [matmuls](BatchMatmul) working with any [precision](MatmulPrecision).

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -123,8 +123,8 @@ impl<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>, S: SpanMatmul, C: CubeD
         let cubes_y = config.cube_count_y();
         let cubes_z = config.cube_count_batch();
 
-        let stage_x = config.stage_dim(Ident::Out).num_elements_x_dim();
-        let stage_y = config.stage_dim(Ident::Out).num_elements_y_dim();
+        let stage_x = config.stage_dim(Ident::Out).total_row();
+        let stage_y = config.stage_dim(Ident::Out).total_col();
         let stage_z = 1;
 
         let (x_index, y_index) = C::x_y_indices();

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -144,7 +144,7 @@ impl<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>, S: SpanMatmul, C: CubeD
     }
 }
 
-#[derive(CubeType, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the OneToOneBatchMatmul
 pub struct Config<G: global::GlobalConfig, C: CubeDispatch> {
     gmm_config: G,

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -159,7 +159,7 @@ impl<G: global::GlobalConfig, C: CubeDispatch> batch::BatchConfig for Config<G, 
         self.gmm_config
     }
 
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim> {
+    fn stage_dim(&self, ident: Ident) -> StageDim {
         self.gmm_config.stage_dim(ident)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -123,7 +123,7 @@ impl<MP: MatmulPrecision, GMM: GlobalMatmul<MP>, C: CubeDispatch> BatchMatmul<MP
     }
 }
 
-#[derive(CubeType, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the OneToOneBatchMatmul
 pub struct Config<G: global::GlobalConfig, C: CubeDispatch> {
     gmm_config: G,

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -138,7 +138,7 @@ impl<G: global::GlobalConfig, C: CubeDispatch> batch::BatchConfig for Config<G, 
         self.gmm_config
     }
 
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim> {
+    fn stage_dim(&self, ident: Ident) -> StageDim {
         self.gmm_config.stage_dim(ident)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -101,8 +101,8 @@ impl<MP: MatmulPrecision, GMM: GlobalMatmul<MP>, C: CubeDispatch> BatchMatmul<MP
         #[comptime] config: Self::Config,
     ) {
         let (x_index, y_index) = C::x_y_indices();
-        let x_offset = x_index * config.stage_dim(Ident::Lhs).num_elements_x_dim();
-        let y_offset = y_index * config.stage_dim(Ident::Rhs).num_elements_y_dim();
+        let x_offset = x_index * config.stage_dim(Ident::Lhs).total_row();
+        let y_offset = y_index * config.stage_dim(Ident::Rhs).total_col();
         let nth_batch = C::batch_index();
         let rank = lhs.rank();
         let k_range = (0, lhs.shape(rank - 1));
@@ -143,11 +143,11 @@ impl<G: global::GlobalConfig, C: CubeDispatch> batch::BatchConfig for Config<G, 
     }
 
     fn max_m(&self) -> u32 {
-        C::max_x(self.cube_count) * self.stage_dim(Ident::Out).num_elements_x_dim()
+        C::max_x(self.cube_count) * self.stage_dim(Ident::Out).total_row()
     }
 
     fn max_n(&self) -> u32 {
-        C::max_y(self.cube_count) * self.stage_dim(Ident::Out).num_elements_y_dim()
+        C::max_y(self.cube_count) * self.stage_dim(Ident::Out).total_col()
     }
 
     fn max_batches(&self) -> u32 {

--- a/crates/cubecl-linalg/src/matmul/components/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/config.rs
@@ -122,46 +122,47 @@ pub struct StageDim {
 }
 
 impl StageDim {
-    /// Returns the total number of elements of the stage
+    /// Returns the total number of elements of the stage.
     pub fn total_size(&self) -> u32 {
         self.total_row() * self.total_col()
     }
 
-    /// Returns the number of elements across the x dimension
+    /// Returns the total number of rows of the stage.
     pub fn total_row(&self) -> u32 {
         self.tile_count_row() * self.tile_size_row()
     }
 
-    /// Returns the number of elements across the y dimension
+    /// Returns the total number of columns of the stage.
     pub fn total_col(&self) -> u32 {
         self.tile_count_col() * self.tile_size_col()
     }
 
-    /// Returns the number of elements within one tile
+    /// Returns the number of elements within one tile.
     pub fn tile_size(&self) -> u32 {
         self.tile_size_row() * self.tile_size_col()
     }
 
-    /// Returns the dimension of a tile across x dimension (rows)
+    /// Returns the size of the row axis of a tile.
     pub fn tile_size_row(&self) -> u32 {
         self.tile_size_row
     }
 
-    /// Returns the dimension of a tile across y dimension (col)
+    /// Returns the size of the column axis of a tile.
     pub fn tile_size_col(&self) -> u32 {
         self.tile_size_col
     }
 
+    /// Returns the number of tiles within the stage.
     pub fn tile_count(&self) -> u32 {
         self.tile_count_row() * self.tile_count_col()
     }
 
-    /// Returns the number of tiles across x dimension (rows)
+    /// Returns the number of tiles across the row axis of the stage.
     pub fn tile_count_row(&self) -> u32 {
         self.tile_count_row
     }
 
-    /// Returns the number of tiles across y dimension (cols)
+    /// Returns the number of tiles across the column axis of the stage.
     pub fn tile_count_col(&self) -> u32 {
         self.tile_count_col
     }

--- a/crates/cubecl-linalg/src/matmul/components/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/config.rs
@@ -58,7 +58,7 @@ pub trait MatmulConfigFactory: Send + Sync + 'static {
 ///
 /// Useful to aggregate many trait bounds
 pub trait MatmulConfig:
-    CubeType + Copy + Clone + Send + Sync + 'static + Eq + PartialEq + Hash + Debug + IntoRuntime
+    Copy + Clone + Send + Sync + 'static + Eq + PartialEq + Hash + Debug
 {
 }
 

--- a/crates/cubecl-linalg/src/matmul/components/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/config.rs
@@ -114,131 +114,131 @@ pub struct StageDims {
 
 pub trait StageDim: 'static + Send + Sync {
     /// Returns the total number of elements of the stage
-    fn total_elements(&self) -> u32 {
-        self.num_elements_x_dim() * self.num_elements_y_dim()
-    }
-
-    /// Returns the number of elements within one tile
-    fn tile_num_elements(&self) -> u32 {
-        self.tile_size_x_dim() * self.tile_size_y_dim()
+    fn total_size(&self) -> u32 {
+        self.total_row() * self.total_col()
     }
 
     /// Returns the number of elements across the x dimension
-    fn num_elements_x_dim(&self) -> u32 {
-        self.num_tiles_x_dim() * self.tile_size_x_dim()
+    fn total_row(&self) -> u32 {
+        self.tile_count_row() * self.tile_size_row()
     }
 
     /// Returns the number of elements across the y dimension
-    fn num_elements_y_dim(&self) -> u32 {
-        self.num_tiles_y_dim() * self.tile_size_y_dim()
+    fn total_col(&self) -> u32 {
+        self.tile_count_col() * self.tile_size_col()
     }
 
-    fn num_tiles(&self) -> u32 {
-        self.num_tiles_x_dim() * self.num_tiles_y_dim()
+    /// Returns the number of elements within one tile
+    fn tile_size(&self) -> u32 {
+        self.tile_size_row() * self.tile_size_col()
     }
+
+    /// Returns the dimension of a tile across x dimension (rows)
+    fn tile_size_row(&self) -> u32;
+
+    /// Returns the dimension of a tile across y dimension (col)
+    fn tile_size_col(&self) -> u32;
+
+    fn tile_count(&self) -> u32 {
+        self.tile_count_row() * self.tile_count_col()
+    }
+
+    /// Returns the number of tiles across x dimension (rows)
+    fn tile_count_row(&self) -> u32;
+
+    /// Returns the number of tiles across y dimension (cols)
+    fn tile_count_col(&self) -> u32;
 
     /// Number of elements in a buffer
     fn buffer_num_elements(&self) -> u32;
-
-    /// Returns the number of tiles across x dimension (rows)
-    fn num_tiles_x_dim(&self) -> u32;
-
-    /// Returns the number of tiles across y dimension (cols)
-    fn num_tiles_y_dim(&self) -> u32;
-
-    /// Returns the dimension of a tile across x dimension (rows)
-    fn tile_size_x_dim(&self) -> u32;
-
-    /// Returns the dimension of a tile across y dimension (col)
-    fn tile_size_y_dim(&self) -> u32;
 }
 
 #[derive(CubeType, Clone, Copy, Debug, Hash, PartialEq, Eq)]
 /// Dimensions for lhs stage.
 pub struct LhsStageDim {
-    pub tile_size_m: u32,
-    pub tile_size_k: u32,
-    pub num_tiles_m: u32,
-    pub num_tiles_k: u32,
+    pub tile_size_row: u32,
+    pub tile_size_col: u32,
+    pub tile_count_row: u32,
+    pub tile_count_col: u32,
 }
 
 #[derive(CubeType, Clone, Copy, Debug, Hash, PartialEq, Eq)]
 /// Dimensions for rhs stage.
 pub struct RhsStageDim {
-    pub tile_size_k: u32,
-    pub tile_size_n: u32,
-    pub num_tiles_k: u32,
-    pub num_tiles_n: u32,
+    pub tile_size_row: u32,
+    pub tile_size_col: u32,
+    pub tile_count_row: u32,
+    pub tile_count_col: u32,
 }
 
 #[derive(CubeType, Clone, Copy, Debug, Hash, PartialEq, Eq)]
 /// Dimensions for out stage.
 pub struct OutStageDim {
-    pub tile_size_m: u32,
-    pub tile_size_n: u32,
-    pub num_tiles_m: u32,
-    pub num_tiles_n: u32,
+    pub tile_size_row: u32,
+    pub tile_size_col: u32,
+    pub tile_count_row: u32,
+    pub tile_count_col: u32,
 }
 
 impl StageDim for LhsStageDim {
-    fn num_tiles_x_dim(&self) -> u32 {
-        self.num_tiles_m
+    fn tile_count_row(&self) -> u32 {
+        self.tile_count_row
     }
 
-    fn num_tiles_y_dim(&self) -> u32 {
-        self.num_tiles_k
+    fn tile_count_col(&self) -> u32 {
+        self.tile_count_col
     }
 
-    fn tile_size_x_dim(&self) -> u32 {
-        self.tile_size_m
+    fn tile_size_row(&self) -> u32 {
+        self.tile_size_row
     }
 
-    fn tile_size_y_dim(&self) -> u32 {
-        self.tile_size_k
+    fn tile_size_col(&self) -> u32 {
+        self.tile_size_col
     }
 
     fn buffer_num_elements(&self) -> u32 {
-        self.num_tiles_m * self.tile_num_elements()
+        self.tile_count_row * self.tile_size()
     }
 }
 
 impl StageDim for RhsStageDim {
-    fn num_tiles_x_dim(&self) -> u32 {
-        self.num_tiles_k
+    fn tile_count_row(&self) -> u32 {
+        self.tile_count_row
     }
 
-    fn num_tiles_y_dim(&self) -> u32 {
-        self.num_tiles_n
+    fn tile_count_col(&self) -> u32 {
+        self.tile_count_col
     }
 
-    fn tile_size_x_dim(&self) -> u32 {
-        self.tile_size_k
+    fn tile_size_row(&self) -> u32 {
+        self.tile_size_row
     }
 
-    fn tile_size_y_dim(&self) -> u32 {
-        self.tile_size_n
+    fn tile_size_col(&self) -> u32 {
+        self.tile_size_col
     }
 
     fn buffer_num_elements(&self) -> u32 {
-        self.num_tiles_n * self.tile_num_elements()
+        self.tile_count_col * self.tile_size()
     }
 }
 
 impl StageDim for OutStageDim {
-    fn num_tiles_x_dim(&self) -> u32 {
-        self.num_tiles_m
+    fn tile_count_row(&self) -> u32 {
+        self.tile_count_row
     }
 
-    fn num_tiles_y_dim(&self) -> u32 {
-        self.num_tiles_n
+    fn tile_count_col(&self) -> u32 {
+        self.tile_count_col
     }
 
-    fn tile_size_x_dim(&self) -> u32 {
-        self.tile_size_m
+    fn tile_size_row(&self) -> u32 {
+        self.tile_size_row
     }
 
-    fn tile_size_y_dim(&self) -> u32 {
-        self.tile_size_n
+    fn tile_size_col(&self) -> u32 {
+        self.tile_size_col
     }
 
     fn buffer_num_elements(&self) -> u32 {

--- a/crates/cubecl-linalg/src/matmul/components/global/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/base.rs
@@ -159,7 +159,7 @@ pub trait GlobalConfig: MatmulConfig {
     fn stage_line_size(&self, ident: Ident) -> u32;
 
     /// Returns the [StageDim] for the given ident
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim>;
+    fn stage_dim(&self, ident: Ident) -> StageDim;
 
     /// Returns the [MatrixLayout] for the given ident
     fn layout(&self, ident: Ident) -> MatrixLayout;

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/buffer_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/buffer_loading.rs
@@ -15,7 +15,7 @@ impl LoadingValidation for BufferLoading {
         let stage_dim = config.stage_dim(ident);
         let line_size = config.global_line_size(ident);
 
-        let num_stage_elements = stage_dim.total_elements();
+        let num_stage_elements = stage_dim.total_size();
         let total_units = config.num_planes() * config.plane_dim();
         let jump_length = total_units * line_size;
 
@@ -67,7 +67,7 @@ impl BufferLoading {
         for i in 0..num_loads_per_unit {
             let unit_position = unit_position_base + i * jump_length;
 
-            let tile_num_elements = stage_dim.tile_num_elements();
+            let tile_num_elements = stage_dim.tile_size();
             let nth_buffer_tile = unit_position / tile_num_elements;
             let pos_within_tile = unit_position % tile_num_elements;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/buffer_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/buffer_loading.rs
@@ -49,7 +49,7 @@ impl BufferLoading {
         let stage_dim = config.stage_dim(ident);
         let line_size = config.global_line_size(ident);
 
-        let num_buffer_elements = stage_dim.buffer_num_elements();
+        let num_buffer_elements = stage_dim.buffer_size(ident.as_input());
 
         let total_units = comptime!(num_producer_planes * config.plane_dim());
         let jump_length = comptime!(total_units * line_size);

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/base.rs
@@ -47,7 +47,7 @@ where
         #[comptime] config: Self::Config,
     ) {
         let num_buffers = 2;
-        let buffer_step = config.stage_dim(Ident::Lhs).tile_size_y_dim();
+        let buffer_step = config.stage_dim(Ident::Lhs).tile_size_col();
         let k_step = num_buffers * buffer_step; // equal to SMM::K
 
         let range = k_range.1 - k_range.0;

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
@@ -54,7 +54,7 @@ where
         BufferLoading::check::<Self::Config>(config, Ident::Lhs)?;
         BufferLoading::check::<Self::Config>(config, Ident::Rhs)?;
 
-        if config.stage_dim(Ident::Lhs).num_tiles_y_dim() != 2 {
+        if config.stage_dim(Ident::Lhs).tile_count_col() != 2 {
             return Err(Box::new("Pipelined matmul needs exactly 2 buffers."));
         }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/loader.rs
@@ -141,7 +141,7 @@ fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig>(
     #[comptime] ident: Ident,
     #[comptime] config: CommonGlobalConfig<S>,
 ) {
-    let buffer_num_elements = config.stage_dim(ident).buffer_num_elements();
+    let buffer_num_elements = config.stage_dim(ident).buffer_size(ident.as_input());
     let line_size = config.stage_line_size(ident);
     let buffer_num_lines = buffer_num_elements / line_size;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/loader.rs
@@ -76,7 +76,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_dim(Ident::Lhs).num_tiles_y_dim(),
+            num_buffers: config.stage_dim(Ident::Lhs).tile_count_col(),
             _config: PhantomData::<S>.runtime(),
         }
     }
@@ -127,7 +127,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_dim(Ident::Rhs).num_tiles_x_dim(),
+            num_buffers: config.stage_dim(Ident::Rhs).tile_count_row(),
             _config: PhantomData::<S>.runtime(),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
@@ -238,7 +238,7 @@ impl<
     }
 }
 
-#[derive(CubeType, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the producer consumer global matmul
 pub struct Config<S: stage::StageConfig> {
     smm_config: S,

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
@@ -46,7 +46,7 @@ where
         if config.num_producers() == 0 {
             return Err(Box::new("There are no producer planes. Make sure there are more planes than the underlying stage matmul requires."));
         }
-        if config.stage_dim(Ident::Lhs).num_tiles_y_dim() <= 1 {
+        if config.stage_dim(Ident::Lhs).tile_count_col() <= 1 {
             return Err(Box::new("Producer-consumer needs at least 2 buffers."));
         }
 
@@ -123,8 +123,8 @@ where
     ) {
         let is_consumer = Self::is_consumer(config);
 
-        let num_buffers = config.stage_dim(Ident::Lhs).num_tiles_y_dim();
-        let buffer_step = config.stage_dim(Ident::Lhs).tile_size_y_dim();
+        let num_buffers = config.stage_dim(Ident::Lhs).tile_count_col();
+        let buffer_step = config.stage_dim(Ident::Lhs).tile_size_col();
         let k_step = num_buffers * buffer_step; // equal to SMM::K
 
         let range = k_range.1 - k_range.0;

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
@@ -272,7 +272,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         self.smm_config.line_size(ident)
     }
 
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim> {
+    fn stage_dim(&self, ident: Ident) -> StageDim {
         self.smm_config.stage_dim(ident)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/loader.rs
@@ -152,7 +152,7 @@ fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig>(
     #[comptime] ident: Ident,
     #[comptime] config: specialized::Config<S>,
 ) {
-    let buffer_num_elements = config.stage_dim(ident).buffer_num_elements();
+    let buffer_num_elements = config.stage_dim(ident).buffer_size(ident.as_input());
     let line_size = config.stage_line_size(ident);
     let buffer_num_lines = buffer_num_elements / line_size;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/loader.rs
@@ -82,7 +82,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_dim(Ident::Lhs).num_tiles_y_dim(),
+            num_buffers: config.stage_dim(Ident::Lhs).tile_count_col(),
             is_producer,
             _config: PhantomData::<S>.runtime(),
         }
@@ -137,7 +137,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_dim(Ident::Rhs).num_tiles_x_dim(),
+            num_buffers: config.stage_dim(Ident::Rhs).tile_count_row(),
             is_producer,
             _config: PhantomData::<S>.runtime(),
         }

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
@@ -244,7 +244,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         self.smm_config.line_size(ident)
     }
 
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim> {
+    fn stage_dim(&self, ident: Ident) -> StageDim {
         self.smm_config.stage_dim(ident)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
@@ -210,7 +210,7 @@ where
     }
 }
 
-#[derive(CubeType, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the full load matmul
 pub struct Config<S: stage::StageConfig> {
     smm_config: S,

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/cyclic_loading.rs
@@ -19,7 +19,7 @@ impl LoadingValidation for CyclicLoading {
         let stage_dim = config.stage_dim(ident);
         let line_size = config.global_line_size(ident);
 
-        let num_stage_elements = stage_dim.total_elements();
+        let num_stage_elements = stage_dim.total_size();
         let total_units = config.num_planes() * config.plane_dim();
         let jump_length = total_units * line_size;
 
@@ -50,8 +50,8 @@ impl LoadingStrategy for CyclicLoading {
     ) {
         let stage_dim = config.stage_dim(ident);
         let line_size = config.global_line_size(ident);
-        let num_stage_lines = stage_dim.total_elements() / line_size;
-        let tile_num_lines = stage_dim.tile_num_elements() / line_size;
+        let num_stage_lines = stage_dim.total_size() / line_size;
+        let tile_num_lines = stage_dim.tile_size() / line_size;
         let jump_length = comptime!(config.num_planes() * config.plane_dim());
         let num_loads_per_unit = comptime!(num_stage_lines / jump_length);
 
@@ -64,13 +64,13 @@ impl LoadingStrategy for CyclicLoading {
             let (tile_x, tile_y) = match config.tiling_order(ident) {
                 TilingOrderConfig::RowMajor => RowMajorTiling::to_x_y(
                     nth_tile,
-                    stage_dim.num_tiles_x_dim(),
-                    stage_dim.num_tiles_y_dim(),
+                    stage_dim.tile_count_row(),
+                    stage_dim.tile_count_col(),
                 ),
                 TilingOrderConfig::ColMajor => ColMajorTiling::to_x_y(
                     nth_tile,
-                    stage_dim.num_tiles_x_dim(),
-                    stage_dim.num_tiles_y_dim(),
+                    stage_dim.tile_count_row(),
+                    stage_dim.tile_count_col(),
                 ),
             };
 
@@ -86,8 +86,8 @@ impl LoadingStrategy for CyclicLoading {
                 true => {
                     let tile_offset = nth_tile * tile_num_lines * line_size;
 
-                    let tile_size_x = config.stage_dim(ident).tile_size_x_dim();
-                    let tile_size_y = config.stage_dim(ident).tile_size_y_dim();
+                    let tile_size_x = config.stage_dim(ident).tile_size_row();
+                    let tile_size_y = config.stage_dim(ident).tile_size_col();
 
                     let (height, width) = match config.layout(ident) {
                         MatrixLayout::RowMajor => (tile_size_x, tile_size_y),

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/tilewise_loading.rs
@@ -20,7 +20,7 @@ impl LoadingValidation for TilewiseLoading {
         let line_size = config.global_line_size(ident);
 
         let num_planes = config.num_planes();
-        let num_tiles = stage_dim.num_tiles();
+        let num_tiles = stage_dim.tile_count();
 
         if num_planes != num_tiles {
             return Err(FormattedConfigError::new(move || {
@@ -58,7 +58,7 @@ impl LoadingStrategy for TilewiseLoading {
         let stage_dim = config.stage_dim(ident);
         let line_size = config.global_line_size(ident);
 
-        let num_lines_per_tile = comptime!(stage_dim.tile_num_elements() / line_size);
+        let num_lines_per_tile = comptime!(stage_dim.tile_size() / line_size);
 
         let nth_tile = UNIT_POS_Y;
         let offset_base = num_lines_per_tile * nth_tile;
@@ -68,13 +68,13 @@ impl LoadingStrategy for TilewiseLoading {
         let (tile_x, tile_y) = match config.tiling_order(ident) {
             TilingOrderConfig::RowMajor => RowMajorTiling::to_x_y(
                 nth_tile,
-                stage_dim.num_tiles_x_dim(),
-                stage_dim.num_tiles_y_dim(),
+                stage_dim.tile_count_row(),
+                stage_dim.tile_count_col(),
             ),
             TilingOrderConfig::ColMajor => ColMajorTiling::to_x_y(
                 nth_tile,
-                stage_dim.num_tiles_x_dim(),
-                stage_dim.num_tiles_y_dim(),
+                stage_dim.tile_count_row(),
+                stage_dim.tile_count_col(),
             ),
         };
 

--- a/crates/cubecl-linalg/src/matmul/components/global/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/shared.rs
@@ -37,7 +37,7 @@ impl<S: stage::StageConfig> super::GlobalConfig for CommonGlobalConfig<S> {
         self.smm_config.line_size(ident)
     }
 
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim> {
+    fn stage_dim(&self, ident: Ident) -> StageDim {
         self.smm_config.stage_dim(ident)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/shared.rs
@@ -1,12 +1,9 @@
-use cubecl_core as cubecl;
-use cubecl_core::prelude::*;
-
 use crate::matmul::components::{
     stage::{self, TilingOrderConfig},
     Ident, MatmulConfig, MatrixLayout, StageDim,
 };
 
-#[derive(CubeType, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the pipelined global matmul
 pub struct CommonGlobalConfig<S: stage::StageConfig> {
     pub smm_config: S,

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
@@ -92,8 +92,8 @@ impl<EG: Numeric> TensorReader<EG> {
         #[comptime] config: G,
     ) -> Line<EG> {
         let line_size = config.global_line_size(ident);
-        let tile_size_x = config.stage_dim(ident).tile_size_x_dim();
-        let tile_size_y = config.stage_dim(ident).tile_size_y_dim();
+        let tile_size_x = config.stage_dim(ident).tile_size_row();
+        let tile_size_y = config.stage_dim(ident).tile_size_col();
 
         let view_tile_x = tile_x * tile_size_x + self.x_offset;
         let view_tile_y = tile_y * tile_size_y + self.y_offset;
@@ -179,11 +179,11 @@ impl<EG: Numeric> TensorWriter<EG> {
     ) {
         let stage_dim = config.stage_dim(Ident::Out);
 
-        let view_x = tile_x * stage_dim.tile_size_x_dim()
-            + unit_id / stage_dim.tile_size_y_dim()
+        let view_x = tile_x * stage_dim.tile_size_row()
+            + unit_id / stage_dim.tile_size_col()
             + self.x_offset;
-        let view_y = tile_y * stage_dim.tile_size_y_dim()
-            + unit_id % stage_dim.tile_size_y_dim()
+        let view_y = tile_y * stage_dim.tile_size_col()
+            + unit_id % stage_dim.tile_size_col()
             + self.y_offset;
 
         let write_position = (view_x * self.stride_x + view_y * self.stride_y + self.batch_offset)

--- a/crates/cubecl-linalg/src/matmul/components/global/tilewise_unloading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tilewise_unloading.rs
@@ -23,7 +23,7 @@ impl TilewiseUnloading {
         let out_line_size = config.global_line_size(Ident::Out);
 
         let unit_step = config.plane_dim() * out_line_size;
-        let num_unit_writes = stage_dim.tile_num_elements() / unit_step;
+        let num_unit_writes = stage_dim.tile_size() / unit_step;
 
         #[allow(clippy::all)]
         let _ = comptime!(check_line_size(out_line_size, slice_line_size));

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -137,7 +137,7 @@ pub trait StageConfig: MatmulConfig {
     fn line_size(&self, ident: Ident) -> u32;
 
     /// Returns the [StageDim] for the given ident
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim>;
+    fn stage_dim(&self, ident: Ident) -> StageDim;
 
     /// Returns the [MatrixLayout] for the given ident
     fn layout(&self, ident: Ident) -> MatrixLayout;

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -51,7 +51,7 @@ impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM>
 
     fn check_config(config: &Self::Config) -> Result<(), InvalidConfigError> {
         check_num_planes(
-            config.stage_dim(Ident::Lhs).num_tiles_x_dim(),
+            config.stage_dim(Ident::Lhs).tile_count_row(),
             config.num_planes(),
         )?;
         TMM::check_config(&config.to_tmm_config())
@@ -173,7 +173,7 @@ where
     ) {
         let out_smem_line_size = global_config.stage_line_size(Ident::Out);
         let num_tile_lines =
-            stage_config.stage_dim(Ident::Out).tile_num_elements() / out_smem_line_size;
+            stage_config.stage_dim(Ident::Out).tile_size() / out_smem_line_size;
 
         let start = num_tile_lines * UNIT_POS_Y;
         let mut out_smem = SharedMemory::<O>::new_lined(

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -172,8 +172,7 @@ where
         #[comptime] global_config: G,
     ) {
         let out_smem_line_size = global_config.stage_line_size(Ident::Out);
-        let num_tile_lines =
-            stage_config.stage_dim(Ident::Out).tile_size() / out_smem_line_size;
+        let num_tile_lines = stage_config.stage_dim(Ident::Out).tile_size() / out_smem_line_size;
 
         let start = num_tile_lines * UNIT_POS_Y;
         let mut out_smem = SharedMemory::<O>::new_lined(

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -1,7 +1,6 @@
 use crate::matmul::components::{
     tile::{TileConfig, TileMatmulFamily},
-    Ident, InputIdent, LhsStageDim, MatmulConfig, MatmulSize, MatrixLayout, OutStageDim,
-    RhsStageDim, StageDim,
+    Ident, InputIdent, MatmulConfig, MatmulSize, MatrixLayout, StageDim,
 };
 
 use super::{StageConfig, TilingOrderConfig};
@@ -29,9 +28,9 @@ pub(super) fn stage_matmul_size<TMM: TileMatmulFamily>(
 pub struct CommonStageConfig<T: TileConfig> {
     pub tmm_config: T,
     pub num_stage: MatmulSize,
-    pub lhs_stage_dim: LhsStageDim,
-    pub rhs_stage_dim: RhsStageDim,
-    pub out_stage_dim: OutStageDim,
+    pub lhs_stage_dim: StageDim,
+    pub rhs_stage_dim: StageDim,
+    pub out_stage_dim: StageDim,
     pub num_planes: u32,
     pub lhs_tiling_order: TilingOrderConfig,
     pub rhs_tiling_order: TilingOrderConfig,
@@ -48,11 +47,11 @@ impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
         self.tmm_config.line_size(ident)
     }
 
-    fn stage_dim(&self, ident: Ident) -> Box<dyn StageDim> {
+    fn stage_dim(&self, ident: Ident) -> StageDim {
         match ident {
-            Ident::Lhs => Box::new(self.lhs_stage_dim),
-            Ident::Rhs => Box::new(self.rhs_stage_dim),
-            Ident::Out => Box::new(self.out_stage_dim),
+            Ident::Lhs => self.lhs_stage_dim,
+            Ident::Rhs => self.rhs_stage_dim,
+            Ident::Out => self.out_stage_dim,
         }
     }
 
@@ -87,9 +86,9 @@ impl<T: TileConfig> CommonStageConfig<T> {
     pub fn new(
         tmm_config: T,
         num_stage: MatmulSize,
-        lhs_stage_dim: LhsStageDim,
-        rhs_stage_dim: RhsStageDim,
-        out_stage_dim: OutStageDim,
+        lhs_stage_dim: StageDim,
+        rhs_stage_dim: StageDim,
+        out_stage_dim: StageDim,
         num_planes: u32,
         lhs_tiling_order: TilingOrderConfig,
         rhs_tiling_order: TilingOrderConfig,

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -1,6 +1,3 @@
-use cubecl::prelude::*;
-use cubecl_core as cubecl;
-
 use crate::matmul::components::{
     tile::{TileConfig, TileMatmulFamily},
     Ident, InputIdent, LhsStageDim, MatmulConfig, MatmulSize, MatrixLayout, OutStageDim,
@@ -27,7 +24,7 @@ pub(super) fn stage_matmul_size<TMM: TileMatmulFamily>(
     }
 }
 
-#[derive(CubeType, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the single buffer matmul
 pub struct CommonStageConfig<T: TileConfig> {
     pub tmm_config: T,

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -191,8 +191,7 @@ where
         #[comptime] global_config: G,
     ) {
         let out_smem_line_size = global_config.stage_line_size(Ident::Out);
-        let num_tile_lines =
-            stage_config.stage_dim(Ident::Out).tile_size() / out_smem_line_size;
+        let num_tile_lines = stage_config.stage_dim(Ident::Out).tile_size() / out_smem_line_size;
 
         let start = num_tile_lines * UNIT_POS_Y;
         let mut out_smem = SharedMemory::<O>::new_lined(

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -14,7 +14,7 @@ use crate::matmul::{
     components::{
         global::{self, AccumulatorLoader},
         stage::{self, StageConfig as _, StageWriter},
-        Ident, MatmulConfigFactory, MatmulProblem, StageDim,
+        Ident, MatmulConfigFactory, MatmulProblem,
     },
     kernels::matmul::{create_stage_dim, AdvancedConfig},
 };

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -88,7 +88,7 @@ where
             lhs_stage_dim,
             rhs_stage_dim,
             out_stage_dim,
-            lhs_stage_dim.num_tiles_x_dim(),
+            lhs_stage_dim.tile_count_row(),
             advanced_config.lhs_tiling_order,
             advanced_config.rhs_tiling_order,
         )
@@ -192,7 +192,7 @@ where
     ) {
         let out_smem_line_size = global_config.stage_line_size(Ident::Out);
         let num_tile_lines =
-            stage_config.stage_dim(Ident::Out).tile_num_elements() / out_smem_line_size;
+            stage_config.stage_dim(Ident::Out).tile_size() / out_smem_line_size;
 
         let start = num_tile_lines * UNIT_POS_Y;
         let mut out_smem = SharedMemory::<O>::new_lined(

--- a/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
@@ -20,7 +20,7 @@ impl<ES: Numeric> Stage<ES> {
         let line_size = config.line_size(ident);
 
         let smem = SharedMemory::new_lined(
-            comptime!(config.stage_dim(ident).total_elements() / line_size),
+            comptime!(config.stage_dim(ident).total_size() / line_size),
             line_size,
         );
 
@@ -41,18 +41,18 @@ impl<ES: Numeric> Stage<ES> {
             TilingOrderConfig::RowMajor => RowMajorTiling::to_nth_tile(
                 x,
                 y,
-                stage_dim.num_tiles_x_dim(),
-                stage_dim.num_tiles_y_dim(),
+                stage_dim.tile_count_row(),
+                stage_dim.tile_count_col(),
             ),
             TilingOrderConfig::ColMajor => ColMajorTiling::to_nth_tile(
                 x,
                 y,
-                stage_dim.num_tiles_x_dim(),
-                stage_dim.num_tiles_y_dim(),
+                stage_dim.tile_count_row(),
+                stage_dim.tile_count_col(),
             ),
         };
 
-        let tile_stride = stage_dim.tile_num_elements() / config.line_size(ident);
+        let tile_stride = stage_dim.tile_size() / config.line_size(ident);
         let start = nth_tile * tile_stride;
 
         self.smem.slice(start, start + tile_stride)

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -1,8 +1,6 @@
 use crate::matmul::components::stage;
-use crate::matmul::components::LhsStageDim;
+use crate::matmul::components::StageDim;
 use crate::matmul::components::MatrixLayout;
-use crate::matmul::components::OutStageDim;
-use crate::matmul::components::RhsStageDim;
 
 /// Configs that may impact performance
 pub struct AdvancedConfig {
@@ -39,30 +37,30 @@ pub fn create_stage_dim(
     tile_size_m: u32,
     tile_size_n: u32,
     tile_size_k: u32,
-) -> (LhsStageDim, RhsStageDim, OutStageDim) {
-    let count_m = stage_m / tile_size_m;
-    let count_k = stage_k / tile_size_k;
-    let count_n = stage_n / tile_size_n;
+) -> (StageDim, StageDim, StageDim) {
+    let tile_count_m = stage_m / tile_size_m;
+    let tile_count_k = stage_k / tile_size_k;
+    let tile_count_n = stage_n / tile_size_n;
 
-    let lhs_stage_dim = LhsStageDim {
+    let lhs_stage_dim = StageDim {
         tile_size_row: tile_size_m,
         tile_size_col: tile_size_k,
-        tile_count_row: count_m,
-        tile_count_col: count_k,
+        tile_count_row: tile_count_m,
+        tile_count_col: tile_count_k,
     };
 
-    let rhs_stage_dim = RhsStageDim {
+    let rhs_stage_dim = StageDim {
         tile_size_row: tile_size_k,
         tile_size_col: tile_size_n,
-        tile_count_row: count_k,
-        tile_count_col: count_n,
+        tile_count_row: tile_count_k,
+        tile_count_col: tile_count_n,
     };
 
-    let out_stage_dim = OutStageDim {
+    let out_stage_dim = StageDim {
         tile_size_row: tile_size_m,
         tile_size_col: tile_size_n,
-        tile_count_row: count_m,
-        tile_count_col: count_n,
+        tile_count_row: tile_count_m,
+        tile_count_col: tile_count_n,
     };
 
     (lhs_stage_dim, rhs_stage_dim, out_stage_dim)

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -1,6 +1,6 @@
 use crate::matmul::components::stage;
-use crate::matmul::components::StageDim;
 use crate::matmul::components::MatrixLayout;
+use crate::matmul::components::StageDim;
 
 /// Configs that may impact performance
 pub struct AdvancedConfig {

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -40,25 +40,29 @@ pub fn create_stage_dim(
     tile_size_n: u32,
     tile_size_k: u32,
 ) -> (LhsStageDim, RhsStageDim, OutStageDim) {
+    let count_m = stage_m / tile_size_m;
+    let count_k = stage_k / tile_size_k;
+    let count_n = stage_n / tile_size_n;
+
     let lhs_stage_dim = LhsStageDim {
-        tile_size_m,
-        tile_size_k,
-        num_tiles_m: stage_m / tile_size_m,
-        num_tiles_k: stage_k / tile_size_k,
+        tile_size_row: tile_size_m,
+        tile_size_col: tile_size_k,
+        tile_count_row: count_m,
+        tile_count_col: count_k,
     };
 
     let rhs_stage_dim = RhsStageDim {
-        tile_size_k,
-        tile_size_n,
-        num_tiles_k: stage_k / tile_size_k,
-        num_tiles_n: stage_n / tile_size_n,
+        tile_size_row: tile_size_k,
+        tile_size_col: tile_size_n,
+        tile_count_row: count_k,
+        tile_count_col: count_n,
     };
 
     let out_stage_dim = OutStageDim {
-        tile_size_m,
-        tile_size_n,
-        num_tiles_m: stage_m / tile_size_m,
-        num_tiles_n: stage_n / tile_size_n,
+        tile_size_row: tile_size_m,
+        tile_size_col: tile_size_n,
+        tile_count_row: count_m,
+        tile_count_col: count_n,
     };
 
     (lhs_stage_dim, rhs_stage_dim, out_stage_dim)


### PR DESCRIPTION
- Remove the `#[derive(CubeType)]` for all matmul config traits and types.
- Remove the `StageDim` trait and merge all implementations within a single struct. I replaced the uses of `Box<dyn StageDim>` with a single `match` expression.
- Improve some naming and documentation.