### PR TITLE
update cudarc to 0.13.9, and fixed typos

### DIFF
--- a/crates/cubecl-core/src/frontend/container/slice.rs
+++ b/crates/cubecl-core/src/frontend/container/slice.rs
@@ -56,7 +56,7 @@ mod metadata {
         }
         /// Try to cast the slice to the given type and panic if the type isn't the same.
         ///
-        /// This function should only be used to satify the Rust type system, when two generic
+        /// This function should only be used to satisfy the Rust type system, when two generic
         /// types are supposed to be the same.
         pub fn try_cast_unchecked<T>(&self) -> Slice<T>
         where

--- a/crates/cubecl-core/src/frontend/element/cube_elem.rs
+++ b/crates/cubecl-core/src/frontend/element/cube_elem.rs
@@ -20,7 +20,7 @@ pub trait CubePrimitive:
 {
     /// Return the element type to use on GPU.
     fn as_elem(_context: &Scope) -> Elem {
-        Self::as_elem_native().expect("To be overriden if not native")
+        Self::as_elem_native().expect("To be overridden if not native")
     }
 
     /// Native or static element type.

--- a/crates/cubecl-core/src/frontend/operation/base.rs
+++ b/crates/cubecl-core/src/frontend/operation/base.rs
@@ -191,7 +191,7 @@ where
     let input_var: Variable = *input;
     let item = input.item;
 
-    let out = scope.create_local_mut(item); // TODO: The mut is safe, but unecessary if the variable is immutable.
+    let out = scope.create_local_mut(item); // TODO: The mut is safe, but unnecessary if the variable is immutable.
     let out_var = *out;
 
     let op = func(input_var);

--- a/crates/cubecl-core/src/frontend/pipeline.rs
+++ b/crates/cubecl-core/src/frontend/pipeline.rs
@@ -1,4 +1,4 @@
-//! This module exposes pipeling utilities for multi-stage asynchronous data copies
+//! This module exposes pipelining utilities for multi-stage asynchronous data copies
 //! with latency hiding.
 //! We call producers all threads that call producer_acquire and producer_commit,
 //! and consumers threads that call consumer_wait and consumer_release.

--- a/crates/cubecl-core/src/runtime_tests/barrier.rs
+++ b/crates/cubecl-core/src/runtime_tests/barrier.rs
@@ -91,7 +91,7 @@ fn two_loads<F: Float>(
 }
 
 #[cube(launch)]
-fn two_independant_loads<F: Float>(
+fn two_independent_loads<F: Float>(
     lhs: &Tensor<Line<F>>,
     rhs: &Tensor<Line<F>>,
     output: &mut Tensor<Line<F>>,
@@ -158,7 +158,7 @@ pub fn test_memcpy_one_load<R: Runtime, F: Float + CubeElement>(
 }
 
 pub fn test_memcpy_two_loads<R: Runtime, F: Float + CubeElement>(
-    independant: bool,
+    independent: bool,
     client: ComputeClient<R::Server, R::Channel>,
 ) {
     if !client.properties().feature_enabled(Feature::Barrier) {
@@ -174,9 +174,9 @@ pub fn test_memcpy_two_loads<R: Runtime, F: Float + CubeElement>(
     let rhs = client.create(F::as_bytes(&rhs_data));
     let output = client.empty(2 * core::mem::size_of::<F>());
 
-    if independant {
+    if independent {
         unsafe {
-            two_independant_loads::launch::<F, R>(
+            two_independent_loads::launch::<F, R>(
                 &client,
                 CubeCount::Static(1, 1, 1),
                 CubeDim::new(2, 1, 1),
@@ -249,7 +249,7 @@ macro_rules! testgen_barrier {
         }
 
         #[test]
-        fn test_barrier_memcpy_async_two_independant_loads() {
+        fn test_barrier_memcpy_async_two_independent_loads() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::barrier::test_memcpy_two_loads::<TestRuntime, FloatType>(
                 true, client,

--- a/crates/cubecl-core/src/runtime_tests/pipeline.rs
+++ b/crates/cubecl-core/src/runtime_tests/pipeline.rs
@@ -186,7 +186,7 @@ fn two_loads<F: Float>(
 }
 
 #[cube(launch)]
-fn two_independant_loads<F: Float>(
+fn two_independent_loads<F: Float>(
     lhs: &Tensor<Line<F>>,
     rhs: &Tensor<Line<F>>,
     output: &mut Tensor<Line<F>>,
@@ -258,7 +258,7 @@ pub fn test_memcpy_one_load<R: Runtime, F: Float + CubeElement>(
 }
 
 pub fn test_memcpy_two_loads<R: Runtime, F: Float + CubeElement>(
-    independant: bool,
+    independent: bool,
     client: ComputeClient<R::Server, R::Channel>,
 ) {
     if !client.properties().feature_enabled(Feature::Pipeline) {
@@ -274,9 +274,9 @@ pub fn test_memcpy_two_loads<R: Runtime, F: Float + CubeElement>(
     let rhs = client.create(F::as_bytes(&rhs_data));
     let output = client.empty(2 * core::mem::size_of::<F>());
 
-    if independant {
+    if independent {
         unsafe {
-            two_independant_loads::launch::<F, R>(
+            two_independent_loads::launch::<F, R>(
                 &client,
                 CubeCount::Static(1, 1, 1),
                 CubeDim::new(2, 1, 1),
@@ -357,7 +357,7 @@ macro_rules! testgen_pipeline {
         }
 
         #[test]
-        fn test_pipeline_memcpy_async_two_independant_loads() {
+        fn test_pipeline_memcpy_async_two_independent_loads() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::pipeline::test_memcpy_two_loads::<TestRuntime, FloatType>(
                 true, client,

--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -30,7 +30,7 @@ cubecl-runtime = { path = "../cubecl-runtime", version = "0.5.0", default-featur
 ] }
 
 bytemuck = { workspace = true }
-cudarc = { version = "0.12.1", features = [
+cudarc = { version = "0.13.9", features = [
   "std",
   "driver",
   "cuda-version-from-build-system",

--- a/crates/cubecl-ir/src/allocator.rs
+++ b/crates/cubecl-ir/src/allocator.rs
@@ -22,7 +22,7 @@ use super::{Item, Matrix, Variable, VariableKind};
 ///
 /// In order, prefer immutable local variables, then mutable, then restricted.
 ///
-/// To enable many compiler optimizations, it is prefered to use the [static single-assignment] strategy for immutable variables.
+/// To enable many compiler optimizations, it is preferred to use the [static single-assignment] strategy for immutable variables.
 /// That is, each variable must be declared and used exactly once.
 ///
 /// [static single-assignment](https://en.wikipedia.org/wiki/Static_single-assignment_form)

--- a/crates/cubecl-macros-internal/src/lib.rs
+++ b/crates/cubecl-macros-internal/src/lib.rs
@@ -49,7 +49,7 @@ pub fn derive_operation(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Generates an opcode enum for an operation, without implemention `OperationReflect`. Allows for
+/// Generates an opcode enum for an operation, without implementation `OperationReflect`. Allows for
 /// manual implementation.
 ///
 /// Use `self.__match_opcode()` to get the opcode for an operation.

--- a/crates/cubecl-reduce/src/config.rs
+++ b/crates/cubecl-reduce/src/config.rs
@@ -96,7 +96,7 @@ impl ReduceConfig {
                 // contiguous in the input and output. This is obtained by taking the head of each list until they are different.
                 // In the above example, only the 0 axis is contiguous in both tensor, but it output sorted axis were [0, 1, 3, 2] instead,
                 // both the 0 and 3 axes would be contiguous in the two tensors.
-                // The corresponding number of entries is the product of the shape for the contigous axes.
+                // The corresponding number of entries is the product of the shape for the contiguous axes.
                 // In the example, it is simply 2.
                 //
                 // This gives us an upper bound on the line size we can used.

--- a/crates/cubecl-reduce/src/lib.rs
+++ b/crates/cubecl-reduce/src/lib.rs
@@ -98,7 +98,7 @@ pub fn reduce<R: Runtime, In: Numeric, Out: Numeric, Inst: Reduce>(
     strategy: Option<ReduceStrategy>,
 ) -> Result<(), ReduceError> {
     validate_axis(input.shape.len(), axis)?;
-    valide_output_shape(input.shape, output.shape, axis)?;
+    valid_output_shape(input.shape, output.shape, axis)?;
     let strategy = strategy
         .map(|s| s.validate::<R>(client))
         .unwrap_or(Ok(ReduceStrategy::new::<R>(client, true)))?;
@@ -124,7 +124,7 @@ fn validate_axis(rank: usize, axis: usize) -> Result<(), ReduceError> {
 }
 
 // Check that the output shape match the input shape with the given axis set to 1.
-fn valide_output_shape(
+fn valid_output_shape(
     input_shape: &[usize],
     output_shape: &[usize],
     axis: usize,

--- a/crates/cubecl-reduce/src/primitives.rs
+++ b/crates/cubecl-reduce/src/primitives.rs
@@ -260,7 +260,7 @@ fn fill_coordinate_line(
 /// Since each individual cube performs a reduction, this function is meant to be called
 /// with a different `accumulator` for each cube based on `CUBE_POS`.
 ///
-/// There is no out-of-bound check, so it is the responsability of the caller to ensure that `size` is at most the length
+/// There is no out-of-bound check, so it is the responsibility of the caller to ensure that `size` is at most the length
 /// of the shared memory and that there are at least `size` units within each cube.
 #[cube]
 pub fn reduce_tree<In: Numeric, Inst: ReduceInstruction<In>>(

--- a/crates/cubecl-reduce/src/shared_sum.rs
+++ b/crates/cubecl-reduce/src/shared_sum.rs
@@ -6,14 +6,14 @@ use crate::ReduceError;
 /// Sum all the elements of the input tensor distributed over `cube_count` cubes.
 ///
 /// This is an optimized version for summing large tensors using multiple cubes.
-/// For summing a single axis, the regular [reduce] entry point is prefered.
+/// For summing a single axis, the regular [reduce] entry point is preferred.
 ///
 /// Return an error if atomic addition is not supported for the type `N`.
 ///
 /// # Important
 ///
 /// This doesn't set the value of output to 0 before computing the sums.
-/// It is the responsability of the caller to ensure that ouput is set to
+/// It is the responsibility of the caller to ensure that output is set to
 /// the proper value. Basically, the behavior of this kernel is akin to the AddAssign operator
 /// as it update the output instead of overwriting it.
 ///

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -102,7 +102,7 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             TuneCacheResult::Miss => {
                 // We don't know the results yet, start autotuning.
                 //
-                // Running benchmarks shound't lock the tuner, since an autotune operation can recursively use the
+                // Running benchmarks should't lock the tuner, since an autotune operation can recursively use the
                 // same tuner.
                 //
                 // # Example

--- a/crates/cubecl-runtime/src/tune/mod.rs
+++ b/crates/cubecl-runtime/src/tune/mod.rs
@@ -26,7 +26,7 @@
 //! # Tunable
 //!
 //! [`Tunable`](crate::tune::Tunable) is implemented automatically for all functions and closures
-//! that take a set of clonable inputs, and return a `Result<Out, impl Into<AutotuneError>>`. If the
+//! that take a set of cloneable inputs, and return a `Result<Out, impl Into<AutotuneError>>`. If the
 //! kernel does not return a [`Result`], use `kernel_fn.ok()` to wrap it in `Ok` and turn it into a
 //! tunable.
 //!

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -45,7 +45,7 @@ impl<
                     operation
                         .clone()
                         .execute(self.inputs.clone())
-                        .expect("Should not fail when previsously tried during the warmup.");
+                        .expect("Should not fail when previously tried during the warmup.");
                     // For benchmarks - we need to wait for all tasks to complete before returning.
                     let duration = match client.sync_elapsed().await {
                         Ok(val) => val,

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -46,7 +46,7 @@ enum AutotuneMessage<K> {
 pub enum AutotuneError {
     /// An unknown error happened.
     Unknown(String),
-    /// An error catched with panic unwind.
+    /// An error caught with panic unwind.
     PanicUnwind(ManuallyDrop<Box<dyn Any + Send>>),
 }
 

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -82,7 +82,7 @@ impl WgpuStream {
             memory_config,
         );
 
-        // Allocate a seperate storage & memory management for 'uniforms' (small bits of data
+        // Allocate a separate storage & memory management for 'uniforms' (small bits of data
         // that need to be uploaded quickly). We allocate these with the BufferUsages::UNIFORM flag
         // to allow binding them as uniforms.
         let uniforms_memory_management = MemoryManagement::from_configuration(
@@ -468,7 +468,7 @@ impl WgpuStream {
             .unwrap();
 
         if let Some(size) = NonZeroU64::new(aligned_len) {
-            // Small buffers are 'locked' if they were previosuly used for compute operations,
+            // Small buffers are 'locked' if they were previously used for compute operations,
             // so we can safely do the data upload first in the copy_uniforms_encoder.
             if uniform_alloc {
                 // Use the staging belt to allocate a staging buffer and write to it.
@@ -525,7 +525,7 @@ impl WgpuStream {
 
     fn flush_if_needed(&mut self) {
         // Flush when there are too many tasks, or when too many handles are locked.
-        // Locked handles should only accumlate in rare circumstances (where uniforms
+        // Locked handles should only accumulate in rare circumstances (where uniforms
         // are being created but no work is submitted).
         if self.tasks_count >= self.tasks_max
             || self.locked_copy_handles.len() >= self.tasks_max * 8

--- a/cubecl-book/src/algorithms/quantized_matmul.md
+++ b/cubecl-book/src/algorithms/quantized_matmul.md
@@ -46,7 +46,7 @@ we have
   q_c =
   z_c + \frac{s_a s_b}{s_c} (q_a - z_a) (q_b - z_b).
 \\]
-Except for the factor \\( (s_a s_b) / s_c \\), the above equation involves only integer artihmetic.
+Except for the factor \\( (s_a s_b) / s_c \\), the above equation involves only integer arithmetic.
 However,
 we can always find two integers \\(u, v\\) such that
 \\[


### PR DESCRIPTION
updates the cudarc version to fix a build issue for nvcc-12.8 (see [cudarc issue](https://github.com/coreylowman/cudarc/issues/332)).

The issue seems to effect building with cargo subcommands. Prior to this, `cargo run --examples fusing --features "cuda"` would work, `cargo debugger --example fusing --manifes
t-path examples/fusing/Cargo.toml --features "cuda"` would not. 

Edit: I also fixed the typos that were causing `cargo xtask validate` to fail. None of the corrections impact public functions