### PR TITLE
Bump rand from 0.8.5 to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ smallvec = { version = "1", features = ["union", "const_generics"] }
 spin = { version = "0.9.8", features = ["mutex", "spin_mutex"] }
 
 getrandom = { version = "0.2.15", default-features = false }
-rand = { version = "0.8.5", default-features = false, features = [
+rand = { version = "0.9.0", default-features = false, features = [
     "std_rng",
 ] } # std_rng is for no_std
 

--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -37,7 +37,7 @@ derive_more = { workspace = true, features = [
 half = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ["thread_rng"] }
 serde = { workspace = true, optional = true }
 spin = { workspace = true } # using in place of use std::sync::Mutex;
 

--- a/crates/cubecl-common/src/rand.rs
+++ b/crates/cubecl-common/src/rand.rs
@@ -1,13 +1,13 @@
 pub use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use rand::distributions::Standard;
+use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
 
 /// Returns a seeded random number generator using entropy.
 #[cfg(feature = "std")]
 #[inline(always)]
 pub fn get_seeded_rng() -> StdRng {
-    StdRng::from_entropy()
+    StdRng::from_os_rng()
 }
 
 /// Returns a seeded random number generator using a pre-generated seed.
@@ -23,9 +23,9 @@ pub fn get_seeded_rng() -> StdRng {
 #[inline]
 pub fn gen_random<T>() -> T
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
-    rand::thread_rng().gen()
+    rand::rng().random()
 }
 
 /// Generates random data from a mutex-protected RNG.
@@ -33,7 +33,7 @@ where
 #[inline]
 pub fn gen_random<T>() -> T
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     use crate::stub::Mutex;
     static RNG: Mutex<Option<StdRng>> = Mutex::new(None);
@@ -41,5 +41,5 @@ where
     if rng.is_none() {
         *rng = Some(get_seeded_rng());
     }
-    rng.as_mut().unwrap().gen()
+    rng.as_mut().unwrap().random()
 }

--- a/crates/cubecl-reduce/src/test.rs
+++ b/crates/cubecl-reduce/src/test.rs
@@ -2,7 +2,7 @@
 
 use cubecl_core::prelude::*;
 use rand::{
-    distributions::{Distribution, Uniform},
+    distr::{Distribution, Uniform},
     rngs::StdRng,
     SeedableRng,
 };
@@ -587,7 +587,7 @@ impl TestCase {
     fn random_input_values<F: Float>(&self) -> Vec<F> {
         let size = self.input_size();
         let rng = StdRng::seed_from_u64(self.pseudo_random_seed());
-        let distribution = Uniform::new_inclusive(-2 * PRECISION, 2 * PRECISION);
+        let distribution = Uniform::new_inclusive(-2 * PRECISION, 2 * PRECISION).unwrap();
         let factor = 1.0 / (PRECISION as f32);
         distribution
             .sample_iter(rng)

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -58,7 +58,7 @@ spin = { workspace = true, features = [
 wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
-rand = { workspace = true }
+rand = { workspace = true, features = ["thread_rng"] }
 serial_test = { workspace = true }
 
 [build-dependencies]

--- a/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
@@ -1,5 +1,5 @@
 #[cfg(autotune_persistent_cache)]
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{distr::Alphanumeric, Rng};
 use std::sync::Arc;
 
 use cubecl_runtime::{
@@ -82,7 +82,7 @@ pub fn cache_test_set(
     .with_tunable(tunable(client.clone(), CacheTestSlowOn3, bindings.clone()).ok());
     if generate_random_checksum {
         set = set.with_custom_checksum(|_| {
-            let rand_string: String = rand::thread_rng()
+            let rand_string: String = rand::rng()
                 .sample_iter(&Alphanumeric)
                 .take(16)
                 .map(char::from)


### PR DESCRIPTION
Required for https://github.com/tracel-ai/burn/pull/2789 (`burn-common` re-exports `cubecl-common`)