### PR TITLE
Add bound checks inner for reduce kernels

### DIFF
--- a/crates/cubecl-reduce/src/config.rs
+++ b/crates/cubecl-reduce/src/config.rs
@@ -15,6 +15,19 @@ pub enum LineMode {
     Perpendicular,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+/// How bound checks is handled for inner reductions.
+pub enum BoundChecksInner {
+    /// No bound check is necessary.
+    None,
+    /// Using a mask is enough for bound checks.
+    Mask,
+    /// Branching is necessary for bound checks.
+    ///
+    /// Probably the right setting when performing fuse on read.
+    Branch,
+}
+
 #[derive(Debug, Clone)]
 pub struct ReduceConfig {
     pub cube_count: CubeCount,
@@ -22,6 +35,7 @@ pub struct ReduceConfig {
     pub line_mode: LineMode,
     pub line_size: u32,
     pub bound_checks: bool,
+    pub bound_checks_inner: BoundChecksInner,
 }
 
 impl ReduceConfig {
@@ -48,6 +62,7 @@ impl ReduceConfig {
             line_mode: LineMode::Parallel,
             line_size: 1,
             bound_checks: true,
+            bound_checks_inner: BoundChecksInner::Mask,
         }
     }
 

--- a/crates/cubecl-reduce/src/config.rs
+++ b/crates/cubecl-reduce/src/config.rs
@@ -21,6 +21,8 @@ pub enum BoundChecksInner {
     /// No bound check is necessary.
     None,
     /// Using a mask is enough for bound checks.
+    /// This will still read the memory in an out-of-bound location,
+    /// but will replace the value by the null value.
     Mask,
     /// Branching is necessary for bound checks.
     ///

--- a/crates/cubecl-reduce/src/primitives.rs
+++ b/crates/cubecl-reduce/src/primitives.rs
@@ -4,6 +4,7 @@ use cubecl_std::tensor::r#virtual::ReadWrite;
 use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 use crate::instructions::*;
+use crate::BoundChecksInner;
 use crate::LineMode;
 
 /// A simple range to specify how to iterate a slice when performing a reduction.
@@ -131,6 +132,7 @@ pub fn reduce_slice_plane<N: Numeric, R: ReduceInstruction<N>>(
     range: ReduceRange,
     #[comptime] line_size: u32,
     #[comptime] line_mode: LineMode,
+    #[comptime] bound_checks: BoundChecksInner,
 ) -> R::AccumulatorItem {
     let mut accumulator = R::null_accumulator(line_size);
 
@@ -140,11 +142,21 @@ pub fn reduce_slice_plane<N: Numeric, R: ReduceInstruction<N>>(
         let coordinates = fill_coordinate_line(first_coordinate + UNIT_POS_X, line_size, line_mode);
 
         let index = first_index + UNIT_POS_X * range.step;
-        let item = select(
-            index < range.end,
-            items.read(index),
-            R::null_input(line_size),
-        );
+        let item = match bound_checks {
+            BoundChecksInner::None => items.read(index),
+            BoundChecksInner::Mask => select(
+                index < range.end,
+                items.read(index),
+                R::null_input(line_size),
+            ),
+            BoundChecksInner::Branch => {
+                if index < range.end {
+                    items.read(index)
+                } else {
+                    R::null_input(line_size)
+                }
+            }
+        };
 
         reduce_inplace::<N, R>(&mut accumulator, item, coordinates, true);
 
@@ -175,6 +187,7 @@ pub fn reduce_slice_shared<N: Numeric, R: ReduceInstruction<N>>(
     #[comptime] line_size: u32,
     #[comptime] line_mode: LineMode,
     #[comptime] use_planes: bool,
+    #[comptime] bound_checks: BoundChecksInner,
 ) -> R::SharedAccumulator {
     // The index used to read and write into the accumulator.
     let accumulator_index = if use_planes { UNIT_POS_Y } else { UNIT_POS };
@@ -191,11 +204,22 @@ pub fn reduce_slice_shared<N: Numeric, R: ReduceInstruction<N>>(
     let mut first_coordinate = 0;
     while first_index < range.end {
         let index = first_index + UNIT_POS * range.step;
-        let item = select(
-            index < range.end,
-            items.read(index),
-            R::null_input(line_size),
-        );
+        let item = match bound_checks {
+            BoundChecksInner::None => items.read(index),
+            BoundChecksInner::Mask => select(
+                index < range.end,
+                items.read(index),
+                R::null_input(line_size),
+            ),
+            BoundChecksInner::Branch => {
+                if index < range.end {
+                    items.read(index)
+                } else {
+                    R::null_input(line_size)
+                }
+            }
+        };
+
         let coordinate = fill_coordinate_line(first_coordinate + UNIT_POS, line_size, line_mode);
         let coordinate = select(
             index < range.end,


### PR DESCRIPTION
The `BoundChecksInner::Branch` fix memory error in the cuda backend when fuse on read is activated for the reduce kernels using the plane and plane shared strategy.