### PR TITLE
Cube option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.204", default-features = false, features = [
     "alloc",
 ] } # alloc is for no_std, derive is needed
 serde_json = { version = "1.0.119", default-features = false }
+ron = { version = "0.8", default-features = false }
 variadics_please = "1"
 
 dashmap = "5.5.3"

--- a/crates/cubecl-core/Cargo.toml
+++ b/crates/cubecl-core/Cargo.toml
@@ -44,6 +44,7 @@ num-traits = { workspace = true }
 paste = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+ron = { workspace = true }
 variadics_please = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cubecl-core/src/frontend/container/mod.rs
+++ b/crates/cubecl-core/src/frontend/container/mod.rs
@@ -1,19 +1,19 @@
 mod array;
 mod iter;
 mod line;
+mod option;
 mod registry;
 mod sequence;
 mod shared_memory;
 mod slice;
 mod tensor;
-mod option;
 
 pub use array::*;
 pub use iter::*;
 pub use line::*;
+pub use option::*;
 pub use registry::*;
 pub use sequence::*;
 pub use shared_memory::*;
 pub use slice::*;
 pub use tensor::*;
-pub use option::*;

--- a/crates/cubecl-core/src/frontend/container/mod.rs
+++ b/crates/cubecl-core/src/frontend/container/mod.rs
@@ -6,6 +6,7 @@ mod sequence;
 mod shared_memory;
 mod slice;
 mod tensor;
+mod option;
 
 pub use array::*;
 pub use iter::*;
@@ -15,3 +16,4 @@ pub use sequence::*;
 pub use shared_memory::*;
 pub use slice::*;
 pub use tensor::*;
+pub use option::*;

--- a/crates/cubecl-core/src/frontend/container/option/base.rs
+++ b/crates/cubecl-core/src/frontend/container/option/base.rs
@@ -1,5 +1,6 @@
 use crate::frontend::CubeType;
 use crate::prelude::CubeDebug;
+use crate::unexpanded;
 use cubecl_ir::Scope;
 
 impl<T: CubeType> CubeType for Option<T>
@@ -11,15 +12,36 @@ where
 
 impl<T: CubeDebug> CubeDebug for Option<T> {
     fn set_debug_name(&self, scope: &mut Scope, name: &'static str) {
-        if let Some(value) = &self {
+        if let Option::Some(value) = &self {
             value.set_debug_name(scope, name)
         }
     }
 }
 
-// impl<T: ExpandElementBaseInit> ExpandElementBaseInit for Option<T> {
-//     fn init_elem(_scope: &mut crate::ir::Scope, elem: ExpandElement) -> ExpandElement {
-//         // The type can't be deeply cloned/copied.
-//         elem
-//     }
-// }
+/// Allows to construct a `Some(T)` inside a kernel.
+pub fn some<T: CubeType>(_t: T) -> Option<T> {
+    unexpanded!()
+}
+
+/// Expand of [some].
+pub mod some {
+    use super::*;
+
+    pub fn expand<T: CubeType>(_context: &mut Scope, t: T::ExpandType) -> Option<T::ExpandType> {
+        Some(t)
+    }
+}
+
+/// Allows to construct a `None` inside a kernel.
+pub fn none<T: CubeType>(_t: T) -> Option<T> {
+    unexpanded!()
+}
+
+/// Expand of [none].
+pub mod none {
+    use super::*;
+
+    pub fn expand<T: CubeType>(_context: &mut Scope) -> Option<T::ExpandType> {
+        None
+    }
+}

--- a/crates/cubecl-core/src/frontend/container/option/base.rs
+++ b/crates/cubecl-core/src/frontend/container/option/base.rs
@@ -1,0 +1,25 @@
+use crate::frontend::CubeType;
+use crate::prelude::CubeDebug;
+use cubecl_ir::Scope;
+
+impl<T: CubeType> CubeType for Option<T>
+where
+    T::ExpandType: Clone,
+{
+    type ExpandType = Option<T::ExpandType>;
+}
+
+impl<T: CubeDebug> CubeDebug for Option<T> {
+    fn set_debug_name(&self, scope: &mut Scope, name: &'static str) {
+        if let Some(value) = &self {
+            value.set_debug_name(scope, name)
+        }
+    }
+}
+
+// impl<T: ExpandElementBaseInit> ExpandElementBaseInit for Option<T> {
+//     fn init_elem(_scope: &mut crate::ir::Scope, elem: ExpandElement) -> ExpandElement {
+//         // The type can't be deeply cloned/copied.
+//         elem
+//     }
+// }

--- a/crates/cubecl-core/src/frontend/container/option/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/option/launch.rs
@@ -1,0 +1,51 @@
+use crate::{
+    compute::{KernelBuilder, KernelLauncher},
+    prelude::{ArgSettings, CompilationArg, LaunchArg, LaunchArgExpand},
+    Runtime,
+};
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub struct CubeOptionCompilationArg<C> {
+    pub inner: Option<C>,
+}
+
+impl<C: CompilationArg> CompilationArg for Option<C> {}
+
+pub struct CubeOptionHandleRef<'a, H, R: Runtime> {
+    pub inner: Option<&'a H>,
+    runtime: PhantomData<R>,
+}
+
+impl<T: LaunchArgExpand> LaunchArgExpand for Option<T> {
+    type CompilationArg = Option<T::CompilationArg>;
+
+    fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> Option<T::ExpandType> {
+        println!("ARG EXPAND : {arg:?}");
+        arg.as_ref().map(|arg| T::expand(arg, builder))
+    }
+
+    fn expand_output(
+        arg: &Self::CompilationArg,
+        builder: &mut KernelBuilder,
+    ) -> Option<T::ExpandType> {
+        arg.as_ref().map(|arg| T::expand_output(arg, builder))
+    }
+}
+
+impl<R: Runtime, A: ArgSettings<R>> ArgSettings<R> for Option<A> {
+    fn register(&self, launcher: &mut KernelLauncher<R>) {
+        if let Some(arg) = self {
+            arg.register(launcher);
+        }
+    }
+}
+
+impl<T: LaunchArg> LaunchArg for Option<T> {
+    type RuntimeArg<'a, R: Runtime> = Option<T::RuntimeArg<'a, R>>;
+
+    fn compilation_arg<R: Runtime>(runtime_arg: &Self::RuntimeArg<'_, R>) -> Self::CompilationArg {
+        runtime_arg.as_ref().map(T::compilation_arg)
+    }
+}

