### PR TITLE
Add memory_cleanup function, rework some dealloc functions

### DIFF
--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -271,7 +271,7 @@ impl ComputeServer for CudaServer {
         async move { duration }
     }
 
-    fn get_resource(&mut self, binding: server::Binding) -> BindingResource<Self> {
+    fn get_resource(&mut self, binding: server::Binding) -> BindingResource<CudaResource> {
         let ctx = self.get_context();
         BindingResource::new(
             binding.clone(),

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -282,7 +282,11 @@ impl ComputeServer for CudaServer {
     }
 
     fn memory_usage(&self) -> MemoryUsage {
-        self.ctx.memory_usage()
+        self.ctx.memory_management.memory_usage()
+    }
+
+    fn memory_cleanup(&mut self) {
+        self.ctx.memory_management.cleanup(true);
     }
 
     fn enable_timestamps(&mut self) {
@@ -423,10 +427,6 @@ impl CudaContext {
             )
             .unwrap();
         };
-    }
-
-    fn memory_usage(&self) -> MemoryUsage {
-        self.memory_management.memory_usage()
     }
 }
 

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -158,6 +158,10 @@ impl ComputeServer for HipServer {
         self.ctx.memory_usage()
     }
 
+    fn memory_cleanup(&mut self) {
+        self.memory_management.cleanup(true);
+    }
+
     fn create(&mut self, data: &[u8]) -> server::Handle {
         let handle = self.empty(data.len());
         let ctx = self.get_context();
@@ -343,10 +347,6 @@ impl HipContext {
 
     fn memory_usage(&self) -> MemoryUsage {
         self.memory_management.memory_usage()
-    }
-
-    fn memory_cleanup(&mut self) {
-        self.memory_management.cleanup(true);
     }
 
     fn compile_kernel(

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -286,7 +286,7 @@ impl ComputeServer for HipServer {
         async move { duration }
     }
 
-    fn get_resource(&mut self, binding: server::Binding) -> BindingResource<Self> {
+    fn get_resource(&mut self, binding: server::Binding) -> BindingResource<HipResource> {
         let ctx = self.get_context();
         BindingResource::new(
             binding.clone(),

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -345,6 +345,10 @@ impl HipContext {
         self.memory_management.memory_usage()
     }
 
+    fn memory_cleanup(&mut self) {
+        self.memory_management.cleanup(true);
+    }
+
     fn compile_kernel(
         &mut self,
         kernel_id: &KernelId,

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -159,7 +159,8 @@ impl ComputeServer for HipServer {
     }
 
     fn memory_cleanup(&mut self) {
-        self.memory_management.cleanup(true);
+        let ctx = self.get_context();
+        ctx.memory_management.cleanup(true);
     }
 
     fn create(&mut self, data: &[u8]) -> server::Handle {

--- a/crates/cubecl-runtime/src/channel/base.rs
+++ b/crates/cubecl-runtime/src/channel/base.rs
@@ -49,6 +49,9 @@ pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send
     /// Get the current memory usage of the server.
     fn memory_usage(&self) -> crate::memory_management::MemoryUsage;
 
+    /// Ask the server to release memory that it can release.
+    fn memory_cleanup(&self);
+
     /// Enable collecting timestamps.
     fn enable_timestamps(&self);
 

--- a/crates/cubecl-runtime/src/channel/base.rs
+++ b/crates/cubecl-runtime/src/channel/base.rs
@@ -3,7 +3,7 @@ use cubecl_common::{benchmark::TimestampsResult, ExecutionMode};
 
 use crate::{
     server::{Binding, ComputeServer, CubeCount, Handle},
-    storage::BindingResource,
+    storage::{BindingResource, ComputeStorage},
 };
 use alloc::vec::Vec;
 
@@ -14,7 +14,10 @@ pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send
     fn read(&self, bindings: Vec<Binding>) -> impl Future<Output = Vec<Vec<u8>>> + Send;
 
     /// Given a resource handle, return the storage resource.
-    fn get_resource(&self, binding: Binding) -> BindingResource<Server>;
+    fn get_resource(
+        &self,
+        binding: Binding,
+    ) -> BindingResource<<Server::Storage as ComputeStorage>::Resource>;
 
     /// Given a resource as bytes, stores it and returns the resource handle
     fn create(&self, data: &[u8]) -> Handle;

--- a/crates/cubecl-runtime/src/channel/cell.rs
+++ b/crates/cubecl-runtime/src/channel/cell.rs
@@ -99,6 +99,10 @@ where
         self.server.borrow_mut().memory_usage()
     }
 
+    fn memory_cleanup(&self) {
+        self.server.borrow_mut().memory_cleanup();
+    }
+
     fn enable_timestamps(&self) {
         self.server.borrow_mut().enable_timestamps();
     }

--- a/crates/cubecl-runtime/src/channel/cell.rs
+++ b/crates/cubecl-runtime/src/channel/cell.rs
@@ -1,6 +1,6 @@
 use super::ComputeChannel;
 use crate::server::{Binding, ComputeServer, CubeCount, Handle};
-use crate::storage::BindingResource;
+use crate::storage::{BindingResource, ComputeStorage};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use cubecl_common::{benchmark::TimestampsResult, ExecutionMode};
@@ -51,7 +51,10 @@ where
         future.await
     }
 
-    fn get_resource(&self, binding: Binding) -> BindingResource<Server> {
+    fn get_resource(
+        &self,
+        binding: Binding,
+    ) -> BindingResource<<Server::Storage as ComputeStorage>::Resource> {
         self.server.borrow_mut().get_resource(binding)
     }
 

--- a/crates/cubecl-runtime/src/channel/mpsc.rs
+++ b/crates/cubecl-runtime/src/channel/mpsc.rs
@@ -6,7 +6,7 @@ use super::ComputeChannel;
 use crate::{
     memory_management::MemoryUsage,
     server::{Binding, ComputeServer, CubeCount, Handle},
-    storage::BindingResource,
+    storage::{BindingResource, ComputeStorage},
 };
 
 /// Create a channel using a [multi-producer, single-consumer channel to communicate with
@@ -35,7 +35,10 @@ where
     Server: ComputeServer,
 {
     Read(Vec<Binding>, Callback<Vec<Vec<u8>>>),
-    GetResource(Binding, Callback<BindingResource<Server>>),
+    GetResource(
+        Binding,
+        Callback<BindingResource<<Server::Storage as ComputeStorage>::Resource>>,
+    ),
     Create(Vec<u8>, Callback<Handle>),
     Empty(usize, Callback<Handle>),
     ExecuteKernel((Server::Kernel, CubeCount, ExecutionMode), Vec<Binding>),
@@ -137,7 +140,10 @@ where
         handle_response(response.recv().await)
     }
 
-    fn get_resource(&self, binding: Binding) -> BindingResource<Server> {
+    fn get_resource(
+        &self,
+        binding: Binding,
+    ) -> BindingResource<<Server::Storage as ComputeStorage>::Resource> {
         let (callback, response) = async_channel::unbounded();
 
         self.state

--- a/crates/cubecl-runtime/src/channel/mutex.rs
+++ b/crates/cubecl-runtime/src/channel/mutex.rs
@@ -1,6 +1,6 @@
 use super::ComputeChannel;
 use crate::server::{Binding, ComputeServer, CubeCount, Handle};
-use crate::storage::BindingResource;
+use crate::storage::{BindingResource, ComputeStorage};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use cubecl_common::{benchmark::TimestampsResult, ExecutionMode};
@@ -46,7 +46,10 @@ where
         fut.await
     }
 
-    fn get_resource(&self, binding: Binding) -> BindingResource<Server> {
+    fn get_resource(
+        &self,
+        binding: Binding,
+    ) -> BindingResource<<Server::Storage as ComputeStorage>::Resource> {
         self.server.lock().get_resource(binding)
     }
 

--- a/crates/cubecl-runtime/src/channel/mutex.rs
+++ b/crates/cubecl-runtime/src/channel/mutex.rs
@@ -96,6 +96,10 @@ where
         self.server.lock().memory_usage()
     }
 
+    fn memory_cleanup(&self) {
+        self.server.lock().memory_cleanup();
+    }
+
     fn enable_timestamps(&self) {
         self.server.lock().enable_timestamps();
     }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -4,7 +4,7 @@ use crate::{
     channel::ComputeChannel,
     memory_management::MemoryUsage,
     server::{Binding, ComputeServer, CubeCount, Handle},
-    storage::BindingResource,
+    storage::{BindingResource, ComputeStorage},
     DeviceProperties,
 };
 use alloc::sync::Arc;
@@ -80,7 +80,10 @@ where
     }
 
     /// Given a resource handle, returns the storage resource.
-    pub fn get_resource(&self, binding: Binding) -> BindingResource<Server> {
+    pub fn get_resource(
+        &self,
+        binding: Binding,
+    ) -> BindingResource<<Server::Storage as ComputeStorage>::Resource> {
         self.channel.get_resource(binding)
     }
 

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -142,6 +142,14 @@ where
         self.channel.memory_usage()
     }
 
+    /// Ask the client to release memory that it can release.
+    ///
+    /// Nb: Results will vary on what the memory allocator deems beneficial,
+    /// so it's not guaranteed any memory is freed.
+    pub fn memory_cleanup(&self) {
+        self.channel.memory_cleanup()
+    }
+
     /// When executing operation within the profile scope, you can call
     /// [sync_elapsed](Self::sync_elapsed) safely even in multithreaded workloads.
     /// Creates a profiling scope that enables safe timing measurements in concurrent contexts.

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -226,7 +226,16 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> {
     }
 
     /// Cleanup allocations in pools that are deemed unnecessary.
-    pub fn cleanup(&mut self) {
+    pub fn cleanup(&mut self, forced: bool) {
+        // As a slightly strange heuristic, we "fast forward" time based on how high
+        // priority the cleanup is.
+        self.alloc_reserve_count += if forced {
+            1000
+        } else {
+            // If not forced, still move time forward slowly so enough cleanup() calls will also release memory.
+            1
+        };
+
         for pool in self.pools.iter_mut() {
             pool.cleanup(&mut self.storage, self.alloc_reserve_count);
         }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
@@ -45,5 +45,10 @@ pub trait MemoryPool {
 
     fn get_memory_usage(&self) -> MemoryUsage;
 
-    fn cleanup<Storage: ComputeStorage>(&mut self, storage: &mut Storage, alloc_nr: u64);
+    fn cleanup<Storage: ComputeStorage>(
+        &mut self,
+        storage: &mut Storage,
+        alloc_nr: u64,
+        explicit: bool,
+    );
 }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
@@ -147,7 +147,12 @@ impl MemoryPool for SlicedPool {
         }
     }
 
-    fn cleanup<Storage: ComputeStorage>(&mut self, _storage: &mut Storage, _alloc_nr: u64) {
+    fn cleanup<Storage: ComputeStorage>(
+        &mut self,
+        _storage: &mut Storage,
+        _alloc_nr: u64,
+        _explicit: bool,
+    ) {
         // This pool doesn't do any shrinking currently.
     }
 }

--- a/crates/cubecl-runtime/src/server.rs
+++ b/crates/cubecl-runtime/src/server.rs
@@ -31,7 +31,10 @@ where
     ) -> impl Future<Output = Vec<Vec<u8>>> + Send + 'static;
 
     /// Given a resource handle, returns the storage resource.
-    fn get_resource(&mut self, binding: Binding) -> BindingResource<Self>;
+    fn get_resource(
+        &mut self,
+        binding: Binding,
+    ) -> BindingResource<<Self::Storage as ComputeStorage>::Resource>;
 
     /// Given a resource as bytes, stores it and returns the memory handle.
     fn create(&mut self, data: &[u8]) -> Handle;

--- a/crates/cubecl-runtime/src/server.rs
+++ b/crates/cubecl-runtime/src/server.rs
@@ -69,6 +69,9 @@ where
     /// The current memory usage of the server.
     fn memory_usage(&self) -> MemoryUsage;
 
+    /// Ask the server to release memory that it can release.
+    fn memory_cleanup(&mut self);
+
     /// Enable collecting timestamps.
     fn enable_timestamps(&mut self);
 

--- a/crates/cubecl-runtime/src/storage/base.rs
+++ b/crates/cubecl-runtime/src/storage/base.rs
@@ -1,7 +1,4 @@
-use crate::{
-    server::{Binding, ComputeServer},
-    storage_id_type,
-};
+use crate::{server::Binding, storage_id_type};
 
 // This ID is used to map a handle to its actual data.
 storage_id_type!(StorageId);
@@ -78,36 +75,28 @@ pub trait ComputeStorage: Send {
     fn alloc(&mut self, size: u64) -> StorageHandle;
 
     /// Deallocates the memory pointed by the given storage id.
+    ///
+    /// These deallocations might need to be flushed with [`Self::perform_deallocations`].
     fn dealloc(&mut self, id: StorageId);
 }
 
 /// Access to the underlying resource for a given binding.
 #[derive(new)]
-pub struct BindingResource<Server: ComputeServer> {
+pub struct BindingResource<Resource: Send> {
     // This binding is here just to keep the underlying allocation alive.
     // If the underlying allocation becomes invalid, someone else might
     // allocate into this resource which could lead to bad behaviour.
     #[allow(unused)]
     binding: Binding,
-    resource: <Server::Storage as ComputeStorage>::Resource,
+    resource: Resource,
 }
 
-impl<Server: ComputeServer> BindingResource<Server> {
+impl<Resource: Send> BindingResource<Resource> {
     /// access the underlying resource. Note: The resource might be bigger
     /// than just the original allocation for the binding. Only the part
     /// for the original binding is guaranteed to remain, other parts
     /// of the resource *will* be re-used.
-    pub fn resource(&self) -> &<Server::Storage as ComputeStorage>::Resource {
+    pub fn resource(&self) -> &Resource {
         &self.resource
-    }
-
-    /// Same as [resource](Self::resource), however consumes the binding.
-    ///
-    /// # Warning
-    ///
-    /// Make sure you use the resource before requesting more memory from the storage, since
-    /// this resource might get allocated again.
-    pub fn into_resource(self) -> <Server::Storage as ComputeStorage>::Resource {
-        self.resource
     }
 }

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use super::DummyKernel;
 use cubecl_runtime::memory_management::MemoryUsage;
 use cubecl_runtime::server::CubeCount;
-use cubecl_runtime::storage::{BindingResource, ComputeStorage};
+use cubecl_runtime::storage::{BindingResource, BytesResource, ComputeStorage};
 use cubecl_runtime::{
     memory_management::MemoryManagement,
     server::{Binding, ComputeServer, Handle},
@@ -61,7 +61,7 @@ impl ComputeServer for DummyServer {
         async move { bytes.into_iter().map(|b| b.read().to_vec()).collect() }
     }
 
-    fn get_resource(&mut self, binding: Binding) -> BindingResource<Self> {
+    fn get_resource(&mut self, binding: Binding) -> BindingResource<BytesResource> {
         let handle = self.memory_management.get(binding.clone().memory).unwrap();
         BindingResource::new(binding, self.memory_management.storage().get(&handle))
     }

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -130,6 +130,10 @@ impl ComputeServer for DummyServer {
         self.memory_management.memory_usage()
     }
 
+    fn memory_cleanup(&mut self) {
+        self.memory_management.cleanup(true);
+    }
+
     fn enable_timestamps(&mut self) {
         self.timestamps.enable();
     }

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -264,6 +264,10 @@ impl ComputeServer for WgpuServer {
         self.stream.memory_usage()
     }
 
+    fn memory_cleanup(&mut self) {
+        self.stream.memory_cleanup();
+    }
+
     fn enable_timestamps(&mut self) {
         self.stream.timestamps.enable(&self.device);
     }

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -1,18 +1,14 @@
 use std::{future::Future, time::Duration};
 
-use super::{
-    stream::{PipelineDispatch, WgpuStream},
-    WgpuStorage,
-};
+use super::WgpuResource;
+use super::{stream::WgpuStream, WgpuStorage};
 use crate::{timestamps::KernelTimestamps, AutoGraphicsApi};
 use crate::{AutoCompiler, GraphicsApi};
 use alloc::sync::Arc;
 use cubecl_common::future;
 use cubecl_core::{
-    compute::DebugInformation,
-    prelude::*,
-    server::{Binding, Handle},
-    Feature, KernelId, MemoryConfiguration, WgpuCompilationOptions,
+    compute::DebugInformation, prelude::*, server::Binding, Feature, KernelId, MemoryConfiguration,
+    WgpuCompilationOptions,
 };
 use cubecl_runtime::{
     debug::{DebugLogger, ProfileLevel},
@@ -110,26 +106,11 @@ impl ComputeServer for WgpuServer {
         &mut self,
         bindings: Vec<Binding>,
     ) -> impl Future<Output = Vec<Vec<u8>>> + Send + 'static {
-        let resources = bindings
-            .into_iter()
-            .map(|binding| {
-                let rb = self.get_resource(binding);
-                let resource = rb.resource();
-
-                (resource.buffer.clone(), resource.offset(), resource.size())
-            })
-            .collect();
-
-        // Clear compute pass.
-        self.stream.read_buffers(resources)
+        self.stream.read_buffers(bindings)
     }
 
-    fn get_resource(&mut self, binding: Binding) -> BindingResource<Self> {
-        let resource = self.stream.get_resource(
-            binding.clone().memory,
-            binding.offset_start,
-            binding.offset_end,
-        );
+    fn get_resource(&mut self, binding: Binding) -> BindingResource<WgpuResource> {
+        let resource = self.stream.get_resource(binding.clone());
         BindingResource::new(binding, resource)
     }
 
@@ -139,11 +120,11 @@ impl ComputeServer for WgpuServer {
     /// This is important, otherwise the compute passes are going to be too small and we won't be able to
     /// fully utilize the GPU.
     fn create(&mut self, data: &[u8]) -> server::Handle {
-        Handle::new(self.stream.create(data), None, None, data.len() as u64)
+        self.stream.create(data)
     }
 
     fn empty(&mut self, size: usize) -> server::Handle {
-        Handle::new(self.stream.empty(size as u64), None, None, size as u64)
+        self.stream.empty(size as u64)
     }
 
     unsafe fn execute(
@@ -174,24 +155,7 @@ impl ComputeServer for WgpuServer {
 
         // Start execution.
         let pipeline = self.pipeline(kernel, mode);
-
-        // Store all the resources we'll be using. This could be eliminated if
-        // there was a way to tie the lifetime of the resource to the memory handle.
-        let resources: Vec<_> = bindings
-            .iter()
-            .map(|binding| self.get_resource(binding.clone()).into_resource())
-            .collect();
-
-        // First resolve the dispatch buffer if needed. The weird ordering is because the lifetime of this
-        // needs to be longer than the compute pass, so we can't do this just before dispatching.
-        let dispatch = match count.clone() {
-            CubeCount::Dynamic(binding) => {
-                PipelineDispatch::Dynamic(self.get_resource(binding).into_resource())
-            }
-            CubeCount::Static(x, y, z) => PipelineDispatch::Static(x, y, z),
-        };
-
-        self.stream.register(pipeline, resources, dispatch);
+        self.stream.register(pipeline, bindings, &count);
 
         // If profiling, write out results.
         if let Some(level) = profile_level {

--- a/crates/cubecl-wgpu/src/compute/storage.rs
+++ b/crates/cubecl-wgpu/src/compute/storage.rs
@@ -6,7 +6,6 @@ use wgpu::BufferUsages;
 /// Buffer storage for wgpu.
 pub struct WgpuStorage {
     memory: HashMap<StorageId, wgpu::Buffer>,
-    deallocations: Vec<StorageId>,
     device: wgpu::Device,
     buffer_usages: BufferUsages,
 }
@@ -21,8 +20,7 @@ impl core::fmt::Debug for WgpuStorage {
 #[derive(new)]
 pub struct WgpuResource {
     /// The wgpu buffer.
-    pub buffer: wgpu::Buffer,
-
+    buffer: wgpu::Buffer,
     offset: u64,
     size: u64,
 }
@@ -38,6 +36,10 @@ impl WgpuResource {
             ),
         };
         wgpu::BindingResource::Buffer(binding)
+    }
+
+    pub fn buffer(&self) -> &wgpu::Buffer {
+        &self.buffer
     }
 
     /// Return the buffer size.
@@ -57,18 +59,8 @@ impl WgpuStorage {
     pub fn new(device: wgpu::Device, usages: BufferUsages) -> Self {
         Self {
             memory: HashMap::new(),
-            deallocations: Vec::new(),
             device,
             buffer_usages: usages,
-        }
-    }
-
-    /// Actually deallocates buffers tagged to be deallocated.
-    pub fn perform_deallocations(&mut self) {
-        for id in self.deallocations.drain(..) {
-            if let Some(buffer) = self.memory.remove(&id) {
-                buffer.destroy()
-            }
         }
     }
 }
@@ -102,6 +94,6 @@ impl ComputeStorage for WgpuStorage {
     }
 
     fn dealloc(&mut self, id: StorageId) {
-        self.deallocations.push(id);
+        self.memory.remove(&id);
     }
 }

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -523,6 +523,11 @@ impl WgpuStream {
             .combine(self.memory_uniforms.memory_usage())
     }
 
+    pub fn memory_cleanup(&mut self) {
+        self.memory_main.cleanup(true);
+        // No need to cleanup uniform memory as that isn't deallocated.
+    }
+
     fn flush_if_needed(&mut self) {
         // Flush when there are too many tasks, or when too many handles are locked.
         // Locked handles should only accumulate in rare circumstances (where uniforms
@@ -570,7 +575,7 @@ impl WgpuStream {
             .regulate(&self.device, self.tasks_count, index);
 
         // Cleanup allocations and deallocations.
-        self.memory_main.cleanup();
+        self.memory_main.cleanup(false);
         self.memory_main.storage().perform_deallocations();
 
         self.tasks_count = 0;

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -119,7 +119,7 @@ impl WgpuStream {
 
         // Allocate a small buffer to use for synchronization.
         #[cfg(target_family = "wasm")]
-        let sync_buffer = Some(Handle::new(memory_uniforms.reserve(32), None, None, 32));
+        let sync_buffer = Some(Handle::new(memory_main.reserve(32), None, None, 32));
 
         #[cfg(not(target_family = "wasm"))]
         let sync_buffer = None;

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -1,4 +1,7 @@
-use cubecl_core::MemoryConfiguration;
+use cubecl_core::{
+    server::{Binding, Handle},
+    CubeCount, MemoryConfiguration,
+};
 use std::{future::Future, num::NonZeroU64, pin::Pin, sync::Arc, time::Duration};
 use web_time::Instant;
 
@@ -6,7 +9,6 @@ use super::{poll::WgpuPoll, timestamps::KernelTimestamps, WgpuResource, WgpuStor
 use cubecl_runtime::{
     memory_management::{
         self, MemoryDeviceProperties, MemoryHandle, MemoryManagement, MemoryPoolOptions,
-        SliceBinding, SliceHandle,
     },
     TimestampsError, TimestampsResult,
 };
@@ -19,11 +21,12 @@ const SMALL_UNIFORMS_BUFFER_SIZE: u64 = 8192;
 #[derive(Debug)]
 pub struct WgpuStream {
     memory_main: MemoryManagement<WgpuStorage>,
+    memory_uniforms: MemoryManagement<WgpuStorage>,
+    memory_queries: MemoryManagement<WgpuStorage>,
 
     uniforms_staging_pool: StagingBelt,
-    memory_uniforms: MemoryManagement<WgpuStorage>,
-
-    locked_copy_handles: Vec<SliceBinding>,
+    locked_copy_handles: Vec<Binding>,
+    sync_buffer: Option<Handle>,
 
     tasks_encoder: wgpu::CommandEncoder,
     copy_uniforms_encoder: wgpu::CommandEncoder,
@@ -36,13 +39,7 @@ pub struct WgpuStream {
     device: wgpu::Device,
     queue: wgpu::Queue,
     poll: WgpuPoll,
-    sync_buffer: Option<wgpu::Buffer>,
     submission_load: SubmissionLoad,
-}
-
-pub enum PipelineDispatch {
-    Static(u32, u32, u32),
-    Dynamic(WgpuResource),
 }
 
 impl WgpuStream {
@@ -56,21 +53,8 @@ impl WgpuStream {
     ) -> Self {
         let poll = WgpuPoll::new(device.clone());
 
-        #[cfg(target_family = "wasm")]
-        let sync_buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
-            label: None,
-            size: 32,
-            usage: wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_SRC
-                | wgpu::BufferUsages::INDIRECT,
-            mapped_at_creation: false,
-        }));
-        #[cfg(not(target_family = "wasm"))]
-        let sync_buffer = None;
-
         // Allocate storage & a memory management for buffers.
-        let main_memory_management = MemoryManagement::from_configuration(
+        let memory_main = MemoryManagement::from_configuration(
             WgpuStorage::new(
                 device.clone(),
                 BufferUsages::STORAGE
@@ -82,10 +66,27 @@ impl WgpuStream {
             memory_config,
         );
 
+        let memory_queries = MemoryManagement::from_configuration(
+            WgpuStorage::new(
+                device.clone(),
+                BufferUsages::COPY_SRC | BufferUsages::QUERY_RESOLVE,
+            ),
+            &memory_properties,
+            MemoryConfiguration::Custom {
+                pool_options: vec![MemoryPoolOptions {
+                    pool_type: memory_management::PoolType::ExclusivePages {
+                        max_alloc_size: 256,
+                    },
+                    dealloc_period: None,
+                }],
+            },
+        );
+
         // Allocate a separate storage & memory management for 'uniforms' (small bits of data
         // that need to be uploaded quickly). We allocate these with the BufferUsages::UNIFORM flag
         // to allow binding them as uniforms.
-        let uniforms_memory_management = MemoryManagement::from_configuration(
+        #[allow(unused_mut)]
+        let mut memory_uniforms = MemoryManagement::from_configuration(
             WgpuStorage::new(
                 device.clone(),
                 BufferUsages::STORAGE
@@ -100,10 +101,17 @@ impl WgpuStream {
                     pool_type: memory_management::PoolType::ExclusivePages {
                         max_alloc_size: SMALL_UNIFORMS_BUFFER_SIZE,
                     },
-                    dealloc_period: Some(5000),
+                    dealloc_period: None,
                 }],
             },
         );
+
+        #[cfg(target_family = "wasm")]
+        // Allocate a small buffer to use for synchronization
+        let sync_buffer = Some(Handle::new(memory_uniforms.reserve(32), None, None, 32));
+
+        #[cfg(not(target_family = "wasm"))]
+        let sync_buffer = None;
 
         // Create a staging belt that can re-use staging buffers we use to upload
         // small uniform buffers. These are then uploaded to the buffers
@@ -111,8 +119,9 @@ impl WgpuStream {
         let uniforms_staging_pool = StagingBelt::new(SMALL_UNIFORMS_BUFFER_SIZE);
 
         Self {
-            memory_main: main_memory_management,
-            memory_uniforms: uniforms_memory_management,
+            memory_main,
+            memory_uniforms,
+            memory_queries,
             locked_copy_handles: Vec::new(),
             compute_pass: None,
             timestamps,
@@ -140,9 +149,21 @@ impl WgpuStream {
     pub fn register(
         &mut self,
         pipeline: Arc<ComputePipeline>,
-        resources: Vec<WgpuResource>,
-        dispatch: PipelineDispatch,
+        bindings: Vec<Binding>,
+        dispatch: &CubeCount,
     ) {
+        let dispatch_resource = match dispatch.clone() {
+            CubeCount::Static(_, _, _) => None,
+            CubeCount::Dynamic(binding) => Some(self.get_resource(binding)),
+        };
+
+        // Store all the resources we'll be using. This could be eliminated if
+        // there was a way to tie the lifetime of the resource to the memory handle.
+        let resources: Vec<_> = bindings
+            .iter()
+            .map(|b| self.get_resource(b.clone()))
+            .collect();
+
         // Start a new compute pass if needed. The forget_lifetime allows
         // to store this with a 'static lifetime, but the compute pass must
         // be dropped before the encoder. This isn't unsafe - it's still checked at runtime.
@@ -192,34 +213,31 @@ impl WgpuStream {
         pass.set_bind_group(0, &bind_group, &[]);
 
         match dispatch {
-            PipelineDispatch::Static(x, y, z) => {
-                pass.dispatch_workgroups(x, y, z);
+            CubeCount::Static(x, y, z) => {
+                pass.dispatch_workgroups(*x, *y, *z);
             }
-            PipelineDispatch::Dynamic(binding_resource) => {
-                pass.dispatch_workgroups_indirect(
-                    &binding_resource.buffer,
-                    binding_resource.offset(),
-                );
+            CubeCount::Dynamic(_) => {
+                let res = dispatch_resource.unwrap();
+                pass.dispatch_workgroups_indirect(res.buffer(), res.offset());
             }
         }
-
         self.flush_if_needed();
     }
 
     pub fn read_buffers(
         &mut self,
-        buffers: Vec<(wgpu::Buffer, u64, u64)>,
+        bindings: Vec<Binding>,
     ) -> impl Future<Output = Vec<Vec<u8>>> + 'static {
         self.compute_pass = None;
-        let mut staging_buffers = Vec::with_capacity(buffers.len());
-        let mut callbacks = Vec::with_capacity(buffers.len());
+        let mut staging_buffers = Vec::with_capacity(bindings.len());
+        let mut callbacks = Vec::with_capacity(bindings.len());
 
-        for (buffer, offset, size) in buffers {
+        for binding in bindings.iter() {
             // Copying into a buffer has to be 4 byte aligned. We can safely do so, as
             // memory is 32 bytes aligned (see WgpuStorage).
             let align = wgpu::COPY_BUFFER_ALIGNMENT;
-            let aligned_len = size.div_ceil(align) * align;
-
+            let resource = self.get_resource(binding.clone());
+            let aligned_len = resource.size().div_ceil(align) * align;
             let staging_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
                 label: None,
                 size: aligned_len,
@@ -227,13 +245,13 @@ impl WgpuStream {
                 mapped_at_creation: false,
             });
             self.tasks_encoder.copy_buffer_to_buffer(
-                &buffer,
-                offset,
+                resource.buffer(),
+                resource.offset(),
                 &staging_buffer,
                 0,
                 aligned_len,
             );
-            staging_buffers.push((staging_buffer, size));
+            staging_buffers.push((staging_buffer, resource.size()));
         }
 
         // Flush all commands to the queue, so GPU gets started on copying to the staging buffer.
@@ -283,23 +301,13 @@ impl WgpuStream {
         }
     }
 
-    pub fn read_buffer(
-        &mut self,
-        buffer: wgpu::Buffer,
-        offset: u64,
-        size: u64,
-    ) -> impl Future<Output = Vec<u8>> + 'static {
-        let fut = self.read_buffers(vec![(buffer, offset, size)]);
-        async move { fut.await.remove(0) }
-    }
-
     pub fn sync_elapsed(
         &mut self,
     ) -> Pin<Box<dyn Future<Output = TimestampsResult> + Send + 'static>> {
         self.compute_pass = None;
 
         enum TimestampMethod {
-            Buffer(wgpu::Buffer, u64),
+            Buffer(Handle),
             StartTime(Instant),
         }
 
@@ -314,17 +322,15 @@ impl WgpuStream {
                     });
                 } else {
                     let size = 2 * size_of::<u64>() as u64;
-                    let resolved = self.device.create_buffer(&wgpu::BufferDescriptor {
-                        label: None,
-                        size,
-                        usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::QUERY_RESOLVE,
-                        mapped_at_creation: false,
-                    });
-
+                    let handle = Handle::new(self.memory_queries.reserve(size), None, None, size);
+                    let resource = self
+                        .memory_queries
+                        .get_resource(handle.clone().binding().memory, None, None)
+                        .expect("Failed to get query resource.");
                     self.tasks_encoder
-                        .resolve_query_set(query_set, 0..2, &resolved, 0);
+                        .resolve_query_set(query_set, 0..2, resource.buffer(), 0);
                     *init = false;
-                    TimestampMethod::Buffer(resolved, size)
+                    TimestampMethod::Buffer(handle)
                 }
             }
             KernelTimestamps::Inferred { start_time } => {
@@ -343,19 +349,18 @@ impl WgpuStream {
         };
 
         match method {
-            TimestampMethod::Buffer(resolved, size) => {
+            TimestampMethod::Buffer(handle) => {
                 let period = self.queue.get_timestamp_period() as f64 * 1e-9;
-                let fut = self.read_buffer(resolved, 0, size);
-
+                let fut = self.read_buffers(vec![handle.binding()]);
                 Box::pin(async move {
                     let data = fut
                         .await
+                        .remove(0)
                         .chunks_exact(8)
                         .map(|x| u64::from_le_bytes(x.try_into().unwrap()))
                         .collect::<Vec<_>>();
                     let delta = u64::checked_sub(data[1], data[0]).unwrap_or(1);
                     let duration = Duration::from_secs_f64(delta as f64 * period);
-
                     Ok(duration)
                 })
             }
@@ -383,9 +388,8 @@ impl WgpuStream {
                 //
                 // For now, instead do a dummy readback. This *seems* to wait for the entire
                 // queue to be done.
-                let fut = self.read_buffer(buf.clone(), 0, 32);
+                let fut = self.read_buffers(vec![buf.clone().binding()]);
                 core::mem::swap(&mut buffer, &mut self.sync_buffer);
-
                 Box::pin(async move {
                     fut.await;
                 })
@@ -404,38 +408,40 @@ impl WgpuStream {
         }
     }
 
-    pub fn get_resource(
-        &mut self,
-        binding: SliceBinding,
-        offset_start: Option<u64>,
-        offset_end: Option<u64>,
-    ) -> WgpuResource {
+    pub fn get_resource(&mut self, binding: Binding) -> WgpuResource {
+        let off_start = binding.offset_start;
+        let off_end = binding.offset_end;
+
         if let Some(res) = self
             .memory_main
-            .get_resource(binding.clone(), offset_start, offset_end)
+            .get_resource(binding.memory.clone(), off_start, off_end)
         {
             res
         } else if let Some(res) =
             self.memory_uniforms
-                .get_resource(binding.clone(), offset_start, offset_end)
+                .get_resource(binding.memory.clone(), off_start, off_end)
         {
             // This resource now might be used for computations, so we _cannot_ use it anymore for create() calls.
             // This keeps the binding alive which means create() won't try to use it.
             self.locked_copy_handles.push(binding);
-
+            res
+        } else if let Some(res) =
+            self.memory_queries
+                .get_resource(binding.memory.clone(), off_start, off_end)
+        {
             res
         } else {
             panic!("Failed to find resource");
         }
     }
 
-    pub fn empty(&mut self, size: u64) -> SliceHandle {
+    pub fn empty(&mut self, size: u64) -> Handle {
         // For empty buffers we always use the main memory even if they are small, as
         // we don't need to upload any data to them.
-        self.memory_main.reserve(size)
+        Handle::new(self.memory_main.reserve(size), None, None, size)
     }
 
-    pub fn create(&mut self, data: &[u8]) -> SliceHandle {
+    pub fn create(&mut self, data: &[u8]) -> Handle {
         // We'd like to keep operations as one long ComputePass. To do so, this tries to submit
         // all copy operations & all execute operations in one batch. To do so, we do all copy operations
         // at the start of the encoder, and all execute operations afterwards. For this re-ordering to be valid,
@@ -444,7 +450,6 @@ impl WgpuStream {
         //   in self.locked_copy_handles which means the allocation won't try to use them.
         // - For bigger buffers, we do restart the compute stream. These bigger allocations
         //   don't happen frequently so this cost isn't big.
-
         let num_bytes = data.len() as u64;
 
         // Copying into a buffer has to be 4 byte aligned. We can safely do so, as
@@ -475,7 +480,7 @@ impl WgpuStream {
                 // This efficiently re-uses the staging buffers.
                 let mut staging = self.uniforms_staging_pool.write_buffer(
                     &mut self.copy_uniforms_encoder,
-                    &resource.buffer,
+                    resource.buffer(),
                     resource.offset(),
                     size,
                     &self.device,
@@ -506,7 +511,7 @@ impl WgpuStream {
                 self.tasks_encoder.copy_buffer_to_buffer(
                     &staging,
                     0,
-                    &resource.buffer,
+                    resource.buffer(),
                     resource.offset(),
                     aligned_len,
                 );
@@ -514,7 +519,7 @@ impl WgpuStream {
         }
 
         self.flush_if_needed();
-        slice
+        Handle::new(slice, None, None, data.len() as u64)
     }
 
     pub fn memory_usage(&self) -> cubecl_runtime::memory_management::MemoryUsage {
@@ -525,7 +530,6 @@ impl WgpuStream {
 
     pub fn memory_cleanup(&mut self) {
         self.memory_main.cleanup(true);
-        // No need to cleanup uniform memory as that isn't deallocated.
     }
 
     fn flush_if_needed(&mut self) {
@@ -576,8 +580,6 @@ impl WgpuStream {
 
         // Cleanup allocations and deallocations.
         self.memory_main.cleanup(false);
-        self.memory_main.storage().perform_deallocations();
-
         self.tasks_count = 0;
     }
 }


### PR DESCRIPTION
Add a function to explicitly cleanup memory when needed.

My model has a seperate 'refine' stage that allocates a bunch of memory every N steps. This sometimes pushes things over GPU limits. Explicatly calling memory cleanup helps a lot with this.

Some other bits:
- Let wgpu manage destroying the buffer. Rather than explicatly calling destroy(), dropping the last reference will just destroy the buffer. This fixes and issue where buffers in async futures ARE still needed by wgpu (even if not by burn) and are deallocated. The current code can crash here. This might also be more efficient as wgpu can decide when/how to release things.

- It's important to have bindings for memory up until the copy is actually in the wgpu queue. The rules around this were a bit tricky before. I've made it harder to get a wgpu buffer while dropping the resource to prevent this. This includes making read_buffers take Vec<Binding> instead of a wgpu buffer. That means using "managed" buffers for the sync buffer and query buffers. Bit annoying perhaps!

- Set the dealloc_period higher. Think I had pushed it a bit low to compensate for some things, but now that I can memory_cleanup manually a higher dealloc period is fine and is noticably faster. That's only for exclusive pages, sliced pages never deallocate atm anyway.