### PR TITLE
Strided Tile + Layout and Loader refactoring

### DIFF
--- a/crates/cubecl-linalg/src/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/base.rs
@@ -7,7 +7,9 @@ use super::{
     components::tile::accelerated::Accelerated,
     kernels::{
         matmul::{
-            self, double_buffering::DoubleBufferingAlgorithm, simple::SimpleAlgorithm, simple_pipelined::SimplePipelinedAlgorithm, simple_strided::SimpleStridedAlgorithm, specialized::SpecializedAlgorithm
+            self, double_buffering::DoubleBufferingAlgorithm, simple::SimpleAlgorithm,
+            simple_pipelined::SimplePipelinedAlgorithm, simple_strided::SimpleStridedAlgorithm,
+            specialized::SpecializedAlgorithm,
         },
         naive,
         tiling2d::{self, Tiling2dConfig},

--- a/crates/cubecl-linalg/src/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/base.rs
@@ -8,7 +8,7 @@ use super::{
     kernels::{
         matmul::{
             self, DoubleBufferingSelector, SimplePipelinedSelector, SimpleSelector,
-            SpecializedSelector,
+            SimpleStridedSelector, SpecializedSelector,
         },
         naive,
         tiling2d::{self, Tiling2dConfig},
@@ -19,6 +19,7 @@ use super::{
 #[derive(Debug, Clone, Default)]
 pub enum Strategy {
     Simple,
+    SimpleStrided,
     SimplePipelined,
     DoubleBuffering,
     Specialized,
@@ -57,6 +58,9 @@ pub fn launch_ref<R: Runtime, EG: MaybeQuantized>(
     match strategy {
         Strategy::Simple => {
             matmul::launch_ref::<R, EG, SimpleSelector<Accelerated>>(client, lhs, rhs, out)
+        }
+        Strategy::SimpleStrided => {
+            matmul::launch_ref::<R, EG, SimpleStridedSelector<Accelerated>>(client, lhs, rhs, out)
         }
         Strategy::SimplePipelined => {
             matmul::launch_ref::<R, EG, SimplePipelinedSelector<Accelerated>>(client, lhs, rhs, out)

--- a/crates/cubecl-linalg/src/matmul/components/batch/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/base.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 
 use crate::matmul::components::global::args::{self, MatmulArgs, TensorInput, TensorOutput};
 use crate::matmul::components::{config::MatmulConfig, global, Ident, MatmulLaunch};
-use crate::matmul::components::{MatmulPrecision, StageTiling};
+use crate::matmul::components::{MatmulPrecision, TilingDimensions};
 use crate::tensor::{ReadWrite, VirtualTensor};
 
 /// A family of [matmuls](BatchMatmul) working with any [precision](MatmulPrecision).
@@ -50,7 +50,7 @@ pub trait BatchConfig: MatmulConfig {
     fn to_gmm_config(&self) -> Self::GmmConfig;
 
     /// Returns the [StageDim] for the given ident
-    fn stage_tiling(&self, ident: Ident) -> StageTiling;
+    fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions;
 
     /// Returns the largest m dimension supported with these configs
     fn max_m(&self) -> u32;

--- a/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
+++ b/crates/cubecl-linalg/src/matmul/components/batch/one_to_many.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::matmul::components::batch::span::{Span, SpanDim, SpanMatmul};
 use crate::matmul::components::global::GlobalMatmulFamily;
 use crate::matmul::components::{
-    batch, config::MatmulConfig, global, Ident, MatmulConfigFactory, MatmulLaunch, StageTiling,
+    batch, config::MatmulConfig, global, Ident, MatmulConfigFactory, MatmulLaunch, TilingDimensions,
 };
 use crate::matmul::components::{
     InputRuntimeArg, InvalidConfigError, MatmulPrecision, MatmulProblem, MatmulSpec,
@@ -131,8 +131,8 @@ impl<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>, S: SpanMatmul, C: CubeD
         let cubes_y = config.cube_count_y();
         let cubes_z = config.cube_count_batch();
 
-        let stage_x = config.stage_tiling(Ident::Out).total_row();
-        let stage_y = config.stage_tiling(Ident::Out).total_col();
+        let stage_x = config.tiling_dimensions(Ident::Out).total_row();
+        let stage_y = config.tiling_dimensions(Ident::Out).total_col();
         let stage_z = 1;
 
         let (x_index, y_index) = C::x_y_indices();
@@ -167,8 +167,8 @@ impl<G: global::GlobalConfig, C: CubeDispatch> batch::BatchConfig for Config<G, 
         self.gmm_config
     }
 
-    fn stage_tiling(&self, ident: Ident) -> StageTiling {
-        self.gmm_config.stage_tiling(ident)
+    fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions {
+        self.gmm_config.tiling_dimensions(ident)
     }
 
     fn max_m(&self) -> u32 {

--- a/crates/cubecl-linalg/src/matmul/components/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/config.rs
@@ -113,21 +113,21 @@ pub struct CompleteStageTiling {
 }
 
 impl CompleteStageTiling {
-    pub fn get(&self, ident: Ident) -> StageTiling {
+    pub fn get(&self, ident: Ident) -> TilingDimensions {
         match ident {
-            Ident::Lhs => StageTiling {
+            Ident::Lhs => TilingDimensions {
                 tile_shape_row: self.tile_shape.m,
                 tile_shape_col: self.tile_shape.k,
                 tile_count_row: self.tile_count.m,
                 tile_count_col: self.tile_count.k,
             },
-            Ident::Rhs => StageTiling {
+            Ident::Rhs => TilingDimensions {
                 tile_shape_row: self.tile_shape.k,
                 tile_shape_col: self.tile_shape.n,
                 tile_count_row: self.tile_count.k,
                 tile_count_col: self.tile_count.n,
             },
-            Ident::Out => StageTiling {
+            Ident::Out => TilingDimensions {
                 tile_shape_row: self.tile_shape.m,
                 tile_shape_col: self.tile_shape.n,
                 tile_count_row: self.tile_count.m,
@@ -147,14 +147,14 @@ impl CompleteStageTiling {
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 /// Dimensions for stage.
-pub struct StageTiling {
+pub struct TilingDimensions {
     pub tile_shape_row: u32,
     pub tile_shape_col: u32,
     pub tile_count_row: u32,
     pub tile_count_col: u32,
 }
 
-impl StageTiling {
+impl TilingDimensions {
     /// Returns the total number of elements of the stage.
     pub fn total_size(&self) -> u32 {
         self.total_row() * self.total_col()

--- a/crates/cubecl-linalg/src/matmul/components/global/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/base.rs
@@ -2,7 +2,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::pipeline::Pipeline;
 use cubecl_core::prelude::*;
 
-use crate::matmul::components::stage::{self, StageWriter, TilingLayout};
+use crate::matmul::components::stage::{self, StageWriter};
 use crate::matmul::components::{config::MatmulConfig, tile};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::components::{InvalidConfigError, MatmulConfigFactory};
@@ -183,9 +183,6 @@ pub trait GlobalConfig: MatmulConfig {
 
     /// Returns the size of the plane dimension
     fn plane_dim(&self) -> u32;
-
-    /// Returns the order in which tiles should be loaded to the stage
-    fn tiling_layout(&self, ident: Ident) -> TilingLayout;
 
     /// Whether to check if accessing a row would exceed bounds.
     fn check_row_bounds(&self, ident: Ident) -> bool;

--- a/crates/cubecl-linalg/src/matmul/components/global/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/base.rs
@@ -9,8 +9,6 @@ use crate::matmul::components::{InvalidConfigError, MatmulConfigFactory};
 use crate::matmul::components::{MatmulPrecision, TilingDimensions};
 use crate::tensor::{ReadWrite, VirtualTensor};
 
-use super::LoadMode;
-
 /// A family of [matmuls](GlobalMatmul) working with any [precision](MatmulPrecision).
 pub trait GlobalMatmulFamily:
     MatmulConfigFactory<Config: GlobalConfig> + Send + Sync + 'static
@@ -187,6 +185,4 @@ pub trait GlobalConfig: MatmulConfig {
 
     /// Whether we transpose data when loading to the stage
     fn transpose_load(&self, ident: Ident) -> bool;
-
-    fn load_mode(&self, ident: Ident) -> LoadMode;
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/base.rs
@@ -168,7 +168,7 @@ pub trait GlobalConfig: MatmulConfig {
     fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions;
 
     /// Returns the [MatrixLayout] for the given ident
-    fn layout(&self, ident: Ident) -> MatrixLayout;
+    fn matrix_layout(&self, ident: Ident) -> MatrixLayout;
 
     /// Returns the number of planes in the cube
     fn num_planes(&self) -> u32;
@@ -188,5 +188,5 @@ pub trait GlobalConfig: MatmulConfig {
     /// Whether we transpose data when loading to the stage
     fn transpose_load(&self, ident: Ident) -> bool;
 
-    fn load_mode(&self) -> LoadMode;
+    fn load_mode(&self, ident: Ident) -> LoadMode;
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/base.rs
@@ -6,7 +6,7 @@ use crate::matmul::components::stage::{self, StageWriter, TilingLayout};
 use crate::matmul::components::{config::MatmulConfig, tile};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::components::{InvalidConfigError, MatmulConfigFactory};
-use crate::matmul::components::{MatmulPrecision, StageTiling};
+use crate::matmul::components::{MatmulPrecision, TilingDimensions};
 use crate::tensor::{ReadWrite, VirtualTensor};
 
 use super::LoadMode;
@@ -165,7 +165,7 @@ pub trait GlobalConfig: MatmulConfig {
     fn stage_line_size(&self, ident: Ident) -> u32;
 
     /// Returns the [StageTiling] for the given ident
-    fn stage_tiling(&self, ident: Ident) -> StageTiling;
+    fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions;
 
     /// Returns the [MatrixLayout] for the given ident
     fn layout(&self, ident: Ident) -> MatrixLayout;

--- a/crates/cubecl-linalg/src/matmul/components/global/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/config.rs
@@ -3,14 +3,6 @@ use crate::matmul::components::{
     Ident, InputIdent, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
-/// Whether each unit loads a line side by side (coalesced)
-/// or a window (i.e. a slice of lines)
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub enum LoadMode {
-    Coalesced,
-    Window,
-}
-
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the pipelined global matmul
 pub struct CommonGlobalConfig<S: stage::StageConfig> {
@@ -24,8 +16,6 @@ pub struct CommonGlobalConfig<S: stage::StageConfig> {
     pub rhs_line_size: u32,
     pub out_line_size: u32,
     pub num_planes: u32,
-    pub load_mode_lhs: LoadMode,
-    pub load_mode_rhs: LoadMode,
 }
 
 impl<S: stage::StageConfig> super::GlobalConfig for CommonGlobalConfig<S> {
@@ -90,13 +80,6 @@ impl<S: stage::StageConfig> super::GlobalConfig for CommonGlobalConfig<S> {
     fn transpose_load(&self, ident: Ident) -> bool {
         self.matrix_layout(ident) != self.smm_config.matrix_layout(ident)
     }
-
-    fn load_mode(&self, ident: Ident) -> LoadMode {
-        match ident.as_input() {
-            InputIdent::Lhs => self.load_mode_lhs,
-            InputIdent::Rhs => self.load_mode_rhs,
-        }
-    }
 }
 
 impl<S: stage::StageConfig> MatmulConfig for CommonGlobalConfig<S> {}
@@ -114,8 +97,6 @@ impl<S: stage::StageConfig> CommonGlobalConfig<S> {
         rhs_line_size: u32,
         out_line_size: u32,
         num_planes: u32,
-        load_mode_lhs: LoadMode,
-        load_mode_rhs: LoadMode,
     ) -> Self {
         Self {
             smm_config,
@@ -128,8 +109,6 @@ impl<S: stage::StageConfig> CommonGlobalConfig<S> {
             rhs_line_size,
             out_line_size,
             num_planes,
-            load_mode_lhs,
-            load_mode_rhs,
         }
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/config.rs
@@ -1,6 +1,6 @@
 use crate::matmul::components::{
     stage::{self, TilingLayout},
-    Ident, MatmulConfig, MatrixLayout, StageTiling,
+    Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
 /// Whether each unit loads a line side by side (coalesced)
@@ -46,8 +46,8 @@ impl<S: stage::StageConfig> super::GlobalConfig for CommonGlobalConfig<S> {
         self.smm_config.line_size(ident)
     }
 
-    fn stage_tiling(&self, ident: Ident) -> StageTiling {
-        self.smm_config.tiling(ident)
+    fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions {
+        self.smm_config.tiling_dimensions(ident)
     }
 
     fn layout(&self, ident: Ident) -> MatrixLayout {

--- a/crates/cubecl-linalg/src/matmul/components/global/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/config.rs
@@ -1,6 +1,6 @@
 use crate::matmul::components::{
     stage::{self, TilingLayout},
-    Ident, InputIdent, MatmulConfig, MatrixLayout, TilingDimensions,
+    Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/cubecl-linalg/src/matmul/components/global/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/config.rs
@@ -1,5 +1,5 @@
 use crate::matmul::components::{
-    stage::{self, TilingLayout},
+    stage::{self},
     Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
@@ -55,10 +55,6 @@ impl<S: stage::StageConfig> super::GlobalConfig for CommonGlobalConfig<S> {
 
     fn plane_dim(&self) -> u32 {
         self.smm_config.plane_dim()
-    }
-
-    fn tiling_layout(&self, ident: Ident) -> TilingLayout {
-        self.smm_config.tiling_layout(ident)
     }
 
     fn check_row_bounds(&self, ident: Ident) -> bool {

--- a/crates/cubecl-linalg/src/matmul/components/global/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/config.rs
@@ -54,7 +54,7 @@ impl<S: stage::StageConfig> super::GlobalConfig for CommonGlobalConfig<S> {
         match ident {
             Ident::Lhs => self.lhs_layout,
             Ident::Rhs => self.rhs_layout,
-            Ident::Out => self.smm_config.layout(Ident::Out),
+            Ident::Out => self.smm_config.matrix_layout(Ident::Out),
         }
     }
 
@@ -87,7 +87,7 @@ impl<S: stage::StageConfig> super::GlobalConfig for CommonGlobalConfig<S> {
     }
 
     fn transpose_load(&self, ident: Ident) -> bool {
-        self.layout(ident) != self.smm_config.layout(ident)
+        self.layout(ident) != self.smm_config.matrix_layout(ident)
     }
 
     fn load_mode(&self) -> LoadMode {

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/buffer_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/buffer_loading.rs
@@ -12,7 +12,7 @@ pub struct BufferLoading {}
 
 impl LoadingValidation for BufferLoading {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
-        let tiling = config.stage_tiling(ident);
+        let tiling = config.tiling_dimensions(ident);
         let line_size = config.global_line_size(ident);
 
         let num_stage_elements = tiling.total_size();
@@ -46,7 +46,7 @@ impl BufferLoading {
         #[comptime] ident: Ident,
         #[comptime] config: G,
     ) {
-        let tiling = config.stage_tiling(ident);
+        let tiling = config.tiling_dimensions(ident);
         let line_size = config.global_line_size(ident);
 
         let num_buffer_elements = tiling.buffer_size(ident.as_input());

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/loader.rs
@@ -85,7 +85,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_tiling(Ident::Lhs).tile_count_col(),
+            num_buffers: config.tiling_dimensions(Ident::Lhs).tile_count_col(),
             _config: PhantomData::<S>.runtime(),
         }
     }
@@ -144,7 +144,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_tiling(Ident::Rhs).tile_count_row(),
+            num_buffers: config.tiling_dimensions(Ident::Rhs).tile_count_row(),
             _config: PhantomData::<S>.runtime(),
         }
     }
@@ -158,7 +158,7 @@ fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig>(
     #[comptime] ident: Ident,
     #[comptime] config: CommonGlobalConfig<S>,
 ) {
-    let buffer_num_elements = config.stage_tiling(ident).buffer_size(ident.as_input());
+    let buffer_num_elements = config.tiling_dimensions(ident).buffer_size(ident.as_input());
     let line_size = config.stage_line_size(ident);
     let buffer_num_lines = buffer_num_elements / line_size;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/loader.rs
@@ -5,14 +5,14 @@ use crate::matmul::components::global::multi_stage::buffer_loading::BufferLoadin
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::{CommonGlobalConfig, InputLoader, SyncInputLoader};
 use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBufferReader};
-use crate::matmul::components::stage::{self, Stage, TilingLayoutTrait};
+use crate::matmul::components::stage::{self, Stage, TilingLayout};
 use crate::matmul::components::Ident;
 use crate::tensor::VirtualTensor;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[derive(CubeType)]
-pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait> {
+pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout> {
     pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES, T>,
     buffer_iter: u32,
@@ -21,7 +21,7 @@ pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: T
 }
 
 #[derive(CubeType)]
-pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait> {
+pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout> {
     pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES, T>,
     buffer_iter: u32,
@@ -30,7 +30,7 @@ pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: T
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     InputLoader<EG, ES, CommonGlobalConfig<S>> for LhsBufferLoader<EG, ES, S, T>
 {
     type StageReader = LhsBufferReader<ES, T>;
@@ -49,7 +49,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     SyncInputLoader<EG, ES, CommonGlobalConfig<S>> for LhsBufferLoader<EG, ES, S, T>
 {
     fn fill_stage(this: &mut Self, #[comptime] config: CommonGlobalConfig<S>) {
@@ -64,7 +64,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     LhsBufferLoader<EG, ES, S, T>
 {
     pub fn new(
@@ -88,7 +88,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     InputLoader<EG, ES, CommonGlobalConfig<S>> for RhsBufferLoader<EG, ES, S, T>
 {
     type StageReader = RhsBufferReader<ES, T>;
@@ -107,7 +107,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     SyncInputLoader<EG, ES, CommonGlobalConfig<S>> for RhsBufferLoader<EG, ES, S, T>
 {
     fn fill_stage(this: &mut Self, #[comptime] config: CommonGlobalConfig<S>) {
@@ -122,7 +122,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     RhsBufferLoader<EG, ES, S, T>
 {
     pub fn new(
@@ -146,7 +146,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>(
+fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>(
     buffer_iter: u32,
     tensor_view: &TensorReader<EG>,
     stage: &mut Stage<ES, T>,

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/loader.rs
@@ -1,44 +1,42 @@
 use std::marker::PhantomData;
 
-use crate::matmul::components::config::InputIdent;
 use crate::matmul::components::global::base::GlobalConfig as _;
 use crate::matmul::components::global::multi_stage::buffer_loading::BufferLoading;
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::{CommonGlobalConfig, InputLoader, SyncInputLoader};
 use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBufferReader};
-use crate::matmul::components::stage::{self, Stage};
-use crate::matmul::components::stage::{TilingLayout, TilingOrder};
-use crate::matmul::components::{global, Ident, InvalidConfigError};
+use crate::matmul::components::stage::{self, Stage, TilingLayoutTrait};
+use crate::matmul::components::Ident;
 use crate::tensor::VirtualTensor;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[derive(CubeType)]
-pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig> {
+pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait> {
     pub tensor_view: TensorReader<EG>,
-    pub stage: Stage<ES>,
+    pub stage: Stage<ES, T>,
     buffer_iter: u32,
     num_buffers: u32,
     _config: PhantomData<S>,
 }
 
 #[derive(CubeType)]
-pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig> {
+pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait> {
     pub tensor_view: TensorReader<EG>,
-    pub stage: Stage<ES>,
+    pub stage: Stage<ES, T>,
     buffer_iter: u32,
     num_buffers: u32,
     _config: PhantomData<S>,
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> InputLoader<EG, ES, CommonGlobalConfig<S>>
-    for LhsBufferLoader<EG, ES, S>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+    InputLoader<EG, ES, CommonGlobalConfig<S>> for LhsBufferLoader<EG, ES, S, T>
 {
-    type StageReader = LhsBufferReader<ES>;
+    type StageReader = LhsBufferReader<ES, T>;
 
     fn as_stage_reader(this: &Self) -> Self::StageReader {
-        LhsBufferReader::<ES> {
+        LhsBufferReader::<ES, T> {
             stage: this.stage,
             buffer: this.buffer_iter,
         }
@@ -51,11 +49,11 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> InputLoader<EG, ES, Common
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> SyncInputLoader<EG, ES, CommonGlobalConfig<S>>
-    for LhsBufferLoader<EG, ES, S>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+    SyncInputLoader<EG, ES, CommonGlobalConfig<S>> for LhsBufferLoader<EG, ES, S, T>
 {
     fn fill_stage(this: &mut Self, #[comptime] config: CommonGlobalConfig<S>) {
-        load_buffer::<EG, ES, S>(
+        load_buffer::<EG, ES, S, T>(
             this.buffer_iter,
             &this.tensor_view,
             &mut this.stage,
@@ -66,7 +64,9 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> SyncInputLoader<EG, ES, Co
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S> {
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+    LhsBufferLoader<EG, ES, S, T>
+{
     pub fn new(
         tensor: VirtualTensor<EG>,
         x_offset: u32,
@@ -77,7 +77,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S>
         let stage = Stage::new::<S>(Ident::Lhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        LhsBufferLoader::<EG, ES, S> {
+        LhsBufferLoader::<EG, ES, S, T> {
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
@@ -88,13 +88,13 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> InputLoader<EG, ES, CommonGlobalConfig<S>>
-    for RhsBufferLoader<EG, ES, S>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+    InputLoader<EG, ES, CommonGlobalConfig<S>> for RhsBufferLoader<EG, ES, S, T>
 {
-    type StageReader = RhsBufferReader<ES>;
+    type StageReader = RhsBufferReader<ES, T>;
 
     fn as_stage_reader(this: &Self) -> Self::StageReader {
-        RhsBufferReader::<ES> {
+        RhsBufferReader::<ES, T> {
             stage: this.stage,
             buffer: this.buffer_iter,
         }
@@ -107,11 +107,11 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> InputLoader<EG, ES, Common
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> SyncInputLoader<EG, ES, CommonGlobalConfig<S>>
-    for RhsBufferLoader<EG, ES, S>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+    SyncInputLoader<EG, ES, CommonGlobalConfig<S>> for RhsBufferLoader<EG, ES, S, T>
 {
     fn fill_stage(this: &mut Self, #[comptime] config: CommonGlobalConfig<S>) {
-        load_buffer::<EG, ES, S>(
+        load_buffer::<EG, ES, S, T>(
             this.buffer_iter,
             &this.tensor_view,
             &mut this.stage,
@@ -122,7 +122,9 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> SyncInputLoader<EG, ES, Co
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S> {
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+    RhsBufferLoader<EG, ES, S, T>
+{
     pub fn new(
         tensor: VirtualTensor<EG>,
         x_offset: u32,
@@ -133,7 +135,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S>
         let stage = Stage::new::<S>(Ident::Rhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        RhsBufferLoader::<EG, ES, S> {
+        RhsBufferLoader::<EG, ES, S, T> {
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
@@ -144,10 +146,10 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S>
 }
 
 #[cube]
-fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig>(
+fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>(
     buffer_iter: u32,
     tensor_view: &TensorReader<EG>,
-    stage: &mut Stage<ES>,
+    stage: &mut Stage<ES, T>,
     #[comptime] ident: Ident,
     #[comptime] config: CommonGlobalConfig<S>,
 ) {
@@ -169,30 +171,4 @@ fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig>(
         ident,
         config,
     );
-}
-
-pub fn check_buffers_contiguous<G: global::GlobalConfig>(
-    ident: Ident,
-    config: &G,
-) -> Result<(), InvalidConfigError> {
-    // TODO
-
-    // match ident.as_input() {
-    //     InputIdent::Lhs => {
-    //         if let TilingLayout::Contiguous(TilingOrder::RowMajor) = config.tiling_layout(ident) {
-    //             return Err(Box::new(
-    //                 "Lhs must have ColMajor tiling order in pipelined setting",
-    //             ));
-    //         }
-    //     }
-    //     InputIdent::Rhs => {
-    //         if let TilingLayout::Contiguous(TilingOrder::ColMajor) = config.tiling_layout(ident) {
-    //             return Err(Box::new(
-    //                 "Rhs must have RowMajor tiling order in pipelined setting",
-    //             ));
-    //         }
-    //     }
-    // }
-
-    Ok(())
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/loader.rs
@@ -175,22 +175,24 @@ pub fn check_buffers_contiguous<G: global::GlobalConfig>(
     ident: Ident,
     config: &G,
 ) -> Result<(), InvalidConfigError> {
-    match ident.as_input() {
-        InputIdent::Lhs => {
-            if let TilingLayout::Contiguous(TilingOrder::RowMajor) = config.tiling_layout(ident) {
-                return Err(Box::new(
-                    "Lhs must have ColMajor tiling order in pipelined setting",
-                ));
-            }
-        }
-        InputIdent::Rhs => {
-            if let TilingLayout::Contiguous(TilingOrder::ColMajor) = config.tiling_layout(ident) {
-                return Err(Box::new(
-                    "Rhs must have RowMajor tiling order in pipelined setting",
-                ));
-            }
-        }
-    }
+    // TODO
+
+    // match ident.as_input() {
+    //     InputIdent::Lhs => {
+    //         if let TilingLayout::Contiguous(TilingOrder::RowMajor) = config.tiling_layout(ident) {
+    //             return Err(Box::new(
+    //                 "Lhs must have ColMajor tiling order in pipelined setting",
+    //             ));
+    //         }
+    //     }
+    //     InputIdent::Rhs => {
+    //         if let TilingLayout::Contiguous(TilingOrder::ColMajor) = config.tiling_layout(ident) {
+    //             return Err(Box::new(
+    //                 "Rhs must have RowMajor tiling order in pipelined setting",
+    //             ));
+    //         }
+    //     }
+    // }
 
     Ok(())
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
@@ -107,6 +107,7 @@ where
             problem.out_line_size as u32,
             cube_dim.y,
             LoadMode::Coalesced,
+            LoadMode::Coalesced,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
@@ -1,5 +1,6 @@
+use crate::matmul::components::global::base::InputLoader;
 use crate::matmul::components::global::output_loader::Unloader;
-use crate::matmul::components::global::{self, CommonGlobalConfig, InputLoader};
+use crate::matmul::components::global::{self, CommonGlobalConfig, SyncInputLoader};
 use crate::matmul::components::global::{GlobalConfig, ZeroAccumulatorLoader};
 use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBufferReader};
 use crate::matmul::components::Ident;

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
@@ -63,7 +63,7 @@ where
         BufferLoading::check::<Self::Config>(config, Ident::Lhs)?;
         BufferLoading::check::<Self::Config>(config, Ident::Rhs)?;
 
-        if config.stage_tiling(Ident::Lhs).tile_count_col() != 2 {
+        if config.tiling_dimensions(Ident::Lhs).tile_count_col() != 2 {
             return Err(Box::new("Pipelined matmul needs exactly 2 buffers."));
         }
 
@@ -149,7 +149,7 @@ where
         #[comptime] config: Self::Config,
     ) {
         let num_buffers = 2;
-        let buffer_step = config.stage_tiling(Ident::Lhs).tile_shape_col();
+        let buffer_step = config.tiling_dimensions(Ident::Lhs).tile_shape_col();
         let k_step = num_buffers * buffer_step; // equal to SMM::K
 
         let range = k_range.1 - k_range.0;

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
@@ -1,5 +1,5 @@
 use crate::matmul::components::global::output_loader::Unloader;
-use crate::matmul::components::global::{self, CommonGlobalConfig, InputLoader, LoadMode};
+use crate::matmul::components::global::{self, CommonGlobalConfig, InputLoader};
 use crate::matmul::components::global::{GlobalConfig, ZeroAccumulatorLoader};
 use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBufferReader};
 use crate::matmul::components::Ident;
@@ -106,8 +106,6 @@ where
             problem.rhs_line_size as u32,
             problem.out_line_size as u32,
             cube_dim.y,
-            LoadMode::Coalesced,
-            LoadMode::Coalesced,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/config.rs
@@ -47,7 +47,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         match ident {
             Ident::Lhs => self.lhs_layout,
             Ident::Rhs => self.rhs_layout,
-            Ident::Out => self.smm_config.layout(Ident::Out),
+            Ident::Out => self.smm_config.matrix_layout(Ident::Out),
         }
     }
 
@@ -80,7 +80,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
     }
 
     fn transpose_load(&self, ident: Ident) -> bool {
-        self.layout(ident) != self.smm_config.layout(ident)
+        self.layout(ident) != self.smm_config.matrix_layout(ident)
     }
 
     fn load_mode(&self) -> LoadMode {

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/config.rs
@@ -1,7 +1,7 @@
 use crate::matmul::components::{
     global::{self, GlobalConfig, LoadMode},
     stage::{self, TilingLayout},
-    Ident, MatmulConfig, MatrixLayout, StageTiling,
+    Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -39,8 +39,8 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         self.smm_config.line_size(ident)
     }
 
-    fn stage_tiling(&self, ident: Ident) -> StageTiling {
-        self.smm_config.tiling(ident)
+    fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions {
+        self.smm_config.tiling_dimensions(ident)
     }
 
     fn layout(&self, ident: Ident) -> MatrixLayout {

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/config.rs
@@ -1,6 +1,6 @@
 use crate::matmul::components::{
     global::{self, GlobalConfig},
-    stage::{self, TilingLayout},
+    stage::{self},
     Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
@@ -56,10 +56,6 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
 
     fn plane_dim(&self) -> u32 {
         self.smm_config.plane_dim()
-    }
-
-    fn tiling_layout(&self, ident: Ident) -> TilingLayout {
-        self.smm_config.tiling_layout(ident)
     }
 
     fn check_row_bounds(&self, ident: Ident) -> bool {

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/config.rs
@@ -1,7 +1,7 @@
 use crate::matmul::components::{
-    global::{self, GlobalConfig, LoadMode},
+    global::{self, GlobalConfig},
     stage::{self, TilingLayout},
-    Ident, InputIdent, MatmulConfig, MatrixLayout, TilingDimensions,
+    Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -17,8 +17,6 @@ pub struct Config<S: stage::StageConfig> {
     rhs_line_size: u32,
     out_line_size: u32,
     num_planes: u32,
-    load_mode_lhs: LoadMode,
-    load_mode_rhs: LoadMode,
 }
 
 impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
@@ -83,13 +81,6 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
     fn transpose_load(&self, ident: Ident) -> bool {
         self.matrix_layout(ident) != self.smm_config.matrix_layout(ident)
     }
-
-    fn load_mode(&self, ident: Ident) -> LoadMode {
-        match ident.as_input() {
-            InputIdent::Lhs => self.load_mode_lhs,
-            InputIdent::Rhs => self.load_mode_rhs,
-        }
-    }
 }
 
 impl<S: stage::StageConfig> MatmulConfig for Config<S> {}
@@ -107,8 +98,6 @@ impl<S: stage::StageConfig> Config<S> {
         rhs_line_size: u32,
         out_line_size: u32,
         num_planes: u32,
-        load_mode_lhs: LoadMode,
-        load_mode_rhs: LoadMode,
     ) -> Self {
         Self {
             smm_config,
@@ -121,8 +110,6 @@ impl<S: stage::StageConfig> Config<S> {
             rhs_line_size,
             out_line_size,
             num_planes,
-            load_mode_lhs,
-            load_mode_rhs,
         }
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/loader.rs
@@ -5,7 +5,7 @@ use crate::matmul::components::global::multi_stage::buffer_loading::BufferLoadin
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::{InputLoader, SyncInputLoader};
 use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBufferReader};
-use crate::matmul::components::stage::{self, Stage, TilingLayoutTrait};
+use crate::matmul::components::stage::{self, Stage, TilingLayout};
 use crate::matmul::components::Ident;
 use crate::tensor::VirtualTensor;
 use cubecl_core as cubecl;
@@ -14,7 +14,7 @@ use cubecl_core::prelude::*;
 use super::config::Config;
 
 #[derive(CubeType)]
-pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait> {
+pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout> {
     pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES, T>,
     buffer_iter: u32,
@@ -24,7 +24,7 @@ pub struct LhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: T
 }
 
 #[derive(CubeType)]
-pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait> {
+pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout> {
     pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES, T>,
     buffer_iter: u32,
@@ -34,7 +34,7 @@ pub struct RhsBufferLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: T
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     InputLoader<EG, ES, Config<S>> for LhsBufferLoader<EG, ES, S, T>
 {
     type StageReader = LhsBufferReader<ES, T>;
@@ -53,7 +53,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     SyncInputLoader<EG, ES, Config<S>> for LhsBufferLoader<EG, ES, S, T>
 {
     fn fill_stage(this: &mut Self, #[comptime] config: Config<S>) {
@@ -70,7 +70,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     LhsBufferLoader<EG, ES, S, T>
 {
     pub fn new(
@@ -96,7 +96,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     InputLoader<EG, ES, Config<S>> for RhsBufferLoader<EG, ES, S, T>
 {
     type StageReader = RhsBufferReader<ES, T>;
@@ -115,7 +115,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     SyncInputLoader<EG, ES, Config<S>> for RhsBufferLoader<EG, ES, S, T>
 {
     fn fill_stage(this: &mut Self, #[comptime] config: Config<S>) {
@@ -132,7 +132,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>
     RhsBufferLoader<EG, ES, S, T>
 {
     pub fn new(
@@ -158,7 +158,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>
 }
 
 #[cube]
-fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayoutTrait>(
+fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig, T: TilingLayout>(
     buffer_iter: u32,
     tensor_view: &TensorReader<EG>,
     stage: &mut Stage<ES, T>,

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/loader.rs
@@ -91,7 +91,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> LhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_tiling(Ident::Lhs).tile_count_col(),
+            num_buffers: config.tiling_dimensions(Ident::Lhs).tile_count_col(),
             is_producer,
             _config: PhantomData::<S>.runtime(),
         }
@@ -154,7 +154,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig> RhsBufferLoader<EG, ES, S>
             tensor_view,
             stage,
             buffer_iter: 0u32.runtime(),
-            num_buffers: config.stage_tiling(Ident::Rhs).tile_count_row(),
+            num_buffers: config.tiling_dimensions(Ident::Rhs).tile_count_row(),
             is_producer,
             _config: PhantomData::<S>.runtime(),
         }
@@ -169,7 +169,7 @@ fn load_buffer<EG: Numeric, ES: Numeric, S: stage::StageConfig>(
     #[comptime] ident: Ident,
     #[comptime] config: Config<S>,
 ) {
-    let buffer_num_elements = config.stage_tiling(ident).buffer_size(ident.as_input());
+    let buffer_num_elements = config.tiling_dimensions(ident).buffer_size(ident.as_input());
     let line_size = config.stage_line_size(ident);
     let buffer_num_lines = buffer_num_elements / line_size;
 

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
@@ -10,7 +10,7 @@ use crate::matmul::components::MatmulPrecision;
 use crate::tensor::{ReadWrite, VirtualTensor};
 
 use super::config::Config;
-use super::loader::{LhsBufferLoader, RhsBufferLoader};
+use super::loader::{check_buffers_contiguous, LhsBufferLoader, RhsBufferLoader};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use std::marker::PhantomData;
@@ -51,6 +51,9 @@ where
     type Config = Config<SMM::Config>;
 
     fn check_config(config: &Self::Config) -> Result<(), InvalidConfigError> {
+        check_buffers_contiguous::<Self::Config>(Ident::Lhs, config)?;
+        check_buffers_contiguous::<Self::Config>(Ident::Rhs, config)?;
+
         if config.num_producers() == 0 {
             return Err(Box::new("There are no producer planes. Make sure there are more planes than the underlying stage matmul requires."));
         }

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
@@ -53,7 +53,7 @@ where
         if config.num_producers() == 0 {
             return Err(Box::new("There are no producer planes. Make sure there are more planes than the underlying stage matmul requires."));
         }
-        if config.stage_tiling(Ident::Lhs).tile_count_col() <= 1 {
+        if config.tiling_dimensions(Ident::Lhs).tile_count_col() <= 1 {
             return Err(Box::new("Producer-consumer needs at least 2 buffers."));
         }
 
@@ -139,8 +139,8 @@ where
     ) {
         let is_consumer = Self::is_consumer(config);
 
-        let num_buffers = config.stage_tiling(Ident::Lhs).tile_count_col();
-        let buffer_step = config.stage_tiling(Ident::Lhs).tile_shape_col();
+        let num_buffers = config.tiling_dimensions(Ident::Lhs).tile_count_col();
+        let buffer_step = config.tiling_dimensions(Ident::Lhs).tile_shape_col();
         let k_step = num_buffers * buffer_step; // equal to SMM::K
 
         let range = k_range.1 - k_range.0;

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
@@ -1,7 +1,8 @@
 use crate::matmul::components::global;
+use crate::matmul::components::global::base::InputLoader;
 use crate::matmul::components::global::output_loader::Unloader;
 use crate::matmul::components::global::ZeroAccumulatorLoader;
-use crate::matmul::components::global::{GlobalMatmul, InputLoader};
+use crate::matmul::components::global::{GlobalMatmul, SyncInputLoader};
 use crate::matmul::components::stage::single_buffer::{LhsBufferReader, RhsBufferReader};
 use crate::matmul::components::stage::StageMatmul;
 use crate::matmul::components::Ident;

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
@@ -97,6 +97,7 @@ where
             problem.out_line_size as u32,
             cube_dim.y,
             global::LoadMode::Coalesced,
+            global::LoadMode::Coalesced,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/specialized/matmul.rs
@@ -96,8 +96,6 @@ where
             problem.rhs_line_size as u32,
             problem.out_line_size as u32,
             cube_dim.y,
-            global::LoadMode::Coalesced,
-            global::LoadMode::Coalesced,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
@@ -1,5 +1,5 @@
 use crate::matmul::components::{
-    global::{self, LoadMode},
+    global::{self},
     stage::{self, TilingLayout},
     Ident, InputIdent, MatmulConfig, MatrixLayout, TilingDimensions,
 };
@@ -17,8 +17,6 @@ pub struct Config<S: stage::StageConfig> {
     rhs_line_size: u32,
     out_line_size: u32,
     pub k_step: u32,
-    load_mode_lhs: LoadMode,
-    load_mode_rhs: LoadMode,
 }
 
 impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
@@ -83,13 +81,6 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
     fn transpose_load(&self, ident: Ident) -> bool {
         self.matrix_layout(ident) != self.smm_config.matrix_layout(ident)
     }
-
-    fn load_mode(&self, ident: Ident) -> LoadMode {
-        match ident.as_input() {
-            InputIdent::Lhs => self.load_mode_lhs,
-            InputIdent::Rhs => self.load_mode_rhs,
-        }
-    }
 }
 
 impl<S: stage::StageConfig> MatmulConfig for Config<S> {}
@@ -107,8 +98,6 @@ impl<S: stage::StageConfig> Config<S> {
         rhs_line_size: u32,
         out_line_size: u32,
         k_step: u32,
-        load_mode_lhs: LoadMode,
-        load_mode_rhs: LoadMode,
     ) -> Self {
         Self {
             smm_config,
@@ -121,8 +110,6 @@ impl<S: stage::StageConfig> Config<S> {
             rhs_line_size,
             out_line_size,
             k_step,
-            load_mode_lhs,
-            load_mode_rhs,
         }
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
@@ -1,6 +1,6 @@
 use crate::matmul::components::{
     global::{self},
-    stage::{self, TilingLayout},
+    stage::{self},
     Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
@@ -56,10 +56,6 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
 
     fn plane_dim(&self) -> u32 {
         self.smm_config.plane_dim()
-    }
-
-    fn tiling_layout(&self, ident: Ident) -> TilingLayout {
-        self.smm_config.tiling_layout(ident)
     }
 
     fn check_row_bounds(&self, ident: Ident) -> bool {

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
@@ -47,7 +47,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         match ident {
             Ident::Lhs => self.lhs_layout,
             Ident::Rhs => self.rhs_layout,
-            Ident::Out => self.smm_config.layout(Ident::Out),
+            Ident::Out => self.smm_config.matrix_layout(Ident::Out),
         }
     }
 
@@ -80,7 +80,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
     }
 
     fn transpose_load(&self, ident: Ident) -> bool {
-        self.layout(ident) != self.smm_config.layout(ident)
+        self.layout(ident) != self.smm_config.matrix_layout(ident)
     }
 
     fn load_mode(&self) -> LoadMode {

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
@@ -1,7 +1,7 @@
 use crate::matmul::components::{
     global::{self},
     stage::{self, TilingLayout},
-    Ident, InputIdent, MatmulConfig, MatrixLayout, TilingDimensions,
+    Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
@@ -1,7 +1,7 @@
 use crate::matmul::components::{
     global::{self, LoadMode},
     stage::{self, TilingLayout},
-    Ident, MatmulConfig, MatrixLayout, TilingDimensions,
+    Ident, InputIdent, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -17,7 +17,8 @@ pub struct Config<S: stage::StageConfig> {
     rhs_line_size: u32,
     out_line_size: u32,
     pub k_step: u32,
-    load_mode: LoadMode,
+    load_mode_lhs: LoadMode,
+    load_mode_rhs: LoadMode,
 }
 
 impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
@@ -43,7 +44,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         self.smm_config.tiling_dimensions(ident)
     }
 
-    fn layout(&self, ident: Ident) -> MatrixLayout {
+    fn matrix_layout(&self, ident: Ident) -> MatrixLayout {
         match ident {
             Ident::Lhs => self.lhs_layout,
             Ident::Rhs => self.rhs_layout,
@@ -80,11 +81,14 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
     }
 
     fn transpose_load(&self, ident: Ident) -> bool {
-        self.layout(ident) != self.smm_config.matrix_layout(ident)
+        self.matrix_layout(ident) != self.smm_config.matrix_layout(ident)
     }
 
-    fn load_mode(&self) -> LoadMode {
-        self.load_mode
+    fn load_mode(&self, ident: Ident) -> LoadMode {
+        match ident.as_input() {
+            InputIdent::Lhs => self.load_mode_lhs,
+            InputIdent::Rhs => self.load_mode_rhs,
+        }
     }
 }
 
@@ -103,7 +107,8 @@ impl<S: stage::StageConfig> Config<S> {
         rhs_line_size: u32,
         out_line_size: u32,
         k_step: u32,
-        load_mode: LoadMode,
+        load_mode_lhs: LoadMode,
+        load_mode_rhs: LoadMode,
     ) -> Self {
         Self {
             smm_config,
@@ -116,7 +121,8 @@ impl<S: stage::StageConfig> Config<S> {
             rhs_line_size,
             out_line_size,
             k_step,
-            load_mode,
+            load_mode_lhs,
+            load_mode_rhs,
         }
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/config.rs
@@ -1,7 +1,7 @@
 use crate::matmul::components::{
     global::{self, LoadMode},
     stage::{self, TilingLayout},
-    Ident, MatmulConfig, MatrixLayout, StageTiling,
+    Ident, MatmulConfig, MatrixLayout, TilingDimensions,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -39,8 +39,8 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         self.smm_config.line_size(ident)
     }
 
-    fn stage_tiling(&self, ident: Ident) -> StageTiling {
-        self.smm_config.tiling(ident)
+    fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions {
+        self.smm_config.tiling_dimensions(ident)
     }
 
     fn layout(&self, ident: Ident) -> MatrixLayout {

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/cooperative_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/cooperative_loading.rs
@@ -1,0 +1,85 @@
+use crate::matmul::components::global::tensor_view::{TensorReader, Window};
+use crate::matmul::components::global::{GlobalConfig, LoadMode, LoadingValidation};
+use crate::matmul::components::stage::TilingLayout;
+use crate::matmul::components::{Ident, InvalidConfigError, MatrixLayout};
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+use pipeline::Pipeline;
+
+use super::loader::LoadingStrategy;
+
+#[derive(CubeType, Clone, Copy)]
+/// Loads the content of all tiles in the tensor view using all planes,
+/// iterating with steps determined by the plane's dimension.
+pub struct CooperativeLoading {}
+
+impl LoadingValidation for CooperativeLoading {
+    fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
+        let tiling_layout = config.tiling_layout(ident);
+
+        match config.load_mode(ident) {
+            LoadMode::Coalesced => {
+                return Err(Box::new(
+                    "Coalesced mode not supported in cooperative loading",
+                ));
+            }
+
+            LoadMode::Window => {
+                if let TilingLayout::Contiguous(_) = tiling_layout {
+                    return Err(Box::new(
+                        "Contiguous tiling layout not supported in cooperative loading",
+                    ));
+                }
+            }
+        };
+
+        Ok(())
+    }
+}
+
+#[cube]
+impl LoadingStrategy for CooperativeLoading {
+    fn load_window<EG: Numeric, ES: Numeric, G: GlobalConfig>(
+        read_view: &TensorReader<EG>,
+        stage_slice: &mut SliceMut<Line<ES>>,
+        pipeline: Pipeline<ES>,
+        #[comptime] ident: Ident,
+        #[comptime] config: G,
+    ) {
+    }
+
+    fn load_to_slice<EG: Numeric, ES: Numeric, G: GlobalConfig>(
+        read_view: &TensorReader<EG>,
+        stage_slice: &mut SliceMut<Line<ES>>,
+        #[comptime] ident: Ident,
+        #[comptime] config: G,
+    ) {
+        // This is for testing when memcpy_async is not available.
+        // It is extremely inefficient as all units perform all the load
+
+        let matrix_layout = config.matrix_layout(ident);
+        let tiling_dimensions = config.tiling_dimensions(ident);
+        let num_slices = match matrix_layout {
+            MatrixLayout::RowMajor => tiling_dimensions.total_row(),
+            MatrixLayout::ColMajor => tiling_dimensions.total_col(),
+        };
+
+        for nth_slice in 0..num_slices {
+            let window: Window<EG> = read_view.load_window_no_tile::<G>(nth_slice, ident, config);
+            let mut destination: SliceMut<Line<ES>> = TilingLayout::nth_slice::<ES, G::SmmConfig>(
+                stage_slice,
+                nth_slice,
+                ident,
+                config.to_smm_config(),
+            );
+            memcpy_slow(window.slice.try_cast_unchecked(), &mut destination);
+        }
+    }
+}
+
+#[cube]
+fn memcpy_slow<ES: Numeric>(source: Slice<Line<ES>>, destination: &mut SliceMut<Line<ES>>) {
+    for i in 0..source.len() {
+        destination[i] = source[i];
+    }
+}

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/cooperative_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/cooperative_loading.rs
@@ -40,11 +40,11 @@ impl LoadingValidation for CooperativeLoading {
 #[cube]
 impl LoadingStrategy for CooperativeLoading {
     fn load_window<EG: Numeric, ES: Numeric, G: GlobalConfig>(
-        read_view: &TensorReader<EG>,
-        stage_slice: &mut SliceMut<Line<ES>>,
-        pipeline: Pipeline<ES>,
-        #[comptime] ident: Ident,
-        #[comptime] config: G,
+        _read_view: &TensorReader<EG>,
+        _stage_slice: &mut SliceMut<Line<ES>>,
+        _pipeline: Pipeline<ES>,
+        #[comptime] _ident: Ident,
+        #[comptime] _config: G,
     ) {
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/cooperative_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/cooperative_loading.rs
@@ -1,5 +1,5 @@
 use crate::matmul::components::global::tensor_view::{TensorReader, Window};
-use crate::matmul::components::global::{GlobalConfig, LoadMode, LoadingValidation};
+use crate::matmul::components::global::{GlobalConfig, LoadingValidation};
 use crate::matmul::components::stage::TilingLayout;
 use crate::matmul::components::{Ident, InvalidConfigError, MatrixLayout};
 use cubecl_core as cubecl;
@@ -17,21 +17,21 @@ impl LoadingValidation for CooperativeLoading {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
         let tiling_layout = config.tiling_layout(ident);
 
-        match config.load_mode(ident) {
-            LoadMode::Coalesced => {
-                return Err(Box::new(
-                    "Coalesced mode not supported in cooperative loading",
-                ));
-            }
+        // match config.load_mode(ident) {
+        //     LoadMode::Coalesced => {
+        //         return Err(Box::new(
+        //             "Coalesced mode not supported in cooperative loading",
+        //         ));
+        //     }
 
-            LoadMode::Window => {
-                if let TilingLayout::Contiguous(_) = tiling_layout {
-                    return Err(Box::new(
-                        "Contiguous tiling layout not supported in cooperative loading",
-                    ));
-                }
-            }
-        };
+        //     LoadMode::Window => {
+        //         if let TilingLayout::Contiguous(_) = tiling_layout {
+        //             return Err(Box::new(
+        //                 "Contiguous tiling layout not supported in cooperative loading",
+        //             ));
+        //         }
+        //     }
+        // };
 
         Ok(())
     }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
@@ -15,7 +15,7 @@ pub struct CyclicLoading {}
 
 impl LoadingValidation for CyclicLoading {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
-        let tiling = config.stage_tiling(ident);
+        let tiling = config.tiling_dimensions(ident);
         let line_size = config.global_line_size(ident);
 
         let num_stage_lines = tiling.total_size() / line_size;
@@ -61,7 +61,7 @@ impl LoadingStrategy for CyclicLoading {
         #[comptime] ident: Ident,
         #[comptime] config: G,
     ) {
-        let stage_dim = config.stage_tiling(ident);
+        let stage_dim = config.tiling_dimensions(ident);
         let total_units = config.plane_dim() * config.num_planes();
         let line_size = config.global_line_size(ident);
 
@@ -119,7 +119,7 @@ impl LoadingStrategy for CyclicLoading {
         #[comptime] ident: Ident,
         #[comptime] config: G,
     ) {
-        let tiling = config.stage_tiling(ident);
+        let tiling = config.tiling_dimensions(ident);
         let line_size = config.global_line_size(ident);
         let num_stage_elements = tiling.total_size();
         let jump_length = comptime!(config.num_planes() * config.plane_dim() * line_size);
@@ -148,8 +148,8 @@ impl LoadingStrategy for CyclicLoading {
                 true => {
                     let tile_offset = nth_tile * tile_num_elements;
 
-                    let tile_shape_x = config.stage_tiling(ident).tile_shape_row();
-                    let tile_shape_y = config.stage_tiling(ident).tile_shape_col();
+                    let tile_shape_x = config.tiling_dimensions(ident).tile_shape_row();
+                    let tile_shape_y = config.tiling_dimensions(ident).tile_shape_col();
 
                     let (height, width) = match config.layout(ident) {
                         MatrixLayout::RowMajor => (tile_shape_x, tile_shape_y),

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
@@ -1,5 +1,5 @@
 use crate::matmul::components::global::tensor_view::TensorReader;
-use crate::matmul::components::global::{GlobalConfig, LoadMode, LoadingValidation};
+use crate::matmul::components::global::{GlobalConfig, LoadingValidation};
 use crate::matmul::components::stage::TilingLayout;
 use crate::matmul::components::{Ident, InvalidConfigError, MatrixLayout};
 use cubecl_core as cubecl;
@@ -21,32 +21,32 @@ impl LoadingValidation for CyclicLoading {
         let num_stage_lines = tiling.total_size() / line_size;
         let total_units = config.num_planes() * config.plane_dim();
 
-        match config.load_mode(ident) {
-            LoadMode::Coalesced => {
-                if num_stage_lines % total_units != 0 {
-                    return Err(Box::new(
-                "Too many data will be loaded, resulting in out of bounds. 
-        Try setting line size and number of planes so that total unit count {:?} divides number of lines in stage.",
-            ));
-                }
-                if config.transpose_load(ident) && config.global_line_size(ident) != 1 {
-                    return Err(Box::new(
-                        "Line size for stage is not supported when transposing",
-                    ));
-                }
-            }
-            LoadMode::Window => {
-                let num_slices = tiling.tile_shape_row() * tiling.tile_count();
-                if num_slices >= total_units && num_slices % total_units != 0 {
-                    return Err(Box::new(format!("Number of units ({total_units:?}) must divide number of slices ({num_slices:?}). Would require units doing different numbers of slices")));
-                }
-                if config.transpose_load(ident) {
-                    return Err(Box::new(
-                        "Transpose load is not supported with window load mode",
-                    ));
-                }
-            }
-        };
+        // match config.load_mode(ident) {
+        //     LoadMode::Coalesced => {
+        //         if num_stage_lines % total_units != 0 {
+        //             return Err(Box::new(
+        //         "Too many data will be loaded, resulting in out of bounds.
+        // Try setting line size and number of planes so that total unit count {:?} divides number of lines in stage.",
+        //     ));
+        //         }
+        //         if config.transpose_load(ident) && config.global_line_size(ident) != 1 {
+        //             return Err(Box::new(
+        //                 "Line size for stage is not supported when transposing",
+        //             ));
+        //         }
+        //     }
+        //     LoadMode::Window => {
+        //         let num_slices = tiling.tile_shape_row() * tiling.tile_count();
+        //         if num_slices >= total_units && num_slices % total_units != 0 {
+        //             return Err(Box::new(format!("Number of units ({total_units:?}) must divide number of slices ({num_slices:?}). Would require units doing different numbers of slices")));
+        //         }
+        //         if config.transpose_load(ident) {
+        //             return Err(Box::new(
+        //                 "Transpose load is not supported with window load mode",
+        //             ));
+        //         }
+        //     }
+        // };
 
         Ok(())
     }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
@@ -21,7 +21,7 @@ impl LoadingValidation for CyclicLoading {
         let num_stage_lines = tiling.total_size() / line_size;
         let total_units = config.num_planes() * config.plane_dim();
 
-        match config.load_mode() {
+        match config.load_mode(ident) {
             LoadMode::Coalesced => {
                 if num_stage_lines % total_units != 0 {
                     return Err(Box::new(
@@ -65,7 +65,7 @@ impl LoadingStrategy for CyclicLoading {
         let total_units = config.plane_dim() * config.num_planes();
         let line_size = config.global_line_size(ident);
 
-        let (num_slices_per_tile, slice_length_in_lines) = match config.layout(ident) {
+        let (num_slices_per_tile, slice_length_in_lines) = match config.matrix_layout(ident) {
             MatrixLayout::RowMajor => (
                 stage_dim.tile_shape_row(),
                 stage_dim.tile_shape_col() / line_size,
@@ -151,7 +151,7 @@ impl LoadingStrategy for CyclicLoading {
                     let tile_shape_x = config.tiling_dimensions(ident).tile_shape_row();
                     let tile_shape_y = config.tiling_dimensions(ident).tile_shape_col();
 
-                    let (height, width) = match config.layout(ident) {
+                    let (height, width) = match config.matrix_layout(ident) {
                         MatrixLayout::RowMajor => (tile_shape_x, tile_shape_y),
                         MatrixLayout::ColMajor => (tile_shape_y, tile_shape_x),
                     };

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
@@ -92,7 +92,8 @@ impl LoadingStrategy for CyclicLoading {
 
             // TODO make branching comptime conditional
             if slice_index < num_slices {
-                let window = read_view.load_window::<G>(tile_x, tile_y, nth_slice, ident, config);
+                let window =
+                    read_view.load_window_in_tile::<G>((tile_x, tile_y), nth_slice, ident, config);
 
                 // Where this unit writes source in the stage
                 let slice_destination_offset =

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/cyclic_loading.rs
@@ -86,12 +86,8 @@ impl LoadingStrategy for CyclicLoading {
             let slice_index = unit_id + total_units * i;
 
             let nth_tile = slice_index / num_slices_per_tile;
-            let (tile_x, tile_y) = TilingLayout::to_x_y(
-                config.tiling_layout(ident),
-                nth_tile,
-                stage_dim.tile_count_row(),
-                stage_dim.tile_count_col(),
-            );
+            let (tile_x, tile_y) =
+                TilingLayout::to_x_y::<G::SmmConfig>(nth_tile, ident, config.to_smm_config());
             let nth_slice = slice_index % num_slices_per_tile;
 
             // TODO make branching comptime conditional
@@ -139,12 +135,8 @@ impl LoadingStrategy for CyclicLoading {
             let nth_tile = unit_position / tile_num_elements;
             let pos_within_tile = unit_position % tile_num_elements;
 
-            let (tile_x, tile_y) = TilingLayout::to_x_y(
-                config.tiling_layout(ident),
-                nth_tile,
-                tiling.tile_count_row(),
-                tiling.tile_count_col(),
-            );
+            let (tile_x, tile_y) =
+                TilingLayout::to_x_y::<G::SmmConfig>(nth_tile, ident, config.to_smm_config());
 
             let line_read =
                 read_view.load_coalesced::<G>(tile_x, tile_y, pos_within_tile, ident, config);

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/async.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/async.rs
@@ -1,18 +1,31 @@
 use std::marker::PhantomData;
 
-use crate::matmul::components::global::single_stage;
 use crate::matmul::components::global::tensor_view::TensorReader;
-use crate::matmul::components::global::{InputLoader, LoadingValidation};
+use crate::matmul::components::global::InputLoader;
+use crate::matmul::components::global::LoadingValidation;
+use crate::matmul::components::global::{single_stage, AsyncInputLoader};
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
 use crate::matmul::components::stage::{self, Stage};
 use crate::matmul::components::{global, Ident};
 use crate::tensor::VirtualTensor;
 use cubecl_core as cubecl;
+use cubecl_core::prelude::pipeline::Pipeline;
 use cubecl_core::prelude::*;
-use pipeline::Pipeline;
+
+#[cube]
+pub trait AsyncLoadingStrategy: 'static + Send + Sync + Clone + LoadingValidation {
+    fn load<EG: Numeric, ES: Numeric, G: global::GlobalConfig>(
+        read_view: &TensorReader<EG>,
+        slice: &mut SliceMut<Line<ES>>,
+        pipeline: Pipeline<ES>,
+        #[comptime] ident: Ident,
+        #[comptime] config: G,
+    );
+}
 
 #[derive(CubeType)]
-pub struct LhsLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy> {
+pub struct AsyncLhsLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: AsyncLoadingStrategy>
+{
     pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
     _config: PhantomData<S>,
@@ -20,7 +33,8 @@ pub struct LhsLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: Loading
 }
 
 #[derive(CubeType)]
-pub struct RhsLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy> {
+pub struct AsyncRhsLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: AsyncLoadingStrategy>
+{
     pub tensor_view: TensorReader<EG>,
     pub stage: Stage<ES>,
     _config: PhantomData<S>,
@@ -28,26 +42,15 @@ pub struct RhsLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: Loading
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy>
-    InputLoader<EG, ES, single_stage::Config<S>> for LhsLoader<EG, ES, S, L>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: AsyncLoadingStrategy>
+    AsyncInputLoader<EG, ES, single_stage::Config<S>> for AsyncLhsLoader<EG, ES, S, L>
 {
-    type StageReader = LhsReader<ES>;
-
-    fn fill_stage(this: &mut Self, #[comptime] config: single_stage::Config<S>) {
-        L::load_to_slice::<EG, ES, single_stage::Config<S>>(
-            &this.tensor_view,
-            &mut this.stage.as_slice_mut(),
-            Ident::Lhs,
-            config,
-        );
-    }
-
-    fn fill_stage_window(
+    fn fill_stage(
         this: &mut Self,
         pipeline: Pipeline<ES>,
         #[comptime] config: single_stage::Config<S>,
     ) {
-        L::load_window::<EG, ES, single_stage::Config<S>>(
+        L::load::<EG, ES, single_stage::Config<S>>(
             &this.tensor_view,
             &mut this.stage.as_slice_mut(),
             pipeline,
@@ -55,6 +58,13 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy>
             config,
         );
     }
+}
+
+#[cube]
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: AsyncLoadingStrategy>
+    InputLoader<EG, ES, single_stage::Config<S>> for AsyncLhsLoader<EG, ES, S, L>
+{
+    type StageReader = LhsReader<ES>;
 
     fn as_stage_reader(this: &Self) -> Self::StageReader {
         LhsReader::new(this.stage)
@@ -66,7 +76,9 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy> LhsLoader<EG, ES, S, L> {
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: AsyncLoadingStrategy>
+    AsyncLhsLoader<EG, ES, S, L>
+{
     pub fn new<G: global::GlobalConfig>(
         tensor: VirtualTensor<EG>,
         x_offset: u32,
@@ -77,7 +89,7 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy> LhsLoa
         let stage = Stage::new::<G::SmmConfig>(Ident::Lhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        LhsLoader::<EG, ES, S, L> {
+        AsyncLhsLoader::<EG, ES, S, L> {
             tensor_view,
             stage,
             _config: PhantomData::<S>.runtime(),
@@ -87,33 +99,10 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy> LhsLoa
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy>
-    InputLoader<EG, ES, single_stage::Config<S>> for RhsLoader<EG, ES, S, L>
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: AsyncLoadingStrategy>
+    InputLoader<EG, ES, single_stage::Config<S>> for AsyncRhsLoader<EG, ES, S, L>
 {
     type StageReader = RhsReader<ES>;
-
-    fn fill_stage(this: &mut Self, #[comptime] config: single_stage::Config<S>) {
-        L::load_to_slice::<EG, ES, single_stage::Config<S>>(
-            &this.tensor_view,
-            &mut this.stage.as_slice_mut(),
-            Ident::Rhs,
-            config,
-        );
-    }
-
-    fn fill_stage_window(
-        this: &mut Self,
-        pipeline: Pipeline<ES>,
-        #[comptime] config: single_stage::Config<S>,
-    ) {
-        L::load_window::<EG, ES, single_stage::Config<S>>(
-            &this.tensor_view,
-            &mut this.stage.as_slice_mut(),
-            pipeline,
-            Ident::Rhs,
-            config,
-        );
-    }
 
     fn as_stage_reader(this: &Self) -> Self::StageReader {
         RhsReader::new(this.stage)
@@ -125,7 +114,28 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy>
 }
 
 #[cube]
-impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy> RhsLoader<EG, ES, S, L> {
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: AsyncLoadingStrategy>
+    AsyncInputLoader<EG, ES, single_stage::Config<S>> for AsyncRhsLoader<EG, ES, S, L>
+{
+    fn fill_stage(
+        this: &mut Self,
+        pipeline: Pipeline<ES>,
+        #[comptime] config: single_stage::Config<S>,
+    ) {
+        L::load::<EG, ES, single_stage::Config<S>>(
+            &this.tensor_view,
+            &mut this.stage.as_slice_mut(),
+            pipeline,
+            Ident::Rhs,
+            config,
+        );
+    }
+}
+
+#[cube]
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: AsyncLoadingStrategy>
+    AsyncRhsLoader<EG, ES, S, L>
+{
     pub fn new<G: global::GlobalConfig>(
         tensor: VirtualTensor<EG>,
         x_offset: u32,
@@ -136,29 +146,11 @@ impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: LoadingStrategy> RhsLoa
         let stage = Stage::new::<G::SmmConfig>(Ident::Rhs, config.to_smm_config());
         let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
-        RhsLoader::<EG, ES, S, L> {
+        AsyncRhsLoader::<EG, ES, S, L> {
             tensor_view,
             stage,
             _config: PhantomData::<S>.runtime(),
             _loading: PhantomData::<L>.runtime(),
         }
     }
-}
-
-#[cube]
-pub trait LoadingStrategy: 'static + Send + Sync + Clone + LoadingValidation {
-    fn load_to_slice<EG: Numeric, ES: Numeric, G: global::GlobalConfig>(
-        read_view: &TensorReader<EG>,
-        slice: &mut SliceMut<Line<ES>>,
-        #[comptime] ident: Ident,
-        #[comptime] config: G,
-    );
-
-    fn load_window<EG: Numeric, ES: Numeric, G: global::GlobalConfig>(
-        read_view: &TensorReader<EG>,
-        slice: &mut SliceMut<Line<ES>>,
-        pipeline: Pipeline<ES>,
-        #[comptime] ident: Ident,
-        #[comptime] config: G,
-    );
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/async.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/async.rs
@@ -5,7 +5,7 @@ use crate::matmul::components::global::InputLoader;
 use crate::matmul::components::global::LoadingValidation;
 use crate::matmul::components::global::{single_stage, AsyncInputLoader};
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
-use crate::matmul::components::stage::TilingLayoutTrait;
+use crate::matmul::components::stage::TilingLayout;
 use crate::matmul::components::stage::{self, Stage};
 use crate::matmul::components::{global, Ident};
 use crate::tensor::VirtualTensor;
@@ -15,7 +15,7 @@ use cubecl_core::prelude::*;
 
 #[cube]
 pub trait AsyncLoadingStrategy: 'static + Send + Sync + Clone + LoadingValidation {
-    type TilingLayout: TilingLayoutTrait;
+    type TilingLayout: TilingLayout;
 
     fn load<EG: Numeric, ES: Numeric, G: global::GlobalConfig>(
         read_view: &TensorReader<EG>,

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/mod.rs
@@ -1,0 +1,5 @@
+mod r#async;
+mod sync;
+
+pub use r#async::*;
+pub use sync::*;

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/sync.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/sync.rs
@@ -1,0 +1,141 @@
+use std::marker::PhantomData;
+
+use crate::matmul::components::global::tensor_view::TensorReader;
+use crate::matmul::components::global::{single_stage, InputLoader};
+use crate::matmul::components::global::{LoadingValidation, SyncInputLoader};
+use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
+use crate::matmul::components::stage::{self, Stage};
+use crate::matmul::components::{global, Ident};
+use crate::tensor::VirtualTensor;
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+#[cube]
+pub trait SyncLoadingStrategy: 'static + Send + Sync + Clone + LoadingValidation {
+    fn load<EG: Numeric, ES: Numeric, G: global::GlobalConfig>(
+        read_view: &TensorReader<EG>,
+        slice: &mut SliceMut<Line<ES>>,
+        #[comptime] ident: Ident,
+        #[comptime] config: G,
+    );
+}
+
+#[derive(CubeType)]
+pub struct SyncLhsLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: SyncLoadingStrategy> {
+    pub tensor_view: TensorReader<EG>,
+    pub stage: Stage<ES>,
+    _config: PhantomData<S>,
+    _loading: PhantomData<L>,
+}
+
+#[derive(CubeType)]
+pub struct SyncRhsLoader<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: SyncLoadingStrategy> {
+    pub tensor_view: TensorReader<EG>,
+    pub stage: Stage<ES>,
+    _config: PhantomData<S>,
+    _loading: PhantomData<L>,
+}
+
+#[cube]
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: SyncLoadingStrategy>
+    InputLoader<EG, ES, single_stage::Config<S>> for SyncLhsLoader<EG, ES, S, L>
+{
+    type StageReader = LhsReader<ES>;
+
+    fn as_stage_reader(this: &Self) -> Self::StageReader {
+        LhsReader::new(this.stage)
+    }
+
+    fn advance_view(this: &mut Self, k_offset: u32) {
+        this.tensor_view.update_view(k_offset, Ident::Lhs);
+    }
+}
+
+#[cube]
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: SyncLoadingStrategy>
+    SyncInputLoader<EG, ES, single_stage::Config<S>> for SyncLhsLoader<EG, ES, S, L>
+{
+    fn fill_stage(this: &mut Self, #[comptime] config: single_stage::Config<S>) {
+        L::load::<EG, ES, single_stage::Config<S>>(
+            &this.tensor_view,
+            &mut this.stage.as_slice_mut(),
+            Ident::Lhs,
+            config,
+        );
+    }
+}
+
+#[cube]
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: SyncLoadingStrategy>
+    SyncLhsLoader<EG, ES, S, L>
+{
+    pub fn new<G: global::GlobalConfig>(
+        tensor: VirtualTensor<EG>,
+        x_offset: u32,
+        y_offset: u32,
+        batch_offset: u32,
+        #[comptime] config: G,
+    ) -> Self {
+        let stage = Stage::new::<G::SmmConfig>(Ident::Lhs, config.to_smm_config());
+        let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
+
+        SyncLhsLoader::<EG, ES, S, L> {
+            tensor_view,
+            stage,
+            _config: PhantomData::<S>.runtime(),
+            _loading: PhantomData::<L>.runtime(),
+        }
+    }
+}
+
+#[cube]
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: SyncLoadingStrategy>
+    InputLoader<EG, ES, single_stage::Config<S>> for SyncRhsLoader<EG, ES, S, L>
+{
+    type StageReader = RhsReader<ES>;
+
+    fn as_stage_reader(this: &Self) -> Self::StageReader {
+        RhsReader::new(this.stage)
+    }
+
+    fn advance_view(this: &mut Self, k_offset: u32) {
+        this.tensor_view.update_view(k_offset, Ident::Rhs);
+    }
+}
+
+#[cube]
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: SyncLoadingStrategy>
+    SyncInputLoader<EG, ES, single_stage::Config<S>> for SyncRhsLoader<EG, ES, S, L>
+{
+    fn fill_stage(this: &mut Self, #[comptime] config: single_stage::Config<S>) {
+        L::load::<EG, ES, single_stage::Config<S>>(
+            &this.tensor_view,
+            &mut this.stage.as_slice_mut(),
+            Ident::Rhs,
+            config,
+        );
+    }
+}
+
+#[cube]
+impl<EG: Numeric, ES: Numeric, S: stage::StageConfig, L: SyncLoadingStrategy>
+    SyncRhsLoader<EG, ES, S, L>
+{
+    pub fn new<G: global::GlobalConfig>(
+        tensor: VirtualTensor<EG>,
+        x_offset: u32,
+        y_offset: u32,
+        batch_offset: u32,
+        #[comptime] config: G,
+    ) -> Self {
+        let stage = Stage::new::<G::SmmConfig>(Ident::Rhs, config.to_smm_config());
+        let tensor_view = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
+
+        SyncRhsLoader::<EG, ES, S, L> {
+            tensor_view,
+            stage,
+            _config: PhantomData::<S>.runtime(),
+            _loading: PhantomData::<L>.runtime(),
+        }
+    }
+}

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/sync.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/loader/sync.rs
@@ -4,7 +4,7 @@ use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::{single_stage, InputLoader};
 use crate::matmul::components::global::{LoadingValidation, SyncInputLoader};
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
-use crate::matmul::components::stage::{self, Stage, TilingLayoutTrait};
+use crate::matmul::components::stage::{self, Stage, TilingLayout};
 use crate::matmul::components::{global, Ident};
 use crate::tensor::VirtualTensor;
 use cubecl_core as cubecl;
@@ -12,7 +12,7 @@ use cubecl_core::prelude::*;
 
 #[cube]
 pub trait SyncLoadingStrategy: 'static + Send + Sync + Clone + LoadingValidation {
-    type TilingLayout: TilingLayoutTrait;
+    type TilingLayout: TilingLayout;
 
     fn load<EG: Numeric, ES: Numeric, G: global::GlobalConfig>(
         read_view: &TensorReader<EG>,

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/mod.rs
@@ -2,9 +2,11 @@ pub mod loader;
 pub mod simple;
 
 mod config;
+mod cooperative_loading;
 mod cyclic_loading;
 mod tilewise_loading;
 
 pub use config::*;
+pub use cooperative_loading::*;
 pub use cyclic_loading::*;
 pub use tilewise_loading::*;

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul.rs
@@ -3,8 +3,8 @@ use crate::matmul::components::global::single_stage::loader::{
     LhsLoader, LoadingStrategy, RhsLoader,
 };
 use crate::matmul::components::global::single_stage::Config;
+use crate::matmul::components::global::ZeroAccumulatorLoader;
 use crate::matmul::components::global::{GlobalMatmul, InputLoader};
-use crate::matmul::components::global::{LoadMode, ZeroAccumulatorLoader};
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
 use crate::matmul::components::stage::StageMatmul;
 use crate::matmul::components::MatmulPrecision;
@@ -88,15 +88,6 @@ where
         );
         let stage_shape = SMM::stage_shape(&smm_config);
 
-        let load_mode_lhs = match advanced_config.lhs_tiling_layout {
-            stage::TilingLayout::Contiguous(_) => LoadMode::Coalesced,
-            stage::TilingLayout::Strided => LoadMode::Window,
-        };
-        let load_mode_rhs = match advanced_config.rhs_tiling_layout {
-            stage::TilingLayout::Contiguous(_) => LoadMode::Coalesced,
-            stage::TilingLayout::Strided => LoadMode::Window,
-        };
-
         Config::new(
             smm_config,
             problem.m as u32 % stage_shape.m != 0,
@@ -108,8 +99,6 @@ where
             problem.rhs_line_size as u32,
             problem.out_line_size as u32,
             stage_shape.k,
-            load_mode_lhs,
-            load_mode_rhs,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul.rs
@@ -45,8 +45,12 @@ where
     LL: SyncLoadingStrategy,
     RL: SyncLoadingStrategy,
 {
-    type Matmul<MP: MatmulPrecision> =
-        SimpleMatmul<MP, SMM::Matmul<MP::ES, MP::EG, MP::EA>, LL, RL>;
+    type Matmul<MP: MatmulPrecision> = SimpleMatmul<
+        MP,
+        SMM::Matmul<MP::ES, MP::EG, MP::EA, LL::TilingLayout, RL::TilingLayout>,
+        LL,
+        RL,
+    >;
 }
 
 impl<SMM, LL, RL> MatmulConfigFactory for SimpleMatmulFamily<SMM, LL, RL>
@@ -126,8 +130,8 @@ where
         MP::ES,
         MP::EG,
         MP::EA,
-        LhsReader = LhsReader<MP::ES>,
-        RhsReader = RhsReader<MP::ES>,
+        LhsReader = LhsReader<MP::ES, LL::TilingLayout>,
+        RhsReader = RhsReader<MP::ES, RL::TilingLayout>,
     >,
     LL: SyncLoadingStrategy,
     RL: SyncLoadingStrategy,

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul.rs
@@ -88,6 +88,15 @@ where
         );
         let stage_shape = SMM::stage_shape(&smm_config);
 
+        let load_mode_lhs = match advanced_config.lhs_tiling_layout {
+            stage::TilingLayout::Contiguous(_) => LoadMode::Coalesced,
+            stage::TilingLayout::Strided => LoadMode::Window,
+        };
+        let load_mode_rhs = match advanced_config.rhs_tiling_layout {
+            stage::TilingLayout::Contiguous(_) => LoadMode::Coalesced,
+            stage::TilingLayout::Strided => LoadMode::Window,
+        };
+
         Config::new(
             smm_config,
             problem.m as u32 % stage_shape.m != 0,
@@ -99,7 +108,8 @@ where
             problem.rhs_line_size as u32,
             problem.out_line_size as u32,
             stage_shape.k,
-            LoadMode::Coalesced,
+            load_mode_lhs,
+            load_mode_rhs,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul.rs
@@ -1,10 +1,11 @@
+use crate::matmul::components::global::base::InputLoader;
 use crate::matmul::components::global::output_loader::Unloader;
 use crate::matmul::components::global::single_stage::loader::{
-    LhsLoader, LoadingStrategy, RhsLoader,
+    SyncLhsLoader, SyncLoadingStrategy, SyncRhsLoader,
 };
 use crate::matmul::components::global::single_stage::Config;
 use crate::matmul::components::global::ZeroAccumulatorLoader;
-use crate::matmul::components::global::{GlobalMatmul, InputLoader};
+use crate::matmul::components::global::{GlobalMatmul, SyncInputLoader};
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
 use crate::matmul::components::stage::StageMatmul;
 use crate::matmul::components::MatmulPrecision;
@@ -30,8 +31,8 @@ use crate::matmul::{
 
 pub struct SimpleMatmulFamily<
     SMM: stage::StageMatmulFamily,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: SyncLoadingStrategy,
+    RL: SyncLoadingStrategy,
 > {
     _stage_matmul: PhantomData<SMM>,
     _lhs_loading: PhantomData<LL>,
@@ -41,8 +42,8 @@ pub struct SimpleMatmulFamily<
 impl<SMM, LL, RL> GlobalMatmulFamily for SimpleMatmulFamily<SMM, LL, RL>
 where
     SMM: stage::StageMatmulFamily<LhsReader = LhsReaderFamily, RhsReader = RhsReaderFamily>,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: SyncLoadingStrategy,
+    RL: SyncLoadingStrategy,
 {
     type Matmul<MP: MatmulPrecision> =
         SimpleMatmul<MP, SMM::Matmul<MP::ES, MP::EG, MP::EA>, LL, RL>;
@@ -51,8 +52,8 @@ where
 impl<SMM, LL, RL> MatmulConfigFactory for SimpleMatmulFamily<SMM, LL, RL>
 where
     SMM: stage::StageMatmulFamily,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: SyncLoadingStrategy,
+    RL: SyncLoadingStrategy,
 {
     type Input = SMM::Input;
     type Config = Config<SMM::Config>;
@@ -109,8 +110,8 @@ where
 pub struct SimpleMatmul<
     MP: MatmulPrecision,
     SMM: StageMatmul<MP::ES, MP::EG, MP::EA>,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: SyncLoadingStrategy,
+    RL: SyncLoadingStrategy,
 > {
     _ms: PhantomData<MP>,
     _stage_matmul: PhantomData<SMM>,
@@ -128,12 +129,12 @@ where
         LhsReader = LhsReader<MP::ES>,
         RhsReader = RhsReader<MP::ES>,
     >,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: SyncLoadingStrategy,
+    RL: SyncLoadingStrategy,
 {
     type Config = Config<SMM::Config>;
-    type LhsLoader = LhsLoader<MP::EG, MP::ES, SMM::Config, LL>;
-    type RhsLoader = RhsLoader<MP::EG, MP::ES, SMM::Config, RL>;
+    type LhsLoader = SyncLhsLoader<MP::EG, MP::ES, SMM::Config, LL>;
+    type RhsLoader = SyncRhsLoader<MP::EG, MP::ES, SMM::Config, RL>;
     type AccumulatorLoader = ZeroAccumulatorLoader;
     type Out = Unloader<MP::EG>;
     type Accumulator = SMM::Accumulator;

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
@@ -3,8 +3,8 @@ use crate::matmul::components::global::single_stage::loader::{
     LhsLoader, LoadingStrategy, RhsLoader,
 };
 use crate::matmul::components::global::single_stage::Config;
+use crate::matmul::components::global::ZeroAccumulatorLoader;
 use crate::matmul::components::global::{GlobalMatmul, InputLoader};
-use crate::matmul::components::global::{LoadMode, ZeroAccumulatorLoader};
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
 use crate::matmul::components::stage::StageMatmul;
 use crate::matmul::components::MatmulPrecision;
@@ -106,8 +106,6 @@ where
             problem.rhs_line_size as u32,
             problem.out_line_size as u32,
             stage_shape.k,
-            LoadMode::Window,
-            LoadMode::Window,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
@@ -1,10 +1,12 @@
+use crate::matmul::components::global::base::AsyncInputLoader;
+use crate::matmul::components::global::base::InputLoader;
 use crate::matmul::components::global::output_loader::Unloader;
 use crate::matmul::components::global::single_stage::loader::{
-    LhsLoader, LoadingStrategy, RhsLoader,
+    AsyncLhsLoader, AsyncLoadingStrategy, AsyncRhsLoader,
 };
 use crate::matmul::components::global::single_stage::Config;
+use crate::matmul::components::global::GlobalMatmul;
 use crate::matmul::components::global::ZeroAccumulatorLoader;
-use crate::matmul::components::global::{GlobalMatmul, InputLoader};
 use crate::matmul::components::stage::multi_buffer::{LhsReader, RhsReader};
 use crate::matmul::components::stage::StageMatmul;
 use crate::matmul::components::MatmulPrecision;
@@ -31,8 +33,8 @@ use crate::matmul::{
 
 pub struct SimplePipelinedMatmulFamily<
     SMM: stage::StageMatmulFamily,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: AsyncLoadingStrategy,
+    RL: AsyncLoadingStrategy,
 > {
     _stage_matmul: PhantomData<SMM>,
     _lhs_loading: PhantomData<LL>,
@@ -42,8 +44,8 @@ pub struct SimplePipelinedMatmulFamily<
 impl<SMM, LL, RL> GlobalMatmulFamily for SimplePipelinedMatmulFamily<SMM, LL, RL>
 where
     SMM: stage::StageMatmulFamily<LhsReader = LhsReaderFamily, RhsReader = RhsReaderFamily>,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: AsyncLoadingStrategy,
+    RL: AsyncLoadingStrategy,
 {
     type Matmul<MP: MatmulPrecision> =
         SimplePipelinedMatmul<MP, SMM::Matmul<MP::ES, MP::EG, MP::EA>, LL, RL>;
@@ -52,8 +54,8 @@ where
 impl<SMM, LL, RL> MatmulConfigFactory for SimplePipelinedMatmulFamily<SMM, LL, RL>
 where
     SMM: stage::StageMatmulFamily,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: AsyncLoadingStrategy,
+    RL: AsyncLoadingStrategy,
 {
     type Input = SMM::Input;
     type Config = Config<SMM::Config>;
@@ -116,8 +118,8 @@ where
 pub struct SimplePipelinedMatmul<
     MP: MatmulPrecision,
     SMM: StageMatmul<MP::ES, MP::EG, MP::EA>,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: AsyncLoadingStrategy,
+    RL: AsyncLoadingStrategy,
 > {
     _ms: PhantomData<MP>,
     _stage_matmul: PhantomData<SMM>,
@@ -135,12 +137,12 @@ where
         LhsReader = LhsReader<MP::ES>,
         RhsReader = RhsReader<MP::ES>,
     >,
-    LL: LoadingStrategy,
-    RL: LoadingStrategy,
+    LL: AsyncLoadingStrategy,
+    RL: AsyncLoadingStrategy,
 {
     type Config = Config<SMM::Config>;
-    type LhsLoader = LhsLoader<MP::EG, MP::ES, SMM::Config, LL>;
-    type RhsLoader = RhsLoader<MP::EG, MP::ES, SMM::Config, RL>;
+    type LhsLoader = AsyncLhsLoader<MP::EG, MP::ES, SMM::Config, LL>;
+    type RhsLoader = AsyncRhsLoader<MP::EG, MP::ES, SMM::Config, RL>;
     type AccumulatorLoader = ZeroAccumulatorLoader;
     type Out = Unloader<MP::EG>;
     type Accumulator = SMM::Accumulator;
@@ -168,8 +170,8 @@ where
 
             // Start loading
             pipeline.producer_acquire();
-            Self::LhsLoader::fill_stage_window(&mut lhs_loader, pipeline, config);
-            Self::RhsLoader::fill_stage_window(&mut rhs_loader, pipeline, config);
+            Self::LhsLoader::fill_stage(&mut lhs_loader, pipeline, config);
+            Self::RhsLoader::fill_stage(&mut rhs_loader, pipeline, config);
             pipeline.producer_commit();
 
             let lhs_stage_reader = &Self::LhsLoader::as_stage_reader(&lhs_loader);

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
@@ -107,6 +107,7 @@ where
             problem.out_line_size as u32,
             stage_shape.k,
             LoadMode::Window,
+            LoadMode::Window,
         )
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
@@ -47,8 +47,12 @@ where
     LL: AsyncLoadingStrategy,
     RL: AsyncLoadingStrategy,
 {
-    type Matmul<MP: MatmulPrecision> =
-        SimplePipelinedMatmul<MP, SMM::Matmul<MP::ES, MP::EG, MP::EA>, LL, RL>;
+    type Matmul<MP: MatmulPrecision> = SimplePipelinedMatmul<
+        MP,
+        SMM::Matmul<MP::ES, MP::EG, MP::EA, LL::TilingLayout, RL::TilingLayout>,
+        LL,
+        RL,
+    >;
 }
 
 impl<SMM, LL, RL> MatmulConfigFactory for SimplePipelinedMatmulFamily<SMM, LL, RL>
@@ -134,8 +138,8 @@ where
         MP::ES,
         MP::EG,
         MP::EA,
-        LhsReader = LhsReader<MP::ES>,
-        RhsReader = RhsReader<MP::ES>,
+        LhsReader = LhsReader<MP::ES, LL::TilingLayout>,
+        RhsReader = RhsReader<MP::ES, RL::TilingLayout>,
     >,
     LL: AsyncLoadingStrategy,
     RL: AsyncLoadingStrategy,

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
@@ -42,7 +42,7 @@ impl LoadingValidation for TilewiseLoading {
             ));
         }
 
-        if let LoadMode::Window = config.load_mode() {
+        if let LoadMode::Window = config.load_mode(ident) {
             return Err(Box::new(
                 "Window load not yet supported in tilewise loading setup",
             ));

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
@@ -15,7 +15,7 @@ pub struct TilewiseLoading {}
 
 impl LoadingValidation for TilewiseLoading {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
-        let tiling = config.stage_tiling(ident);
+        let tiling = config.tiling_dimensions(ident);
         let line_size = config.global_line_size(ident);
 
         let num_planes = config.num_planes();
@@ -70,7 +70,7 @@ impl LoadingStrategy for TilewiseLoading {
         #[comptime] ident: Ident,
         #[comptime] config: G,
     ) {
-        let tiling = config.stage_tiling(ident);
+        let tiling = config.tiling_dimensions(ident);
         let line_size = config.global_line_size(ident);
 
         let num_lines_per_tile = comptime!(tiling.tile_size() / line_size);

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
@@ -80,12 +80,8 @@ impl LoadingStrategy for TilewiseLoading {
 
         let num_loads_per_unit = num_lines_per_tile / config.plane_dim();
 
-        let (tile_x, tile_y) = TilingLayout::to_x_y(
-            config.tiling_layout(ident),
-            nth_tile,
-            tiling.tile_count_row(),
-            tiling.tile_count_col(),
-        );
+        let (tile_x, tile_y) =
+            TilingLayout::to_x_y::<G::SmmConfig>(nth_tile, ident, config.to_smm_config());
 
         for i in 0..num_loads_per_unit {
             let pos_within_tile = i * config.plane_dim() + UNIT_POS_X;

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
@@ -1,5 +1,5 @@
 use crate::matmul::components::global::tensor_view::TensorReader;
-use crate::matmul::components::global::{GlobalConfig, LoadMode, LoadingValidation};
+use crate::matmul::components::global::{GlobalConfig, LoadingValidation};
 use crate::matmul::components::stage::TilingLayout;
 use crate::matmul::components::{FormattedConfigError, Ident, InvalidConfigError};
 use cubecl_core as cubecl;
@@ -42,11 +42,11 @@ impl LoadingValidation for TilewiseLoading {
             ));
         }
 
-        if let LoadMode::Window = config.load_mode(ident) {
-            return Err(Box::new(
-                "Window load not yet supported in tilewise loading setup",
-            ));
-        }
+        // if let LoadMode::Window = config.load_mode(ident) {
+        //     return Err(Box::new(
+        //         "Window load not yet supported in tilewise loading setup",
+        //     ));
+        // }
 
         Ok(())
     }

--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/tilewise_loading.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::matmul::components::global::tensor_view::TensorReader;
 use crate::matmul::components::global::{GlobalConfig, LoadingValidation};
-use crate::matmul::components::stage::{ContiguousTilingLayout, TilingOrderTrait};
+use crate::matmul::components::stage::{ContiguousTilingLayout, TilingOrder};
 use crate::matmul::components::{FormattedConfigError, Ident, InvalidConfigError};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -12,11 +12,11 @@ use super::loader::SyncLoadingStrategy;
 #[derive(CubeType, Clone, Copy)]
 /// Loads the content of all tiles in the tensor view using
 /// one plane per tile.
-pub struct TilewiseCoalescedLoading<T: TilingOrderTrait> {
+pub struct TilewiseCoalescedLoading<T: TilingOrder> {
     tiling_order: PhantomData<T>,
 }
 
-impl<T: TilingOrderTrait> LoadingValidation for TilewiseCoalescedLoading<T> {
+impl<T: TilingOrder> LoadingValidation for TilewiseCoalescedLoading<T> {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
         let tiling = config.tiling_dimensions(ident);
         let line_size = config.global_line_size(ident);
@@ -50,7 +50,7 @@ impl<T: TilingOrderTrait> LoadingValidation for TilewiseCoalescedLoading<T> {
 }
 
 #[cube]
-impl<T: TilingOrderTrait> SyncLoadingStrategy for TilewiseCoalescedLoading<T> {
+impl<T: TilingOrder> SyncLoadingStrategy for TilewiseCoalescedLoading<T> {
     type TilingLayout = ContiguousTilingLayout<T>;
 
     fn load<EG: Numeric, ES: Numeric, G: GlobalConfig>(

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
@@ -98,7 +98,7 @@ impl<EG: Numeric> TensorReader<EG> {
         #[comptime] config: G,
     ) -> Window<EG> {
         let line_size = config.global_line_size(ident);
-        let stage_tiling = config.stage_tiling(ident);
+        let stage_tiling = config.tiling_dimensions(ident);
         let tile_size_x = stage_tiling.tile_shape_row();
         let tile_size_y = stage_tiling.tile_shape_col();
         let tile_lines_x = tile_size_x / line_size;
@@ -176,8 +176,8 @@ impl<EG: Numeric> TensorReader<EG> {
         #[comptime] config: G,
     ) -> Line<EG> {
         let line_size = config.global_line_size(ident);
-        let tile_shape_x = config.stage_tiling(ident).tile_shape_row();
-        let tile_shape_y = config.stage_tiling(ident).tile_shape_col();
+        let tile_shape_x = config.tiling_dimensions(ident).tile_shape_row();
+        let tile_shape_y = config.tiling_dimensions(ident).tile_shape_col();
 
         let view_tile_x = tile_x * tile_shape_x + self.x_offset;
         let view_tile_y = tile_y * tile_shape_y + self.y_offset;
@@ -255,7 +255,7 @@ impl<EG: Numeric> TensorWriter<EG> {
         value: Line<ES>,
         #[comptime] config: G,
     ) {
-        let tiling = config.stage_tiling(Ident::Out);
+        let tiling = config.tiling_dimensions(Ident::Out);
 
         let view_x =
             tile_x * tiling.tile_shape_row() + unit_id / tiling.tile_shape_col() + self.x_offset;

--- a/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tensor_view.rs
@@ -1,5 +1,3 @@
-use core::num;
-
 use crate::matmul::components::config::InputIdent;
 use crate::matmul::components::global;
 use crate::matmul::components::{Ident, MatrixLayout};

--- a/crates/cubecl-linalg/src/matmul/components/global/tilewise_unloading.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/tilewise_unloading.rs
@@ -18,7 +18,7 @@ impl TilewiseUnloading {
         tile_y: u32,
         #[comptime] config: G,
     ) {
-        let tiling = config.stage_tiling(Ident::Out);
+        let tiling = config.tiling_dimensions(Ident::Out);
         let slice_line_size = config.stage_line_size(Ident::Out);
         let out_line_size = config.global_line_size(Ident::Out);
 

--- a/crates/cubecl-linalg/src/matmul/components/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/components/mod.rs
@@ -10,6 +10,6 @@ mod spec;
 
 pub use base::*;
 pub use config::*;
-pub use config::{as_cmma_layout, Ident, MatmulConfig, MatrixLayout, StageTiling};
+pub use config::{as_cmma_layout, Ident, MatmulConfig, MatrixLayout, TilingDimensions};
 pub use problem::MatmulProblem;
 pub use spec::*;

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -25,14 +25,13 @@ pub trait StageMatmulFamily:
     /// Returns the number of tiles in each axis of the stage.
     fn tile_count(config: &Self::Config) -> MatmulSize;
 
-    type Matmul<I: Numeric, O: Numeric, Acc: Numeric, T: TilingLayoutTrait>: StageMatmul<
+    type Matmul<I: Numeric, O: Numeric, Acc: Numeric, TL: TilingLayoutTrait, TR: TilingLayoutTrait>: StageMatmul<
         I,
         O,
         Acc,
-        T,
         Config = Self::Config,
-        LhsReader = <Self::LhsReader as ReaderFamily>::Reader<I, T>,
-        RhsReader = <Self::RhsReader as ReaderFamily>::Reader<I, T>,
+        LhsReader = <Self::LhsReader as ReaderFamily>::Reader<I, TL>,
+        RhsReader = <Self::RhsReader as ReaderFamily>::Reader<I, TR>,
     >;
 }
 
@@ -51,9 +50,7 @@ pub trait StageMatmulFamily:
 ///  - Data given as inputs by stage readers must always be valid. If the actual matrix multiplication
 ///    should be done on smaller sizes than M, N and K, padding with zeros must be done beforehand.
 ///  - Enough planes are launched to perform the whole computation
-pub trait StageMatmul<I: Numeric, O: Numeric, Acc: Numeric, T: TilingLayoutTrait>:
-    'static + Send + Sync
-{
+pub trait StageMatmul<I: Numeric, O: Numeric, Acc: Numeric>: 'static + Send + Sync {
     type Config: StageConfig;
 
     /// Contains the matrix multiplication output, that can be shared across the different planes of the cube.

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -7,10 +7,10 @@ use crate::matmul::components::{global, MatmulConfigFactory};
 use crate::matmul::components::{Ident, MatrixLayout};
 use crate::matmul::components::{MatmulSize, TilingDimensions};
 
-use super::TilingLayoutTrait;
+use super::TilingLayout;
 
 pub trait ReaderFamily {
-    type Reader<I: Numeric, T: TilingLayoutTrait>: CubeType;
+    type Reader<I: Numeric, T: TilingLayout>: CubeType;
 }
 
 pub trait StageMatmulFamily:
@@ -25,7 +25,7 @@ pub trait StageMatmulFamily:
     /// Returns the number of tiles in each axis of the stage.
     fn tile_count(config: &Self::Config) -> MatmulSize;
 
-    type Matmul<I: Numeric, O: Numeric, Acc: Numeric, TL: TilingLayoutTrait, TR: TilingLayoutTrait>: StageMatmul<
+    type Matmul<I: Numeric, O: Numeric, Acc: Numeric, TL: TilingLayout, TR: TilingLayout>: StageMatmul<
         I,
         O,
         Acc,

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -142,7 +142,7 @@ pub trait StageConfig: MatmulConfig {
     fn tiling(&self, ident: Ident) -> StageTiling;
 
     /// Returns the [MatrixLayout] for the given ident
-    fn layout(&self, ident: Ident) -> MatrixLayout;
+    fn matrix_layout(&self, ident: Ident) -> MatrixLayout;
 
     /// Returns the number of planes in the cube
     fn num_planes(&self) -> u32;

--- a/crates/cubecl-linalg/src/matmul/components/stage/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/base.rs
@@ -5,7 +5,7 @@ use crate::matmul::components::tile::TileConfig;
 use crate::matmul::components::{config::MatmulConfig, global::AccumulatorLoader};
 use crate::matmul::components::{global, MatmulConfigFactory};
 use crate::matmul::components::{Ident, MatrixLayout};
-use crate::matmul::components::{MatmulSize, StageTiling};
+use crate::matmul::components::{MatmulSize, TilingDimensions};
 
 use super::TilingLayout;
 
@@ -139,7 +139,7 @@ pub trait StageConfig: MatmulConfig {
     fn line_size(&self, ident: Ident) -> u32;
 
     /// Returns the [StageTiling] for the given ident
-    fn tiling(&self, ident: Ident) -> StageTiling;
+    fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions;
 
     /// Returns the [MatrixLayout] for the given ident
     fn matrix_layout(&self, ident: Ident) -> MatrixLayout;

--- a/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
@@ -29,32 +29,19 @@ pub enum TilingOrder {
 #[cube]
 impl TilingLayout {
     /// Converts a tile index in the stage to its (x,y) position
-    pub fn to_x_y(#[comptime] this: TilingLayout, nth: u32, num_x: u32, num_y: u32) -> (u32, u32) {
-        match comptime!(this) {
-            TilingLayout::Contiguous(tiling_order) => match comptime!(tiling_order) {
-                TilingOrder::RowMajor => (nth / num_y, nth % num_y),
-                TilingOrder::ColMajor => (nth % num_x, nth / num_x),
-            },
-            TilingLayout::Strided => todo!(),
-        }
-    }
-
-    /// Converts an (x,y) position to its tile index in the stage
-    pub fn to_nth_tile<S: StageConfig>(
-        x: u32,
-        y: u32,
+    pub fn to_x_y<S: StageConfig>(
+        nth: u32,
         #[comptime] ident: Ident,
         #[comptime] config: S,
-    ) -> u32 {
+    ) -> (u32, u32) {
         let stage_tiling = config.tiling(ident);
         let num_x = stage_tiling.tile_count_row();
         let num_y = stage_tiling.tile_count_col();
-        let tiling_layout = config.tiling_layout(ident);
 
-        match comptime!(tiling_layout) {
+        match comptime!(config.tiling_layout(ident)) {
             TilingLayout::Contiguous(tiling_order) => match comptime!(tiling_order) {
-                TilingOrder::RowMajor => x * num_y + y,
-                TilingOrder::ColMajor => y * num_x + x,
+                TilingOrder::RowMajor => (nth / num_y, nth % num_y),
+                TilingOrder::ColMajor => (nth % num_x, nth / num_x),
             },
             TilingLayout::Strided => todo!(),
         }

--- a/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
@@ -159,10 +159,9 @@ impl TilingLayout {
 
         let start = x * tile_shape_x * stride_x + y * tile_shape_y * stride_y;
         // TODO less wacky calculation
-        // line_size is brought back because the slice is cast to unlined
-        let stride = Max::max(stride_x, stride_y) * line_size;
+        let stride_in_lines = Max::max(stride_x, stride_y);
 
-        Tile::new_strided(stage_slice.slice(start, start + length), stride)
+        Tile::new_strided(stage_slice.slice(start, start + length), stride_in_lines)
     }
 
     /// Returns the nth slice of the stage

--- a/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
@@ -3,7 +3,6 @@ use cubecl_core::{self as cubecl};
 
 use crate::matmul::components::tile::Tile;
 use crate::matmul::components::{Ident, MatrixLayout};
-use crate::tensor::matrix_layout;
 
 use super::StageConfig;
 

--- a/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
@@ -1,6 +1,10 @@
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
 
+use crate::matmul::components::{Ident, MatrixLayout};
+
+use super::StageConfig;
+
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// How the tiles are stored in shared memory
 pub enum TilingLayout {
@@ -36,19 +40,80 @@ impl TilingLayout {
     }
 
     /// Converts an (x,y) position to its tile index in the stage
-    pub fn to_nth_tile(
-        #[comptime] this: TilingLayout,
+    pub fn to_nth_tile<S: StageConfig>(
         x: u32,
         y: u32,
-        num_x: u32,
-        num_y: u32,
+        #[comptime] ident: Ident,
+        #[comptime] config: S,
     ) -> u32 {
-        match comptime!(this) {
+        let stage_tiling = config.tiling(ident);
+        let num_x = stage_tiling.tile_count_row();
+        let num_y = stage_tiling.tile_count_col();
+        let tiling_layout = config.tiling_layout(ident);
+
+        match comptime!(tiling_layout) {
             TilingLayout::Contiguous(tiling_order) => match comptime!(tiling_order) {
                 TilingOrder::RowMajor => x * num_y + y,
                 TilingOrder::ColMajor => y * num_x + x,
             },
             TilingLayout::Strided => todo!(),
         }
+    }
+
+    /// Returns the start and end bounds that encompass all tile elements  
+    /// containing the given (x, y) position.  
+    pub fn tile_bounds<S: StageConfig>(
+        x: u32,
+        y: u32,
+        #[comptime] ident: Ident,
+        #[comptime] config: S,
+    ) -> (u32, u32) {
+        let line_size = config.line_size(ident);
+        let stage_tiling = config.tiling(ident);
+        let matrix_layout = config.matrix_layout(ident);
+        let tile_count_x = stage_tiling.tile_count_row();
+        let tile_count_y = stage_tiling.tile_count_col();
+        let (tile_shape_x, tile_shape_y) = match matrix_layout {
+            MatrixLayout::RowMajor => (
+                stage_tiling.tile_shape_row(),
+                stage_tiling.tile_shape_col() / line_size,
+            ),
+            MatrixLayout::ColMajor => (
+                stage_tiling.tile_shape_row() / line_size,
+                stage_tiling.tile_shape_col(),
+            ),
+        };
+
+        // TODO could be inside stage_tiling
+        let tiling_layout = config.tiling_layout(ident);
+
+        let (stride_x, stride_y) = comptime! {match tiling_layout {
+            TilingLayout::Contiguous(_) => match matrix_layout{
+                MatrixLayout::RowMajor => (tile_shape_y, 1u32),
+                MatrixLayout::ColMajor => (1u32, tile_shape_x),
+            },
+            TilingLayout::Strided => match matrix_layout {
+                MatrixLayout::RowMajor => (tile_count_y * tile_shape_y, 1u32),
+                MatrixLayout::ColMajor => (1u32, tile_count_x * tile_shape_x),
+            },
+        }};
+
+        let start = match tiling_layout {
+            TilingLayout::Contiguous(tiling_order) => {
+                tile_shape_x
+                    * tile_shape_y
+                    * match tiling_order {
+                        TilingOrder::RowMajor => x * tile_count_y + y,
+                        TilingOrder::ColMajor => y * tile_count_x + x,
+                    }
+            }
+            TilingLayout::Strided => x * tile_shape_x * stride_x + y * tile_shape_y * stride_y,
+        };
+        let length = match matrix_layout {
+            MatrixLayout::RowMajor => (tile_shape_x - 1) * stride_x + tile_shape_y * stride_y,
+            MatrixLayout::ColMajor => (tile_shape_y - 1) * stride_y + tile_shape_x * stride_x,
+        };
+
+        (start, start + length)
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
@@ -158,12 +158,9 @@ impl TilingLayout {
         }};
 
         let start = x * tile_shape_x * stride_x + y * tile_shape_y * stride_y;
+        let stride = Max::max(stride_x, stride_y);
 
-        Tile::new_contiguous::<S::TmmConfig>(
-            stage_slice.slice(start, start + length),
-            ident,
-            config.to_tmm_config(),
-        )
+        Tile::new_strided(stage_slice.slice(start, start + length), stride)
     }
 
     /// Returns the nth slice of the stage

--- a/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
@@ -120,11 +120,11 @@ impl TilingLayout {
     /// Only for strided layout
     /// TODO: rethink abstractions
     pub fn nth_slice<ES: Numeric, S: StageConfig>(
-        stage_slice: Slice<Line<ES>>,
+        stage_slice: &mut SliceMut<Line<ES>>,
         nth: u32,
         #[comptime] ident: Ident,
         #[comptime] config: S,
-    ) -> Slice<Line<ES>> {
+    ) -> SliceMut<Line<ES>> {
         let tiling_dimensions = config.tiling_dimensions(ident);
         let matrix_layout = config.matrix_layout(ident);
         let tiling_layout = config.tiling_layout(ident);
@@ -140,6 +140,6 @@ impl TilingLayout {
         } / line_size;
 
         let start = slice_length * nth;
-        stage_slice.slice(start, start + slice_length)
+        stage_slice.slice_mut(start, start + slice_length)
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
@@ -158,7 +158,9 @@ impl TilingLayout {
         }};
 
         let start = x * tile_shape_x * stride_x + y * tile_shape_y * stride_y;
-        let stride = Max::max(stride_x, stride_y);
+        // TODO less wacky calculation
+        // line_size is brought back because the slice is cast to unlined
+        let stride = Max::max(stride_x, stride_y) * line_size;
 
         Tile::new_strided(stage_slice.slice(start, start + length), stride)
     }

--- a/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/layout.rs
@@ -1,6 +1,7 @@
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
 
+use crate::matmul::components::tile::Tile;
 use crate::matmul::components::{Ident, MatrixLayout};
 
 use super::StageConfig;
@@ -29,34 +30,41 @@ pub enum TilingOrder {
 #[cube]
 impl TilingLayout {
     /// Converts a tile index in the stage to its (x,y) position
+    /// Only for contiguous tiling layout
+    /// TODO: rethink abstraction
     pub fn to_x_y<S: StageConfig>(
         nth: u32,
         #[comptime] ident: Ident,
         #[comptime] config: S,
     ) -> (u32, u32) {
-        let stage_tiling = config.tiling(ident);
+        let stage_tiling = config.tiling_dimensions(ident);
         let num_x = stage_tiling.tile_count_row();
         let num_y = stage_tiling.tile_count_col();
 
-        match comptime!(config.tiling_layout(ident)) {
-            TilingLayout::Contiguous(tiling_order) => match comptime!(tiling_order) {
-                TilingOrder::RowMajor => (nth / num_y, nth % num_y),
-                TilingOrder::ColMajor => (nth % num_x, nth / num_x),
-            },
-            TilingLayout::Strided => todo!(),
+        let tiling_order = match comptime!(config.tiling_layout(ident)) {
+            TilingLayout::Contiguous(order) => order,
+            _ => comptime!(panic!(
+                "to_x_y only makes sense in contiguous tiling layout"
+            )),
+        };
+
+        match comptime!(tiling_order) {
+            TilingOrder::RowMajor => (nth / num_y, nth % num_y),
+            TilingOrder::ColMajor => (nth % num_x, nth / num_x),
         }
     }
 
-    /// Returns the start and end bounds that encompass all tile elements  
-    /// containing the given (x, y) position.  
-    pub fn tile_bounds<S: StageConfig>(
+    /// Returns the smallest slice that encompasses all tile elements  
+    /// of the tile at (x, y) position.  
+    pub fn get_tile<ES: Numeric, S: StageConfig>(
+        stage_slice: Slice<Line<ES>>,
         x: u32,
         y: u32,
         #[comptime] ident: Ident,
         #[comptime] config: S,
-    ) -> (u32, u32) {
+    ) -> Tile<ES> {
         let line_size = config.line_size(ident);
-        let stage_tiling = config.tiling(ident);
+        let stage_tiling = config.tiling_dimensions(ident);
         let matrix_layout = config.matrix_layout(ident);
         let tile_count_x = stage_tiling.tile_count_row();
         let tile_count_y = stage_tiling.tile_count_col();
@@ -101,6 +109,37 @@ impl TilingLayout {
             MatrixLayout::ColMajor => (tile_shape_y - 1) * stride_y + tile_shape_x * stride_x,
         };
 
-        (start, start + length)
+        Tile::new_contiguous::<S::TmmConfig>(
+            stage_slice.slice(start, start + length),
+            ident,
+            config.to_tmm_config(),
+        )
+    }
+
+    /// Returns the nth slice of the stage
+    /// Only for strided layout
+    /// TODO: rethink abstractions
+    pub fn nth_slice<ES: Numeric, S: StageConfig>(
+        stage_slice: Slice<Line<ES>>,
+        nth: u32,
+        #[comptime] ident: Ident,
+        #[comptime] config: S,
+    ) -> Slice<Line<ES>> {
+        let tiling_dimensions = config.tiling_dimensions(ident);
+        let matrix_layout = config.matrix_layout(ident);
+        let tiling_layout = config.tiling_layout(ident);
+        let line_size = config.line_size(ident);
+
+        if let TilingLayout::Contiguous(_) = tiling_layout {
+            comptime!(panic!("nth slice only makes sense in strided layout"));
+        }
+
+        let slice_length = match comptime!(matrix_layout) {
+            MatrixLayout::RowMajor => tiling_dimensions.total_col(),
+            MatrixLayout::ColMajor => tiling_dimensions.total_row(),
+        } / line_size;
+
+        let start = slice_length * nth;
+        stage_slice.slice(start, start + slice_length)
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -48,7 +48,7 @@ impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM>
 
     fn check_config(config: &Self::Config) -> Result<(), InvalidConfigError> {
         check_num_planes(
-            config.tiling(Ident::Lhs).tile_count_row(),
+            config.tiling_dimensions(Ident::Lhs).tile_count_row(),
             config.num_planes(),
         )?;
         TMM::check_config(&config.to_tmm_config())
@@ -170,7 +170,7 @@ where
         #[comptime] global_config: G,
     ) {
         let out_smem_line_size = global_config.stage_line_size(Ident::Out);
-        let num_tile_lines = stage_config.tiling(Ident::Out).tile_size() / out_smem_line_size;
+        let num_tile_lines = stage_config.tiling_dimensions(Ident::Out).tile_size() / out_smem_line_size;
 
         let start = num_tile_lines * UNIT_POS_Y;
         let mut out_smem = SharedMemory::<O>::new_lined(

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -5,7 +5,7 @@ use cubecl_core::prelude::*;
 
 use crate::matmul::components::global::AccumulatorLoader;
 use crate::matmul::components::stage::shared::CommonStageConfig;
-use crate::matmul::components::stage::{StageMatmul, StageMatmulFamily};
+use crate::matmul::components::stage::{StageMatmul, StageMatmulFamily, TilingLayoutTrait};
 use crate::matmul::components::tile::TileMatmulFamily;
 use crate::matmul::components::{
     CompleteStageTiling, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatmulSize,
@@ -38,8 +38,8 @@ impl<TMM: TileMatmulFamily> StageMatmulFamily for MultiBufferMatmulFamily<TMM> {
 
     type LhsReader = LhsReaderFamily;
     type RhsReader = RhsReaderFamily;
-    type Matmul<I: Numeric, O: Numeric, Acc: Numeric> =
-        MultiBufferMatmul<I, O, Acc, TMM::Matmul<I, Acc>>;
+    type Matmul<I: Numeric, O: Numeric, Acc: Numeric, T: TilingLayoutTrait> =
+        MultiBufferMatmul<I, O, Acc, TMM::Matmul<I, Acc>, T>;
 }
 
 impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM> {
@@ -86,14 +86,7 @@ impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM>
             tile_count,
         };
 
-        CommonStageConfig::new(
-            tmm_config,
-            tiling,
-            cube_dim.y,
-            advanced_config.lhs_tiling_layout,
-            advanced_config.rhs_tiling_layout,
-            quantized,
-        )
+        CommonStageConfig::new(tmm_config, tiling, cube_dim.y, quantized)
     }
 }
 
@@ -103,32 +96,40 @@ impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM>
 ///
 /// # Assumptions
 /// - There are as many planes as the stage size in m
-pub struct MultiBufferMatmul<I: Numeric, O: Numeric, EA: Numeric, TMM: tile::TileMatmul<I, EA>> {
+pub struct MultiBufferMatmul<
+    I: Numeric,
+    O: Numeric,
+    EA: Numeric,
+    TMM: tile::TileMatmul<I, EA>,
+    T: TilingLayoutTrait,
+> {
     _input_precision: PhantomData<I>,
     _output_precision: PhantomData<O>,
     _accumulator_precision: PhantomData<EA>,
     _instruction: PhantomData<TMM>,
+    _tiling_layout: PhantomData<T>,
 }
 
 #[cube]
-impl<I, O, EA, TMM> StageMatmul<I, O, EA> for MultiBufferMatmul<I, O, EA, TMM>
+impl<I, O, EA, TMM, T> StageMatmul<I, O, EA, T> for MultiBufferMatmul<I, O, EA, TMM, T>
 where
     I: Numeric,
     O: Numeric,
     EA: Numeric,
     TMM: tile::TileMatmul<I, EA>,
+    T: TilingLayoutTrait,
 {
     type Config = CommonStageConfig<TMM::Config>;
 
-    type LhsReader = LhsReader<I>;
-    type RhsReader = RhsReader<I>;
+    type LhsReader = LhsReader<I, T>;
+    type RhsReader = RhsReader<I, T>;
     type Accumulator = Sequence<TMM::Accumulator>;
     type LhsTile = TMM::Lhs;
     type RhsTile = TMM::Rhs;
 
     fn execute(
-        lhs_reader: &LhsReader<I>,
-        rhs_reader: &RhsReader<I>,
+        lhs_reader: &LhsReader<I, T>,
+        rhs_reader: &RhsReader<I, T>,
         lhs_tile: &mut Self::LhsTile,
         rhs_tile: &mut Self::RhsTile,
         acc: &mut Self::Accumulator,
@@ -170,7 +171,8 @@ where
         #[comptime] global_config: G,
     ) {
         let out_smem_line_size = global_config.stage_line_size(Ident::Out);
-        let num_tile_lines = stage_config.tiling_dimensions(Ident::Out).tile_size() / out_smem_line_size;
+        let num_tile_lines =
+            stage_config.tiling_dimensions(Ident::Out).tile_size() / out_smem_line_size;
 
         let start = num_tile_lines * UNIT_POS_Y;
         let mut out_smem = SharedMemory::<O>::new_lined(

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -5,7 +5,7 @@ use cubecl_core::prelude::*;
 
 use crate::matmul::components::global::AccumulatorLoader;
 use crate::matmul::components::stage::shared::CommonStageConfig;
-use crate::matmul::components::stage::{StageMatmul, StageMatmulFamily, TilingLayoutTrait};
+use crate::matmul::components::stage::{StageMatmul, StageMatmulFamily, TilingLayout};
 use crate::matmul::components::tile::TileMatmulFamily;
 use crate::matmul::components::{
     CompleteStageTiling, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatmulSize,
@@ -42,8 +42,8 @@ impl<TMM: TileMatmulFamily> StageMatmulFamily for MultiBufferMatmulFamily<TMM> {
         I: Numeric,
         O: Numeric,
         Acc: Numeric,
-        TL: TilingLayoutTrait,
-        TR: TilingLayoutTrait,
+        TL: TilingLayout,
+        TR: TilingLayout,
     > = MultiBufferMatmul<I, O, Acc, TMM::Matmul<I, Acc>, TL, TR>;
 }
 
@@ -106,8 +106,8 @@ pub struct MultiBufferMatmul<
     O: Numeric,
     EA: Numeric,
     TMM: tile::TileMatmul<I, EA>,
-    TL: TilingLayoutTrait,
-    TR: TilingLayoutTrait,
+    TL: TilingLayout,
+    TR: TilingLayout,
 > {
     _input_precision: PhantomData<I>,
     _output_precision: PhantomData<O>,
@@ -124,8 +124,8 @@ where
     O: Numeric,
     EA: Numeric,
     TMM: tile::TileMatmul<I, EA>,
-    TL: TilingLayoutTrait,
-    TR: TilingLayoutTrait,
+    TL: TilingLayout,
+    TR: TilingLayout,
 {
     type Config = CommonStageConfig<TMM::Config>;
 

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/base.rs
@@ -38,13 +38,8 @@ impl<TMM: TileMatmulFamily> StageMatmulFamily for MultiBufferMatmulFamily<TMM> {
 
     type LhsReader = LhsReaderFamily;
     type RhsReader = RhsReaderFamily;
-    type Matmul<
-        I: Numeric,
-        O: Numeric,
-        Acc: Numeric,
-        TL: TilingLayout,
-        TR: TilingLayout,
-    > = MultiBufferMatmul<I, O, Acc, TMM::Matmul<I, Acc>, TL, TR>;
+    type Matmul<I: Numeric, O: Numeric, Acc: Numeric, TL: TilingLayout, TR: TilingLayout> =
+        MultiBufferMatmul<I, O, Acc, TMM::Matmul<I, Acc>, TL, TR>;
 }
 
 impl<TMM: TileMatmulFamily> MatmulConfigFactory for MultiBufferMatmulFamily<TMM> {

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/reader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/reader.rs
@@ -1,6 +1,7 @@
 use crate::matmul::components::stage::shared::CommonStageConfig;
 use crate::matmul::components::stage::ReaderFamily;
 use crate::matmul::components::stage::Stage;
+use crate::matmul::components::tile::Tile;
 use crate::matmul::components::tile::TileConfig;
 use crate::matmul::components::Ident;
 use cubecl_core as cubecl;
@@ -36,7 +37,7 @@ impl<ES: Numeric> LhsReader<ES> {
         compute_plane_offset: u32,
         buffer_offset: u32,
         #[comptime] config: CommonStageConfig<T>,
-    ) -> Slice<Line<ES>> {
+    ) -> Tile<ES> {
         this.stage.get_tile::<CommonStageConfig<T>>(
             compute_plane_offset,
             buffer_offset,
@@ -53,7 +54,7 @@ impl<ES: Numeric> RhsReader<ES> {
         buffer_offset: u32,
         accumulator_offset: u32,
         #[comptime] config: CommonStageConfig<T>,
-    ) -> Slice<Line<ES>> {
+    ) -> Tile<ES> {
         this.stage.get_tile::<CommonStageConfig<T>>(
             buffer_offset,
             accumulator_offset,

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/reader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/reader.rs
@@ -1,7 +1,7 @@
 use crate::matmul::components::stage::shared::CommonStageConfig;
 use crate::matmul::components::stage::ReaderFamily;
 use crate::matmul::components::stage::Stage;
-use crate::matmul::components::stage::TilingLayoutTrait;
+use crate::matmul::components::stage::TilingLayout;
 use crate::matmul::components::tile::Tile;
 use crate::matmul::components::tile::TileConfig;
 use crate::matmul::components::Ident;
@@ -10,13 +10,13 @@ use cubecl_core::prelude::*;
 
 #[derive(CubeType)]
 /// Stage reader for LHS
-pub struct LhsReader<ES: Numeric, T: TilingLayoutTrait> {
+pub struct LhsReader<ES: Numeric, T: TilingLayout> {
     pub stage: Stage<ES, T>,
 }
 
 #[derive(CubeType)]
 /// Stage reader for RHS
-pub struct RhsReader<ES: Numeric, T: TilingLayoutTrait> {
+pub struct RhsReader<ES: Numeric, T: TilingLayout> {
     pub stage: Stage<ES, T>,
 }
 
@@ -24,15 +24,15 @@ pub struct LhsReaderFamily;
 pub struct RhsReaderFamily;
 
 impl ReaderFamily for LhsReaderFamily {
-    type Reader<I: Numeric, T: TilingLayoutTrait> = LhsReader<I, T>;
+    type Reader<I: Numeric, T: TilingLayout> = LhsReader<I, T>;
 }
 
 impl ReaderFamily for RhsReaderFamily {
-    type Reader<I: Numeric, T: TilingLayoutTrait> = RhsReader<I, T>;
+    type Reader<I: Numeric, T: TilingLayout> = RhsReader<I, T>;
 }
 
 #[cube]
-impl<ES: Numeric, T: TilingLayoutTrait> LhsReader<ES, T> {
+impl<ES: Numeric, T: TilingLayout> LhsReader<ES, T> {
     pub fn read_tile<TC: TileConfig>(
         this: &Self,
         compute_plane_offset: u32,
@@ -49,7 +49,7 @@ impl<ES: Numeric, T: TilingLayoutTrait> LhsReader<ES, T> {
 }
 
 #[cube]
-impl<ES: Numeric, T: TilingLayoutTrait> RhsReader<ES, T> {
+impl<ES: Numeric, T: TilingLayout> RhsReader<ES, T> {
     pub fn read_tile<TC: TileConfig>(
         this: &Self,
         buffer_offset: u32,
@@ -66,14 +66,14 @@ impl<ES: Numeric, T: TilingLayoutTrait> RhsReader<ES, T> {
 }
 
 #[cube]
-impl<ES: Numeric, T: TilingLayoutTrait> LhsReader<ES, T> {
+impl<ES: Numeric, T: TilingLayout> LhsReader<ES, T> {
     pub fn new(stage: Stage<ES, T>) -> LhsReader<ES, T> {
         LhsReader::<ES, T> { stage }
     }
 }
 
 #[cube]
-impl<ES: Numeric, T: TilingLayoutTrait> RhsReader<ES, T> {
+impl<ES: Numeric, T: TilingLayout> RhsReader<ES, T> {
     pub fn new(stage: Stage<ES, T>) -> RhsReader<ES, T> {
         RhsReader::<ES, T> { stage }
     }

--- a/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/reader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/multi_buffer/reader.rs
@@ -1,6 +1,7 @@
 use crate::matmul::components::stage::shared::CommonStageConfig;
 use crate::matmul::components::stage::ReaderFamily;
 use crate::matmul::components::stage::Stage;
+use crate::matmul::components::stage::TilingLayoutTrait;
 use crate::matmul::components::tile::Tile;
 use crate::matmul::components::tile::TileConfig;
 use crate::matmul::components::Ident;
@@ -9,36 +10,36 @@ use cubecl_core::prelude::*;
 
 #[derive(CubeType)]
 /// Stage reader for LHS
-pub struct LhsReader<ES: Numeric> {
-    pub stage: Stage<ES>,
+pub struct LhsReader<ES: Numeric, T: TilingLayoutTrait> {
+    pub stage: Stage<ES, T>,
 }
 
 #[derive(CubeType)]
 /// Stage reader for RHS
-pub struct RhsReader<ES: Numeric> {
-    pub stage: Stage<ES>,
+pub struct RhsReader<ES: Numeric, T: TilingLayoutTrait> {
+    pub stage: Stage<ES, T>,
 }
 
 pub struct LhsReaderFamily;
 pub struct RhsReaderFamily;
 
 impl ReaderFamily for LhsReaderFamily {
-    type Reader<I: Numeric> = LhsReader<I>;
+    type Reader<I: Numeric, T: TilingLayoutTrait> = LhsReader<I, T>;
 }
 
 impl ReaderFamily for RhsReaderFamily {
-    type Reader<I: Numeric> = RhsReader<I>;
+    type Reader<I: Numeric, T: TilingLayoutTrait> = RhsReader<I, T>;
 }
 
 #[cube]
-impl<ES: Numeric> LhsReader<ES> {
-    pub fn read_tile<T: TileConfig>(
+impl<ES: Numeric, T: TilingLayoutTrait> LhsReader<ES, T> {
+    pub fn read_tile<TC: TileConfig>(
         this: &Self,
         compute_plane_offset: u32,
         buffer_offset: u32,
-        #[comptime] config: CommonStageConfig<T>,
+        #[comptime] config: CommonStageConfig<TC>,
     ) -> Tile<ES> {
-        this.stage.get_tile::<CommonStageConfig<T>>(
+        this.stage.get_tile::<CommonStageConfig<TC>>(
             compute_plane_offset,
             buffer_offset,
             Ident::Lhs,
@@ -48,14 +49,14 @@ impl<ES: Numeric> LhsReader<ES> {
 }
 
 #[cube]
-impl<ES: Numeric> RhsReader<ES> {
-    pub fn read_tile<T: TileConfig>(
+impl<ES: Numeric, T: TilingLayoutTrait> RhsReader<ES, T> {
+    pub fn read_tile<TC: TileConfig>(
         this: &Self,
         buffer_offset: u32,
         accumulator_offset: u32,
-        #[comptime] config: CommonStageConfig<T>,
+        #[comptime] config: CommonStageConfig<TC>,
     ) -> Tile<ES> {
-        this.stage.get_tile::<CommonStageConfig<T>>(
+        this.stage.get_tile::<CommonStageConfig<TC>>(
             buffer_offset,
             accumulator_offset,
             Ident::Rhs,
@@ -65,15 +66,15 @@ impl<ES: Numeric> RhsReader<ES> {
 }
 
 #[cube]
-impl<ES: Numeric> LhsReader<ES> {
-    pub fn new(stage: Stage<ES>) -> LhsReader<ES> {
-        LhsReader::<ES> { stage }
+impl<ES: Numeric, T: TilingLayoutTrait> LhsReader<ES, T> {
+    pub fn new(stage: Stage<ES, T>) -> LhsReader<ES, T> {
+        LhsReader::<ES, T> { stage }
     }
 }
 
 #[cube]
-impl<ES: Numeric> RhsReader<ES> {
-    pub fn new(stage: Stage<ES>) -> RhsReader<ES> {
-        RhsReader::<ES> { stage }
+impl<ES: Numeric, T: TilingLayoutTrait> RhsReader<ES, T> {
+    pub fn new(stage: Stage<ES, T>) -> RhsReader<ES, T> {
+        RhsReader::<ES, T> { stage }
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -1,6 +1,6 @@
 use crate::matmul::components::{
     tile::TileConfig, CompleteStageTiling, Ident, InputIdent, MatmulConfig, MatmulSize,
-    MatrixLayout, StageTiling,
+    MatrixLayout, TilingDimensions,
 };
 
 use super::{StageConfig, TilingLayout};
@@ -27,7 +27,7 @@ impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
         self.tmm_config.line_size(ident)
     }
 
-    fn tiling(&self, ident: Ident) -> StageTiling {
+    fn tiling_dimensions(&self, ident: Ident) -> TilingDimensions {
         self.tiling.get(ident)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -32,7 +32,7 @@ impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
     }
 
     fn matrix_layout(&self, ident: Ident) -> MatrixLayout {
-        self.tmm_config.layout(ident)
+        self.tmm_config.matrix_layout(ident)
     }
 
     fn num_planes(&self) -> u32 {

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -1,9 +1,9 @@
 use crate::matmul::components::{
-    tile::TileConfig, CompleteStageTiling, Ident, InputIdent, MatmulConfig, MatmulSize,
-    MatrixLayout, TilingDimensions,
+    tile::TileConfig, CompleteStageTiling, Ident, MatmulConfig, MatmulSize, MatrixLayout,
+    TilingDimensions,
 };
 
-use super::{StageConfig, TilingLayout};
+use super::StageConfig;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the single buffer matmul
@@ -11,8 +11,6 @@ pub struct CommonStageConfig<T: TileConfig> {
     pub tmm_config: T,
     pub tiling: CompleteStageTiling,
     pub num_planes: u32,
-    pub lhs_tiling_layout: TilingLayout,
-    pub rhs_tiling_layout: TilingLayout,
     pub quantized: bool,
 }
 
@@ -43,13 +41,6 @@ impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
         self.tmm_config.plane_dim()
     }
 
-    fn tiling_layout(&self, ident: Ident) -> TilingLayout {
-        match ident.as_input() {
-            InputIdent::Lhs => self.lhs_tiling_layout,
-            InputIdent::Rhs => self.rhs_tiling_layout,
-        }
-    }
-
     fn tile_count(&self) -> &MatmulSize {
         &self.tiling.tile_count
     }
@@ -63,16 +54,12 @@ impl<T: TileConfig> CommonStageConfig<T> {
         tmm_config: T,
         tiling: CompleteStageTiling,
         num_planes: u32,
-        lhs_tiling_layout: TilingLayout,
-        rhs_tiling_layout: TilingLayout,
         quantized: bool,
     ) -> Self {
         Self {
             tmm_config,
             tiling,
             num_planes,
-            lhs_tiling_layout,
-            rhs_tiling_layout,
             quantized,
         }
     }

--- a/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/shared.rs
@@ -31,7 +31,7 @@ impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
         self.tiling.get(ident)
     }
 
-    fn layout(&self, ident: Ident) -> MatrixLayout {
+    fn matrix_layout(&self, ident: Ident) -> MatrixLayout {
         self.tmm_config.layout(ident)
     }
 

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -190,7 +190,7 @@ where
         #[comptime] global_config: G,
     ) {
         let out_smem_line_size = global_config.stage_line_size(Ident::Out);
-        let num_tile_lines = stage_config.tiling(Ident::Out).tile_size() / out_smem_line_size;
+        let num_tile_lines = stage_config.tiling_dimensions(Ident::Out).tile_size() / out_smem_line_size;
 
         let start = num_tile_lines * UNIT_POS_Y;
         let mut out_smem = SharedMemory::<O>::new_lined(

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -36,13 +36,8 @@ impl<TMM: TileMatmulFamily> StageMatmulFamily for SingleBufferMatmulFamily<TMM> 
 
     type LhsReader = LhsBufferReaderFamily;
     type RhsReader = RhsBufferReaderFamily;
-    type Matmul<
-        I: Numeric,
-        O: Numeric,
-        Acc: Numeric,
-        TL: TilingLayout,
-        TR: TilingLayout,
-    > = SingleBufferMatmul<I, O, Acc, TMM::Matmul<I, Acc>, TL, TR>;
+    type Matmul<I: Numeric, O: Numeric, Acc: Numeric, TL: TilingLayout, TR: TilingLayout> =
+        SingleBufferMatmul<I, O, Acc, TMM::Matmul<I, Acc>, TL, TR>;
 }
 
 impl<TMM> MatmulConfigFactory for SingleBufferMatmulFamily<TMM>
@@ -117,7 +112,8 @@ pub struct SingleBufferMatmul<
 }
 
 #[cube]
-impl<I, O, EA, TMM, TL, TR> stage::StageMatmul<I, O, EA> for SingleBufferMatmul<I, O, EA, TMM, TL, TR>
+impl<I, O, EA, TMM, TL, TR> stage::StageMatmul<I, O, EA>
+    for SingleBufferMatmul<I, O, EA, TMM, TL, TR>
 where
     I: Numeric,
     O: Numeric,

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/base.rs
@@ -4,7 +4,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::matmul::components::stage::shared::CommonStageConfig;
-use crate::matmul::components::stage::{StageMatmulFamily, TilingLayoutTrait};
+use crate::matmul::components::stage::{StageMatmulFamily, TilingLayout};
 use crate::matmul::components::tile::{TileMatmul, TileMatmulFamily};
 use crate::matmul::components::{
     CompleteStageTiling, InvalidConfigError, MatmulPrecision, MatmulSize,
@@ -40,8 +40,8 @@ impl<TMM: TileMatmulFamily> StageMatmulFamily for SingleBufferMatmulFamily<TMM> 
         I: Numeric,
         O: Numeric,
         Acc: Numeric,
-        TL: TilingLayoutTrait,
-        TR: TilingLayoutTrait,
+        TL: TilingLayout,
+        TR: TilingLayout,
     > = SingleBufferMatmul<I, O, Acc, TMM::Matmul<I, Acc>, TL, TR>;
 }
 
@@ -105,8 +105,8 @@ pub struct SingleBufferMatmul<
     O: Numeric,
     EA: Numeric,
     TMM: TileMatmul<I, EA>,
-    TL: TilingLayoutTrait,
-    TR: TilingLayoutTrait,
+    TL: TilingLayout,
+    TR: TilingLayout,
 > {
     _input_precision: PhantomData<I>,
     _output_precision: PhantomData<O>,
@@ -123,8 +123,8 @@ where
     O: Numeric,
     EA: Numeric,
     TMM: TileMatmul<I, EA>,
-    TL: TilingLayoutTrait,
-    TR: TilingLayoutTrait,
+    TL: TilingLayout,
+    TR: TilingLayout,
 {
     type Config = CommonStageConfig<TMM::Config>;
     type LhsReader = LhsBufferReader<I, TL>;

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/reader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/reader.rs
@@ -1,5 +1,5 @@
 use crate::matmul::components::{
-    stage::{shared::CommonStageConfig, ReaderFamily, TilingLayoutTrait},
+    stage::{shared::CommonStageConfig, ReaderFamily, TilingLayout},
     tile::{Tile, TileConfig},
 };
 use cubecl_core as cubecl;
@@ -8,13 +8,13 @@ use cubecl_core::prelude::*;
 use crate::matmul::components::{stage::Stage, Ident};
 
 #[derive(CubeType)]
-pub struct LhsBufferReader<ES: Numeric, T: TilingLayoutTrait> {
+pub struct LhsBufferReader<ES: Numeric, T: TilingLayout> {
     pub stage: Stage<ES, T>,
     pub buffer: u32,
 }
 
 #[derive(CubeType)]
-pub struct RhsBufferReader<ES: Numeric, T: TilingLayoutTrait> {
+pub struct RhsBufferReader<ES: Numeric, T: TilingLayout> {
     pub stage: Stage<ES, T>,
     pub buffer: u32,
 }
@@ -23,15 +23,15 @@ pub struct LhsBufferReaderFamily;
 pub struct RhsBufferReaderFamily;
 
 impl ReaderFamily for LhsBufferReaderFamily {
-    type Reader<I: Numeric, T: TilingLayoutTrait> = LhsBufferReader<I, T>;
+    type Reader<I: Numeric, T: TilingLayout> = LhsBufferReader<I, T>;
 }
 
 impl ReaderFamily for RhsBufferReaderFamily {
-    type Reader<I: Numeric, T: TilingLayoutTrait> = RhsBufferReader<I, T>;
+    type Reader<I: Numeric, T: TilingLayout> = RhsBufferReader<I, T>;
 }
 
 #[cube]
-impl<ES: Numeric, T: TilingLayoutTrait> LhsBufferReader<ES, T> {
+impl<ES: Numeric, T: TilingLayout> LhsBufferReader<ES, T> {
     pub fn read_tile<TC: TileConfig>(
         this: &Self,
         compute_plane_offset: u32,
@@ -47,7 +47,7 @@ impl<ES: Numeric, T: TilingLayoutTrait> LhsBufferReader<ES, T> {
 }
 
 #[cube]
-impl<ES: Numeric, T: TilingLayoutTrait> RhsBufferReader<ES, T> {
+impl<ES: Numeric, T: TilingLayout> RhsBufferReader<ES, T> {
     pub fn read_tile<TC: TileConfig>(
         this: &Self,
         accumulator_offset: u32,

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/reader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/reader.rs
@@ -1,5 +1,5 @@
 use crate::matmul::components::{
-    stage::{shared::CommonStageConfig, ReaderFamily},
+    stage::{shared::CommonStageConfig, ReaderFamily, TilingLayoutTrait},
     tile::{Tile, TileConfig},
 };
 use cubecl_core as cubecl;
@@ -8,14 +8,14 @@ use cubecl_core::prelude::*;
 use crate::matmul::components::{stage::Stage, Ident};
 
 #[derive(CubeType)]
-pub struct LhsBufferReader<ES: Numeric> {
-    pub stage: Stage<ES>,
+pub struct LhsBufferReader<ES: Numeric, T: TilingLayoutTrait> {
+    pub stage: Stage<ES, T>,
     pub buffer: u32,
 }
 
 #[derive(CubeType)]
-pub struct RhsBufferReader<ES: Numeric> {
-    pub stage: Stage<ES>,
+pub struct RhsBufferReader<ES: Numeric, T: TilingLayoutTrait> {
+    pub stage: Stage<ES, T>,
     pub buffer: u32,
 }
 
@@ -23,21 +23,21 @@ pub struct LhsBufferReaderFamily;
 pub struct RhsBufferReaderFamily;
 
 impl ReaderFamily for LhsBufferReaderFamily {
-    type Reader<I: Numeric> = LhsBufferReader<I>;
+    type Reader<I: Numeric, T: TilingLayoutTrait> = LhsBufferReader<I, T>;
 }
 
 impl ReaderFamily for RhsBufferReaderFamily {
-    type Reader<I: Numeric> = RhsBufferReader<I>;
+    type Reader<I: Numeric, T: TilingLayoutTrait> = RhsBufferReader<I, T>;
 }
 
 #[cube]
-impl<ES: Numeric> LhsBufferReader<ES> {
-    pub fn read_tile<T: TileConfig>(
+impl<ES: Numeric, T: TilingLayoutTrait> LhsBufferReader<ES, T> {
+    pub fn read_tile<TC: TileConfig>(
         this: &Self,
         compute_plane_offset: u32,
-        #[comptime] config: CommonStageConfig<T>,
+        #[comptime] config: CommonStageConfig<TC>,
     ) -> Tile<ES> {
-        this.stage.get_tile::<CommonStageConfig<T>>(
+        this.stage.get_tile::<CommonStageConfig<TC>>(
             compute_plane_offset,
             this.buffer,
             Ident::Lhs,
@@ -47,13 +47,13 @@ impl<ES: Numeric> LhsBufferReader<ES> {
 }
 
 #[cube]
-impl<ES: Numeric> RhsBufferReader<ES> {
-    pub fn read_tile<T: TileConfig>(
+impl<ES: Numeric, T: TilingLayoutTrait> RhsBufferReader<ES, T> {
+    pub fn read_tile<TC: TileConfig>(
         this: &Self,
         accumulator_offset: u32,
-        #[comptime] config: CommonStageConfig<T>,
+        #[comptime] config: CommonStageConfig<TC>,
     ) -> Tile<ES> {
-        this.stage.get_tile::<CommonStageConfig<T>>(
+        this.stage.get_tile::<CommonStageConfig<TC>>(
             this.buffer,
             accumulator_offset,
             Ident::Rhs,

--- a/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/reader.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/single_buffer/reader.rs
@@ -1,6 +1,6 @@
 use crate::matmul::components::{
     stage::{shared::CommonStageConfig, ReaderFamily},
-    tile::TileConfig,
+    tile::{Tile, TileConfig},
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -36,7 +36,7 @@ impl<ES: Numeric> LhsBufferReader<ES> {
         this: &Self,
         compute_plane_offset: u32,
         #[comptime] config: CommonStageConfig<T>,
-    ) -> Slice<Line<ES>> {
+    ) -> Tile<ES> {
         this.stage.get_tile::<CommonStageConfig<T>>(
             compute_plane_offset,
             this.buffer,
@@ -52,7 +52,7 @@ impl<ES: Numeric> RhsBufferReader<ES> {
         this: &Self,
         accumulator_offset: u32,
         #[comptime] config: CommonStageConfig<T>,
-    ) -> Slice<Line<ES>> {
+    ) -> Tile<ES> {
         this.stage.get_tile::<CommonStageConfig<T>>(
             this.buffer,
             accumulator_offset,

--- a/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
@@ -18,7 +18,7 @@ impl<ES: Numeric> Stage<ES> {
         let line_size = config.line_size(ident);
 
         let smem = SharedMemory::new_lined(
-            comptime!(config.tiling(ident).total_size() / line_size),
+            comptime!(config.tiling_dimensions(ident).total_size() / line_size),
             line_size,
         );
 
@@ -33,13 +33,7 @@ impl<ES: Numeric> Stage<ES> {
         #[comptime] ident: Ident,
         #[comptime] config: S,
     ) -> Tile<ES> {
-        let (start, end) = TilingLayout::tile_bounds::<S>(x, y, ident, config);
-
-        Tile::new_contiguous::<S::TmmConfig>(
-            self.smem.slice(start, end),
-            ident,
-            config.to_tmm_config(),
-        )
+        TilingLayout::get_tile::<ES, S>(self.smem.to_slice(), x, y, ident, config)
     }
 
     /// Return the whole stage as a mutable slice, for loading

--- a/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
+++ b/crates/cubecl-linalg/src/matmul/components/stage/staging.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::matmul::components::stage::{StageConfig, TilingLayoutTrait};
+use crate::matmul::components::stage::{StageConfig, TilingLayout};
 use crate::matmul::components::tile::Tile;
 use crate::matmul::components::Ident;
 use cubecl_core as cubecl;
@@ -9,13 +9,13 @@ use cubecl_core::prelude::*;
 #[derive(CubeType, Clone, Copy)]
 /// Wrapper over the shared memory used for staging,
 /// abstracting its layout
-pub struct Stage<ES: Numeric, T: TilingLayoutTrait> {
+pub struct Stage<ES: Numeric, T: TilingLayout> {
     pub smem: SharedMemory<Line<ES>>,
     tiling_layout: PhantomData<T>,
 }
 
 #[cube]
-impl<ES: Numeric, T: TilingLayoutTrait> Stage<ES, T> {
+impl<ES: Numeric, T: TilingLayout> Stage<ES, T> {
     /// Instantiate a new stage for the given identifier
     pub fn new<S: StageConfig>(#[comptime] ident: Ident, #[comptime] config: S) -> Stage<ES, T> {
         let line_size = config.line_size(ident);

--- a/crates/cubecl-linalg/src/matmul/components/tile/accelerated.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/accelerated.rs
@@ -80,14 +80,10 @@ impl<I: Numeric, O: Numeric> TileMatmul<I, O> for Accelerated {
         cmma::load(rhs, &slice, stride);
     }
 
-    fn fill_accumulator(
-        slice: &Slice<Line<O>>,
-        acc: &mut Self::Accumulator,
-        stride: u32,
-        #[comptime] config: Config,
-    ) {
+    fn fill_accumulator(tile: &Tile<O>, acc: &mut Self::Accumulator, #[comptime] config: Config) {
         let layout = comptime!(as_cmma_layout(config.matrix_layout(Ident::Out)));
-        cmma::load_with_layout(acc, slice, stride, layout);
+        let (slice, stride) = tile.as_unlined::<Config>(Ident::Out, config);
+        cmma::load_with_layout(acc, &slice, stride, layout);
     }
 
     fn read_accumulator<C: Numeric>(

--- a/crates/cubecl-linalg/src/matmul/components/tile/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/base.rs
@@ -66,9 +66,8 @@ pub trait TileMatmul<I: Numeric, O: Numeric>: 'static + Send + Sync {
 
     /// Fill the accumulator with data
     fn fill_accumulator(
-        slice: &Slice<Line<O>>, // TODO Tile
+        tile: &Tile<O>,
         acc: &mut Self::Accumulator,
-        stride: u32,
         #[comptime] config: Self::Config,
     );
 

--- a/crates/cubecl-linalg/src/matmul/components/tile/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/base.rs
@@ -2,7 +2,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::matmul::components::{
-    config::MatmulConfig, Ident, MatmulConfigFactory, MatmulSize, MatrixLayout,
+    config::MatmulConfig, Ident, InputIdent, MatmulConfigFactory, MatmulSize, MatrixLayout,
 };
 
 pub trait TileMatmulFamily: MatmulConfigFactory<Input = MatmulSize, Config: TileConfig> {
@@ -59,14 +59,14 @@ pub trait TileMatmul<I: Numeric, O: Numeric>: 'static + Send + Sync {
     fn allocate_rhs(#[comptime] config: Self::Config) -> Self::Rhs;
 
     /// Fill the container of LHS with data
-    fn fill_lhs(slice: &Slice<Line<I>>, lhs: &mut Self::Lhs, #[comptime] config: Self::Config);
+    fn fill_lhs(slice: &Tile<I>, lhs: &mut Self::Lhs, #[comptime] config: Self::Config);
 
     /// Fill the container of RHS with data
-    fn fill_rhs(slice: &Slice<Line<I>>, rhs: &mut Self::Rhs, #[comptime] config: Self::Config);
+    fn fill_rhs(slice: &Tile<I>, rhs: &mut Self::Rhs, #[comptime] config: Self::Config);
 
     /// Fill the accumulator with data
     fn fill_accumulator(
-        slice: &Slice<Line<O>>,
+        slice: &Slice<Line<O>>, // TODO Tile
         acc: &mut Self::Accumulator,
         stride: u32,
         #[comptime] config: Self::Config,
@@ -106,4 +106,40 @@ pub trait TileConfig: MatmulConfig {
 
     /// Returns the shape of the tiles in the three axes m, k and n.
     fn tile_shape(&self) -> &MatmulSize;
+}
+
+#[derive(CubeType)]
+/// Data to be handed to the tile matmul
+pub struct Tile<ES: Numeric> {
+    /// Slice containing all data
+    pub slice: Slice<Line<ES>>,
+    /// Stride between each row/col, depending on MatrixLayout (the other is assumed to be 1)
+    pub stride: u32,
+}
+
+#[cube]
+impl<ES: Numeric> Tile<ES> {
+    pub fn new_contiguous<T: TileConfig>(
+        slice: Slice<Line<ES>>,
+        #[comptime] ident: Ident,
+        #[comptime] config: T,
+    ) -> Tile<ES> {
+        let stride = comptime! {
+            match ident.as_input() {
+            InputIdent::Lhs => match config.layout(ident) {
+                MatrixLayout::RowMajor => config.tile_shape().k,
+                MatrixLayout::ColMajor => config.tile_shape().m,
+            },
+            InputIdent::Rhs => match config.layout(ident) {
+                MatrixLayout::RowMajor => config.tile_shape().n,
+                MatrixLayout::ColMajor => config.tile_shape().k,
+            },
+        }};
+
+        Tile::<ES> { slice, stride }
+    }
+
+    pub fn new_strided(slice: Slice<Line<ES>>, stride: u32) -> Tile<ES> {
+        Tile::<ES> { slice, stride }
+    }
 }

--- a/crates/cubecl-linalg/src/matmul/components/tile/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/base.rs
@@ -112,7 +112,7 @@ pub trait TileConfig: MatmulConfig {
 /// Data to be handed to the tile matmul
 pub struct Tile<ES: Numeric> {
     /// Slice containing all data
-    pub slice: Slice<Line<ES>>,
+    pub slice: Slice<ES>,
     /// Stride between each row/col, depending on MatrixLayout (the other is assumed to be 1)
     pub stride: u32,
 }
@@ -136,10 +136,16 @@ impl<ES: Numeric> Tile<ES> {
             },
         }};
 
-        Tile::<ES> { slice, stride }
+        Tile::<ES> {
+            slice: slice.try_cast_unchecked(),
+            stride,
+        }
     }
 
     pub fn new_strided(slice: Slice<Line<ES>>, stride: u32) -> Tile<ES> {
-        Tile::<ES> { slice, stride }
+        Tile::<ES> {
+            slice: slice.try_cast_unchecked(),
+            stride,
+        }
     }
 }

--- a/crates/cubecl-linalg/src/matmul/components/tile/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/base.rs
@@ -124,7 +124,7 @@ impl<ES: Numeric> Tile<ES> {
         #[comptime] config: T,
     ) -> Tile<ES> {
         let stride = comptime! {
-            match ident.as_input() {
+            (match ident.as_input() {
             InputIdent::Lhs => match config.matrix_layout(ident) {
                 MatrixLayout::RowMajor => config.tile_shape().k,
                 MatrixLayout::ColMajor => config.tile_shape().m,
@@ -133,7 +133,7 @@ impl<ES: Numeric> Tile<ES> {
                 MatrixLayout::RowMajor => config.tile_shape().n,
                 MatrixLayout::ColMajor => config.tile_shape().k,
             },
-        }};
+        }) / config.line_size(ident)};
 
         Tile::<ES> { slice, stride }
     }

--- a/crates/cubecl-linalg/src/matmul/components/tile/base.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/base.rs
@@ -136,10 +136,7 @@ impl<ES: Numeric> Tile<ES> {
             },
         }};
 
-        Tile::<ES> {
-            slice: slice.try_cast_unchecked(),
-            stride,
-        }
+        Tile::<ES> { slice, stride }
     }
 
     pub fn new_strided(slice: Slice<Line<ES>>, stride: u32) -> Tile<ES> {

--- a/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
@@ -82,49 +82,51 @@ impl<I: Numeric, O: Numeric> TileMatmul<I, O> for PlaneMma {
     }
 
     fn fill_lhs(tile: &Tile<I>, lhs: &mut Self::Lhs, #[comptime] config: Config) {
-        match config.layout(Ident::Lhs) {
-            MatrixLayout::RowMajor => fill_parallel_lhs(
-                &tile.slice,
-                &mut lhs.to_slice_mut(),
-                UNIT_POS_X,
-                config.size.m,
-                config.size.k,
-                config.line_size(Ident::Lhs),
-                config.plane_dim(),
-            ),
-            MatrixLayout::ColMajor => fill_perpendicular_lhs(
-                &tile.slice,
-                &mut lhs.to_slice_mut(),
-                UNIT_POS_X,
-                config.size.m,
-                config.size.k,
-                config.line_size(Ident::Lhs),
-                config.plane_dim(),
-            ),
-        }
+        // TODO reactivate
+        // match config.layout(Ident::Lhs) {
+        //     MatrixLayout::RowMajor => fill_parallel_lhs(
+        //         &tile.slice,
+        //         &mut lhs.to_slice_mut(),
+        //         UNIT_POS_X,
+        //         config.size.m,
+        //         config.size.k,
+        //         config.line_size(Ident::Lhs),
+        //         config.plane_dim(),
+        //     ),
+        //     MatrixLayout::ColMajor => fill_perpendicular_lhs(
+        //         &tile.slice,
+        //         &mut lhs.to_slice_mut(),
+        //         UNIT_POS_X,
+        //         config.size.m,
+        //         config.size.k,
+        //         config.line_size(Ident::Lhs),
+        //         config.plane_dim(),
+        //     ),
+        // }
     }
 
     fn fill_rhs(tile: &Tile<I>, rhs: &mut Self::Rhs, #[comptime] config: Config) {
-        match comptime!(config.layout(Ident::Rhs)) {
-            MatrixLayout::RowMajor => fill_perpendicular_rhs(
-                &tile.slice,
-                &mut rhs.to_slice_mut(),
-                UNIT_POS_X,
-                config.size.n,
-                config.size.k,
-                config.line_size(Ident::Rhs),
-                config.plane_dim(),
-            ),
-            MatrixLayout::ColMajor => fill_parallel_rhs(
-                &tile.slice,
-                &mut rhs.to_slice_mut(),
-                UNIT_POS_X,
-                config.size.n,
-                config.size.k,
-                config.line_size(Ident::Rhs),
-                config.plane_dim(),
-            ),
-        }
+        // TODO reactivate
+        // match comptime!(config.layout(Ident::Rhs)) {
+        //     MatrixLayout::RowMajor => fill_perpendicular_rhs(
+        //         &tile.slice,
+        //         &mut rhs.to_slice_mut(),
+        //         UNIT_POS_X,
+        //         config.size.n,
+        //         config.size.k,
+        //         config.line_size(Ident::Rhs),
+        //         config.plane_dim(),
+        //     ),
+        //     MatrixLayout::ColMajor => fill_parallel_rhs(
+        //         &tile.slice,
+        //         &mut rhs.to_slice_mut(),
+        //         UNIT_POS_X,
+        //         config.size.n,
+        //         config.size.k,
+        //         config.line_size(Ident::Rhs),
+        //         config.plane_dim(),
+        //     ),
+        // }
     }
 
     fn fill_accumulator(

--- a/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
+++ b/crates/cubecl-linalg/src/matmul/components/tile/plane.rs
@@ -82,51 +82,49 @@ impl<I: Numeric, O: Numeric> TileMatmul<I, O> for PlaneMma {
     }
 
     fn fill_lhs(tile: &Tile<I>, lhs: &mut Self::Lhs, #[comptime] config: Config) {
-        // TODO reactivate
-        // match config.layout(Ident::Lhs) {
-        //     MatrixLayout::RowMajor => fill_parallel_lhs(
-        //         &tile.slice,
-        //         &mut lhs.to_slice_mut(),
-        //         UNIT_POS_X,
-        //         config.size.m,
-        //         config.size.k,
-        //         config.line_size(Ident::Lhs),
-        //         config.plane_dim(),
-        //     ),
-        //     MatrixLayout::ColMajor => fill_perpendicular_lhs(
-        //         &tile.slice,
-        //         &mut lhs.to_slice_mut(),
-        //         UNIT_POS_X,
-        //         config.size.m,
-        //         config.size.k,
-        //         config.line_size(Ident::Lhs),
-        //         config.plane_dim(),
-        //     ),
-        // }
+        match config.matrix_layout(Ident::Lhs) {
+            MatrixLayout::RowMajor => fill_parallel_lhs(
+                &tile.slice,
+                &mut lhs.to_slice_mut(),
+                UNIT_POS_X,
+                config.size.m,
+                config.size.k,
+                config.line_size(Ident::Lhs),
+                config.plane_dim(),
+            ),
+            MatrixLayout::ColMajor => fill_perpendicular_lhs(
+                &tile.slice,
+                &mut lhs.to_slice_mut(),
+                UNIT_POS_X,
+                config.size.m,
+                config.size.k,
+                config.line_size(Ident::Lhs),
+                config.plane_dim(),
+            ),
+        }
     }
 
     fn fill_rhs(tile: &Tile<I>, rhs: &mut Self::Rhs, #[comptime] config: Config) {
-        // TODO reactivate
-        // match comptime!(config.layout(Ident::Rhs)) {
-        //     MatrixLayout::RowMajor => fill_perpendicular_rhs(
-        //         &tile.slice,
-        //         &mut rhs.to_slice_mut(),
-        //         UNIT_POS_X,
-        //         config.size.n,
-        //         config.size.k,
-        //         config.line_size(Ident::Rhs),
-        //         config.plane_dim(),
-        //     ),
-        //     MatrixLayout::ColMajor => fill_parallel_rhs(
-        //         &tile.slice,
-        //         &mut rhs.to_slice_mut(),
-        //         UNIT_POS_X,
-        //         config.size.n,
-        //         config.size.k,
-        //         config.line_size(Ident::Rhs),
-        //         config.plane_dim(),
-        //     ),
-        // }
+        match comptime!(config.matrix_layout(Ident::Rhs)) {
+            MatrixLayout::RowMajor => fill_perpendicular_rhs(
+                &tile.slice,
+                &mut rhs.to_slice_mut(),
+                UNIT_POS_X,
+                config.size.n,
+                config.size.k,
+                config.line_size(Ident::Rhs),
+                config.plane_dim(),
+            ),
+            MatrixLayout::ColMajor => fill_parallel_rhs(
+                &tile.slice,
+                &mut rhs.to_slice_mut(),
+                UNIT_POS_X,
+                config.size.n,
+                config.size.k,
+                config.line_size(Ident::Rhs),
+                config.plane_dim(),
+            ),
+        }
     }
 
     fn fill_accumulator(
@@ -437,7 +435,7 @@ impl TileConfig for Config {
         self.plane_dim
     }
 
-    fn layout(&self, ident: Ident) -> MatrixLayout {
+    fn matrix_layout(&self, ident: Ident) -> MatrixLayout {
         match ident {
             Ident::Lhs => self.lhs_layout,
             Ident::Rhs => self.rhs_layout,

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/double_buffering.rs
@@ -41,8 +41,8 @@ where
 
     fn advanced_config() -> crate::matmul::kernels::matmul::AdvancedConfig {
         crate::matmul::kernels::matmul::AdvancedConfig {
-            lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
-            rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
+            // lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
+            // rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/double_buffering.rs
@@ -41,8 +41,6 @@ where
 
     fn advanced_config() -> crate::matmul::kernels::matmul::AdvancedConfig {
         crate::matmul::kernels::matmul::AdvancedConfig {
-            // lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
-            // rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/mod.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/mod.rs
@@ -4,6 +4,7 @@ mod selector;
 pub mod double_buffering;
 pub mod simple;
 pub mod simple_pipelined;
+pub mod simple_strided;
 pub mod specialized;
 
 pub use base::Algorithm;

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use crate::matmul::components::batch::{CubeCountDispatch, CubeDispatch};
 use crate::matmul::components::global::single_stage::CyclicCoalescedLoading;
-use crate::matmul::components::stage::{self};
+use crate::matmul::components::stage::{self, ColMajorTilingOrder, RowMajorTilingOrder};
 use crate::matmul::components::MatmulProblem;
 use crate::matmul::components::{batch, global};
 use crate::matmul::components::{tile, MatmulSelection};
@@ -23,8 +23,8 @@ where
     type StageMatmul = stage::multi_buffer::MultiBufferMatmulFamily<Self::TileMatmul>;
     type GlobalMatmul = global::single_stage::simple::SimpleMatmulFamily<
         Self::StageMatmul,
-        CyclicCoalescedLoading,
-        CyclicCoalescedLoading,
+        CyclicCoalescedLoading<ColMajorTilingOrder>,
+        CyclicCoalescedLoading<RowMajorTilingOrder>,
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
@@ -44,8 +44,6 @@ where
 
     fn advanced_config() -> crate::matmul::kernels::matmul::AdvancedConfig {
         crate::matmul::kernels::matmul::AdvancedConfig {
-            lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
-            rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
 use crate::matmul::components::batch::{CubeCountDispatch, CubeDispatch};
-use crate::matmul::components::global::single_stage::CyclicLoading;
+use crate::matmul::components::global::single_stage::CyclicCoalescedLoading;
 use crate::matmul::components::stage::{self};
 use crate::matmul::components::MatmulProblem;
 use crate::matmul::components::{batch, global};
@@ -23,8 +23,8 @@ where
     type StageMatmul = stage::multi_buffer::MultiBufferMatmulFamily<Self::TileMatmul>;
     type GlobalMatmul = global::single_stage::simple::SimpleMatmulFamily<
         Self::StageMatmul,
-        CyclicLoading,
-        CyclicLoading,
+        CyclicCoalescedLoading,
+        CyclicCoalescedLoading,
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
 use crate::matmul::components::batch::{CubeCountDispatch, CubeDispatch};
-use crate::matmul::components::global::single_stage::CyclicLoading;
+use crate::matmul::components::global::single_stage::{CooperativeLoading, CyclicLoading};
 use crate::matmul::components::stage::{self};
 use crate::matmul::components::MatmulProblem;
 use crate::matmul::components::{batch, global};
@@ -23,8 +23,8 @@ where
     type StageMatmul = stage::multi_buffer::MultiBufferMatmulFamily<Self::TileMatmul>;
     type GlobalMatmul = global::single_stage::simple::SimpleMatmulFamily<
         Self::StageMatmul,
-        CyclicLoading,
-        CyclicLoading,
+        CooperativeLoading,
+        CooperativeLoading,
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
@@ -45,8 +45,10 @@ where
 
     fn advanced_config() -> crate::matmul::kernels::matmul::AdvancedConfig {
         crate::matmul::kernels::matmul::AdvancedConfig {
-            lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
-            rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
+            lhs_tiling_layout: stage::TilingLayout::Strided,
+            rhs_tiling_layout: stage::TilingLayout::Strided,
+            // lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
+            // rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple_pipelined.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple_pipelined.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use crate::matmul::components::batch::{CubeCountDispatch, CubeDispatch};
 use crate::matmul::components::global::single_stage::CyclicWindowLoading;
-use crate::matmul::components::stage::{self};
+use crate::matmul::components::stage::{self, ColMajorTilingOrder, RowMajorTilingOrder};
 use crate::matmul::components::MatmulProblem;
 use crate::matmul::components::{batch, global};
 use crate::matmul::components::{tile, MatmulSelection};
@@ -23,8 +23,8 @@ where
     type StageMatmul = stage::multi_buffer::MultiBufferMatmulFamily<Self::TileMatmul>;
     type GlobalMatmul = global::single_stage::simple::SimplePipelinedMatmulFamily<
         Self::StageMatmul,
-        CyclicWindowLoading,
-        CyclicWindowLoading,
+        CyclicWindowLoading<ColMajorTilingOrder>,
+        CyclicWindowLoading<RowMajorTilingOrder>,
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
@@ -44,8 +44,6 @@ where
 
     fn advanced_config() -> crate::matmul::kernels::matmul::AdvancedConfig {
         crate::matmul::kernels::matmul::AdvancedConfig {
-            lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
-            rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple_pipelined.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple_pipelined.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
 use crate::matmul::components::batch::{CubeCountDispatch, CubeDispatch};
-use crate::matmul::components::global::single_stage::CyclicLoading;
+use crate::matmul::components::global::single_stage::CyclicWindowLoading;
 use crate::matmul::components::stage::{self};
 use crate::matmul::components::MatmulProblem;
 use crate::matmul::components::{batch, global};
@@ -23,8 +23,8 @@ where
     type StageMatmul = stage::multi_buffer::MultiBufferMatmulFamily<Self::TileMatmul>;
     type GlobalMatmul = global::single_stage::simple::SimplePipelinedMatmulFamily<
         Self::StageMatmul,
-        CyclicLoading,
-        CyclicLoading,
+        CyclicWindowLoading,
+        CyclicWindowLoading,
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple_strided.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple_strided.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
 use crate::matmul::components::batch::{CubeCountDispatch, CubeDispatch};
-use crate::matmul::components::global::single_stage::CooperativeLoading;
+use crate::matmul::components::global::single_stage::CooperativeDummyLoading;
 use crate::matmul::components::stage::{self};
 use crate::matmul::components::MatmulProblem;
 use crate::matmul::components::{batch, global};
@@ -23,8 +23,8 @@ where
     type StageMatmul = stage::multi_buffer::MultiBufferMatmulFamily<Self::TileMatmul>;
     type GlobalMatmul = global::single_stage::simple::SimpleMatmulFamily<
         Self::StageMatmul,
-        CooperativeLoading,
-        CooperativeLoading,
+        CooperativeDummyLoading,
+        CooperativeDummyLoading,
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple_strided.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/simple_strided.rs
@@ -44,8 +44,6 @@ where
 
     fn advanced_config() -> crate::matmul::kernels::matmul::AdvancedConfig {
         crate::matmul::kernels::matmul::AdvancedConfig {
-            lhs_tiling_layout: stage::TilingLayout::Strided,
-            rhs_tiling_layout: stage::TilingLayout::Strided,
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/specialized.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/specialized.rs
@@ -45,8 +45,8 @@ where
 
     fn advanced_config() -> crate::matmul::kernels::matmul::AdvancedConfig {
         crate::matmul::kernels::matmul::AdvancedConfig {
-            lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
-            rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
+            // lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
+            // rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/specialized.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/specialized.rs
@@ -45,8 +45,6 @@ where
 
     fn advanced_config() -> crate::matmul::kernels::matmul::AdvancedConfig {
         crate::matmul::kernels::matmul::AdvancedConfig {
-            // lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::ColMajor),
-            // rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -1,6 +1,7 @@
 use crate::matmul::components::MatrixLayout;
 
 /// Configs that may impact performance
+#[derive(Default)]
 pub struct AdvancedConfig {
     /// Ensure the inputs to tile matmul are in specified layout
     ///
@@ -14,10 +15,3 @@ pub struct AdvancedConfig {
     pub enforced_matrix_layout: (Option<MatrixLayout>, Option<MatrixLayout>),
 }
 
-impl Default for AdvancedConfig {
-    fn default() -> Self {
-        Self {
-            enforced_matrix_layout: (None, None),
-        }
-    }
-}

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -3,10 +3,6 @@ use crate::matmul::components::MatrixLayout;
 
 /// Configs that may impact performance
 pub struct AdvancedConfig {
-    /// Layout in which tiles should be in lhs shared memory
-    pub lhs_tiling_layout: stage::TilingLayout,
-    /// Layout in which tiles should be in rhs shared memory
-    pub rhs_tiling_layout: stage::TilingLayout,
     /// Ensure the inputs to tile matmul are in specified layout
     ///
     /// # Notes
@@ -22,8 +18,6 @@ pub struct AdvancedConfig {
 impl Default for AdvancedConfig {
     fn default() -> Self {
         Self {
-            lhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
-            rhs_tiling_layout: stage::TilingLayout::Contiguous(stage::TilingOrder::RowMajor),
             enforced_matrix_layout: (None, None),
         }
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/config.rs
@@ -1,4 +1,3 @@
-use crate::matmul::components::stage;
 use crate::matmul::components::MatrixLayout;
 
 /// Configs that may impact performance

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
@@ -292,11 +292,26 @@ macro_rules! matmul_standard_tests {
         use $crate::matmul::kernels::matmul::double_buffering::DoubleBufferingAlgorithm;
         use $crate::matmul::kernels::matmul::simple::SimpleAlgorithm;
         use $crate::matmul::kernels::matmul::simple_pipelined::SimplePipelinedAlgorithm;
+        use $crate::matmul::kernels::matmul::simple_strided::SimpleStridedAlgorithm;
         use $crate::matmul::kernels::matmul::specialized::SpecializedAlgorithm;
 
         #[test]
-        pub fn simple_sync() {
+        pub fn simple() {
             cubecl_linalg::matmul::tests::test_algo::<SimpleAlgorithm<TMM>, Precision, TestRuntime>(
+                (MatrixLayout::$lhs_layout, MatrixLayout::$rhs_layout),
+                $tile,
+                $stage,
+                $problem,
+            );
+        }
+
+        #[test]
+        pub fn simple_strided() {
+            cubecl_linalg::matmul::tests::test_algo::<
+                SimpleStridedAlgorithm<TMM>,
+                Precision,
+                TestRuntime,
+            >(
                 (MatrixLayout::$lhs_layout, MatrixLayout::$rhs_layout),
                 $tile,
                 $stage,

--- a/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
+++ b/crates/cubecl-linalg/src/matmul/tests/test_macros/cmma/suite.rs
@@ -295,7 +295,7 @@ macro_rules! matmul_standard_tests {
         use $crate::matmul::kernels::matmul::specialized::SpecializedAlgorithm;
 
         #[test]
-        pub fn simple() {
+        pub fn simple_sync() {
             cubecl_linalg::matmul::tests::test_algo::<SimpleAlgorithm<TMM>, Precision, TestRuntime>(
                 (MatrixLayout::$lhs_layout, MatrixLayout::$rhs_layout),
                 $tile,

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -144,6 +144,7 @@ fn main() {
         use half::f16;
 
         run::<cubecl::cuda::CudaRuntime, f16>(Default::default(), matmul::Strategy::Simple);
+        run::<cubecl::cuda::CudaRuntime, f16>(Default::default(), matmul::Strategy::SimpleStrided);
         run::<cubecl::cuda::CudaRuntime, f16>(
             Default::default(),
             matmul::Strategy::SimplePipelined,
@@ -153,7 +154,12 @@ fn main() {
             Default::default(),
             matmul::Strategy::DoubleBuffering,
         );
+
         run::<cubecl::cuda::CudaRuntime, flex32>(Default::default(), matmul::Strategy::Simple);
+        run::<cubecl::cuda::CudaRuntime, flex32>(
+            Default::default(),
+            matmul::Strategy::SimpleStrided,
+        );
         run::<cubecl::cuda::CudaRuntime, flex32>(
             Default::default(),
             matmul::Strategy::SimplePipelined,
@@ -163,7 +169,9 @@ fn main() {
             Default::default(),
             matmul::Strategy::DoubleBuffering,
         );
+
         run::<cubecl::cuda::CudaRuntime, f32>(Default::default(), matmul::Strategy::Simple);
+        run::<cubecl::cuda::CudaRuntime, f32>(Default::default(), matmul::Strategy::SimpleStrided);
         run::<cubecl::cuda::CudaRuntime, f32>(
             Default::default(),
             matmul::Strategy::SimplePipelined,


### PR DESCRIPTION
- Added the SimpleStrided strategy [warning: uses a dummy loader for now, so it's very slow. Fix in the upcoming PRs]
- Upgraded tiling order to tiling layout, which can be contiguous (like before, and uses an underlying tiling order), or strided. The strided one gives strided tiles, and reflects the global memory layout exactly. 
- Refactored loaders into sync and async, as they do not have the same interface. Now a global matmul can be generic over all sync loaders, while being unable to use an async one, for instance.
- Remove some config and advanced config, like the tiling order/layout and the load mode, which are now encoded within the type system. 

Correctness and performance:
- All tests still pass. 
- No performance regression on my end. 