--- a/crates/cubecl-core/src/frontend/container/option/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/option/launch.rs
@@ -22,7 +22,6 @@ impl<T: LaunchArgExpand> LaunchArgExpand for Option<T> {
     type CompilationArg = Option<T::CompilationArg>;
 
     fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> Option<T::ExpandType> {
-        println!("ARG EXPAND : {arg:?}");
         arg.as_ref().map(|arg| T::expand(arg, builder))
     }
 

--- a/crates/cubecl-core/src/frontend/container/option/mod.rs
+++ b/crates/cubecl-core/src/frontend/container/option/mod.rs
@@ -1,0 +1,5 @@
+mod base;
+mod launch;
+
+pub use base::*;
+pub use launch::*;

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -80,9 +80,8 @@ pub trait CompilationArg:
     /// Without this, the compilation time is unreasonable. The performance drop isn't a concern
     /// since this is only done once when compiling a kernel for the first time.
     fn dynamic_cast<Arg: CompilationArg>(&self) -> Arg {
-        let val = serde_json::to_string(self).unwrap();
-
-        serde_json::from_str(&val)
+        let val = ron::to_string(self).unwrap();
+        ron::from_str(&val)
             .expect("Compilation argument should be the same even with different element types")
     }
 }

--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -12,6 +12,7 @@ pub mod launch;
 pub mod line;
 pub mod memcpy_async;
 pub mod metadata;
+pub mod option;
 pub mod pipeline;
 pub mod plane;
 pub mod sequence;
@@ -121,6 +122,8 @@ macro_rules! testgen_untyped {
         cubecl_core::testgen_constants!();
         cubecl_core::testgen_tensor_indexing!();
         cubecl_core::testgen_debug!();
+
+        cubecl_core::testgen_option!();
     };
 }
 

--- a/crates/cubecl-core/src/runtime_tests/option.rs
+++ b/crates/cubecl-core/src/runtime_tests/option.rs
@@ -20,7 +20,7 @@ pub fn test_option_scalar_none<R: Runtime>(client: ComputeClient<R::Server, R::C
             CubeCount::Static(1, 1, 1),
             CubeDim::new(1, 1, 1),
             ArrayArg::from_raw_parts::<i32>(&array, 1, 1),
-            Option::None,
+            None,
         )
     };
 
