### PR TITLE
fix pipeline zeroing

### DIFF
--- a/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/single_stage/simple/matmul_pipelined.rs
@@ -169,8 +169,17 @@ where
         let (mut lhs_tile, mut rhs_tile) = SMM::init_tile_inputs(config.to_smm_config());
         SMM::zero_accumulator(acc, config.to_smm_config());
 
-        for _ in 0..num_loops {
+        for loop_iter in 0..num_loops {
             sync_units();
+
+            #[allow(clippy::collapsible_if)]
+            if comptime!(config.check_k_bounds()) {
+                if loop_iter == num_loops - 1 {
+                    Self::LhsLoader::clear_stage(&mut lhs_loader, config);
+                    Self::RhsLoader::clear_stage(&mut rhs_loader, config);
+                    sync_units();
+                }
+            }
 
             // Start loading
             pipeline.producer_acquire();


### PR DESCRIPTION
Had done it for simple_barrier, but forgot for simple_pipeline: we must zero out the shared memory before the last iteration if there are out of bounds. 