### PR TITLE
Clean stage again

### DIFF
--- a/crates/cubecl-linalg/src/matmul/components/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/base.rs
@@ -11,8 +11,8 @@ pub struct MatmulSize {
 }
 
 pub struct MatmulSelection {
-    pub tile: MatmulSize,
-    pub num_stagess: MatmulSize,
+    pub tile_shape: MatmulSize,
+    pub tile_count: MatmulSize,
     pub plane_dim: u32,
 }
 

--- a/crates/cubecl-linalg/src/matmul/components/batch/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/base.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 
 use crate::matmul::components::global::args::{self, MatmulArgs, TensorInput, TensorOutput};
 use crate::matmul::components::{config::MatmulConfig, global, Ident, MatmulLaunch};
-use crate::matmul::components::{MatmulPrecision, StageDim};
+use crate::matmul::components::{MatmulPrecision, StageTiling};
 use crate::tensor::{ReadWrite, VirtualTensor};
 
 /// A family of [matmuls](BatchMatmul) working with any [precision](MatmulPrecision).
@@ -50,7 +50,7 @@ pub trait BatchConfig: MatmulConfig {
     fn to_gmm_config(&self) -> Self::GmmConfig;
 
     /// Returns the [StageDim] for the given ident
-    fn stage_dim(&self, ident: Ident) -> StageDim;
+    fn stage_tiling(&self, ident: Ident) -> StageTiling;
 
     /// Returns the largest m dimension supported with these configs
     fn max_m(&self) -> u32;

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::matmul::components::batch::span::{Span, SpanDim, SpanMatmul};
 use crate::matmul::components::global::GlobalMatmulFamily;
 use crate::matmul::components::{
-    batch, config::MatmulConfig, global, Ident, MatmulConfigFactory, MatmulLaunch, StageDim,
+    batch, config::MatmulConfig, global, Ident, MatmulConfigFactory, MatmulLaunch, StageTiling,
 };
 use crate::matmul::components::{
     InputRuntimeArg, InvalidConfigError, MatmulPrecision, MatmulProblem, MatmulSpec,
@@ -123,8 +123,8 @@ impl<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>, S: SpanMatmul, C: CubeD
         let cubes_y = config.cube_count_y();
         let cubes_z = config.cube_count_batch();
 
-        let stage_x = config.stage_dim(Ident::Out).total_row();
-        let stage_y = config.stage_dim(Ident::Out).total_col();
+        let stage_x = config.stage_tiling(Ident::Out).total_row();
+        let stage_y = config.stage_tiling(Ident::Out).total_col();
         let stage_z = 1;
 
         let (x_index, y_index) = C::x_y_indices();
@@ -159,8 +159,8 @@ impl<G: global::GlobalConfig, C: CubeDispatch> batch::BatchConfig for Config<G, 
         self.gmm_config
     }
 
-    fn stage_dim(&self, ident: Ident) -> StageDim {
-        self.gmm_config.stage_dim(ident)
+    fn stage_tiling(&self, ident: Ident) -> StageTiling {
+        self.gmm_config.stage_tiling(ident)
     }
 
     fn max_m(&self) -> u32 {

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::matmul::components::batch::shared::gmm_execute;
 use crate::matmul::components::global::{GlobalMatmul, GlobalMatmulFamily};
 use crate::matmul::components::{
-    batch, config::MatmulConfig, global, Ident, MatmulConfigFactory, MatmulLaunch, StageDim,
+    batch, config::MatmulConfig, global, Ident, MatmulConfigFactory, MatmulLaunch, StageTiling,
 };
 use crate::matmul::components::{
     InputRuntimeArg, InvalidConfigError, MatmulPrecision, MatmulProblem, MatmulSpec,
@@ -101,8 +101,8 @@ impl<MP: MatmulPrecision, GMM: GlobalMatmul<MP>, C: CubeDispatch> BatchMatmul<MP
         #[comptime] config: Self::Config,
     ) {
         let (x_index, y_index) = C::x_y_indices();
-        let x_offset = x_index * config.stage_dim(Ident::Lhs).total_row();
-        let y_offset = y_index * config.stage_dim(Ident::Rhs).total_col();
+        let x_offset = x_index * config.stage_tiling(Ident::Lhs).total_row();
+        let y_offset = y_index * config.stage_tiling(Ident::Rhs).total_col();
         let nth_batch = C::batch_index();
         let rank = lhs.rank();
         let k_range = (0, lhs.shape(rank - 1));
@@ -138,16 +138,16 @@ impl<G: global::GlobalConfig, C: CubeDispatch> batch::BatchConfig for Config<G, 
         self.gmm_config
     }
 
-    fn stage_dim(&self, ident: Ident) -> StageDim {
-        self.gmm_config.stage_dim(ident)
+    fn stage_tiling(&self, ident: Ident) -> StageTiling {
+        self.gmm_config.stage_tiling(ident)
     }
 
     fn max_m(&self) -> u32 {
-        C::max_x(self.cube_count) * self.stage_dim(Ident::Out).total_row()
+        C::max_x(self.cube_count) * self.stage_tiling(Ident::Out).total_row()
     }
 
     fn max_n(&self) -> u32 {
-        C::max_y(self.cube_count) * self.stage_dim(Ident::Out).total_col()
+        C::max_y(self.cube_count) * self.stage_tiling(Ident::Out).total_col()
     }
 
     fn max_batches(&self) -> u32 {

--- a/crates/cubecl-linalg/src/matmul/components/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/config.rs
@@ -115,8 +115,8 @@ pub struct StageDims {
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 /// Dimensions for stage.
 pub struct StageDim {
-    pub tile_size_row: u32,
-    pub tile_size_col: u32,
+    pub tile_shape_row: u32,
+    pub tile_shape_col: u32,
     pub tile_count_row: u32,
     pub tile_count_col: u32,
 }
@@ -129,27 +129,27 @@ impl StageDim {
 
     /// Returns the total number of rows of the stage.
     pub fn total_row(&self) -> u32 {
-        self.tile_count_row() * self.tile_size_row()
+        self.tile_count_row() * self.tile_shape_row()
     }
 
     /// Returns the total number of columns of the stage.
     pub fn total_col(&self) -> u32 {
-        self.tile_count_col() * self.tile_size_col()
+        self.tile_count_col() * self.tile_shape_col()
     }
 
     /// Returns the number of elements within one tile.
     pub fn tile_size(&self) -> u32 {
-        self.tile_size_row() * self.tile_size_col()
+        self.tile_shape_row() * self.tile_shape_col()
     }
 
     /// Returns the size of the row axis of a tile.
-    pub fn tile_size_row(&self) -> u32 {
-        self.tile_size_row
+    pub fn tile_shape_row(&self) -> u32 {
+        self.tile_shape_row
     }
 
     /// Returns the size of the column axis of a tile.
-    pub fn tile_size_col(&self) -> u32 {
-        self.tile_size_col
+    pub fn tile_shape_col(&self) -> u32 {
+        self.tile_shape_col
     }
 
     /// Returns the number of tiles within the stage.

--- a/crates/cubecl-linalg/src/matmul/components/global/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/base.rs
@@ -5,7 +5,7 @@ use crate::matmul::components::stage::{self, StageWriter, TilingOrderConfig};
 use crate::matmul::components::{config::MatmulConfig, tile};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::components::{InvalidConfigError, MatmulConfigFactory};
-use crate::matmul::components::{MatmulPrecision, StageDim};
+use crate::matmul::components::{MatmulPrecision, StageTiling};
 use crate::tensor::{ReadWrite, VirtualTensor};
 
 /// A family of [matmuls](GlobalMatmul) working with any [precision](MatmulPrecision).
@@ -158,8 +158,8 @@ pub trait GlobalConfig: MatmulConfig {
     /// Returns the line size for the stage of the given ident
     fn stage_line_size(&self, ident: Ident) -> u32;
 
-    /// Returns the [StageDim] for the given ident
-    fn stage_dim(&self, ident: Ident) -> StageDim;
+    /// Returns the [StageTiling] for the given ident
+    fn stage_tiling(&self, ident: Ident) -> StageTiling;
 
     /// Returns the [MatrixLayout] for the given ident
     fn layout(&self, ident: Ident) -> MatrixLayout;

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/buffer_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/buffer_loading.rs
@@ -12,10 +12,10 @@ pub struct BufferLoading {}
 
 impl LoadingValidation for BufferLoading {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
-        let stage_dim = config.stage_dim(ident);
+        let tiling = config.stage_tiling(ident);
         let line_size = config.global_line_size(ident);
 
-        let num_stage_elements = stage_dim.total_size();
+        let num_stage_elements = tiling.total_size();
         let total_units = config.num_planes() * config.plane_dim();
         let jump_length = total_units * line_size;
 
@@ -46,10 +46,10 @@ impl BufferLoading {
         #[comptime] ident: Ident,
         #[comptime] config: G,
     ) {
-        let stage_dim = config.stage_dim(ident);
+        let tiling = config.stage_tiling(ident);
         let line_size = config.global_line_size(ident);
 
-        let num_buffer_elements = stage_dim.buffer_size(ident.as_input());
+        let num_buffer_elements = tiling.buffer_size(ident.as_input());
 
         let total_units = comptime!(num_producer_planes * config.plane_dim());
         let jump_length = comptime!(total_units * line_size);
@@ -67,7 +67,7 @@ impl BufferLoading {
         for i in 0..num_loads_per_unit {
             let unit_position = unit_position_base + i * jump_length;
 
-            let tile_num_elements = stage_dim.tile_size();
+            let tile_num_elements = tiling.tile_size();
             let nth_buffer_tile = unit_position / tile_num_elements;
             let pos_within_tile = unit_position % tile_num_elements;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/base.rs
@@ -47,7 +47,7 @@ where
         #[comptime] config: Self::Config,
     ) {
         let num_buffers = 2;
-        let buffer_step = config.stage_dim(Ident::Lhs).tile_shape_col();
+        let buffer_step = config.stage_tiling(Ident::Lhs).tile_shape_col();
         let k_step = num_buffers * buffer_step; // equal to SMM::K
 
         let range = k_range.1 - k_range.0;

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/base.rs
@@ -47,7 +47,7 @@ where
         #[comptime] config: Self::Config,
     ) {
         let num_buffers = 2;
-        let buffer_step = config.stage_dim(Ident::Lhs).tile_size_col();
+        let buffer_step = config.stage_dim(Ident::Lhs).tile_shape_col();
         let k_step = num_buffers * buffer_step; // equal to SMM::K
 
         let range = k_range.1 - k_range.0;

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
@@ -54,7 +54,7 @@ where
         BufferLoading::check::<Self::Config>(config, Ident::Lhs)?;
         BufferLoading::check::<Self::Config>(config, Ident::Rhs)?;
 
-        if config.stage_dim(Ident::Lhs).tile_count_col() != 2 {
+        if config.stage_tiling(Ident::Lhs).tile_count_col() != 2 {
             return Err(Box::new("Pipelined matmul needs exactly 2 buffers."));
         }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
@@ -45,9 +45,9 @@ where
         check_buffers_contiguous::<Self::Config>(Ident::Rhs, config)?;
 
         let tmm_config = config.smm_config.to_tmm_config();
-        let tmm_size = tmm_config.size();
+        let tile_shape = tmm_config.tile_shape();
 
-        if tmm_size.m != tmm_size.n || tmm_size.n != tmm_size.k {
+        if tile_shape.m != tile_shape.n || tile_shape.n != tile_shape.k {
             return Err(Box::new("Only support square tiling"));
         }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
@@ -76,13 +76,13 @@ where
         advanced_config: &AdvancedConfig,
     ) -> Self::Config {
         let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config);
-        let size = SMM::size(&smm_config);
+        let stage_shape = SMM::stage_shape(&smm_config);
 
         CommonGlobalConfig::new(
             smm_config,
-            problem.m as u32 % size.m != 0,
-            problem.n as u32 % size.n != 0,
-            problem.k as u32 % size.k != 0,
+            problem.m as u32 % stage_shape.m != 0,
+            problem.n as u32 % stage_shape.n != 0,
+            problem.k as u32 % stage_shape.k != 0,
             problem.lhs_layout,
             problem.rhs_layout,
             problem.lhs_line_size as u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/loader.rs
@@ -76,7 +76,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_dim(Ident::Lhs).tile_count_col(),
+            num_buffers: config.stage_tiling(Ident::Lhs).tile_count_col(),
             _config: PhantomData::<S>.runtime(),
         }
     }
@@ -127,7 +127,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_dim(Ident::Rhs).tile_count_row(),
+            num_buffers: config.stage_tiling(Ident::Rhs).tile_count_row(),
             _config: PhantomData::<S>.runtime(),
         }
     }
@@ -141,7 +141,7 @@ fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig>(
     #[comptime] ident: Ident,
     #[comptime] config: CommonGlobalConfig<S>,
 ) {
-    let buffer_num_elements = config.stage_dim(ident).buffer_size(ident.as_input());
+    let buffer_num_elements = config.stage_tiling(ident).buffer_size(ident.as_input());
     let line_size = config.stage_line_size(ident);
     let buffer_num_lines = buffer_num_elements / line_size;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
@@ -68,13 +68,13 @@ where
         advanced_config: &AdvancedConfig,
     ) -> Self::Config {
         let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config);
-        let size = SMM::size(&smm_config);
+        let stage_shape = SMM::stage_shape(&smm_config);
 
         Config::new(
             smm_config,
-            problem.m as u32 % size.m != 0,
-            problem.n as u32 % size.n != 0,
-            problem.k as u32 % size.k != 0,
+            problem.m as u32 % stage_shape.m != 0,
+            problem.n as u32 % stage_shape.n != 0,
+            problem.k as u32 % stage_shape.k != 0,
             problem.lhs_layout,
             problem.rhs_layout,
             problem.lhs_line_size as u32,

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
@@ -124,7 +124,7 @@ where
         let is_consumer = Self::is_consumer(config);
 
         let num_buffers = config.stage_dim(Ident::Lhs).tile_count_col();
-        let buffer_step = config.stage_dim(Ident::Lhs).tile_size_col();
+        let buffer_step = config.stage_dim(Ident::Lhs).tile_shape_col();
         let k_step = num_buffers * buffer_step; // equal to SMM::K
 
         let range = k_range.1 - k_range.0;

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/loader.rs
@@ -82,7 +82,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_dim(Ident::Lhs).tile_count_col(),
+            num_buffers: config.stage_tiling(Ident::Lhs).tile_count_col(),
             is_producer,
             _config: PhantomData::<S>.runtime(),
         }
@@ -137,7 +137,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_dim(Ident::Rhs).tile_count_row(),
+            num_buffers: config.stage_tiling(Ident::Rhs).tile_count_row(),
             is_producer,
             _config: PhantomData::<S>.runtime(),
         }
@@ -152,7 +152,7 @@ fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig>(
     #[comptime] ident: Ident,
     #[comptime] config: specialized::Config<S>,
 ) {
-    let buffer_num_elements = config.stage_dim(ident).buffer_size(ident.as_input());
+    let buffer_num_elements = config.stage_tiling(ident).buffer_size(ident.as_input());
     let line_size = config.stage_line_size(ident);
     let buffer_num_lines = buffer_num_elements / line_size;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
@@ -6,7 +6,7 @@ use crate::matmul::components::stage::multi_buffer::{
     LhsReader, LhsReaderFamily, RhsReader, RhsReaderFamily,
 };
 use crate::matmul::components::stage::{StageMatmul, TilingOrderConfig};
-use crate::matmul::components::StageDim;
+use crate::matmul::components::StageTiling;
 use crate::matmul::components::{config::MatmulConfig, global::ZeroAccumulatorLoader};
 use crate::matmul::components::{global, MatmulProblem};
 use crate::matmul::components::{stage, InvalidConfigError};
@@ -244,8 +244,8 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         self.smm_config.line_size(ident)
     }
 
-    fn stage_dim(&self, ident: Ident) -> StageDim {
-        self.smm_config.stage_dim(ident)
+    fn stage_tiling(&self, ident: Ident) -> StageTiling {
+        self.smm_config.tiling(ident)
     }
 
     fn layout(&self, ident: Ident) -> MatrixLayout {

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
@@ -72,19 +72,19 @@ where
         advanced_config: &AdvancedConfig,
     ) -> Self::Config {
         let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config);
-        let size = SMM::size(&smm_config);
+        let stage_shape = SMM::stage_shape(&smm_config);
 
         Config::new(
             smm_config,
-            problem.m as u32 % size.m != 0,
-            problem.n as u32 % size.n != 0,
-            problem.k as u32 % size.k != 0,
+            problem.m as u32 % stage_shape.m != 0,
+            problem.n as u32 % stage_shape.n != 0,
+            problem.k as u32 % stage_shape.k != 0,
             problem.lhs_layout,
             problem.rhs_layout,
             problem.lhs_line_size as u32,
             problem.rhs_line_size as u32,
             problem.out_line_size as u32,
-            size.k,
+            stage_shape.k,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/cyclic_loading.rs
@@ -86,12 +86,12 @@ impl LoadingStrategy for CyclicLoading {
                 true => {
                     let tile_offset = nth_tile * tile_num_lines * line_size;
 
-                    let tile_size_x = config.stage_dim(ident).tile_size_row();
-                    let tile_size_y = config.stage_dim(ident).tile_size_col();
+                    let tile_shape_x = config.stage_dim(ident).tile_shape_row();
+                    let tile_shape_y = config.stage_dim(ident).tile_shape_col();
 
                     let (height, width) = match config.layout(ident) {
-                        MatrixLayout::RowMajor => (tile_size_x, tile_size_y),
-                        MatrixLayout::ColMajor => (tile_size_y, tile_size_x),
+                        MatrixLayout::RowMajor => (tile_shape_x, tile_shape_y),
+                        MatrixLayout::ColMajor => (tile_shape_y, tile_shape_x),
                     };
 
                     let global_strided_idx = pos_within_tile / width;

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/tilewise_loading.rs
@@ -16,11 +16,11 @@ pub struct TilewiseLoading {}
 
 impl LoadingValidation for TilewiseLoading {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
-        let stage_dim = config.stage_dim(ident);
+        let tiling = config.stage_tiling(ident);
         let line_size = config.global_line_size(ident);
 
         let num_planes = config.num_planes();
-        let num_tiles = stage_dim.tile_count();
+        let num_tiles = tiling.tile_count();
 
         if num_planes != num_tiles {
             return Err(FormattedConfigError::new(move || {
@@ -55,10 +55,10 @@ impl LoadingStrategy for TilewiseLoading {
         #[comptime] ident: Ident,
         #[comptime] config: G,
     ) {
-        let stage_dim = config.stage_dim(ident);
+        let tiling = config.stage_tiling(ident);
         let line_size = config.global_line_size(ident);
 
-        let num_lines_per_tile = comptime!(stage_dim.tile_size() / line_size);
+        let num_lines_per_tile = comptime!(tiling.tile_size() / line_size);
 
         let nth_tile = UNIT_POS_Y;
         let offset_base = num_lines_per_tile * nth_tile;
@@ -68,13 +68,13 @@ impl LoadingStrategy for TilewiseLoading {
         let (tile_x, tile_y) = match config.tiling_order(ident) {
             TilingOrderConfig::RowMajor => RowMajorTiling::to_x_y(
                 nth_tile,
-                stage_dim.tile_count_row(),
-                stage_dim.tile_count_col(),
+                tiling.tile_count_row(),
+                tiling.tile_count_col(),
             ),
             TilingOrderConfig::ColMajor => ColMajorTiling::to_x_y(
                 nth_tile,
-                stage_dim.tile_count_row(),
-                stage_dim.tile_count_col(),
+                tiling.tile_count_row(),
+                tiling.tile_count_col(),
             ),
         };
 

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/tilewise_loading.rs
@@ -66,16 +66,12 @@ impl LoadingStrategy for TilewiseLoading {
         let num_loads_per_unit = num_lines_per_tile / config.plane_dim();
 
         let (tile_x, tile_y) = match config.tiling_order(ident) {
-            TilingOrderConfig::RowMajor => RowMajorTiling::to_x_y(
-                nth_tile,
-                tiling.tile_count_row(),
-                tiling.tile_count_col(),
-            ),
-            TilingOrderConfig::ColMajor => ColMajorTiling::to_x_y(
-                nth_tile,
-                tiling.tile_count_row(),
-                tiling.tile_count_col(),
-            ),
+            TilingOrderConfig::RowMajor => {
+                RowMajorTiling::to_x_y(nth_tile, tiling.tile_count_row(), tiling.tile_count_col())
+            }
+            TilingOrderConfig::ColMajor => {
+                ColMajorTiling::to_x_y(nth_tile, tiling.tile_count_row(), tiling.tile_count_col())
+            }
         };
 
         for i in 0..num_loads_per_unit {

--- a/crates/cubecl-linalg/src/matmul/components/global/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/shared.rs
@@ -1,6 +1,6 @@
 use crate::matmul::components::{
     stage::{self, TilingOrderConfig},
-    Ident, MatmulConfig, MatrixLayout, StageDim,
+    Ident, MatmulConfig, MatrixLayout, StageTiling,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -37,8 +37,8 @@ impl<S: stage::StageConfig> super::GlobalConfig for CommonGlobalConfig<S> {
         self.smm_config.line_size(ident)
     }
 
-    fn stage_dim(&self, ident: Ident) -> StageDim {
-        self.smm_config.stage_dim(ident)
+    fn stage_tiling(&self, ident: Ident) -> StageTiling {
+        self.smm_config.tiling(ident)
     }
 
     fn layout(&self, ident: Ident) -> MatrixLayout {

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
@@ -179,12 +179,10 @@ impl<EG: Numeric> TensorWriter<EG> {
     ) {
         let tiling = config.stage_tiling(Ident::Out);
 
-        let view_x = tile_x * tiling.tile_shape_row()
-            + unit_id / tiling.tile_shape_col()
-            + self.x_offset;
-        let view_y = tile_y * tiling.tile_shape_col()
-            + unit_id % tiling.tile_shape_col()
-            + self.y_offset;
+        let view_x =
+            tile_x * tiling.tile_shape_row() + unit_id / tiling.tile_shape_col() + self.x_offset;
+        let view_y =
+            tile_y * tiling.tile_shape_col() + unit_id % tiling.tile_shape_col() + self.y_offset;
 
         let write_position = (view_x * self.stride_x + view_y * self.stride_y + self.batch_offset)
             / config.global_line_size(Ident::Out);

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
@@ -92,8 +92,8 @@ impl<EG: Numeric> TensorReader<EG> {
         #[comptime] config: G,
     ) -> Line<EG> {
         let line_size = config.global_line_size(ident);
-        let tile_shape_x = config.stage_dim(ident).tile_shape_row();
-        let tile_shape_y = config.stage_dim(ident).tile_shape_col();
+        let tile_shape_x = config.stage_tiling(ident).tile_shape_row();
+        let tile_shape_y = config.stage_tiling(ident).tile_shape_col();
 
         let view_tile_x = tile_x * tile_shape_x + self.x_offset;
         let view_tile_y = tile_y * tile_shape_y + self.y_offset;
@@ -177,13 +177,13 @@ impl<EG: Numeric> TensorWriter<EG> {
         value: Line<ES>,
         #[comptime] config: G,
     ) {
-        let stage_dim = config.stage_dim(Ident::Out);
+        let tiling = config.stage_tiling(Ident::Out);
 
-        let view_x = tile_x * stage_dim.tile_shape_row()
-            + unit_id / stage_dim.tile_shape_col()
+        let view_x = tile_x * tiling.tile_shape_row()
+            + unit_id / tiling.tile_shape_col()
             + self.x_offset;
-        let view_y = tile_y * stage_dim.tile_shape_col()
-            + unit_id % stage_dim.tile_shape_col()
+        let view_y = tile_y * tiling.tile_shape_col()
+            + unit_id % tiling.tile_shape_col()
             + self.y_offset;
 
         let write_position = (view_x * self.stride_x + view_y * self.stride_y + self.batch_offset)

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
@@ -92,15 +92,15 @@ impl<EG: Numeric> TensorReader<EG> {
         #[comptime] config: G,
     ) -> Line<EG> {
         let line_size = config.global_line_size(ident);
-        let tile_size_x = config.stage_dim(ident).tile_size_row();
-        let tile_size_y = config.stage_dim(ident).tile_size_col();
+        let tile_shape_x = config.stage_dim(ident).tile_shape_row();
+        let tile_shape_y = config.stage_dim(ident).tile_shape_col();
 
-        let view_tile_x = tile_x * tile_size_x + self.x_offset;
-        let view_tile_y = tile_y * tile_size_y + self.y_offset;
+        let view_tile_x = tile_x * tile_shape_x + self.x_offset;
+        let view_tile_y = tile_y * tile_shape_y + self.y_offset;
 
         let (load_x, load_y) = match config.layout(ident) {
-            MatrixLayout::RowMajor => (unit_id / tile_size_y, unit_id % tile_size_y),
-            MatrixLayout::ColMajor => (unit_id % tile_size_x, unit_id / tile_size_x),
+            MatrixLayout::RowMajor => (unit_id / tile_shape_y, unit_id % tile_shape_y),
+            MatrixLayout::ColMajor => (unit_id % tile_shape_x, unit_id / tile_shape_x),
         };
 
         let view_x = view_tile_x + load_x;
@@ -166,7 +166,7 @@ impl<EG: Numeric> TensorWriter<EG> {
         }
     }
 
-    /// Writes data into the tensor view at the specified coordinates (write_x, write_y).
+    /// Writes data into the tensor view at the specified coordinates (tile_x, tile_y).
     ///
     /// Each unit writes one line in a coalesced manner for improved efficiency, assuming row-major layout.
     pub fn write_coalesced<ES: Numeric, G: global::GlobalConfig>(
@@ -179,11 +179,11 @@ impl<EG: Numeric> TensorWriter<EG> {
     ) {
         let stage_dim = config.stage_dim(Ident::Out);
 
-        let view_x = tile_x * stage_dim.tile_size_row()
-            + unit_id / stage_dim.tile_size_col()
+        let view_x = tile_x * stage_dim.tile_shape_row()
+            + unit_id / stage_dim.tile_shape_col()
             + self.x_offset;
-        let view_y = tile_y * stage_dim.tile_size_col()
-            + unit_id % stage_dim.tile_size_col()
+        let view_y = tile_y * stage_dim.tile_shape_col()
+            + unit_id % stage_dim.tile_shape_col()
             + self.y_offset;
 
         let write_position = (view_x * self.stride_x + view_y * self.stride_y + self.batch_offset)

--- a/crates/cubecl-linalg/src/matmul/components/global/tilewise_unloading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tilewise_unloading.rs
@@ -18,12 +18,12 @@ impl TilewiseUnloading {
         tile_y: u32,
         #[comptime] config: G,
     ) {
-        let stage_dim = config.stage_dim(Ident::Out);
+        let tiling = config.stage_tiling(Ident::Out);
         let slice_line_size = config.stage_line_size(Ident::Out);
         let out_line_size = config.global_line_size(Ident::Out);
 
         let unit_step = config.plane_dim() * out_line_size;
-        let num_unit_writes = stage_dim.tile_size() / unit_step;
+        let num_unit_writes = tiling.tile_size() / unit_step;
 
         #[allow(clippy::all)]
         let _ = comptime!(check_line_size(out_line_size, slice_line_size));

--- a/crates/cubecl-linalg/src/matmul/components/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/components/mod.rs
@@ -10,6 +10,6 @@ mod spec;
 
 pub use base::*;
 pub use config::*;
-pub use config::{as_cmma_layout, Ident, MatmulConfig, MatrixLayout, StageDim};
+pub use config::{as_cmma_layout, Ident, MatmulConfig, MatrixLayout, StageTiling};
 pub use problem::MatmulProblem;
 pub use spec::*;

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -5,7 +5,7 @@ use crate::matmul::components::tile::TileConfig;
 use crate::matmul::components::{config::MatmulConfig, global::AccumulatorLoader};
 use crate::matmul::components::{global, MatmulConfigFactory};
 use crate::matmul::components::{Ident, MatrixLayout};
-use crate::matmul::components::{MatmulSize, StageDim};
+use crate::matmul::components::{MatmulSize, StageTiling};
 
 use super::tiling_order::TilingOrderConfig;
 
@@ -13,6 +13,7 @@ pub trait ReaderFamily {
     type Reader<I: Numeric>: CubeType;
 }
 
+// TODO Bad names and doc
 pub trait StageMatmulFamily:
     MatmulConfigFactory<Config: StageConfig> + Send + Sync + 'static
 {
@@ -137,7 +138,7 @@ pub trait StageConfig: MatmulConfig {
     fn line_size(&self, ident: Ident) -> u32;
 
     /// Returns the [StageDim] for the given ident
-    fn stage_dim(&self, ident: Ident) -> StageDim;
+    fn tiling(&self, ident: Ident) -> StageTiling;
 
     /// Returns the [MatrixLayout] for the given ident
     fn layout(&self, ident: Ident) -> MatrixLayout;

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -138,7 +138,7 @@ pub trait StageConfig: MatmulConfig {
     /// Returns the line size for the given ident
     fn line_size(&self, ident: Ident) -> u32;
 
-    /// Returns the [StageDim] for the given ident
+    /// Returns the [StageTiling] for the given ident
     fn tiling(&self, ident: Ident) -> StageTiling;
 
     /// Returns the [MatrixLayout] for the given ident

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -13,16 +13,17 @@ pub trait ReaderFamily {
     type Reader<I: Numeric>: CubeType;
 }
 
-// TODO Bad names and doc
 pub trait StageMatmulFamily:
     MatmulConfigFactory<Config: StageConfig> + Send + Sync + 'static
 {
     type LhsReader: ReaderFamily;
     type RhsReader: ReaderFamily;
 
-    fn size(config: &Self::Config) -> MatmulSize;
-    /// Return the number of matmuls computed by the stage.
-    fn num(config: &Self::Config) -> MatmulSize;
+    /// Returns the shape of the stage. This is the number of elements per axis.
+    fn stage_shape(config: &Self::Config) -> MatmulSize;
+
+    /// Returns the number of tiles in each axis of the stage.
+    fn tile_count(config: &Self::Config) -> MatmulSize;
 
     type Matmul<I: Numeric, O: Numeric, Acc: Numeric>: StageMatmul<
         I,

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -151,5 +151,5 @@ pub trait StageConfig: MatmulConfig {
     /// Returns the order in which tiles should be loaded to the stage
     fn tiling_order(&self, ident: Ident) -> TilingOrderConfig;
 
-    fn num_stages(&self) -> &MatmulSize;
+    fn tile_count(&self) -> &MatmulSize;
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/mod.rs
@@ -9,5 +9,3 @@ mod tiling_order;
 pub use base::*;
 pub use staging::Stage;
 pub use tiling_order::*;
-
-pub use shared::CommonStageInput;

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -72,15 +72,15 @@ impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM>
         advanced_config: &AdvancedConfig,
     ) -> Self::Config {
         let tile_shape = input.tile_shape;
+        let tile_count = input.tile_count;
+
         let tmm_config =
             TMM::make_config(tile_shape, problem, cube_dim, cube_count, advanced_config);
-        let stage_size = stage_matmul_size::<TMM>(&tmm_config, &input.tile_count);
 
-        // TODO Clean
         let (lhs_stage_dim, rhs_stage_dim, out_stage_dim) = create_stage_dim(
-            stage_size.m,
-            stage_size.n,
-            stage_size.k,
+            tile_count.m,
+            tile_count.n,
+            tile_count.k,
             tile_shape.m,
             tile_shape.n,
             tile_shape.k,

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -28,11 +28,11 @@ pub struct MultiBufferMatmulFamily<TMM: TileMatmulFamily> {
 }
 
 impl<TMM: TileMatmulFamily> StageMatmulFamily for MultiBufferMatmulFamily<TMM> {
-    fn size(config: &Self::Config) -> MatmulSize {
+    fn stage_shape(config: &Self::Config) -> MatmulSize {
         config.tiling.total_shape()
     }
 
-    fn num(config: &Self::Config) -> MatmulSize {
+    fn tile_count(config: &Self::Config) -> MatmulSize {
         config.tiling.tile_count
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -4,7 +4,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::matmul::components::global::AccumulatorLoader;
-use crate::matmul::components::stage::shared::{CommonStageConfig, CommonStageInput};
+use crate::matmul::components::stage::shared::CommonStageConfig;
 use crate::matmul::components::stage::{StageMatmul, StageMatmulFamily};
 use crate::matmul::components::tile::TileMatmulFamily;
 use crate::matmul::components::{
@@ -43,7 +43,7 @@ impl<TMM: TileMatmulFamily> StageMatmulFamily for MultiBufferMatmulFamily<TMM> {
 }
 
 impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM> {
-    type Input = CommonStageInput;
+    type Input = CompleteStageTiling;
     type Config = CommonStageConfig<TMM::Config>;
 
     fn check_config(config: &Self::Config) -> Result<(), InvalidConfigError> {

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -5,16 +5,16 @@ use crate::matmul::components::{
 
 use super::{StageConfig, TilingOrderConfig};
 
-pub struct CommonStageInput<TMM: TileMatmulFamily> {
-    pub tile: TMM::Input,
-    pub num_stages: MatmulSize,
+pub struct CommonStageInput {
+    pub tile_shape: MatmulSize,
+    pub tile_count: MatmulSize,
 }
 
 pub(super) fn stage_matmul_size<TMM: TileMatmulFamily>(
     config: &TMM::Config,
     num_stage: &MatmulSize,
 ) -> MatmulSize {
-    let size = TMM::size(config);
+    let size = TMM::tile_shape(config);
 
     MatmulSize {
         m: num_stage.m * size.m,
@@ -27,7 +27,7 @@ pub(super) fn stage_matmul_size<TMM: TileMatmulFamily>(
 /// Configuration for the single buffer matmul
 pub struct CommonStageConfig<T: TileConfig> {
     pub tmm_config: T,
-    pub num_stage: MatmulSize,
+    pub tile_count: MatmulSize,
     pub lhs_stage_dim: StageDim,
     pub rhs_stage_dim: StageDim,
     pub out_stage_dim: StageDim,
@@ -74,8 +74,8 @@ impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
         }
     }
 
-    fn num_stages(&self) -> &MatmulSize {
-        &self.num_stage
+    fn tile_count(&self) -> &MatmulSize {
+        &self.tile_count
     }
 }
 
@@ -94,7 +94,7 @@ impl<T: TileConfig> CommonStageConfig<T> {
         rhs_tiling_order: TilingOrderConfig,
     ) -> Self {
         Self {
-            num_stage,
+            tile_count: num_stage,
             tmm_config,
             lhs_stage_dim,
             rhs_stage_dim,

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -5,20 +5,11 @@ use crate::matmul::components::{
 
 use super::{StageConfig, TilingOrderConfig};
 
-pub struct CommonStageInput {
-    pub tile_shape: MatmulSize,
-    pub tile_count: MatmulSize,
-}
-
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the single buffer matmul
 pub struct CommonStageConfig<T: TileConfig> {
     pub tmm_config: T,
     pub tiling: CompleteStageTiling,
-    // TODO
-    // pub lhs_stage_tiling: StageTiling,
-    // pub rhs_stage_tiling: StageTiling,
-    // pub out_stage_tiling: StageTiling,
     pub num_planes: u32,
     pub lhs_tiling_order: TilingOrderConfig,
     pub rhs_tiling_order: TilingOrderConfig,

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -26,11 +26,11 @@ pub struct SingleBufferMatmulFamily<TMM: TileMatmulFamily> {
 }
 
 impl<TMM: TileMatmulFamily> StageMatmulFamily for SingleBufferMatmulFamily<TMM> {
-    fn size(config: &Self::Config) -> MatmulSize {
+    fn stage_shape(config: &Self::Config) -> MatmulSize {
         config.tiling.total_shape()
     }
 
-    fn num(config: &Self::Config) -> MatmulSize {
+    fn tile_count(config: &Self::Config) -> MatmulSize {
         config.tiling.tile_count
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -67,16 +67,15 @@ where
         advanced_config: &AdvancedConfig,
     ) -> Self::Config {
         let tile_shape = input.tile_shape;
+        let tile_count = input.tile_count;
 
         let tmm_config =
             TMM::make_config(tile_shape, problem, cube_dim, cube_count, advanced_config);
-        let stage_size = stage_matmul_size::<TMM>(&tmm_config, &input.tile_count);
 
-        // TODO Clean, we use tile_count to compute stage size to compute back tile count.
         let (lhs_stage_dim, rhs_stage_dim, out_stage_dim) = create_stage_dim(
-            stage_size.m,
-            stage_size.n,
-            stage_size.k,
+            tile_count.m,
+            tile_count.n,
+            tile_count.k,
             tile_shape.m,
             tile_shape.n,
             tile_shape.k,

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use crate::matmul::components::stage::shared::{CommonStageConfig, CommonStageInput};
+use crate::matmul::components::stage::shared::CommonStageConfig;
 use crate::matmul::components::stage::StageMatmulFamily;
 use crate::matmul::components::tile::{TileMatmul, TileMatmulFamily};
 use crate::matmul::components::{
@@ -44,7 +44,7 @@ impl<TMM> MatmulConfigFactory for SingleBufferMatmulFamily<TMM>
 where
     TMM: TileMatmulFamily,
 {
-    type Input = CommonStageInput;
+    type Input = CompleteStageTiling;
     type Config = CommonStageConfig<TMM::Config>;
 
     fn check_config(config: &Self::Config) -> Result<(), InvalidConfigError> {

--- a/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
@@ -20,7 +20,7 @@ impl<ES: Numeric> Stage<ES> {
         let line_size = config.line_size(ident);
 
         let smem = SharedMemory::new_lined(
-            comptime!(config.stage_dim(ident).total_size() / line_size),
+            comptime!(config.tiling(ident).total_size() / line_size),
             line_size,
         );
 
@@ -35,24 +35,18 @@ impl<ES: Numeric> Stage<ES> {
         #[comptime] ident: Ident,
         #[comptime] config: S,
     ) -> Slice<Line<ES>> {
-        let stage_dim = config.stage_dim(ident);
+        let tiling = config.tiling(ident);
 
         let nth_tile = match config.tiling_order(ident) {
-            TilingOrderConfig::RowMajor => RowMajorTiling::to_nth_tile(
-                x,
-                y,
-                stage_dim.tile_count_row(),
-                stage_dim.tile_count_col(),
-            ),
-            TilingOrderConfig::ColMajor => ColMajorTiling::to_nth_tile(
-                x,
-                y,
-                stage_dim.tile_count_row(),
-                stage_dim.tile_count_col(),
-            ),
+            TilingOrderConfig::RowMajor => {
+                RowMajorTiling::to_nth_tile(x, y, tiling.tile_count_row(), tiling.tile_count_col())
+            }
+            TilingOrderConfig::ColMajor => {
+                ColMajorTiling::to_nth_tile(x, y, tiling.tile_count_row(), tiling.tile_count_col())
+            }
         };
 
-        let tile_stride = stage_dim.tile_size() / config.line_size(ident);
+        let tile_stride = tiling.tile_size() / config.line_size(ident);
         let start = nth_tile * tile_stride;
 
         self.smem.slice(start, start + tile_stride)

--- a/crates/cubecl-linalg/src/matmul/components/tile/accelerated.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/accelerated.rs
@@ -15,12 +15,8 @@ pub struct Accelerated;
 impl TileMatmulFamily for Accelerated {
     type Matmul<I: Numeric, O: Numeric> = Accelerated;
 
-    fn size(config: &Self::Config) -> MatmulSize {
+    fn tile_shape(config: &Self::Config) -> MatmulSize {
         config.size
-    }
-
-    fn input(tile_size: MatmulSize) -> Self::Input {
-        tile_size
     }
 
     fn requires_tensor_cores() -> bool {
@@ -251,7 +247,7 @@ impl TileConfig for Config {
         }
     }
 
-    fn size(&self) -> &MatmulSize {
+    fn tile_shape(&self) -> &MatmulSize {
         &self.size
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/tile/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/base.rs
@@ -5,9 +5,8 @@ use crate::matmul::components::{
     config::MatmulConfig, Ident, MatmulConfigFactory, MatmulSize, MatrixLayout,
 };
 
-pub trait TileMatmulFamily: MatmulConfigFactory<Config: TileConfig> {
-    fn size(config: &Self::Config) -> MatmulSize;
-    fn input(tile_size: MatmulSize) -> Self::Input;
+pub trait TileMatmulFamily: MatmulConfigFactory<Input = MatmulSize, Config: TileConfig> {
+    fn tile_shape(config: &Self::Config) -> MatmulSize;
     fn requires_tensor_cores() -> bool;
 
     type Matmul<I: Numeric, O: Numeric>: TileMatmul<I, O, Config = Self::Config>;
@@ -105,6 +104,6 @@ pub trait TileConfig: MatmulConfig {
     /// Returns the line size for the given ident
     fn line_size(&self, ident: Ident) -> u32;
 
-    /// Returns the line size for the given ident
-    fn size(&self) -> &MatmulSize;
+    /// Returns the shape of the tiles in the three axes m, k and n.
+    fn tile_shape(&self) -> &MatmulSize;
 }

--- a/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
@@ -24,12 +24,8 @@ pub struct PlaneMma;
 impl TileMatmulFamily for PlaneMma {
     type Matmul<I: Numeric, O: Numeric> = Self;
 
-    fn size(config: &Self::Config) -> MatmulSize {
+    fn tile_shape(config: &Self::Config) -> MatmulSize {
         config.size
-    }
-
-    fn input(tile_size: MatmulSize) -> Self::Input {
-        tile_size
     }
 
     fn requires_tensor_cores() -> bool {
@@ -453,7 +449,7 @@ impl TileConfig for Config {
         }
     }
 
-    fn size(&self) -> &MatmulSize {
+    fn tile_shape(&self) -> &MatmulSize {
         &self.size
     }
 }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
@@ -9,9 +9,9 @@ use crate::matmul::kernels::{MatmulAvailabilityError, MatmulLaunchError};
 /// Specifications for a matmul algorithm
 pub trait Algorithm {
     type TileMatmul: tile::TileMatmulFamily;
-    type StageMatmul: stage::StageMatmulFamily<Input = CommonStageInput<Self::TileMatmul>>;
+    type StageMatmul: stage::StageMatmulFamily<Input = CommonStageInput>;
     type GlobalMatmul: global::GlobalMatmulFamily;
-    type BatchMatmul: batch::BatchMatmulFamily<Input = CommonStageInput<Self::TileMatmul>>;
+    type BatchMatmul: batch::BatchMatmulFamily<Input = CommonStageInput>;
     type Selection;
 
     fn cube_dim(selection: &Self::Selection) -> CubeDim;

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
@@ -1,17 +1,17 @@
 use cubecl_core::prelude::*;
 
-use crate::matmul::components::stage::{self, CommonStageInput};
-use crate::matmul::components::{batch, global, tile, MatmulPrecision};
-use crate::matmul::components::{MatmulConfigFactory, MatmulProblem};
-use crate::matmul::kernels::matmul::AdvancedConfig;
-use crate::matmul::kernels::{MatmulAvailabilityError, MatmulLaunchError};
+use crate::matmul::components::{
+    batch, global, stage, tile, CompleteStageTiling, MatmulConfigFactory, MatmulPrecision,
+    MatmulProblem,
+};
+use crate::matmul::kernels::{matmul::AdvancedConfig, MatmulAvailabilityError, MatmulLaunchError};
 
 /// Specifications for a matmul algorithm
 pub trait Algorithm {
     type TileMatmul: tile::TileMatmulFamily;
-    type StageMatmul: stage::StageMatmulFamily<Input = CommonStageInput>;
+    type StageMatmul: stage::StageMatmulFamily<Input = CompleteStageTiling>;
     type GlobalMatmul: global::GlobalMatmulFamily;
-    type BatchMatmul: batch::BatchMatmulFamily<Input = CommonStageInput>;
+    type BatchMatmul: batch::BatchMatmulFamily<Input = CompleteStageTiling>;
     type Selection;
 
     fn cube_dim(selection: &Self::Selection) -> CubeDim;

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/pipelined.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/pipelined.rs
@@ -27,12 +27,12 @@ where
     type Selection = MatmulSelection;
 
     fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        CubeDim::new(selection.plane_dim, selection.num_stagess.m, 1)
+        CubeDim::new(selection.plane_dim, selection.tile_count.m, 1)
     }
 
     fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.num_stagess.m * selection.tile.m;
-        let n_stage = selection.num_stagess.n * selection.tile.n;
+        let m_stage = selection.tile_count.m * selection.tile_shape.m;
+        let n_stage = selection.tile_count.n * selection.tile_shape.n;
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
@@ -239,12 +239,12 @@ fn matmul_selection<TMM: TileMatmulFamily, MS: MatmulSpec, R: Runtime>(
     );
 
     MatmulSelection {
-        tile: MatmulSize {
+        tile_shape: MatmulSize {
             m: instruction_m as u32,
             n: instruction_n as u32,
             k: instruction_k as u32,
         },
-        num_stagess: MatmulSize {
+        tile_count: MatmulSize {
             m: stage_size_m_n as u32,
             n: stage_size_m_n as u32,
             k: 2,

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
@@ -5,7 +5,7 @@ use cubecl_runtime::DeviceProperties;
 
 use crate::matmul::{
     components::{
-        batch::TransposedDispatch, stage::*, tile::TileMatmulFamily, InputRuntimeArg,
+        batch::TransposedDispatch, tile::TileMatmulFamily, CompleteStageTiling, InputRuntimeArg,
         MatmulProblem, MatmulSelection, MatmulSize, MatmulSpec, OutputRuntimeArg,
     },
     kernels::{matmul::base::matmul_cube_preparation, MatmulLaunchError},
@@ -51,7 +51,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for StandardSelector<TMM> {
         plane_dim: u32,
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
-        let config_input = CommonStageInput {
+        let config_input = CompleteStageTiling {
             tile_shape: selection.tile_shape,
             tile_count: selection.tile_count,
         };
@@ -80,7 +80,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for PipelinedSelector<TMM> {
         plane_dim: u32,
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
-        let config_input = CommonStageInput {
+        let config_input = CompleteStageTiling {
             tile_shape: selection.tile_shape,
             tile_count: selection.tile_count,
         };
@@ -109,7 +109,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for SpecializedSelector<TMM> {
         plane_dim: u32,
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
-        let config_input = CommonStageInput {
+        let config_input = CompleteStageTiling {
             tile_shape: selection.tile_shape,
             tile_count: selection.tile_count,
         };

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
@@ -52,8 +52,8 @@ impl<TMM: TileMatmulFamily> MatmulSelector for StandardSelector<TMM> {
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
         let config_input = CommonStageInput {
-            tile: TMM::input(selection.tile),
-            num_stages: selection.num_stagess,
+            tile_shape: selection.tile_shape,
+            tile_count: selection.tile_count,
         };
 
         matmul_cube_preparation::<MS, R, StandardAlgorithm<TMM>>(
@@ -81,8 +81,8 @@ impl<TMM: TileMatmulFamily> MatmulSelector for PipelinedSelector<TMM> {
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
         let config_input = CommonStageInput {
-            tile: TMM::input(selection.tile),
-            num_stages: selection.num_stagess,
+            tile_shape: selection.tile_shape,
+            tile_count: selection.tile_count,
         };
 
         matmul_cube_preparation::<MS, R, PipelinedAlgorithm<TMM>>(
@@ -110,8 +110,8 @@ impl<TMM: TileMatmulFamily> MatmulSelector for SpecializedSelector<TMM> {
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
         let config_input = CommonStageInput {
-            tile: TMM::input(selection.tile),
-            num_stages: selection.num_stagess,
+            tile_shape: selection.tile_shape,
+            tile_count: selection.tile_count,
         };
 
         matmul_cube_preparation::<MS, R, SpecializedAlgorithm<TMM>>(

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/specialized.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/specialized.rs
@@ -29,14 +29,14 @@ where
     fn cube_dim(selection: &MatmulSelection) -> CubeDim {
         CubeDim::new(
             selection.plane_dim,
-            selection.num_stagess.m + core::cmp::max(1u32, selection.num_stagess.m / 2),
+            selection.tile_count.m + core::cmp::max(1u32, selection.tile_count.m / 2),
             1,
         )
     }
 
     fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.num_stagess.m * selection.tile.m;
-        let n_stage = selection.num_stagess.n * selection.tile.n;
+        let m_stage = selection.tile_count.m * selection.tile_shape.m;
+        let n_stage = selection.tile_count.n * selection.tile_shape.n;
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/standard.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/standard.rs
@@ -28,12 +28,12 @@ where
     type Selection = MatmulSelection;
 
     fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        CubeDim::new(selection.plane_dim, selection.num_stagess.m, 1)
+        CubeDim::new(selection.plane_dim, selection.tile_count.m, 1)
     }
 
     fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.num_stagess.m * selection.tile.m;
-        let n_stage = selection.num_stagess.n * selection.tile.n;
+        let m_stage = selection.tile_count.m * selection.tile_shape.m;
+        let n_stage = selection.tile_count.n * selection.tile_shape.n;
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -1,6 +1,5 @@
 use crate::matmul::components::stage;
 use crate::matmul::components::MatrixLayout;
-use crate::matmul::components::StageDim;
 
 /// Configs that may impact performance
 pub struct AdvancedConfig {
@@ -28,36 +27,4 @@ impl Default for AdvancedConfig {
             enforced_tile_layout: (None, None),
         }
     }
-}
-
-pub fn create_stage_dim(
-    tile_count_m: u32,
-    tile_count_n: u32,
-    tile_count_k: u32,
-    tile_shape_m: u32,
-    tile_shape_n: u32,
-    tile_shape_k: u32,
-) -> (StageDim, StageDim, StageDim) {
-    let lhs_stage_dim = StageDim {
-        tile_shape_row: tile_shape_m,
-        tile_shape_col: tile_shape_k,
-        tile_count_row: tile_count_m,
-        tile_count_col: tile_count_k,
-    };
-
-    let rhs_stage_dim = StageDim {
-        tile_shape_row: tile_shape_k,
-        tile_shape_col: tile_shape_n,
-        tile_count_row: tile_count_k,
-        tile_count_col: tile_count_n,
-    };
-
-    let out_stage_dim = StageDim {
-        tile_shape_row: tile_shape_m,
-        tile_shape_col: tile_shape_n,
-        tile_count_row: tile_count_m,
-        tile_count_col: tile_count_n,
-    };
-
-    (lhs_stage_dim, rhs_stage_dim, out_stage_dim)
 }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -31,17 +31,13 @@ impl Default for AdvancedConfig {
 }
 
 pub fn create_stage_dim(
-    stage_m: u32,
-    stage_n: u32,
-    stage_k: u32,
+    tile_count_m: u32,
+    tile_count_n: u32,
+    tile_count_k: u32,
     tile_shape_m: u32,
     tile_shape_n: u32,
     tile_shape_k: u32,
 ) -> (StageDim, StageDim, StageDim) {
-    let tile_count_m = stage_m / tile_shape_m;
-    let tile_count_k = stage_k / tile_shape_k;
-    let tile_count_n = stage_n / tile_shape_n;
-
     let lhs_stage_dim = StageDim {
         tile_shape_row: tile_shape_m,
         tile_shape_col: tile_shape_k,

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -34,31 +34,31 @@ pub fn create_stage_dim(
     stage_m: u32,
     stage_n: u32,
     stage_k: u32,
-    tile_size_m: u32,
-    tile_size_n: u32,
-    tile_size_k: u32,
+    tile_shape_m: u32,
+    tile_shape_n: u32,
+    tile_shape_k: u32,
 ) -> (StageDim, StageDim, StageDim) {
-    let tile_count_m = stage_m / tile_size_m;
-    let tile_count_k = stage_k / tile_size_k;
-    let tile_count_n = stage_n / tile_size_n;
+    let tile_count_m = stage_m / tile_shape_m;
+    let tile_count_k = stage_k / tile_shape_k;
+    let tile_count_n = stage_n / tile_shape_n;
 
     let lhs_stage_dim = StageDim {
-        tile_size_row: tile_size_m,
-        tile_size_col: tile_size_k,
+        tile_shape_row: tile_shape_m,
+        tile_shape_col: tile_shape_k,
         tile_count_row: tile_count_m,
         tile_count_col: tile_count_k,
     };
 
     let rhs_stage_dim = StageDim {
-        tile_size_row: tile_size_k,
-        tile_size_col: tile_size_n,
+        tile_shape_row: tile_shape_k,
+        tile_shape_col: tile_shape_n,
         tile_count_row: tile_count_k,
         tile_count_col: tile_count_n,
     };
 
     let out_stage_dim = StageDim {
-        tile_size_row: tile_size_m,
-        tile_size_col: tile_size_n,
+        tile_shape_row: tile_shape_m,
+        tile_shape_col: tile_shape_n,
         tile_count_row: tile_count_m,
         tile_count_col: tile_count_n,
     };

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/mod.rs
@@ -5,4 +5,4 @@ mod algorithm;
 
 pub use algorithm::*;
 pub use base::{launch, launch_ref};
-pub use config::{create_stage_dim, AdvancedConfig};
+pub use config::AdvancedConfig;

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
 use crate::matmul::components::stage::CommonStageInput;
-use crate::matmul::components::tile::TileMatmulFamily;
 use crate::matmul::components::{MatmulProblem, MatrixLayout};
 use crate::matmul::components::{MatmulSelection, MatmulSize};
 use crate::matmul::kernels::matmul::Algorithm;
@@ -13,8 +12,8 @@ use cubecl_core::{CubeElement, Runtime};
 
 pub fn test_algo<A: Algorithm<Selection = MatmulSelection>, P: TestPrecision, R: Runtime>(
     layouts: (MatrixLayout, MatrixLayout),
-    tile: MatmulSize,
-    stage: MatmulSize,
+    tile_shape: MatmulSize,
+    stage_count: MatmulSize,
     problem: MatmulSize,
 ) {
     let client = R::client(&Default::default());
@@ -43,13 +42,13 @@ pub fn test_algo<A: Algorithm<Selection = MatmulSelection>, P: TestPrecision, R:
     };
 
     let selection = MatmulSelection {
-        tile,
-        num_stagess: stage,
+        tile_shape,
+        tile_count: stage_count,
         plane_dim,
     };
     let config_input = CommonStageInput {
-        tile: A::TileMatmul::input(selection.tile),
-        num_stages: selection.num_stagess,
+        tile_shape: selection.tile_shape,
+        tile_count: selection.tile_count,
     };
 
     test_matmul_algorithm::<A, P::EG, P::ES, R>(client, problem, config_input, selection);

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
@@ -13,7 +13,7 @@ use cubecl_core::{CubeElement, Runtime};
 pub fn test_algo<A: Algorithm<Selection = MatmulSelection>, P: TestPrecision, R: Runtime>(
     layouts: (MatrixLayout, MatrixLayout),
     tile_shape: MatmulSize,
-    stage_count: MatmulSize,
+    tile_count: MatmulSize,
     problem: MatmulSize,
 ) {
     let client = R::client(&Default::default());
@@ -43,7 +43,7 @@ pub fn test_algo<A: Algorithm<Selection = MatmulSelection>, P: TestPrecision, R:
 
     let selection = MatmulSelection {
         tile_shape,
-        tile_count: stage_count,
+        tile_count,
         plane_dim,
     };
     let config_input = CommonStageInput {

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
-use crate::matmul::components::stage::CommonStageInput;
-use crate::matmul::components::{MatmulProblem, MatrixLayout};
+use crate::matmul::components::{CompleteStageTiling, MatmulProblem, MatrixLayout};
 use crate::matmul::components::{MatmulSelection, MatmulSize};
 use crate::matmul::kernels::matmul::Algorithm;
 use crate::matmul::tests::cmma_matmul::matmul_test_launcher::test_matmul_algorithm;
@@ -46,7 +45,7 @@ pub fn test_algo<A: Algorithm<Selection = MatmulSelection>, P: TestPrecision, R:
         tile_count,
         plane_dim,
     };
-    let config_input = CommonStageInput {
+    let config_input = CompleteStageTiling {
         tile_shape: selection.tile_shape,
         tile_count: selection.tile_count,
     };


### PR DESCRIPTION
- Uniformize many names and clarify some short (or  wrong) names.
  - Use `tile_count` with either the `m`, `n` and `k` axes or the `row` and `col` axes
    for the number of tiles within a stage.
  - Use `tile_shape` for the shape of a tile. 
  - Use `tile_size` for the total number of elements in a tile. The product of all shape of a time.
- Introduce a new concept of `StageTiling` that replace many previously used traits and structs related to tiling. A `CompleteStageTiling` is able to work with both the mnk axes and the row-col axes.
- Remove a few now unused traits, structs and functions.