@@ -39,7 +39,7 @@ pub fn test_option_scalar_some<R: Runtime>(client: ComputeClient<R::Server, R::C
             CubeCount::Static(1, 1, 1),
             CubeDim::new(1, 1, 1),
             ArrayArg::from_raw_parts::<i32>(&array, 1, 1),
-            Option::Some(ScalarArg::new(10)),
+            Some(ScalarArg::new(10)),
         )
     };
 
@@ -54,8 +54,8 @@ pub fn test_option_scalar_some<R: Runtime>(client: ComputeClient<R::Server, R::C
 #[cube(launch)]
 pub fn kernel_option_array(array: &mut Array<i32>, data: &Option<Array<i32>>) {
     match comptime!(data) {
-        Option::Some(data) => array[UNIT_POS] = data[UNIT_POS],
-        Option::None => {}
+        Some(data) => array[UNIT_POS] = data[UNIT_POS],
+        None => {}
     }
 }
 
@@ -69,7 +69,7 @@ pub fn test_option_array_none<R: Runtime>(client: ComputeClient<R::Server, R::Ch
             CubeCount::Static(1, 1, 1),
             CubeDim::new(1, 1, 1),
             ArrayArg::from_raw_parts::<i32>(&array, 2, 1),
-            Option::None,
+            None,
         )
     };
 
@@ -89,7 +89,7 @@ pub fn test_option_array_some<R: Runtime>(client: ComputeClient<R::Server, R::Ch
             CubeCount::Static(1, 1, 1),
             CubeDim::new(2, 1, 1),
             ArrayArg::from_raw_parts::<i32>(&array, 2, 1),
-            Option::Some(ArrayArg::from_raw_parts::<i32>(&data, 2, 1)),
+            Some(ArrayArg::from_raw_parts::<i32>(&data, 2, 1)),
         )
     };
 
