### PR TITLE
More flexible matmul test

### DIFF
--- a/crates/cubecl-cuda/src/lib.rs
+++ b/crates/cubecl-cuda/src/lib.rs
@@ -16,7 +16,8 @@ mod tests {
     pub use half::{bf16, f16};
 
     cubecl_core::testgen_all!(f32: [f16, bf16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
-    cubecl_linalg::testgen_matmul_accelerated!([f32]);
+    cubecl_linalg::testgen_matmul_accelerated!([f16]);
+    cubecl_linalg::testgen_matmul_quantized!();
     cubecl_linalg::testgen_matmul_simple!([f16, bf16, f32]);
     cubecl_linalg::testgen_matmul_tiling2d!([f16, bf16, f32]);
     cubecl_linalg::testgen_tensor_identity!([f16, bf16, f32, u32]);

--- a/crates/cubecl-cuda/src/lib.rs
+++ b/crates/cubecl-cuda/src/lib.rs
@@ -16,7 +16,7 @@ mod tests {
     pub use half::{bf16, f16};
 
     cubecl_core::testgen_all!(f32: [f16, bf16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
-    cubecl_linalg::testgen_matmul_accelerated!([f16]);
+    cubecl_linalg::testgen_matmul_accelerated!([f32]);
     cubecl_linalg::testgen_matmul_simple!([f16, bf16, f32]);
     cubecl_linalg::testgen_matmul_tiling2d!([f16, bf16, f32]);
     cubecl_linalg::testgen_tensor_identity!([f16, bf16, f32, u32]);

--- a/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
@@ -1,50 +1,38 @@
-use std::fmt::Display;
-
 use cubecl_core::prelude::*;
 use cubecl_core::server::Handle;
 use cubecl_core::tensor_line_size_parallel;
 use cubecl_core::CubeElement;
-use cubecl_core::Feature;
 
 use crate::matmul::components::global::args::TensorInputsLaunch;
-use crate::matmul::components::tile::accelerated::Accelerated;
-use crate::matmul::components::tile::plane::PlaneMma;
 use crate::matmul::components::Ident;
 use crate::matmul::components::MatmulConfigFactory;
 use crate::matmul::components::MatmulLaunch;
 use crate::matmul::components::MatmulProblem;
 use crate::matmul::components::MatrixLayout;
 use crate::matmul::components::SingleMatmulSpec;
-use crate::matmul::kernels::matmul;
 use crate::matmul::kernels::matmul::Algorithm;
-use crate::matmul::kernels::matmul::StandardSelector;
-use crate::matmul::tests::test_utils::CastInto;
 use crate::matmul::tests::test_utils::Sample;
-use crate::tensor::TensorHandle;
+use crate::matmul::tests::test_utils::TestPrecision;
 
-use crate::matmul::tests::test_utils::assert_equals_approx;
-use crate::matmul::tests::test_utils::matmul_cpu_reference;
-
-struct TensorRawParts<F: Float + CubeElement> {
+struct TensorRawParts<N: Numeric + CubeElement> {
     handle: Handle,
     shape: Vec<usize>,
     strides: Vec<usize>,
-    original_data: Option<Vec<F>>,
+    original_data: Option<Vec<N>>,
 }
 
 type Spec<EG, ES> = SingleMatmulSpec<EG, ES, f32>;
 
 /// Test the correctness of the specified Matmul on the given device,
 /// against a naive CPU implementation over the given problem
-pub fn test_matmul_algorithm<A, EG, ES, R>(
+pub fn test_matmul_algorithm<A, P, R>(
     client: ComputeClient<R::Server, R::Channel>,
     mut problem: MatmulProblem,
     input: <A::BatchMatmul as MatmulConfigFactory>::Input,
     selection: A::Selection,
 ) where
     A: Algorithm,
-    EG: Float + CubeElement + Display + CastInto<ES> + Sample,
-    ES: Float + CubeElement + Display + CastInto<EG>,
+    P: TestPrecision,
     R: Runtime,
 {
     let env = std::env::var("MATMUL_TEST_MODE");
@@ -57,24 +45,24 @@ pub fn test_matmul_algorithm<A, EG, ES, R>(
         },
         Err(_) => false,
     };
-    let lhs = tensor_raw_parts::<EG, R>(&client, &problem, Ident::Lhs);
-    let rhs = tensor_raw_parts::<EG, R>(&client, &problem, Ident::Rhs);
-    let out = tensor_raw_parts::<EG, R>(&client, &problem, Ident::Out);
+    let lhs = tensor_raw_parts::<P::EG, R>(&client, &problem, Ident::Lhs);
+    let rhs = tensor_raw_parts::<P::EG, R>(&client, &problem, Ident::Rhs);
+    let out = tensor_raw_parts::<P::EG, R>(&client, &problem, Ident::Out);
 
     problem.lhs_line_size = tensor_line_size_parallel(
-        R::line_size_elem(&EG::as_elem_native_unchecked()),
+        R::line_size_elem(&P::EG::as_elem_native_unchecked()),
         &lhs.shape,
         &lhs.strides,
         lhs.strides.len() - 1,
     );
     problem.rhs_line_size = tensor_line_size_parallel(
-        R::line_size_elem(&EG::as_elem_native_unchecked()),
+        R::line_size_elem(&P::EG::as_elem_native_unchecked()),
         &rhs.shape,
         &rhs.strides,
         rhs.strides.len() - 1,
     );
     problem.out_line_size = tensor_line_size_parallel(
-        R::line_size_elem(&EG::as_elem_native_unchecked()),
+        R::line_size_elem(&P::EG::as_elem_native_unchecked()),
         &out.shape,
         &out.strides,
         out.strides.len() - 1,
@@ -101,7 +89,7 @@ pub fn test_matmul_algorithm<A, EG, ES, R>(
         }
     };
 
-    if A::check_availability::<R, (EG, ES, f32)>(&client, &config).is_err() {
+    if A::check_availability::<R, (P::EG, P::ES, f32)>(&client, &config).is_err() {
         // Can't execute the test.
         println!("Skipped - not supported!");
         client.flush();
@@ -109,25 +97,25 @@ pub fn test_matmul_algorithm<A, EG, ES, R>(
     }
 
     unsafe {
-        A::BatchMatmul::launch_unchecked::<Spec<EG, ES>, R>(
+        A::BatchMatmul::launch_unchecked::<Spec<P::EG, P::ES>, R>(
             &client,
             cube_dim,
             cube_count,
             TensorInputsLaunch::new(
-                TensorArg::<R>::from_raw_parts::<EG>(
+                TensorArg::<R>::from_raw_parts::<P::EG>(
                     &lhs.handle,
                     &lhs.strides,
                     &lhs.shape,
                     problem.lhs_line_size,
                 ),
-                TensorArg::<R>::from_raw_parts::<EG>(
+                TensorArg::<R>::from_raw_parts::<P::EG>(
                     &rhs.handle,
                     &rhs.strides,
                     &rhs.shape,
                     problem.rhs_line_size,
                 ),
             ),
-            TensorArg::<R>::from_raw_parts::<EG>(
+            TensorArg::<R>::from_raw_parts::<P::EG>(
                 &out.handle,
                 &out.strides,
                 &out.shape,
@@ -137,66 +125,16 @@ pub fn test_matmul_algorithm<A, EG, ES, R>(
         );
     }
 
-    assert_result::<EG, ES, R>(
+    P::assert_result::<R>(
         &lhs.original_data.unwrap(),
         &rhs.original_data.unwrap(),
         &problem,
         &client,
         out.handle,
-        None,
     );
 }
 
-/// Test the correctness of the high-level Matmul on the given device,
-/// against a naive CPU implementation over the given problem
-pub fn test_matmul_launch<EG: Float + CubeElement + Display + Sample, R: Runtime>(
-    problem: MatmulProblem,
-    device: &R::Device,
-) {
-    let client: ComputeClient<<R as Runtime>::Server, <R as Runtime>::Channel> = R::client(device);
-
-    if !(client.properties().feature_enabled(Feature::Plane)
-        && client.properties().feature_enabled(Feature::Type(
-            EG::as_elem_native().expect("To be a native type"),
-        )))
-    {
-        // Can't execute the test.
-        return;
-    }
-
-    let lhs = tensor_raw_parts::<EG, R>(&client, &problem, Ident::Lhs);
-    let rhs = tensor_raw_parts::<EG, R>(&client, &problem, Ident::Rhs);
-    let out = tensor_raw_parts::<EG, R>(&client, &problem, Ident::Out);
-
-    let lhs_handle = TensorHandle::new(lhs.shape, lhs.strides, lhs.handle);
-    let rhs_handle = TensorHandle::new(rhs.shape, rhs.strides, rhs.handle);
-    let out_handle = TensorHandle::new(out.shape, out.strides, out.handle);
-
-    let out = matmul::launch::<R, EG, StandardSelector<Accelerated>>(
-        &client,
-        lhs_handle.clone(),
-        rhs_handle.clone(),
-        out_handle.clone(),
-    )
-    .unwrap_or_else(|_| {
-        matmul::launch::<R, EG, StandardSelector<PlaneMma>>(
-            &client, lhs_handle, rhs_handle, out_handle,
-        )
-        .unwrap()
-    });
-
-    assert_result::<EG, EG, R>(
-        &lhs.original_data.unwrap(),
-        &rhs.original_data.unwrap(),
-        &problem,
-        &client,
-        out.handle,
-        // We cannot assume the inner precision of the matmul, therefore we need a permissive epsilon
-        Some(10e-2),
-    );
-}
-
-fn tensor_raw_parts<EG: Float + CubeElement + Sample, R: Runtime>(
+fn tensor_raw_parts<EG: Numeric + CubeElement + Sample, R: Runtime>(
     client: &ComputeClient<R::Server, R::Channel>,
     problem: &MatmulProblem,
     ident: Ident,
@@ -262,44 +200,6 @@ fn transpose<E: Copy>(array: &[E], batches: usize, rows: usize, cols: usize) -> 
         }
     }
     result
-}
-
-fn assert_result<
-    EG: Float + CubeElement + Display + CastInto<ES>,
-    ES: Float + CubeElement + CastInto<EG>,
-    R: Runtime,
->(
-    lhs: &[EG],
-    rhs: &[EG],
-    problem: &MatmulProblem,
-    client: &ComputeClient<R::Server, R::Channel>,
-    out: Handle,
-    epsilon: Option<f32>,
-) {
-    let epsilon = match epsilon {
-        Some(epsilon) => epsilon,
-        None => {
-            let maybe_cmma = client.properties().feature_enabled(Feature::Cmma {
-                a: ES::as_elem_native().expect("To be a native type"),
-                b: ES::as_elem_native().expect("To be a native type"),
-                c: EG::as_elem_native().expect("To be a native type"),
-                m: 16,
-                k: 16,
-                n: 16,
-            });
-
-            // Need to compensate for the temporary conversion to f16/tf32
-            match maybe_cmma {
-                true => 10e-5 / EG::EPSILON.to_f32().unwrap() * half::f16::EPSILON.to_f32(),
-                false => 10e-5,
-            }
-        }
-    };
-
-    let expected = matmul_cpu_reference(lhs, rhs, problem);
-    if let Err(e) = assert_equals_approx::<R, EG>(client, out, &expected, epsilon) {
-        panic!("{}", e);
-    }
 }
 
 /// Returns the total number of elements for the identified tensor, inferred by the problem definition

--- a/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
@@ -21,8 +21,6 @@ struct TensorRawParts<N: Numeric + CubeElement> {
     original_data: Option<Vec<N>>,
 }
 
-type Spec<EG, ES> = SingleMatmulSpec<EG, ES, f32>;
-
 /// Test the correctness of the specified Matmul on the given device,
 /// against a naive CPU implementation over the given problem
 pub fn test_matmul_algorithm<A, P, R>(
@@ -97,7 +95,7 @@ pub fn test_matmul_algorithm<A, P, R>(
     }
 
     unsafe {
-        A::BatchMatmul::launch_unchecked::<Spec<P::EG, P::ES>, R>(
+        A::BatchMatmul::launch_unchecked::<SingleMatmulSpec<P::EG, P::ES, P::EA>, R>(
             &client,
             cube_dim,
             cube_count,

--- a/crates/cubecl-linalg/src/matmul/tests/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/mod.rs
@@ -7,3 +7,4 @@ mod test_utils;
 pub mod tiling2d;
 
 pub use test_macros::cmma::suite::*;
+pub use test_utils::Quantized;

--- a/crates/cubecl-linalg/src/matmul/tests/simple.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/simple.rs
@@ -4,9 +4,9 @@ use cubecl_core::{prelude::Float, CubeElement, Runtime};
 
 use crate::{matmul::kernels::simple, tensor::TensorHandle};
 
-use super::test_utils::{assert_equals_approx, MatmulTestCase};
+use super::test_utils::{assert_equals_approx, MatmulTestCase, Sample};
 
-pub fn test_small<R: Runtime, F: Float + CubeElement + Display>(device: &R::Device) {
+pub fn test_small<R: Runtime, F: Float + CubeElement + Display + Sample>(device: &R::Device) {
     let case = MatmulTestCase {
         m: 64,
         k: 64,
@@ -17,7 +17,7 @@ pub fn test_small<R: Runtime, F: Float + CubeElement + Display>(device: &R::Devi
     test_simple::<R, F>(case, device);
 }
 
-pub fn test_large<R: Runtime, F: Float + CubeElement + Display>(device: &R::Device) {
+pub fn test_large<R: Runtime, F: Float + CubeElement + Display + Sample>(device: &R::Device) {
     let case = MatmulTestCase {
         m: 256,
         k: 256,
@@ -28,7 +28,9 @@ pub fn test_large<R: Runtime, F: Float + CubeElement + Display>(device: &R::Devi
     test_simple::<R, F>(case, device);
 }
 
-pub fn test_with_check_bounds<R: Runtime, F: Float + CubeElement + Display>(device: &R::Device) {
+pub fn test_with_check_bounds<R: Runtime, F: Float + CubeElement + Display + Sample>(
+    device: &R::Device,
+) {
     let case = MatmulTestCase {
         m: 60,
         k: 60,
@@ -39,7 +41,9 @@ pub fn test_with_check_bounds<R: Runtime, F: Float + CubeElement + Display>(devi
     test_simple::<R, F>(case, device);
 }
 
-pub fn test_with_batches<R: Runtime, F: Float + CubeElement + Display>(device: &R::Device) {
+pub fn test_with_batches<R: Runtime, F: Float + CubeElement + Display + Sample>(
+    device: &R::Device,
+) {
     let case = MatmulTestCase {
         m: 64,
         k: 64,
@@ -50,7 +54,7 @@ pub fn test_with_batches<R: Runtime, F: Float + CubeElement + Display>(device: &
     test_simple::<R, F>(case, device);
 }
 
-fn test_simple<R: Runtime, F: Float + CubeElement + Display>(
+fn test_simple<R: Runtime, F: Float + CubeElement + Display + Sample>(
     case: MatmulTestCase,
     device: &R::Device,
 ) {

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/mod.rs
@@ -5,8 +5,7 @@ pub mod suite;
 #[macro_export]
 macro_rules! testgen_matmul_accelerated {
     ($eg:ty, $es:ty) => {
-        type EG = $eg;
-        type ES = $es;
+        type Precision = ($eg, $es);
 
         $crate::matmul_standard_tests!();
     };
@@ -26,11 +25,26 @@ macro_rules! testgen_matmul_accelerated {
         }
     };
 }
+
+#[macro_export]
+macro_rules! testgen_matmul_quantized {
+    () => {
+        #[allow(non_snake_case)]
+        mod matmul_quantized {
+            use super::*;
+
+            type Precision = $crate::matmul::tests::Quantized;
+            type TMM = $crate::matmul::components::tile::accelerated::Accelerated;
+
+            $crate::matmul_standard_tests!();
+        }
+    };
+}
+
 #[macro_export]
 macro_rules! testgen_matmul_plane {
     ($float:ident) => {
-        type EG = $float;
-        type ES = $float;
+        type Precision = ($eg, $es);
 
         $crate::matmul_standard_tests!();
     };

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
@@ -4,7 +4,7 @@ use crate::matmul::components::{CompleteStageTiling, MatmulProblem, MatrixLayout
 use crate::matmul::components::{MatmulSelection, MatmulSize};
 use crate::matmul::kernels::matmul::Algorithm;
 use crate::matmul::tests::cmma_matmul::matmul_test_launcher::test_matmul_algorithm;
-use crate::matmul::tests::test_utils::CastInto;
+use crate::matmul::tests::test_utils::{CastInto, Sample};
 
 use cubecl_core::prelude::Float;
 use cubecl_core::{CubeElement, Runtime};
@@ -202,13 +202,13 @@ macro_rules! matmul_standard_tests {
 }
 
 pub trait TestPrecision {
-    type EG: Float + CubeElement + Display + CastInto<Self::ES>;
+    type EG: Float + CubeElement + Display + CastInto<Self::ES> + Sample;
     type ES: Float + CubeElement + Display + CastInto<Self::EG>;
 }
 
 impl<EG, ES> TestPrecision for (EG, ES)
 where
-    EG: Float + CubeElement + Display + CastInto<ES>,
+    EG: Float + CubeElement + Display + CastInto<ES> + Sample,
     ES: Float + CubeElement + Display + CastInto<EG>,
 {
     type EG = EG;

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
@@ -1,13 +1,9 @@
-use std::fmt::Display;
-
 use crate::matmul::components::{CompleteStageTiling, MatmulProblem, MatrixLayout};
 use crate::matmul::components::{MatmulSelection, MatmulSize};
 use crate::matmul::kernels::matmul::Algorithm;
 use crate::matmul::tests::cmma_matmul::matmul_test_launcher::test_matmul_algorithm;
-use crate::matmul::tests::test_utils::{CastInto, Sample};
-
-use cubecl_core::prelude::Float;
-use cubecl_core::{CubeElement, Runtime};
+use crate::matmul::tests::test_utils::TestPrecision;
+use cubecl_core::Runtime;
 
 pub fn test_algo<A: Algorithm<Selection = MatmulSelection>, P: TestPrecision, R: Runtime>(
     layouts: (MatrixLayout, MatrixLayout),
@@ -50,7 +46,7 @@ pub fn test_algo<A: Algorithm<Selection = MatmulSelection>, P: TestPrecision, R:
         tile_count: selection.tile_count,
     };
 
-    test_matmul_algorithm::<A, P::EG, P::ES, R>(client, problem, config_input, selection);
+    test_matmul_algorithm::<A, P, R>(client, problem, config_input, selection);
 }
 
 #[allow(missing_docs)]
@@ -199,18 +195,4 @@ macro_rules! matmul_standard_tests {
             );
         }
     };
-}
-
-pub trait TestPrecision {
-    type EG: Float + CubeElement + Display + CastInto<Self::ES> + Sample;
-    type ES: Float + CubeElement + Display + CastInto<Self::EG>;
-}
-
-impl<EG, ES> TestPrecision for (EG, ES)
-where
-    EG: Float + CubeElement + Display + CastInto<ES> + Sample,
-    ES: Float + CubeElement + Display + CastInto<EG>,
-{
-    type EG = EG;
-    type ES = ES;
 }

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
@@ -46,7 +46,9 @@ pub fn test_algo<A: Algorithm<Selection = MatmulSelection>, P: TestPrecision, R:
         tile_count: selection.tile_count,
     };
 
-    test_matmul_algorithm::<A, P, R>(client, problem, config_input, selection);
+    if P::should_run::<A>(layouts) {
+        test_matmul_algorithm::<A, P, R>(client, problem, config_input, selection);
+    }
 }
 
 #[allow(missing_docs)]
@@ -167,7 +169,7 @@ macro_rules! matmul_standard_tests {
 
         #[test]
         pub fn standard() {
-            cubecl_linalg::matmul::tests::test_algo::<StandardAlgorithm<TMM>, (EG, ES), TestRuntime>(
+            cubecl_linalg::matmul::tests::test_algo::<StandardAlgorithm<TMM>, Precision, TestRuntime>(
                 (MatrixLayout::$lhs_layout, MatrixLayout::$rhs_layout),
                 $tile,
                 $stage,
@@ -177,7 +179,7 @@ macro_rules! matmul_standard_tests {
 
         #[test]
         pub fn specialized() {
-            cubecl_linalg::matmul::tests::test_algo::<SpecializedAlgorithm<TMM>, (EG, ES), TestRuntime>(
+            cubecl_linalg::matmul::tests::test_algo::<SpecializedAlgorithm<TMM>, Precision, TestRuntime>(
                 (MatrixLayout::$lhs_layout, MatrixLayout::$rhs_layout),
                 $tile,
                 $stage,
@@ -187,7 +189,7 @@ macro_rules! matmul_standard_tests {
 
         #[test]
         pub fn pipelined() {
-            cubecl_linalg::matmul::tests::test_algo::<PipelinedAlgorithm<TMM>, (EG, ES), TestRuntime>(
+            cubecl_linalg::matmul::tests::test_algo::<PipelinedAlgorithm<TMM>, Precision, TestRuntime>(
                 (MatrixLayout::$lhs_layout, MatrixLayout::$rhs_layout),
                 $tile,
                 $stage,

--- a/crates/cubecl-linalg/src/matmul/tests/test_utils.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_utils.rs
@@ -5,7 +5,7 @@ use cubecl_core::{
     flex32,
     prelude::{Float, Numeric},
     server::Handle,
-    CubeElement, Runtime,
+    tf32, CubeElement, Feature, Runtime,
 };
 
 use crate::{
@@ -15,6 +15,63 @@ use crate::{
     },
     tensor::TensorHandle,
 };
+
+pub trait TestPrecision {
+    type EG: Numeric + CubeElement + Display + CastInto<Self::ES> + Sample;
+    type ES: Numeric + CubeElement + Display + CastInto<Self::EA>;
+    type EA: Numeric + CubeElement + Display + CastInto<Self::EG>;
+
+    fn assert_result<R: Runtime>(
+        lhs: &[Self::EG],
+        rhs: &[Self::EG],
+        problem: &MatmulProblem,
+        client: &ComputeClient<R::Server, R::Channel>,
+        out: Handle,
+    );
+}
+
+impl<EG, ES> TestPrecision for (EG, ES)
+where
+    EG: Float + CubeElement + Display + CastInto<ES> + Sample,
+    ES: Float + CubeElement + Display + CastInto<f32>,
+    f32: CastInto<EG>,
+{
+    type EG = EG;
+    type ES = ES;
+    type EA = f32;
+
+    fn assert_result<R: Runtime>(
+        lhs: &[EG],
+        rhs: &[EG],
+        problem: &MatmulProblem,
+        client: &ComputeClient<R::Server, R::Channel>,
+        out: Handle,
+    ) {
+        let maybe_cmma = client.properties().feature_enabled(Feature::Cmma {
+            a: ES::as_elem_native().expect("To be a native type"),
+            b: ES::as_elem_native().expect("To be a native type"),
+            c: EG::as_elem_native().expect("To be a native type"),
+            m: 16,
+            k: 16,
+            n: 16,
+        });
+
+        // Need to compensate for the temporary conversion to f16/tf32
+        let epsilon = match maybe_cmma {
+            true => 10e-5 / EG::EPSILON.to_f32().unwrap() * half::f16::EPSILON.to_f32(),
+            false => 10e-5,
+        };
+
+        let expected = matmul_cpu_reference::<Self>(lhs, rhs, problem)
+            .into_iter()
+            .map(|x| x.cast_into())
+            .collect::<Vec<EG>>();
+
+        if let Err(e) = assert_equals_approx::<R, EG>(client, out, &expected, epsilon) {
+            panic!("{}", e);
+        }
+    }
+}
 
 /// Compares the content of a handle to a given slice of f32.
 pub(crate) fn assert_equals_approx<R: Runtime, F: Float + CubeElement + Display>(
@@ -46,6 +103,31 @@ pub(crate) fn assert_equals_approx<R: Runtime, F: Float + CubeElement + Display>
     }
 
     Ok(())
+}
+
+// TODO: Add different conversions from i32 to u8.
+pub struct Quantized;
+
+impl TestPrecision for Quantized {
+    type EG = u8;
+    type ES = u8;
+    type EA = i32;
+
+    fn assert_result<R: Runtime>(
+        lhs: &[u8],
+        rhs: &[u8],
+        problem: &MatmulProblem,
+        client: &ComputeClient<R::Server, R::Channel>,
+        out: Handle,
+    ) {
+        let expected = matmul_cpu_reference::<Self>(lhs, rhs, problem)
+            .into_iter()
+            .map(|x| x.cast_into()) // TODO: Improve with different conversions.
+            .collect::<Vec<u8>>();
+        let actual = client.read_one(out.binding());
+        let actual = u8::from_bytes(&actual);
+        assert_eq!(actual, expected);
+    }
 }
 
 pub trait CastInto<E> {
@@ -118,40 +200,76 @@ impl CastInto<flex32> for f32 {
     }
 }
 
+impl CastInto<i32> for u8 {
+    fn cast_into(self) -> i32 {
+        self as i32
+    }
+}
+
+impl CastInto<u8> for i32 {
+    fn cast_into(self) -> u8 {
+        self as u8
+    }
+}
+
 pub trait Sample: Sized {
     fn sample(num_elements: usize, seed: u64) -> Vec<Self>;
 }
 
-impl<F> Sample for F
-where
-    F: Float,
-{
+macro_rules! sample_float {
+    ($($t:ty),*) => {
+        $(
+            impl Sample for $t
+            {
+                fn sample(num_elements: usize, mut seed: u64) -> Vec<Self> {
+                    fn lcg(seed: &mut u64) -> f32 {
+                        const A: u64 = 1664525;
+                        const C: u64 = 1013904223;
+                        const M: f64 = 2u64.pow(32) as f64;
+
+                        *seed = (A.wrapping_mul(*seed).wrapping_add(C)) % (1u64 << 32);
+                        (*seed as f64 / M * 2.0 - 1.0) as f32
+                    }
+
+                    (0..num_elements).map(|_| <$t as Float>::new(lcg(&mut seed))).collect()
+                }
+            }
+        )*
+    };
+}
+
+sample_float!(half::f16);
+sample_float!(half::bf16);
+sample_float!(flex32);
+sample_float!(f32);
+sample_float!(tf32);
+sample_float!(f64);
+
+impl Sample for u8 {
     fn sample(num_elements: usize, mut seed: u64) -> Vec<Self> {
-        fn lcg(seed: &mut u64) -> f32 {
+        fn lcg(seed: &mut u64) -> u8 {
             const A: u64 = 1664525;
             const C: u64 = 1013904223;
-            const M: f64 = 2u64.pow(32) as f64;
+            const M: u64 = 2u64.pow(32);
 
-            *seed = (A.wrapping_mul(*seed).wrapping_add(C)) % (1u64 << 32);
-            (*seed as f64 / M * 2.0 - 1.0) as f32
+            *seed = (A.wrapping_mul(*seed).wrapping_add(C)) % M;
+            (*seed % 4) as u8
         }
 
-        (0..num_elements).map(|_| F::new(lcg(&mut seed))).collect()
+        (0..num_elements).map(|_| lcg(&mut seed)).collect()
     }
 }
 
-/// Solves a matmul problem with EG inputs, multiplied as ES
+/// Solves a matmul problem with EG inputs, multiplied as ES and accumulated as EA.
 ///
 /// This is a naive CPU implementation, very slow on large payloads,
 /// not designed to be used for other purposes than testing.
-pub(crate) fn matmul_cpu_reference<EG, ES>(
-    lhs: &[EG],
-    rhs: &[EG],
+pub(crate) fn matmul_cpu_reference<P: TestPrecision>(
+    lhs: &[P::EG],
+    rhs: &[P::EG],
     problem: &MatmulProblem,
-) -> Vec<EG>
+) -> Vec<P::EA>
 where
-    EG: Numeric + CubeElement + CastInto<ES>,
-    ES: Numeric + CubeElement + CastInto<EG>,
 {
     let m = problem.m;
     let n = problem.n;
@@ -165,7 +283,7 @@ where
     let rhs_strides = strides(problem, Ident::Rhs);
     let out_strides = strides(problem, Ident::Out);
 
-    let mut out = vec![EG::from_int(0); m * n * num_batches];
+    let mut out = vec![P::EA::from_int(0); m * n * num_batches];
 
     for nth_batch in 0..num_batches {
         let batch_out = nth_batch * m * n;
@@ -184,12 +302,11 @@ where
                     let rhs_index = k_ * n + j;
                     let out_index = i * n + j;
 
-                    let l: ES = lhs[batch_lhs + lhs_index].cast_into();
-                    let r: ES = rhs[batch_rhs + rhs_index].cast_into();
+                    let l: P::ES = lhs[batch_lhs + lhs_index].cast_into();
+                    let r: P::ES = rhs[batch_rhs + rhs_index].cast_into();
                     let prod = l * r;
-                    let casted: EG = prod.cast_into();
 
-                    out[batch_out + out_index] += casted;
+                    out[batch_out + out_index] += prod.cast_into();
                 }
             }
         }

--- a/crates/cubecl-linalg/src/matmul/tests/tiling2d.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/tiling2d.rs
@@ -4,9 +4,9 @@ use cubecl_core::{prelude::Float, CubeElement, Runtime};
 
 use crate::matmul::kernels::tiling2d;
 
-use super::test_utils::{assert_equals_approx, MatmulTestCase};
+use super::test_utils::{assert_equals_approx, MatmulTestCase, Sample};
 
-pub fn test_one_cube<R: Runtime, F: Float + CubeElement + Display>(device: &R::Device) {
+pub fn test_one_cube<R: Runtime, F: Float + CubeElement + Display + Sample>(device: &R::Device) {
     let case = MatmulTestCase {
         m: 64,
         k: 64,
@@ -17,7 +17,9 @@ pub fn test_one_cube<R: Runtime, F: Float + CubeElement + Display>(device: &R::D
     test_tiling2d::<R, F>(case, device);
 }
 
-pub fn test_several_cubes<R: Runtime, F: Float + CubeElement + Display>(device: &R::Device) {
+pub fn test_several_cubes<R: Runtime, F: Float + CubeElement + Display + Sample>(
+    device: &R::Device,
+) {
     let case = MatmulTestCase {
         m: 256,
         k: 256,
@@ -28,7 +30,9 @@ pub fn test_several_cubes<R: Runtime, F: Float + CubeElement + Display>(device: 
     test_tiling2d::<R, F>(case, device);
 }
 
-pub fn test_with_check_bounds<R: Runtime, F: Float + CubeElement + Display>(device: &R::Device) {
+pub fn test_with_check_bounds<R: Runtime, F: Float + CubeElement + Display + Sample>(
+    device: &R::Device,
+) {
     let case = MatmulTestCase {
         m: 60,
         k: 60,
@@ -39,7 +43,9 @@ pub fn test_with_check_bounds<R: Runtime, F: Float + CubeElement + Display>(devi
     test_tiling2d::<R, F>(case, device);
 }
 
-pub fn test_with_batches<R: Runtime, F: Float + CubeElement + Display>(device: &R::Device) {
+pub fn test_with_batches<R: Runtime, F: Float + CubeElement + Display + Sample>(
+    device: &R::Device,
+) {
     let case = MatmulTestCase {
         m: 64,
         k: 64,
@@ -50,7 +56,7 @@ pub fn test_with_batches<R: Runtime, F: Float + CubeElement + Display>(device: &
     test_tiling2d::<R, F>(case, device);
 }
 
-fn test_tiling2d<R: Runtime, F: Float + CubeElement + Display>(
+fn test_tiling2d<R: Runtime, F: Float + CubeElement + Display + Sample>(
     case: MatmulTestCase,
     device: &R::Device,
 ) {


### PR DESCRIPTION
Prepare the matmul tests to be ready for quantization. However, this currently skip all tests related to quantization as it is not implemented yet. The strategy will be to partially enable quantization tests during development using this method:

https://github.com/tracel-ai/cubecl/blob/c1c333c56461aeea2bba6aac9f72c897ad725d01/crates/cubecl-linalg/src/matmul/tests/test_utils.rs#L148C1-L152C6