### PR TITLE
Derive enum

### DIFF
--- a/crates/cubecl-core/src/frontend/branch.rs
+++ b/crates/cubecl-core/src/frontend/branch.rs
@@ -363,7 +363,7 @@ impl<C: CubePrimitive> IfElseExprExpand<C> {
             } => {
                 let mut else_child = scope.child();
                 let ret = else_block(&mut else_child);
-                assign::expand(&mut else_child, ret, out.clone());
+                assign::expand::<C>(&mut else_child, ret, out.clone());
 
                 scope.register(Branch::IfElse(Box::new(IfElse {
                     cond: *runtime_cond,
@@ -394,7 +394,7 @@ pub fn if_else_expr_expand<C: CubePrimitive>(
             let mut then_child = scope.child();
             let ret = then_block(&mut then_child);
             let out: ExpandElementTyped<C> = scope.create_local_mut(ret.expand.item).into();
-            assign::expand(&mut then_child, ret, out.clone());
+            assign::expand::<C>(&mut then_child, ret, out.clone());
 
             IfElseExprExpand::Runtime {
                 runtime_cond,
@@ -471,7 +471,7 @@ impl<I: Int, C: CubePrimitive> SwitchExpandExpr<I, C> {
         let value = I::from(value).unwrap();
         let mut case_child = scope.child();
         let ret = block(&mut case_child);
-        assign::expand(&mut case_child, ret, self.out.clone());
+        assign::expand::<C>(&mut case_child, ret, self.out.clone());
         self.cases.push((value.into(), case_child));
         self
     }
@@ -499,7 +499,7 @@ pub fn switch_expand_expr<I: Int, C: CubePrimitive>(
     let mut default_child = scope.child();
     let default = default_block(&mut default_child);
     let out: ExpandElementTyped<C> = scope.create_local_mut(default.expand.item).into();
-    assign::expand(&mut default_child, default, out.clone());
+    assign::expand::<C>(&mut default_child, default, out.clone());
 
     SwitchExpandExpr {
         value,

--- a/crates/cubecl-core/src/frontend/container/array/base.rs
+++ b/crates/cubecl-core/src/frontend/container/array/base.rs
@@ -183,7 +183,7 @@ mod vectorization {
                     self.clone(),
                     ExpandElementTyped::from_lit(scope, 0u32),
                 );
-                assign::expand(scope, element, new_var.clone().into());
+                assign::expand::<C>(scope, element, new_var.clone().into());
                 new_var
             } else {
                 let new_var = scope.create_local_mut(item);

--- a/crates/cubecl-core/src/frontend/container/option/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/option/launch.rs
@@ -3,13 +3,7 @@ use crate::{
     prelude::{ArgSettings, CompilationArg, LaunchArg, LaunchArgExpand},
     Runtime,
 };
-use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
-
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
-pub struct CubeOptionCompilationArg<C> {
-    pub inner: Option<C>,
-}
 
 impl<C: CompilationArg> CompilationArg for Option<C> {}
 
@@ -43,7 +37,6 @@ impl<R: Runtime, A: ArgSettings<R>> ArgSettings<R> for Option<A> {
 
 impl<T: LaunchArg> LaunchArg for Option<T> {
     type RuntimeArg<'a, R: Runtime> = Option<T::RuntimeArg<'a, R>>;
-
     fn compilation_arg<R: Runtime>(runtime_arg: &Self::RuntimeArg<'_, R>) -> Self::CompilationArg {
         runtime_arg.as_ref().map(T::compilation_arg)
     }

--- a/crates/cubecl-core/src/runtime_tests/enums.rs
+++ b/crates/cubecl-core/src/runtime_tests/enums.rs
@@ -1,0 +1,153 @@
+use crate as cubecl;
+use cubecl::prelude::*;
+
+#[derive(CubeLaunch, Clone, Debug, Hash, PartialEq, Eq, Copy)]
+pub enum TestEnum<
+    T: std::fmt::Debug + CubeType + Clone + IntoRuntime + LaunchArg + std::cmp::Eq + std::hash::Hash,
+> {
+    A(i32, u32),
+    B(BStruct),
+    C(T),
+    D,
+    E { x: i32 },
+    F { x: i32, y: u32 },
+}
+
+#[derive(CubeLaunch, Clone, Debug, Hash, PartialEq, Eq, Copy)]
+pub struct BStruct {
+    x: i32,
+    y: u32,
+}
+
+// We just check that it compiles for the syntax.
+#[allow(unused_variables)]
+#[allow(clippy::needless_match)]
+#[cube(launch)]
+pub fn kernel_comptime_variants(#[comptime] test: TestEnum<i32>) {
+    let test2 = comptime! {
+        match test {
+            TestEnum::A(x, y) => TestEnum::A(x, y),
+            TestEnum::B(x) => TestEnum::B(x),
+            TestEnum::C(x) => TestEnum::C(x),
+            TestEnum::D => TestEnum::D,
+            TestEnum::E {x} => TestEnum::E { x },
+            TestEnum::F {x, ..} => TestEnum::F { x, y: 2 }
+        }
+    };
+}
+
+// We just check that it compiles for the syntax.
+#[allow(unused_variables)]
+#[allow(clippy::needless_match)]
+#[allow(clippy::clone_on_copy)]
+#[cube(launch)]
+pub fn kernel_runtime_variants(test: TestEnum<i32>) {
+    let test2: TestEnum<i32> = match test.clone() {
+        TestEnum::A(x, y) => TestEnum::new_A(x, y),
+        TestEnum::B(x) => TestEnum::new_B(x),
+        TestEnum::C(x) => TestEnum::new_C(x),
+        TestEnum::D => TestEnum::new_D(),
+        TestEnum::E { x } => TestEnum::new_E(x),
+        TestEnum::F { x, .. } => TestEnum::new_F(x, 2),
+    };
+}
+
+#[cube(launch)]
+pub fn kernel_scalar_enum(test: TestEnum<i32>, output: &mut Array<f32>) {
+    match test {
+        TestEnum::A(x, y) | TestEnum::F { x, y } => {
+            output[0] = f32::cast_from(x) + f32::cast_from(y);
+        }
+        TestEnum::B(b) => {
+            output[0] = f32::cast_from(b.x) + f32::cast_from(b.y);
+        }
+        TestEnum::C(x) | TestEnum::E { x } => {
+            output[0] = f32::cast_from(x);
+        }
+        TestEnum::D => {
+            output[0] = 999.0;
+        }
+    };
+}
+
+pub fn test_scalar_enum<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
+    let array = client.empty(std::mem::size_of::<f32>());
+
+    kernel_scalar_enum::launch::<R>(
+        &client,
+        CubeCount::new_single(),
+        CubeDim::new_single(),
+        TestEnumArgs::<i32, R>::C(ScalarArg::new(10)),
+        unsafe { ArrayArg::<R>::from_raw_parts::<f32>(&array, 1, 1) },
+    );
+    let bytes = client.read_one(array.binding());
+    let actual = f32::from_bytes(&bytes);
+
+    assert_eq!(actual[0], 10.0);
+}
+
+#[derive(CubeLaunch)]
+pub enum ArrayFloatInt {
+    Float(Array<f32>),
+    Int(Array<i32>),
+}
+
+#[cube(launch)]
+fn kernel_array_float_int(array: &mut ArrayFloatInt) {
+    if UNIT_POS == 0 {
+        match array {
+            ArrayFloatInt::Float(array) => array[0] = 10.0,
+            ArrayFloatInt::Int(array) => array[0] = 20,
+        }
+    }
+}
+
+pub fn test_array_float_int<R: Runtime, T: CubePrimitive + CubeElement>(
+    client: &ComputeClient<R::Server, R::Channel>,
+    expected: T,
+) {
+    let array = client.empty(std::mem::size_of::<T>());
+
+    kernel_array_float_int::launch(
+        client,
+        CubeCount::new_single(),
+        CubeDim::new_single(),
+        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<f32>() {
+            ArrayFloatIntArgs::Float(unsafe { ArrayArg::<R>::from_raw_parts::<f32>(&array, 1, 1) })
+        } else {
+            ArrayFloatIntArgs::Int(unsafe { ArrayArg::<R>::from_raw_parts::<i32>(&array, 1, 1) })
+        },
+    );
+
+    let bytes = client.read_one(array.binding());
+    let actual = T::from_bytes(&bytes);
+
+    assert_eq!(actual[0], expected);
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! testgen_enums {
+    () => {
+        mod enums {
+            use super::*;
+
+            #[test]
+            fn scalar_enum() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_core::runtime_tests::enums::test_scalar_enum::<TestRuntime>(client);
+            }
+
+            #[test]
+            fn array_float_int() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_core::runtime_tests::enums::test_array_float_int::<TestRuntime, f32>(
+                    &client, 10.0,
+                );
+                cubecl_core::runtime_tests::enums::test_array_float_int::<TestRuntime, i32>(
+                    &client, 20,
+                );
+            }
+        }
+    };
+}

--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -21,6 +21,7 @@ pub mod tensor;
 pub mod topology;
 pub mod traits;
 pub mod unary;
+pub mod enums;
 
 #[allow(missing_docs)]
 #[macro_export]
@@ -124,6 +125,7 @@ macro_rules! testgen_untyped {
         cubecl_core::testgen_debug!();
 
         cubecl_core::testgen_option!();
+        cubecl_core::testgen_enums!();
     };
 }
 

--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -8,6 +8,7 @@ pub mod const_match;
 pub mod constants;
 pub mod debug;
 pub mod different_rank;
+pub mod enums;
 pub mod index;
 pub mod launch;
 pub mod line;
@@ -21,7 +22,6 @@ pub mod tensor;
 pub mod topology;
 pub mod traits;
 pub mod unary;
-pub mod enums;
 
 #[allow(missing_docs)]
 #[macro_export]

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -141,10 +141,16 @@ pub enum Expression {
         path: Path,
         fields: Vec<(Member, Expression)>,
     },
+    NamedEnumInit {
+        path: Path,
+        variant: Ident,
+        fields: Vec<(Member, Expression)>,
+    },
     Keyword {
-        name: syn::Ident,
+        name: Ident,
     },
     ConstMatch {
+        runtime_variant: bool,
         const_expr: syn::Expr,
         arms: Vec<ConstMatchArm>,
     },
@@ -159,6 +165,7 @@ pub struct ConstMatchArm {
     pub pat: syn::Pat,
     pub expr: Box<Expression>,
 }
+
 
 #[derive(Clone, Debug, Default)]
 pub struct Block {
@@ -199,6 +206,7 @@ impl Expression {
             Expression::VerbatimTerminated { .. } => None,
             Expression::Reference { inner } => inner.ty(),
             Expression::StructInit { .. } => None,
+            Expression::NamedEnumInit { .. } => None,
             Expression::Closure { .. } => None,
             Expression::Keyword { .. } => None,
             Expression::CompilerIntrinsic { .. } => None,

--- a/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
@@ -379,7 +379,6 @@ impl CubeTypeEnum {
         let compilation_arg =
             Ident::new(&format!("{}CompilationArg", self.ident), Span::call_site());
 
-        // let generics = self.expanded_generics();
         let (generics, generic_names, where_clause) = self.generics.split_for_impl();
 
         let branches_expand = self

--- a/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
@@ -2,22 +2,42 @@ use crate::{
     parse::cube_type::{CubeTypeEnum, CubeTypeVariant, VariantKind},
     paths::prelude_type,
 };
-use proc_macro2::TokenStream;
-use quote::quote;
-use syn::Ident;
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::{Ident, PathArguments, Type};
 
 impl CubeTypeEnum {
     pub fn generate(&self, with_launch: bool) -> TokenStream {
-        assert!(!with_launch, "Can't create launchable enum yet.");
-
         let expand_ty = self.expand_ty();
         let cube_type_impl = self.cube_type_impl();
         let expand_type_impl = self.expand_type_impl();
 
-        quote! {
-           #expand_ty
-           #cube_type_impl
-           #expand_type_impl
+        if with_launch {
+            let args_ty = self.args_ty();
+            let arg_settings_impl = self.arg_settings_impl();
+            let launch_arg_impl = self.launch_arg_impl();
+
+            let compilation_arg_ty = self.compilation_arg_ty();
+            let launch_arg_expand_impl = self.launch_arg_expand_impl();
+
+            quote! {
+                #expand_ty
+                #cube_type_impl
+                #expand_type_impl
+
+                #args_ty
+                #arg_settings_impl
+                #launch_arg_impl
+
+                #compilation_arg_ty
+                #launch_arg_expand_impl
+            }
+        } else {
+            quote! {
+                #expand_ty
+                #cube_type_impl
+                #expand_type_impl
+            }
         }
     }
 
@@ -34,6 +54,7 @@ impl CubeTypeEnum {
             }
         }
     }
+
     fn cube_type_impl(&self) -> proc_macro2::TokenStream {
         let cube_type = prelude_type("CubeType");
         let name = &self.ident;
@@ -74,6 +95,11 @@ impl CubeTypeEnum {
                 .collect(),
         );
 
+        let new_variant_functions = self
+            .variants
+            .iter()
+            .map(|v| v.new_variant_function(name_expand, &generic_names));
+
         quote! {
             impl #generics #init for #name_expand #generic_names #where_clause {
                 fn init(self, context: &mut #context) -> Self {
@@ -81,12 +107,396 @@ impl CubeTypeEnum {
                 }
             }
 
+            impl #generics #debug for #name #generic_names #where_clause {}
+
             impl #generics #debug for #name_expand #generic_names #where_clause {}
 
             impl #generics #into_runtime for #name #generic_names #where_clause {
                 fn __expand_runtime_method(self, context: &mut #context) -> Self::ExpandType {
                     let expand = #body_into_runtime;
                     #init::init(expand, context)
+                }
+            }
+
+            #[allow(non_snake_case)]
+            #[allow(unused)]
+            impl #generics #name #generic_names #where_clause {
+                #(
+                    #new_variant_functions
+                )*
+            }
+        }
+    }
+
+    fn args_ty(&self) -> proc_macro2::TokenStream {
+        let name = Ident::new(&format!("{}Args", self.ident), Span::call_site());
+        let vis = &self.vis;
+
+        let generics = self.expanded_generics();
+
+        let variants = self.variants.iter().map(|variant| {
+            let variant_name = &variant.ident;
+            match variant.kind {
+                VariantKind::Named => {
+                    let args = variant.fields.iter().map(|f| {
+                        let field_name = &f.ident;
+                        let field_ty = &f.ty;
+                        quote! { #field_name: <#field_ty as LaunchArg>::RuntimeArg<'a, R> }
+                    });
+                    quote! {
+                        #variant_name {
+                            #(
+                                #args,
+                            )*
+                        }
+                    }
+                }
+                VariantKind::Unnamed => {
+                    let args = variant.fields.iter().map(|f| {
+                        let field_ty = &f.ty;
+                        quote! { <#field_ty as LaunchArg>::RuntimeArg<'a, R> }
+                    });
+                    quote! {
+                        #variant_name(#(#args),*)
+                    }
+                }
+                VariantKind::Empty => {
+                    quote! {
+                        #variant_name
+                    }
+                }
+            }
+        });
+
+        quote! {
+            #vis enum #name #generics {
+                #(
+                    #variants
+                ),*
+            }
+        }
+    }
+
+    fn arg_settings_impl(&self) -> proc_macro2::TokenStream {
+        let arg_settings = prelude_type("ArgSettings");
+        let kernel_launcher = prelude_type("KernelLauncher");
+        let name = Ident::new(&format!("{}Args", self.ident), Span::call_site());
+
+        let generics = self.expanded_generics();
+        let (generics, generic_names, where_clause) = generics.split_for_impl();
+
+        let branches = self
+            .variants
+            .iter()
+            .map(|variant| {
+                let variant_name = &variant.ident;
+                match variant.kind {
+                    VariantKind::Named => {
+                        let args = &variant.field_names;
+                        quote! {
+                            #name::#variant_name { #(#args),* } => {
+                                #(
+                                    #args.register(launcher);
+                                )*
+                            }
+                        }
+                    }
+                    VariantKind::Unnamed => {
+                        let args = variant
+                            .fields
+                            .iter()
+                            .enumerate()
+                            .map(|(i, _)| Ident::new(&format!("_{i}"), Span::call_site()))
+                            .collect::<Vec<_>>();
+                        quote! {
+                            #name::#variant_name(#(#args),*) => {
+                                #(
+                                    #args.register(launcher);
+                                )*
+                            }
+                        }
+                    }
+                    VariantKind::Empty => {
+                        quote! {
+                            #name::#variant_name => {}
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        let body = self.match_impl(quote! {self}, branches);
+
+        quote! {
+            impl #generics #arg_settings<R> for #name #generic_names #where_clause {
+                fn register(&self, launcher: &mut #kernel_launcher<R>) {
+                    #body
+                }
+            }
+        }
+    }
+
+    fn launch_arg_impl(&self) -> proc_macro2::TokenStream {
+        let launch_arg = prelude_type("LaunchArg");
+
+        let name = &self.ident;
+        let name_args = Ident::new(&format!("{}Args", self.ident), Span::call_site());
+        let compilation_arg =
+            Ident::new(&format!("{}CompilationArg", self.ident), Span::call_site());
+
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+
+        let assoc_generics = self.assoc_generics();
+        let all = self.expanded_generics();
+        let (_, all_generic_names, _) = all.split_for_impl();
+
+        let branches = self
+            .variants
+            .iter()
+            .map(|variant| {
+                let variant_name = &variant.ident;
+                match variant.kind {
+                    VariantKind::Named => {
+                        let args = &variant.field_names;
+                        let body = variant.fields.iter().map(|f| {
+                            let ty = add_double_colon_in_type(f.ty.clone());
+                            let name = &f.ident;
+                            quote! { #name: #ty::compilation_arg::<R>(#name), }
+                        });
+                        quote! {
+                            #name_args::#variant_name { #(#args),* } => #compilation_arg::#variant_name {
+                                #(
+                                    #body
+                                )*
+                            }
+                        }
+                    }
+                    VariantKind::Unnamed => {
+                        let args = variant
+                            .fields
+                            .iter()
+                            .enumerate()
+                            .map(|(i, _)| Ident::new(&format!("_{i}"), Span::call_site()));
+                        let body = variant.fields.iter().enumerate().map(|(i, f)| {
+                            let ty = add_double_colon_in_type(f.ty.clone());
+                            let name = Ident::new(&format!("_{i}"), Span::call_site());
+                            quote! { #ty::compilation_arg::<R>(#name), }
+                        });
+                        quote! {
+                            #name_args::#variant_name(#(#args),*) => #compilation_arg::#variant_name (
+                                #(
+                                    #body
+                                )*
+                            )
+                        }
+                    }
+                    VariantKind::Empty => {
+                        quote! {
+                            #name_args::#variant_name => #compilation_arg::#variant_name
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        let body = self.match_impl(quote! {runtime_arg}, branches);
+
+        quote! {
+            impl #generics #launch_arg for #name #generic_names #where_clause {
+                type RuntimeArg #assoc_generics = #name_args #all_generic_names;
+
+                fn compilation_arg #assoc_generics(runtime_arg: &Self::RuntimeArg<'a, R>) -> Self::CompilationArg {
+                    #body
+                }
+            }
+        }
+    }
+
+    fn compilation_arg_ty(&self) -> proc_macro2::TokenStream {
+        let compilation_arg = prelude_type("CompilationArg");
+
+        let name = Ident::new(&format!("{}CompilationArg", self.ident), Span::call_site());
+        let vis = &self.vis;
+
+        let generics = &self.generics;
+
+        let variants = self.variants.iter().map(|variant| {
+            let variant_name = &variant.ident;
+            match variant.kind {
+                VariantKind::Named => {
+                    let args = variant.fields.iter().map(|f| {
+                        let field_name = &f.ident;
+                        let field_ty = &f.ty;
+                        quote! { #field_name: <#field_ty as LaunchArgExpand>::CompilationArg }
+                    });
+                    quote! {
+                        #variant_name {
+                            #(
+                                #args,
+                            )*
+                        }
+                    }
+                }
+                VariantKind::Unnamed => {
+                    let args = variant.fields.iter().map(|f| {
+                        let field_ty = &f.ty;
+                        quote! { <#field_ty as LaunchArgExpand>::CompilationArg }
+                    });
+                    quote! {
+                        #variant_name(#(#args),*)
+                    }
+                }
+                VariantKind::Empty => {
+                    quote! {
+                        #variant_name
+                    }
+                }
+            }
+        });
+
+        let (generics_impl, generic_names, where_clause) = self.generics.split_for_impl();
+
+        quote! {
+            #[derive(Clone, serde::Serialize, serde::Deserialize, Hash, PartialEq, Eq, Debug)]
+            #[serde(bound(serialize = "", deserialize = ""))]
+            #vis enum #name #generics {
+                #(
+                    #variants
+                ),*
+            }
+
+            impl #generics_impl #compilation_arg for #name #generic_names #where_clause {}
+        }
+    }
+
+    fn launch_arg_expand_impl(&self) -> proc_macro2::TokenStream {
+        let launch_arg_expand = prelude_type("LaunchArgExpand");
+        let cube_type = prelude_type("CubeType");
+        let kernel_builder = prelude_type("KernelBuilder");
+
+        let name = &self.ident;
+        let name_expand = Ident::new(&format!("{}Expand", self.ident), Span::call_site());
+        let compilation_arg =
+            Ident::new(&format!("{}CompilationArg", self.ident), Span::call_site());
+
+        // let generics = self.expanded_generics();
+        let (generics, generic_names, where_clause) = self.generics.split_for_impl();
+
+        let branches_expand = self
+            .variants
+            .iter()
+            .map(|variant| {
+                let variant_name = &variant.ident;
+                match variant.kind {
+                    VariantKind::Named => {
+                        let args = &variant.field_names;
+                        let body = variant.fields.iter().map(|f| {
+                            let ty = add_double_colon_in_type(f.ty.clone());
+                            let name = &f.ident;
+                            quote! { #name: #ty::expand(#name, builder), }
+                        });
+                        quote! {
+                            #compilation_arg::#variant_name { #(#args),* } => #name_expand::#variant_name {
+                                #(
+                                    #body
+                                )*
+                            }
+                        }
+                    }
+                    VariantKind::Unnamed => {
+                        let args = variant
+                            .fields
+                            .iter()
+                            .enumerate()
+                            .map(|(i, _)| Ident::new(&format!("_{i}"), Span::call_site()));
+                        let compilation_args = variant.fields.iter().enumerate().map(|(i, f)| {
+                            let ty = add_double_colon_in_type(f.ty.clone());
+                            let name = Ident::new(&format!("_{i}"), Span::call_site());
+                            quote! { #ty::expand(#name, builder), }
+                        });
+                        quote! {
+                            #compilation_arg::#variant_name(#(#args),*) => #name_expand::#variant_name (
+                                #(
+                                    #compilation_args
+                                )*
+                            )
+                        }
+                    }
+                    VariantKind::Empty => {
+                        quote! {
+                            #compilation_arg::#variant_name => #name_expand::#variant_name
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        let body_expand = self.match_impl(quote! {arg}, branches_expand);
+
+        let branches_expand_output = self
+            .variants
+            .iter()
+            .map(|variant| {
+                let variant_name = &variant.ident;
+                match variant.kind {
+                    VariantKind::Named => {
+                        let args = &variant.field_names;
+                        let body = variant.fields.iter().map(|f| {
+                            let ty = add_double_colon_in_type(f.ty.clone());
+                            let name = &f.ident;
+                            quote! { #name: #ty::expand_output(#name, builder), }
+                        });
+                        quote! {
+                            #compilation_arg::#variant_name { #(#args),* } => #name_expand::#variant_name {
+                                #(
+                                    #body
+                                )*
+                            }
+                        }
+                    }
+                    VariantKind::Unnamed => {
+                        let args = variant
+                            .fields
+                            .iter()
+                            .enumerate()
+                            .map(|(i, _)| Ident::new(&format!("_{i}"), Span::call_site()));
+                        let compilation_args = variant.fields.iter().enumerate().map(|(i, f)| {
+                            let ty = add_double_colon_in_type(f.ty.clone());
+                            let name = Ident::new(&format!("_{i}"), Span::call_site());
+                            quote! { #ty::expand_output(#name, builder), }
+                        });
+                        quote! {
+                            #compilation_arg::#variant_name(#(#args),*) => #name_expand::#variant_name (
+                                #(
+                                    #compilation_args
+                                )*
+                            )
+                        }
+                    }
+                    VariantKind::Empty => {
+                        quote! {
+                            #compilation_arg::#variant_name => #name_expand::#variant_name
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        let body_expand_output = self.match_impl(quote! {arg}, branches_expand_output);
+
+        quote! {
+            impl #generics #launch_arg_expand for #name #generic_names #where_clause {
+                type CompilationArg = #compilation_arg #generic_names;
+
+                fn expand(arg: &Self::CompilationArg, builder: &mut #kernel_builder) -> <Self as #cube_type>::ExpandType {
+                    #body_expand
+                }
+
+                fn expand_output(
+                    arg: &Self::CompilationArg,
+                    builder: &mut #kernel_builder,
+                ) -> <Self as #cube_type>::ExpandType {
+                    #body_expand_output
                 }
             }
         }
@@ -111,7 +521,7 @@ impl CubeTypeVariant {
         let cube_type = prelude_type("CubeType");
 
         let fields = self.fields.iter().map(|field| {
-            let ty = &field.ty;
+            let ty = add_double_colon_in_type(field.ty.clone());
             match &field.ident {
                 Some(name) => {
                     quote! {#name: <#ty as #cube_type>::ExpandType}
@@ -167,12 +577,102 @@ impl CubeTypeVariant {
         });
 
         let body = match self.kind {
-            VariantKind::Named => quote![#ident_ty_expand::#name { #(#body),*} ],
+            VariantKind::Named => quote![#ident_ty_expand::#name { #(#body),* } ],
             VariantKind::Unnamed => quote![#ident_ty_expand::#name ( #(#body),* ) ],
             VariantKind::Empty => quote![#ident_ty_expand::#name],
         };
 
         self.run_on_variants(ident_ty_expand, body)
+    }
+
+    fn new_variant_function(
+        &self,
+        ident_ty_expand: &Ident,
+        generics: &syn::TypeGenerics,
+    ) -> TokenStream {
+        let cube_type = prelude_type("CubeType");
+        let context = prelude_type("Scope");
+        let ident = &self.ident;
+        let base_function = Ident::new(&format!("new_{}", ident), ident.span());
+        let expand_function = Ident::new(&format!("__expand_new_{}", ident), ident.span());
+
+        let turbofish = generics.as_turbofish();
+
+        match self.kind {
+            VariantKind::Named => {
+                let args_with_base_types = self.fields.iter().map(|f| {
+                    let ty = &f.ty;
+                    let name = &f.ident;
+                    quote! {
+                        #name: #ty
+                    }
+                });
+
+                let args_with_expand_types = self.fields.iter().map(|f| {
+                    let ty = &f.ty;
+                    let name = &f.ident;
+                    quote! {
+                        #name: <#ty as #cube_type>::ExpandType
+                    }
+                });
+
+                let args = self.fields.iter().map(|f| &f.ident);
+
+                quote! {
+                    pub fn #base_function(#(#args_with_base_types),*) -> Self {
+                        cubecl::unexpanded!()
+                    }
+
+                    pub fn #expand_function(_: &mut #context, #(#args_with_expand_types),*) -> #ident_ty_expand #generics {
+                        #ident_ty_expand #turbofish ::#ident {#(#args),*}
+                    }
+                }
+            }
+            VariantKind::Unnamed => {
+                let args_with_base_types = self.fields.iter().enumerate().map(|(i, f)| {
+                    let ty = &f.ty;
+                    let name = Ident::new(&format!("_{i}"), Span::call_site());
+                    quote! {
+                        #name: #ty
+                    }
+                });
+
+                let args_with_expand_types = self.fields.iter().enumerate().map(|(i, f)| {
+                    let ty = &f.ty;
+                    let name = Ident::new(&format!("_{i}"), Span::call_site());
+                    quote! {
+                        #name: <#ty as #cube_type>::ExpandType
+                    }
+                });
+
+                let args = self
+                    .fields
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| Ident::new(&format!("_{i}"), Span::call_site()));
+
+                quote! {
+                    pub fn #base_function(#(#args_with_base_types),*) -> Self {
+                        cubecl::unexpanded!()
+                    }
+
+                    pub fn #expand_function(_: &mut #context, #(#args_with_expand_types),*) -> #ident_ty_expand #generics {
+                        #ident_ty_expand #turbofish ::#ident(#(#args),*)
+                    }
+                }
+            }
+            VariantKind::Empty => {
+                quote! {
+                    pub fn #base_function() -> Self {
+                        cubecl::unexpanded!()
+                    }
+
+                    pub fn #expand_function(_: &mut #context) -> #ident_ty_expand #generics {
+                        #ident_ty_expand #turbofish ::#ident
+                    }
+                }
+            }
+        }
     }
 
     fn run_on_variants(&self, parent_ty: &Ident, body: TokenStream) -> TokenStream {
@@ -194,5 +694,24 @@ impl CubeTypeVariant {
                 #parent_ty::#ident => #body
             },
         }
+    }
+}
+
+fn add_double_colon_in_type(mut ty: Type) -> TokenStream {
+    match ty {
+        Type::Path(ref mut ty) => ty
+            .path
+            .segments
+            .last_mut()
+            .map(|ty| match ty.clone().arguments {
+                PathArguments::AngleBracketed(arg) => {
+                    let mut new_ty = ty.clone();
+                    new_ty.arguments = PathArguments::None;
+                    quote! { #new_ty :: #arg }
+                }
+                _ => ty.to_token_stream(),
+            })
+            .expect("type path must contains at least a segment"),
+        ty => ty.to_token_stream(),
     }
 }

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -572,7 +572,6 @@ impl MatchArm {
             Pat::Wild(_) => {}
             _ => {
                 panic!("unsupported pattern in match");
-                // panic!("{pat:?}");
                 // NOTE: From the documentation https://docs.rs/syn/latest/syn/enum.Pat.html
                 //       I don't think we should support any other patterns.
                 //       Users can always use a big if, else if, else pattern instead.

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -109,7 +109,6 @@ fn cube_impl(args: TokenStream, input: TokenStream) -> syn::Result<TokenStream> 
 /// Derive macro to define a cube type that is launched with a kernel
 #[proc_macro_derive(CubeLaunch, attributes(expand, cube))]
 pub fn module_derive_cube_launch(input: TokenStream) -> TokenStream {
-    // panic!("{gen}");
     gen_cube_type(input, true)
 }
 

--- a/crates/cubecl-macros/src/parse/cube_type/parse_enum.rs
+++ b/crates/cubecl-macros/src/parse/cube_type/parse_enum.rs
@@ -1,6 +1,10 @@
+use std::iter;
+
 use darling::FromDeriveInput;
 use proc_macro2::Span;
-use syn::{spanned::Spanned, Ident};
+use syn::{parse_quote, punctuated::Punctuated, spanned::Spanned, Generics, Ident};
+
+use crate::paths::prelude_type;
 
 #[derive(Debug)]
 pub struct CubeTypeEnum {
@@ -71,5 +75,21 @@ impl FromDeriveInput for CubeTypeEnum {
             }),
             _ => Err(darling::Error::custom("Only enum are supported.")),
         }
+    }
+}
+
+impl CubeTypeEnum {
+    pub fn expanded_generics(&self) -> Generics {
+        let runtime = prelude_type("Runtime");
+        let mut generics = self.generics.clone();
+        generics.params.push(parse_quote![R: #runtime]);
+        let all = iter::once(parse_quote!['a]).chain(generics.params);
+        generics.params = Punctuated::from_iter(all);
+        generics
+    }
+
+    pub fn assoc_generics(&self) -> Generics {
+        let runtime = prelude_type("Runtime");
+        parse_quote![<'a, R: #runtime>]
     }
 }

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -1,7 +1,8 @@
 use proc_macro2::Span;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::{
-    parse_quote, spanned::Spanned, Expr, ExprUnary, Lit, LitInt, Pat, Path, PathSegment, RangeLimits, Type, UnOp,
+    parse_quote, spanned::Spanned, Expr, ExprUnary, Lit, LitInt, Pat, Path, PathSegment,
+    RangeLimits, Type, UnOp,
 };
 
 use crate::{
@@ -408,7 +409,7 @@ fn add_variables_from_pat(pat: &Pat, context: &mut Context) {
         Pat::TupleStruct(pat) => pat.elems.iter().for_each(|pat| {
             add_variables_from_pat(pat, context);
         }),
-        _ => {},
+        _ => {}
     }
 }
 

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -67,14 +67,12 @@ impl Expression {
             Expr::Path(path) => {
                 let name = path.path.get_ident();
                 if let Some(var) = name.and_then(|ident| context.variable(ident)) {
-                    // panic!("HELLO NATH {var:?};");
                     if var.is_keyword {
                         Expression::Keyword { name: var.name }
                     } else {
                         Expression::Variable(var)
                     }
                 } else {
-                    // panic!("NAME  {name:?}\n CONTEXT {context:?}");
                     // If it's not in the scope, it's not a managed local variable. Treat it as an
                     // external value like a Rust `const`.
                     Expression::Path { path: path.path }

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -297,10 +297,25 @@ impl Expression {
                 } else if let Some(switch) = numeric_match(mat, context) {
                     switch
                 } else {
-                    Err(syn::Error::new(
-                        span,
-                        "Only numeric match expression is supported at runtime",
-                    ))?
+                    // TODO: Runtime match to support funky enums.
+                    let mut arms = Vec::new();
+
+                    for arm in mat.arms.iter() {
+                        arms.push(RuntimeMatchArg { // TODO RuntimeMAtchArg
+                            pat: arm.pat.clone(),
+                            expr: Box::new(Self::from_expr(arm.body.as_ref().clone(), context)?),
+                        });
+                    }
+
+                    Expression::RuntimeMatch { // TODO RuntimeMatch
+                        const_expr: mat.expr.as_ref().clone(),
+                        arms,
+                    }
+
+                    // Err(syn::Error::new(
+                    //     span,
+                    //     "Only numeric match expression is supported at runtime",
+                    // ))?
                 }
             }
             Expr::Macro(mac) if is_comptime_macro(&mac.mac.path) => {

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -32,7 +32,6 @@ impl Expression {
                 let left = Self::from_expr(*binary.left, context)?;
                 let right = Self::from_expr(*binary.right, context)?;
                 if left.is_const() && right.is_const() {
-                    // panic!("left -> {left:?}");
                     Expression::Verbatim {
                         tokens: quote![#expr],
                     }

--- a/crates/cubecl-macros/src/scope.rs
+++ b/crates/cubecl-macros/src/scope.rs
@@ -37,7 +37,7 @@ pub const KEYWORDS: [&str; 22] = [
 pub type Scope = usize;
 type ManagedScope = Vec<ManagedVar>;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Context {
     pub return_type: Type,
     scopes: Vec<ManagedScope>,


### PR DESCRIPTION
Finally, here is the PR for the improved enum bahavior. They are now usable in launch function and we can perform comptime match with runtime variant. 

The only unpolished part is that we need to use `MyEnum::new_VariantName(x, y, z)` instead of `MyEnum::VariantName { x, y, z }` with runtime values. This is a limitation because they are no syntactic difference between `MyEnum::Variant` and `some_path::MyStruct`. However, for the former, we need to call the expand type of `MyEnum` (the first segment of the path) and, for the later, we need to call the expand type of `MyStruct` (the last segment of the path). I decided to keep the original behavior to keep struct working as they are today by introducing the `new_Variant` pattern