@@ -104,18 +104,16 @@ pub fn test_option_array_some<R: Runtime>(client: ComputeClient<R::Server, R::Ch
 #[cube(launch)]
 pub fn kernel_option_map(array: &mut Array<i32>, value: Option<i32>) {
     let memory = match comptime!(value) {
-        Option::Some(value) => {
+        Some(value) => {
             let mut m = SharedMemory::new(2);
             m[UNIT_POS] = value;
             some::<SharedMemory<i32>>(m)
         }
-        Option::None => Option::None,
+        None => None,
     };
     let slice = match comptime!(memory) {
-        Option::Some(memory) => {
-            some::<Slice<i32>>(memory.to_slice())
-        }
-        Option::None => Option::None,
+        Some(memory) => some::<Slice<i32>>(memory.to_slice()),
+        None => None,
     };
     option_map(array.to_slice_mut(), slice);
 }
@@ -123,8 +121,8 @@ pub fn kernel_option_map(array: &mut Array<i32>, value: Option<i32>) {
 #[cube]
 fn option_map(mut output: SliceMut<i32>, data: Option<Slice<i32>>) {
     match comptime!(data) {
-        Option::Some(data) => output[UNIT_POS] = data[UNIT_POS],
-        Option::None => {}
+        Some(data) => output[UNIT_POS] = data[UNIT_POS],
+        None => {}
     }
 }
 
@@ -137,7 +135,7 @@ pub fn test_option_map_none<R: Runtime>(client: ComputeClient<R::Server, R::Chan
             CubeCount::Static(1, 1, 1),
             CubeDim::new(1, 1, 1),
             ArrayArg::from_raw_parts::<i32>(&array, 2, 1),
-            Option::None,
+            None,
         )
     };
 
@@ -156,7 +154,7 @@ pub fn test_option_map_some<R: Runtime>(client: ComputeClient<R::Server, R::Chan
             CubeCount::Static(1, 1, 1),
             CubeDim::new(2, 1, 1),
             ArrayArg::from_raw_parts::<i32>(&array, 2, 1),
-            Option::Some(ScalarArg::new(10)),
+            Some(ScalarArg::new(10)),
         )
     };
 

--- a/crates/cubecl-core/src/runtime_tests/option.rs
+++ b/crates/cubecl-core/src/runtime_tests/option.rs
@@ -1,138 +1,15 @@
 use crate as cubecl;
 use cubecl::prelude::*;
 
+// SCALAR
+
 #[cube(launch)]
 pub fn kernel_option_scalar(array: &mut Array<i32>, value: Option<i32>) {
-    if UNIT_POS == 0 {
-        match comptime!(value) {
-            Some(value) => array[0] = value,
-            None => {}
-        }
+    match comptime!(value) {
+        Some(value) => array[0] = value,
+        None => {}
     }
 }
-
-// pub mod kernel_option_scalar {
-//     use super::*;
-//     #[allow(unused, clippy::all)]
-//     pub fn expand(
-//         context: &mut cubecl::prelude::Scope,
-//         array: <Array<i32> as cubecl::prelude::CubeType>::ExpandType,
-//         value: <Option<i32> as cubecl::prelude::CubeType>::ExpandType,
-//     ) -> <() as cubecl::prelude::CubeType>::ExpandType {
-//         cubecl::frontend::debug_source_expand(
-//             context,
-//             "kernel_option_scalar",
-//             file!(),
-//             "",
-//             line!(),
-//             column!(),
-//         );
-//         cubecl::frontend::CubeDebug::set_debug_name(&array, context, "array");
-//         cubecl::frontend::CubeDebug::set_debug_name(&value, context, "value");
-//         use cubecl::prelude::IntoRuntime as _;
-//         {
-//             {
-//                 let _cond = {
-//                     let _lhs = UNIT_POS::expand(context);
-//                     let _rhs = cubecl::frontend::ExpandElementTyped::from_lit(context, 0);
-//                     cubecl::frontend::spanned_expand(context, line!(), column!(), |context| {
-//                         cubecl::frontend::eq::expand(context, _lhs.into(), _rhs.into())
-//                     })
-//                 };
-//                 cubecl::frontend::branch::if_expand(context, _cond.into(), |context| {
-//                     match comptime!(value) {
-//                         Some(value) => {
-//                             let _array = array;
-//                             let _index = cubecl::frontend::ExpandElementTyped::from_lit(context, 0);
-//                             let _value = value;
-//                             cubecl::frontend::index_assign::expand(
-//                                 context,
-//                                 _array.into(),
-//                                 _index.into(),
-//                                 _value.into(),
-//                             )
-//                         }
-//                         None => {}
-//                     }
-//                 });
-//             }
-//         }
-//     }
-//     ///kernel_option_scalar Kernel
-//     pub struct KernelOptionScalar<__R: cubecl::prelude::Runtime> {
-//         settings: cubecl::prelude::KernelSettings,
-//         value: <Option<i32> as cubecl::prelude::LaunchArgExpand>::CompilationArg,
-//         array: <Array<i32> as cubecl::prelude::LaunchArgExpand>::CompilationArg,
-//         __ty: ::core::marker::PhantomData<(__R)>,
-//     }
-//     #[allow(clippy::too_many_arguments)]
-//     impl<__R: cubecl::prelude::Runtime> KernelOptionScalar<__R> {
-//         pub fn new(
-//             settings: cubecl::prelude::KernelSettings,
-//             value: <Option<i32> as cubecl::prelude::LaunchArgExpand>::CompilationArg,
-//             array: <Array<i32> as cubecl::prelude::LaunchArgExpand>::CompilationArg,
-//         ) -> Self {
-//             println!("NEW VALUE: {value:?}");
-//             Self {
-//                 settings: settings.kernel_name("kernel_option_scalar"),
-//                 value,
-//                 array,
-//                 __ty: ::core::marker::PhantomData,
-//             }
-//         }
-//     }
-//     impl<__R: cubecl::prelude::Runtime> cubecl::Kernel for KernelOptionScalar<__R> {
-//         fn define(&self) -> cubecl::prelude::KernelDefinition {
-//             let mut builder = cubecl::prelude::KernelBuilder::default();
-//             println!("BEFORE CAST: {:?}", self.value);
-//             // println!(
-//             //     "AFTER CAST: {:?}",
-//             //     self.value
-//             //         .dynamic_cast::<<Option<i32> as LaunchArgExpand>::CompilationArg>()
-//             // );
-
-//             let value = <Option<i32> as cubecl::prelude::LaunchArgExpand>::expand(
-//                 // &self.value.dynamic_cast(),
-//                 &self.value,
-//                 &mut builder,
-//             );
-//             println!("VALUE IN DEFINE: {value:?}");
-//             let array = <Array<i32> as cubecl::prelude::LaunchArgExpand>::expand_output(
-//                 &self.array.dynamic_cast(),
-//                 &mut builder,
-//             );
-//             expand(&mut builder.context, array.clone(), value.clone());
-//             builder.build(self.settings.clone())
-//         }
-//         fn id(&self) -> cubecl::KernelId {
-//             let cube_dim = self.settings.cube_dim.clone();
-//             cubecl::KernelId::new::<Self>().info((cube_dim, self.value.clone(), self.array.clone()))
-//         }
-//     }
-//     #[allow(clippy::too_many_arguments)]
-//     ///Launch the kernel [kernel_option_scalar()] on the given runtime
-//     pub fn launch<'kernel, __R: cubecl::prelude::Runtime>(
-//         __client: &cubecl::prelude::ComputeClient<__R::Server, __R::Channel>,
-//         __cube_count: cubecl::prelude::CubeCount,
-//         __cube_dim: cubecl::prelude::CubeDim,
-//         array: cubecl::RuntimeArg<'kernel, Array<i32>, __R>,
-//         value: cubecl::RuntimeArg<'kernel, Option<i32>, __R>,
-//     ) -> () {
-//         use cubecl::frontend::ArgSettings as _;
-//         let mut __settings = cubecl::prelude::KernelSettings::default().cube_dim(__cube_dim);
-//         let input_arg_0 =
-//             <Option<i32> as cubecl::prelude::LaunchArg>::compilation_arg::<__R>(&value);
-//         println!("INPUT ARG 0 {input_arg_0:?}");
-//         let output_arg_0 =
-//             <Array<i32> as cubecl::prelude::LaunchArg>::compilation_arg::<__R>(&array);
-//         let __kernel = KernelOptionScalar::<__R>::new(__settings, input_arg_0, output_arg_0);
-//         let mut launcher = cubecl::prelude::KernelLauncher::<__R>::default();
-//         println!("VALUE {value:?}");
-//         value.register(&mut launcher);
-//         array.register(&mut launcher);
-//         launcher.launch(__cube_count, __kernel, __client);
-//     }
-// }
 
 pub fn test_option_scalar_none<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
     let array = client.create(i32::as_bytes(&[5]));
@@ -143,7 +20,7 @@ pub fn test_option_scalar_none<R: Runtime>(client: ComputeClient<R::Server, R::C
             CubeCount::Static(1, 1, 1),
             CubeDim::new(1, 1, 1),
             ArrayArg::from_raw_parts::<i32>(&array, 1, 1),
-            None,
+            Option::None,
         )
     };
 
@@ -162,7 +39,7 @@ pub fn test_option_scalar_some<R: Runtime>(client: ComputeClient<R::Server, R::C
             CubeCount::Static(1, 1, 1),
             CubeDim::new(1, 1, 1),
             ArrayArg::from_raw_parts::<i32>(&array, 1, 1),
-            Some(ScalarArg::new(10)),
+            Option::Some(ScalarArg::new(10)),
         )
     };
 
