### PR TITLE
Make matmul launch ready for quantization

### DIFF
--- a/crates/cubecl-linalg/Cargo.toml
+++ b/crates/cubecl-linalg/Cargo.toml
@@ -22,6 +22,7 @@ std = ["cubecl-runtime/std", "cubecl-core/std"]
 bytemuck = { workspace = true }
 cubecl-core = { path = "../cubecl-core", version = "0.5.0", default-features = false }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.5.0", default-features = false }
+cubecl-std = { path = "../cubecl-std", version = "0.5.0", default-features = false }
 half = { workspace = true, features = ["bytemuck"] }
 pretty_assertions = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -52,8 +52,9 @@ impl<GMM: GlobalMatmulFamily, S: SpanMatmul, C: CubeDispatch> MatmulConfigFactor
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool,
     ) -> Self::Config {
-        let gmm_config = GMM::make_config(input, problem, cube_dim, cube_count, advanced_config);
+        let gmm_config = GMM::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
         let cube_count = if let CubeCount::Static(x, y, z) = cube_count {
             (*x, *y, *z)
         } else {

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -54,7 +54,14 @@ impl<GMM: GlobalMatmulFamily, S: SpanMatmul, C: CubeDispatch> MatmulConfigFactor
         advanced_config: &AdvancedConfig,
         quantized: bool,
     ) -> Self::Config {
-        let gmm_config = GMM::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
+        let gmm_config = GMM::make_config(
+            input,
+            problem,
+            cube_dim,
+            cube_count,
+            advanced_config,
+            quantized,
+        );
         let cube_count = if let CubeCount::Static(x, y, z) = cube_count {
             (*x, *y, *z)
         } else {

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -50,8 +50,9 @@ impl<GMM: GlobalMatmulFamily, C: CubeDispatch> MatmulConfigFactory
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool,
     ) -> Self::Config {
-        let gmm_config = GMM::make_config(input, problem, cube_dim, cube_count, advanced_config);
+        let gmm_config = GMM::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
         let cube_count = if let CubeCount::Static(x, y, z) = cube_count {
             (*x, *y, *z)
         } else {

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_one.rs
@@ -52,7 +52,14 @@ impl<GMM: GlobalMatmulFamily, C: CubeDispatch> MatmulConfigFactory
         advanced_config: &AdvancedConfig,
         quantized: bool,
     ) -> Self::Config {
-        let gmm_config = GMM::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
+        let gmm_config = GMM::make_config(
+            input,
+            problem,
+            cube_dim,
+            cube_count,
+            advanced_config,
+            quantized,
+        );
         let cube_count = if let CubeCount::Static(x, y, z) = cube_count {
             (*x, *y, *z)
         } else {

--- a/crates/cubecl-linalg/src/matmul/components/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/config.rs
@@ -51,6 +51,7 @@ pub trait MatmulConfigFactory: Send + Sync + 'static {
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool
     ) -> Self::Config;
 }
 

--- a/crates/cubecl-linalg/src/matmul/components/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/config.rs
@@ -51,7 +51,7 @@ pub trait MatmulConfigFactory: Send + Sync + 'static {
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
-        quantized: bool
+        quantized: bool,
     ) -> Self::Config;
 }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
@@ -76,7 +76,14 @@ where
         advanced_config: &AdvancedConfig,
         quantized: bool,
     ) -> Self::Config {
-        let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
+        let smm_config = SMM::make_config(
+            input,
+            problem,
+            cube_dim,
+            cube_count,
+            advanced_config,
+            quantized,
+        );
         let stage_shape = SMM::stage_shape(&smm_config);
 
         CommonGlobalConfig::new(

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/pipelined/family.rs
@@ -74,8 +74,9 @@ where
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool,
     ) -> Self::Config {
-        let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config);
+        let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
         let stage_shape = SMM::stage_shape(&smm_config);
 
         CommonGlobalConfig::new(

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
@@ -66,8 +66,9 @@ where
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool
     ) -> Self::Config {
-        let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config);
+        let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
         let stage_shape = SMM::stage_shape(&smm_config);
 
         Config::new(

--- a/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/buffered/specialized/base.rs
@@ -66,9 +66,16 @@ where
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
-        quantized: bool
+        quantized: bool,
     ) -> Self::Config {
-        let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
+        let smm_config = SMM::make_config(
+            input,
+            problem,
+            cube_dim,
+            cube_count,
+            advanced_config,
+            quantized,
+        );
         let stage_shape = SMM::stage_shape(&smm_config);
 
         Config::new(

--- a/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/full_load/base.rs
@@ -70,8 +70,16 @@ where
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool,
     ) -> Self::Config {
-        let smm_config = SMM::make_config(input, problem, cube_dim, cube_count, advanced_config);
+        let smm_config = SMM::make_config(
+            input,
+            problem,
+            cube_dim,
+            cube_count,
+            advanced_config,
+            quantized,
+        );
         let stage_shape = SMM::stage_shape(&smm_config);
 
         Config::new(

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -67,12 +67,19 @@ impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM>
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool,
     ) -> Self::Config {
         let tile_shape = input.tile_shape;
         let tile_count = input.tile_count;
 
-        let tmm_config =
-            TMM::make_config(tile_shape, problem, cube_dim, cube_count, advanced_config);
+        let tmm_config = TMM::make_config(
+            tile_shape,
+            problem,
+            cube_dim,
+            cube_count,
+            advanced_config,
+            quantized,
+        );
 
         let tiling = CompleteStageTiling {
             tile_shape,
@@ -85,6 +92,7 @@ impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM>
             cube_dim.y,
             advanced_config.lhs_tiling_order,
             advanced_config.rhs_tiling_order,
+            quantized
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -92,7 +92,7 @@ impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM>
             cube_dim.y,
             advanced_config.lhs_tiling_order,
             advanced_config.rhs_tiling_order,
-            quantized
+            quantized,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -13,6 +13,7 @@ pub struct CommonStageConfig<T: TileConfig> {
     pub num_planes: u32,
     pub lhs_tiling_order: TilingOrderConfig,
     pub rhs_tiling_order: TilingOrderConfig,
+    pub quantized: bool,
 }
 
 impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
@@ -64,6 +65,7 @@ impl<T: TileConfig> CommonStageConfig<T> {
         num_planes: u32,
         lhs_tiling_order: TilingOrderConfig,
         rhs_tiling_order: TilingOrderConfig,
+        quantized: bool,
     ) -> Self {
         Self {
             tmm_config,
@@ -71,6 +73,7 @@ impl<T: TileConfig> CommonStageConfig<T> {
             num_planes,
             lhs_tiling_order,
             rhs_tiling_order,
+            quantized,
         }
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -64,12 +64,19 @@ where
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool,
     ) -> Self::Config {
         let tile_shape = input.tile_shape;
         let tile_count = input.tile_count;
 
-        let tmm_config =
-            TMM::make_config(tile_shape, problem, cube_dim, cube_count, advanced_config);
+        let tmm_config = TMM::make_config(
+            tile_shape,
+            problem,
+            cube_dim,
+            cube_count,
+            advanced_config,
+            quantized,
+        );
 
         let tiling = CompleteStageTiling {
             tile_count,
@@ -82,6 +89,7 @@ where
             cube_dim.y,
             advanced_config.lhs_tiling_order,
             advanced_config.rhs_tiling_order,
+            quantized,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/tile/accelerated.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/accelerated.rs
@@ -191,6 +191,7 @@ impl MatmulConfigFactory for Accelerated {
         cube_dim: &CubeDim,
         _cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        _quantized: bool,
     ) -> Self::Config {
         let (lhs_tile_layout, lhs_tile_line_size) = match advanced_config.enforced_tile_layout.0 {
             Some(enforced_layout) if enforced_layout != problem.lhs_layout => (enforced_layout, 1),

--- a/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
@@ -5,7 +5,6 @@ use crate::matmul::components::{
 use crate::matmul::components::{MatmulProblem, MatmulSize};
 use crate::matmul::kernels::matmul::AdvancedConfig;
 use crate::matmul::kernels::MatmulAvailabilityError;
-
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl, Feature};
 use tile::{TileConfig, TileMatmul, TileMatmulFamily};
@@ -370,6 +369,7 @@ impl MatmulConfigFactory for PlaneMma {
         cube_dim: &CubeDim,
         _cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        _quantized: bool,
     ) -> Self::Config {
         let (lhs_tile_layout, lhs_tile_line_size) = match advanced_config.enforced_tile_layout.0 {
             Some(enforced_layout) if enforced_layout != problem.lhs_layout => (enforced_layout, 1),

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
@@ -24,9 +24,10 @@ pub trait Algorithm {
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
         advanced_config: &AdvancedConfig,
+        quantized: bool,
     ) -> Result<<Self::BatchMatmul as MatmulConfigFactory>::Config, MatmulLaunchError> {
         let config =
-            Self::BatchMatmul::make_config(input, problem, cube_dim, cube_count, advanced_config);
+            Self::BatchMatmul::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
         problem.check_config(&config)?;
         Self::BatchMatmul::check_config(&config)?;
         Ok(config)

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/base.rs
@@ -26,8 +26,14 @@ pub trait Algorithm {
         advanced_config: &AdvancedConfig,
         quantized: bool,
     ) -> Result<<Self::BatchMatmul as MatmulConfigFactory>::Config, MatmulLaunchError> {
-        let config =
-            Self::BatchMatmul::make_config(input, problem, cube_dim, cube_count, advanced_config, quantized);
+        let config = Self::BatchMatmul::make_config(
+            input,
+            problem,
+            cube_dim,
+            cube_count,
+            advanced_config,
+            quantized,
+        );
         problem.check_config(&config)?;
         Self::BatchMatmul::check_config(&config)?;
         Ok(config)

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
@@ -25,6 +25,7 @@ pub trait MatmulSelector {
         output: OutputRuntimeArg<'a, MS, R>,
         problem: MatmulProblem,
         plane_dim: u32,
+        quantized: bool,
     ) -> Result<(), MatmulLaunchError>;
     fn stage_tf32_supported() -> bool;
 }
@@ -49,6 +50,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for StandardSelector<TMM> {
         output: OutputRuntimeArg<'a, MS, R>,
         problem: MatmulProblem,
         plane_dim: u32,
+        quantized: bool,
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
         let config_input = CompleteStageTiling {
@@ -63,6 +65,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for StandardSelector<TMM> {
             problem,
             config_input,
             selection,
+            quantized,
         )
     }
 
@@ -78,6 +81,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for PipelinedSelector<TMM> {
         output: OutputRuntimeArg<'a, MS, R>,
         problem: MatmulProblem,
         plane_dim: u32,
+        quantized: bool,
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
         let config_input = CompleteStageTiling {
@@ -92,6 +96,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for PipelinedSelector<TMM> {
             problem,
             config_input,
             selection,
+            quantized,
         )
     }
 
@@ -107,6 +112,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for SpecializedSelector<TMM> {
         output: OutputRuntimeArg<'a, MS, R>,
         problem: MatmulProblem,
         plane_dim: u32,
+        quantized: bool,
     ) -> Result<(), MatmulLaunchError> {
         let selection = matmul_selection::<TMM, MS, R>(client, &problem, plane_dim);
         let config_input = CompleteStageTiling {
@@ -121,6 +127,7 @@ impl<TMM: TileMatmulFamily> MatmulSelector for SpecializedSelector<TMM> {
             problem,
             config_input,
             selection,
+            quantized,
         )
     }
 

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/base.rs
@@ -1,17 +1,17 @@
-use core::any::TypeId;
-use cubecl_core::prelude::*;
-use cubecl_core::{
-    client::ComputeClient, frontend::TensorHandleRef, tensor_line_size_parallel, Runtime,
-};
-use cubecl_std::MaybeQuantized;
+use crate::matmul;
 use crate::matmul::components::global::args::TensorInputsLaunch;
 use crate::matmul::components::{
     InputRuntimeArg, MatmulConfigFactory, MatmulLaunch, MatmulProblem, MatmulSpec,
     OutputRuntimeArg, SingleMatmulSpec,
 };
 use crate::matmul::kernels::{MatmulAvailabilityError, MatmulLaunchError};
-use crate::matmul;
 use crate::tensor::{into_contiguous, matrix_layout, MatrixLayout, TensorHandle};
+use core::any::TypeId;
+use cubecl_core::prelude::*;
+use cubecl_core::{
+    client::ComputeClient, frontend::TensorHandleRef, tensor_line_size_parallel, Runtime,
+};
+use cubecl_std::MaybeQuantized;
 
 use super::algorithm::MatmulSelector;
 use super::config::AdvancedConfig;

--- a/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/cmma_matmul/matmul_test_launcher.rs
@@ -74,6 +74,7 @@ pub fn test_matmul_algorithm<A, P, R>(
         &cube_dim,
         &cube_count,
         &A::advanced_config(),
+        P::QUANTIZED,
     ) {
         Ok(config) => config,
         Err(err) => {

--- a/crates/cubecl-linalg/src/matmul/tests/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/mod.rs
@@ -7,4 +7,4 @@ mod test_utils;
 pub mod tiling2d;
 
 pub use test_macros::cmma::suite::*;
-pub use test_utils::Quantized;
+pub use test_utils::*;

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/mod.rs
@@ -33,7 +33,7 @@ macro_rules! testgen_matmul_quantized {
         mod matmul_quantized {
             use super::*;
 
-            type Precision = $crate::matmul::tests::Quantized;
+            type Precision = $crate::matmul::tests::Q8;
             type TMM = $crate::matmul::components::tile::accelerated::Accelerated;
 
             $crate::matmul_standard_tests!();

--- a/crates/cubecl-linalg/src/matmul/tests/test_utils.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_utils.rs
@@ -8,6 +8,8 @@ use cubecl_core::{
     tf32, CubeElement, Feature, Runtime,
 };
 
+pub use cubecl_std::Q8;
+
 use crate::{
     matmul::{
         components::{Ident, MatmulProblem, MatmulSelection, MatrixLayout},
@@ -21,6 +23,7 @@ pub trait TestPrecision {
     type EG: Numeric + CubeElement + Display + CastInto<Self::ES> + Sample;
     type ES: Numeric + CubeElement + Display + CastInto<Self::EA>;
     type EA: Numeric + CubeElement + Display + CastInto<Self::EG>;
+    const QUANTIZED: bool;
 
     fn assert_result<R: Runtime>(
         lhs: &[Self::EG],
@@ -47,6 +50,7 @@ where
     type EG = EG;
     type ES = ES;
     type EA = f32;
+    const QUANTIZED: bool = false;
 
     fn assert_result<R: Runtime>(
         lhs: &[EG],
@@ -122,12 +126,12 @@ pub(crate) fn assert_equals_approx<R: Runtime, F: Float + CubeElement + Display>
 // TODO:
 //   - Add different conversions from i32 to u8.
 //   - Add support for multipliers (zero_offsets).
-pub struct Quantized;
-
-impl TestPrecision for Quantized {
+impl TestPrecision for Q8 {
     type EG = u8;
     type ES = u16;
     type EA = i32;
+
+    const QUANTIZED: bool = true;
 
     fn assert_result<R: Runtime>(
         lhs: &[u8],

--- a/crates/cubecl-std/src/lib.rs
+++ b/crates/cubecl-std/src/lib.rs
@@ -1,1 +1,4 @@
 //! Cubecl standard library.
+
+mod quantization;
+pub use quantization::*;

--- a/crates/cubecl-std/src/quantization.rs
+++ b/crates/cubecl-std/src/quantization.rs
@@ -10,23 +10,11 @@ use cubecl_core::prelude::*;
 ///
 /// ```ignored
 ///
-/// // With a regular function.
-///
 /// pub fn double_if_quantized<N: MaybeQuantized>(x: N::Numeric) -> N::Numeric {
 ///     if N::QUANTIZED {
 ///         x * N::Numeric::from_int(2)
 ///     } else {
 ///         x
-///     }
-/// }
-///
-///
-/// // With a cube function. (N::QUANTIZED is resolved at comptime)
-///
-/// #[cube]
-/// pub fn set_to_zero_if_quantized<N: MaybeQuantized>(array: &mut Array<N::Numeric>) {
-///     if N::QUANTIZED {
-///         array[UNIT_POS] = N::Numeric::from_int(0);
 ///     }
 /// }
 ///
@@ -38,7 +26,6 @@ use cubecl_core::prelude::*;
 /// let z = double_if_quantized::<Q8>(3);
 /// assert_eq!(z, 6);
 /// ```
-#[cube]
 pub trait MaybeQuantized {
     type Numeric: Numeric;
     const QUANTIZED: bool;

--- a/crates/cubecl-std/src/quantization.rs
+++ b/crates/cubecl-std/src/quantization.rs
@@ -34,7 +34,7 @@ use cubecl_core::prelude::*;
 ///
 /// let y = double_if_quantized::<u8>(3);
 /// assert_eq!(y, 3);
-/// 
+///
 /// let z = double_if_quantized::<Q8>(3);
 /// assert_eq!(z, 6);
 /// ```

--- a/crates/cubecl-std/src/quantization.rs
+++ b/crates/cubecl-std/src/quantization.rs
@@ -1,0 +1,76 @@
+use cubecl_core::prelude::*;
+
+/// Useful for functions that may change their implementation depending on quantization.
+/// This trait can be used to keep a simple signature and then dispatch on depending on `QUANTIZED`.
+///
+/// Currently, this is implemented with `QUANTIZED == false` for all types that implement `Numeric`.
+/// To add a new quantized type, one should create a static type. See [Q8] for example.
+///
+/// # Examples
+///
+/// ```ignored
+///
+/// // With a regular function.
+///
+/// pub fn double_if_quantized<N: MaybeQuantized>(x: N::Numeric) -> N::Numeric {
+///     if N::QUANTIZED {
+///         x * N::Numeric::from_int(2)
+///     } else {
+///         x
+///     }
+/// }
+///
+///
+/// // With a cube function. (N::QUANTIZED is resolved at comptime)
+///
+/// #[cube]
+/// pub fn set_to_zero_if_quantized<N: MaybeQuantized>(array: &mut Array<N::Numeric>) {
+///     if N::QUANTIZED {
+///         array[UNIT_POS] = N::Numeric::from_int(0);
+///     }
+/// }
+///
+/// // At call site (similar for cube functions).
+///
+/// let y = double_if_quantized::<u8>(3);
+/// assert_eq!(y, 3);
+/// 
+/// let z = double_if_quantized::<Q8>(3);
+/// assert_eq!(z, 6);
+/// ```
+#[cube]
+pub trait MaybeQuantized {
+    type Numeric: Numeric;
+    const QUANTIZED: bool;
+}
+
+impl<N: Numeric> MaybeQuantized for N {
+    type Numeric = N;
+    const QUANTIZED: bool = false;
+}
+
+/// Represent the quantization of a f32 into a u8.
+pub struct Q8;
+
+impl MaybeQuantized for Q8 {
+    type Numeric = u8;
+    const QUANTIZED: bool = true;
+}
+
+impl Q8 {
+    pub fn quantize(val: f32, scaling: f32, zero_offset: u8) -> u8 {
+        let min = -scaling * (zero_offset as f32);
+        let max = min + 255.0 * scaling;
+        if val < min {
+            0
+        } else if val > max {
+            255
+        } else {
+            ((val - min) / scaling).round() as u8
+        }
+    }
+
+    pub fn dequantize(val: u8, scaling: f32, zero_offset: u8) -> f32 {
+        (val as i16 - zero_offset as i16) as f32 * scaling
+    }
+}


### PR DESCRIPTION
This introduce a new trait for quantization in `cubecl_std`. Then, it is used in all the matmul launch functions. 

Currently, I stop propagating the new types at the function `matmul_launch_kernel` since I am uncertain how this abstraction will interact with fusion. From that point, I simply move the quantized argument into the config of the different components. I may consider propagating the change further down the stack. I would appreciate your input on that.