@@ -170,6 +47,123 @@ pub fn test_option_scalar_some<R: Runtime>(client: ComputeClient<R::Server, R::C
     let actual = i32::from_bytes(&actual);
 
     assert_eq!(actual[0], 10);
+}
+
+// ARRAY
+
+#[cube(launch)]
+pub fn kernel_option_array(array: &mut Array<i32>, data: &Option<Array<i32>>) {
+    match comptime!(data) {
+        Option::Some(data) => array[UNIT_POS] = data[UNIT_POS],
+        Option::None => {}
+    }
+}
+
+//
+pub fn test_option_array_none<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
+    let array = client.create(i32::as_bytes(&[5, 5]));
+
+    unsafe {
+        kernel_option_array::launch::<R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new(1, 1, 1),
+            ArrayArg::from_raw_parts::<i32>(&array, 2, 1),
+            Option::None,
+        )
+    };
+
+    let actual = client.read_one(array.binding());
+    let actual = i32::from_bytes(&actual);
+
+    assert_eq!(actual, [5, 5]);
+}
+
+pub fn test_option_array_some<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
+    let array = client.create(i32::as_bytes(&[5, 5]));
+    let data = client.create(i32::as_bytes(&[10, 20]));
+
+    unsafe {
+        kernel_option_array::launch::<R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new(2, 1, 1),
+            ArrayArg::from_raw_parts::<i32>(&array, 2, 1),
+            Option::Some(ArrayArg::from_raw_parts::<i32>(&data, 2, 1)),
+        )
+    };
+
+    let actual = client.read_one(array.binding());
+    let actual = i32::from_bytes(&actual);
+
+    assert_eq!(actual, [10, 20]);
+}
+
+// MAP
+
+#[cube(launch)]
+pub fn kernel_option_map(array: &mut Array<i32>, value: Option<i32>) {
+    let memory = match comptime!(value) {
+        Option::Some(value) => {
+            let mut m = SharedMemory::new(2);
+            m[UNIT_POS] = value;
+            some::<SharedMemory<i32>>(m)
+        }
+        Option::None => Option::None,
+    };
+    let slice = match comptime!(memory) {
+        Option::Some(memory) => {
+            some::<Slice<i32>>(memory.to_slice())
+        }
+        Option::None => Option::None,
+    };
+    option_map(array.to_slice_mut(), slice);
+}
+
+#[cube]
+fn option_map(mut output: SliceMut<i32>, data: Option<Slice<i32>>) {
+    match comptime!(data) {
+        Option::Some(data) => output[UNIT_POS] = data[UNIT_POS],
+        Option::None => {}
+    }
+}
+
+pub fn test_option_map_none<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
+    let array = client.create(i32::as_bytes(&[5, 5]));
+
+    unsafe {
+        kernel_option_map::launch::<R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new(1, 1, 1),
+            ArrayArg::from_raw_parts::<i32>(&array, 2, 1),
+            Option::None,
+        )
+    };
+
+    let actual = client.read_one(array.binding());
+    let actual = i32::from_bytes(&actual);
+
+    assert_eq!(actual, [5, 5]);
+}
+
+pub fn test_option_map_some<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
+    let array = client.create(i32::as_bytes(&[5, 5]));
+
+    unsafe {
+        kernel_option_map::launch::<R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new(2, 1, 1),
+            ArrayArg::from_raw_parts::<i32>(&array, 2, 1),
+            Option::Some(ScalarArg::new(10)),
+        )
+    };
+
+    let actual = client.read_one(array.binding());
+    let actual = i32::from_bytes(&actual);
+
+    assert_eq!(actual, [10, 10]);
 }
 
 #[allow(missing_docs)]
@@ -188,6 +182,30 @@ macro_rules! testgen_option {
         fn test_option_scalar_some() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::option::test_option_scalar_some::<TestRuntime>(client);
+        }
+
+        #[test]
+        fn test_option_array_none() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::option::test_option_array_none::<TestRuntime>(client);
+        }
+
+        #[test]
+        fn test_option_array_some() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::option::test_option_array_some::<TestRuntime>(client);
+        }
+
+        #[test]
+        fn test_option_map_none() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::option::test_option_map_none::<TestRuntime>(client);
+        }
+
+        #[test]
+        fn test_option_map_some() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::option::test_option_map_some::<TestRuntime>(client);
         }
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/option.rs
+++ b/crates/cubecl-core/src/runtime_tests/option.rs
@@ -1,0 +1,193 @@
+use crate as cubecl;
+use cubecl::prelude::*;
+
+#[cube(launch)]
+pub fn kernel_option_scalar(array: &mut Array<i32>, value: Option<i32>) {
+    if UNIT_POS == 0 {
+        match comptime!(value) {
+            Some(value) => array[0] = value,
+            None => {}
+        }
+    }
+}
+
+// pub mod kernel_option_scalar {
+//     use super::*;
+//     #[allow(unused, clippy::all)]
+//     pub fn expand(
+//         context: &mut cubecl::prelude::Scope,
+//         array: <Array<i32> as cubecl::prelude::CubeType>::ExpandType,
+//         value: <Option<i32> as cubecl::prelude::CubeType>::ExpandType,
+//     ) -> <() as cubecl::prelude::CubeType>::ExpandType {
+//         cubecl::frontend::debug_source_expand(
+//             context,
+//             "kernel_option_scalar",
+//             file!(),
+//             "",
+//             line!(),
+//             column!(),
+//         );
+//         cubecl::frontend::CubeDebug::set_debug_name(&array, context, "array");
+//         cubecl::frontend::CubeDebug::set_debug_name(&value, context, "value");
+//         use cubecl::prelude::IntoRuntime as _;
+//         {
+//             {
+//                 let _cond = {
+//                     let _lhs = UNIT_POS::expand(context);
+//                     let _rhs = cubecl::frontend::ExpandElementTyped::from_lit(context, 0);
+//                     cubecl::frontend::spanned_expand(context, line!(), column!(), |context| {
+//                         cubecl::frontend::eq::expand(context, _lhs.into(), _rhs.into())
+//                     })
+//                 };
+//                 cubecl::frontend::branch::if_expand(context, _cond.into(), |context| {
+//                     match comptime!(value) {
+//                         Some(value) => {
+//                             let _array = array;
+//                             let _index = cubecl::frontend::ExpandElementTyped::from_lit(context, 0);
+//                             let _value = value;
+//                             cubecl::frontend::index_assign::expand(
+//                                 context,
+//                                 _array.into(),
+//                                 _index.into(),
+//                                 _value.into(),
+//                             )
+//                         }
+//                         None => {}
+//                     }
+//                 });
+//             }
+//         }
+//     }
+//     ///kernel_option_scalar Kernel
+//     pub struct KernelOptionScalar<__R: cubecl::prelude::Runtime> {
+//         settings: cubecl::prelude::KernelSettings,
+//         value: <Option<i32> as cubecl::prelude::LaunchArgExpand>::CompilationArg,
+//         array: <Array<i32> as cubecl::prelude::LaunchArgExpand>::CompilationArg,
+//         __ty: ::core::marker::PhantomData<(__R)>,
+//     }
+//     #[allow(clippy::too_many_arguments)]
+//     impl<__R: cubecl::prelude::Runtime> KernelOptionScalar<__R> {
+//         pub fn new(
+//             settings: cubecl::prelude::KernelSettings,
+//             value: <Option<i32> as cubecl::prelude::LaunchArgExpand>::CompilationArg,
+//             array: <Array<i32> as cubecl::prelude::LaunchArgExpand>::CompilationArg,
+//         ) -> Self {
+//             println!("NEW VALUE: {value:?}");
+//             Self {
+//                 settings: settings.kernel_name("kernel_option_scalar"),
+//                 value,
+//                 array,
+//                 __ty: ::core::marker::PhantomData,
+//             }
+//         }
+//     }
+//     impl<__R: cubecl::prelude::Runtime> cubecl::Kernel for KernelOptionScalar<__R> {
+//         fn define(&self) -> cubecl::prelude::KernelDefinition {
+//             let mut builder = cubecl::prelude::KernelBuilder::default();
+//             println!("BEFORE CAST: {:?}", self.value);
+//             // println!(
+//             //     "AFTER CAST: {:?}",
+//             //     self.value
+//             //         .dynamic_cast::<<Option<i32> as LaunchArgExpand>::CompilationArg>()
+//             // );
+
+//             let value = <Option<i32> as cubecl::prelude::LaunchArgExpand>::expand(
+//                 // &self.value.dynamic_cast(),
+//                 &self.value,
+//                 &mut builder,
+//             );
+//             println!("VALUE IN DEFINE: {value:?}");
+//             let array = <Array<i32> as cubecl::prelude::LaunchArgExpand>::expand_output(
+//                 &self.array.dynamic_cast(),
+//                 &mut builder,
+//             );
+//             expand(&mut builder.context, array.clone(), value.clone());
+//             builder.build(self.settings.clone())
+//         }
+//         fn id(&self) -> cubecl::KernelId {
+//             let cube_dim = self.settings.cube_dim.clone();
+//             cubecl::KernelId::new::<Self>().info((cube_dim, self.value.clone(), self.array.clone()))
+//         }
+//     }
+//     #[allow(clippy::too_many_arguments)]
+//     ///Launch the kernel [kernel_option_scalar()] on the given runtime
+//     pub fn launch<'kernel, __R: cubecl::prelude::Runtime>(
+//         __client: &cubecl::prelude::ComputeClient<__R::Server, __R::Channel>,
+//         __cube_count: cubecl::prelude::CubeCount,
+//         __cube_dim: cubecl::prelude::CubeDim,
+//         array: cubecl::RuntimeArg<'kernel, Array<i32>, __R>,
+//         value: cubecl::RuntimeArg<'kernel, Option<i32>, __R>,
+//     ) -> () {
+//         use cubecl::frontend::ArgSettings as _;
+//         let mut __settings = cubecl::prelude::KernelSettings::default().cube_dim(__cube_dim);
+//         let input_arg_0 =
+//             <Option<i32> as cubecl::prelude::LaunchArg>::compilation_arg::<__R>(&value);
+//         println!("INPUT ARG 0 {input_arg_0:?}");
+//         let output_arg_0 =
+//             <Array<i32> as cubecl::prelude::LaunchArg>::compilation_arg::<__R>(&array);
+//         let __kernel = KernelOptionScalar::<__R>::new(__settings, input_arg_0, output_arg_0);
+//         let mut launcher = cubecl::prelude::KernelLauncher::<__R>::default();
+//         println!("VALUE {value:?}");
+//         value.register(&mut launcher);
+//         array.register(&mut launcher);
+//         launcher.launch(__cube_count, __kernel, __client);
+//     }
+// }
+
+pub fn test_option_scalar_none<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
+    let array = client.create(i32::as_bytes(&[5]));
+
+    unsafe {
+        kernel_option_scalar::launch::<R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new(1, 1, 1),
+            ArrayArg::from_raw_parts::<i32>(&array, 1, 1),
+            None,
+        )
+    };
+
+    let actual = client.read_one(array.binding());
+    let actual = i32::from_bytes(&actual);
+
+    assert_eq!(actual[0], 5);
+}
+
+pub fn test_option_scalar_some<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
+    let array = client.create(i32::as_bytes(&[5]));
+
+    unsafe {
+        kernel_option_scalar::launch::<R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new(1, 1, 1),
+            ArrayArg::from_raw_parts::<i32>(&array, 1, 1),
+            Some(ScalarArg::new(10)),
+        )
+    };
+
+    let actual = client.read_one(array.binding());
+    let actual = i32::from_bytes(&actual);
+
+    assert_eq!(actual[0], 10);
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! testgen_option {
+    () => {
+        use super::*;
+
+        #[test]
+        fn test_option_scalar_none() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::option::test_option_scalar_none::<TestRuntime>(client);
+        }
+
+        #[test]
+        fn test_option_scalar_some() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::option::test_option_scalar_some::<TestRuntime>(client);
+        }
+    };
+}


### PR DESCRIPTION
This make `Option<T>` where `T: LaunchArg` launchable in a cubecl kernel. 
Combined with 
```rust
match comptime!(option) { \* ... *\ }
```
it allows to match at comptime data that are runtime known. For example, for the first test named `kernel_option_scalar`, we can generate two different kernels based on an argument
of type `Option<i32>`.

```cuda

// When option is None
extern "C" __global__ void kernel_option_scalar(int output_0[], uint info[]) {

  int threadIdxGlobal = threadIdx.x + threadIdx.y * blockDim.x +
                        threadIdx.z * (blockDim.x * blockDim.y);
  const bool l_0 = threadIdxGlobal == uint(0);
  if (l_0) {
  }
}

// When option is Some(value: i32)
extern "C" __global__ void kernel_option_scalar(int output_0[], uint info[],
                                                int scalars_i32[]) {

  int threadIdxGlobal = threadIdx.x + threadIdx.y * blockDim.x +
                        threadIdx.z * (blockDim.x * blockDim.y);
  const bool l_0 = threadIdxGlobal == uint(0);
  if (l_0) {
    const uint l_1 = info[uint(0)];
    const bool l_2 = uint(0) < l_1;
    if (l_2) {
      output_0[uint(0)] = scalars_i32[0];
    }
  }
}
```

## Limitations

First, we can't use 
```rust
let x = Some(y);
``` 
directly in a kernel. Thus, I introduce a new function named `some` that does exactly. However, it has some issue with type inference. A proper fix of the way we expand enum variant should solve the issue.

Second, we can't use stuff like `option.map(|x| 2 * x)` to generate code at comptime. Currently, we have to use a match statement to achieve this behavior. 

## Design choices

I hesitated between introducing a new enum 
```rust
pub enum CubeOption<T> {
    Some(T),
    None
}
```
for which we could implement more utilities similar to `std::Option`. However, I decided to go with `std::Option` directly for now as a first step. 

## Justification

I believe this will quite useful to implement quantization in the matmul without doubling all implementations.