### PR TITLE
Add max cube count and dim to hardware properties

### DIFF
--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -2,7 +2,7 @@ use std::mem::MaybeUninit;
 
 use cubecl_core::{
     ir::{Elem, FloatKind},
-    AtomicFeature, DeviceId, Feature, MemoryConfiguration, Runtime,
+    AtomicFeature, CubeDim, DeviceId, Feature, MemoryConfiguration, Runtime,
 };
 use cubecl_runtime::{
     channel::MutexComputeChannel,
@@ -72,27 +72,40 @@ fn create_client(device: &CudaDevice, options: RuntimeOptions) -> ComputeClient<
         cudarc::driver::sys::lib().cuDeviceTotalMem_v2(bytes.as_mut_ptr(), device_ptr);
         bytes.assume_init() as u64
     };
-    let max_shared = unsafe {
-        cudarc::driver::result::device::get_attribute(device_ptr, cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,).unwrap() as usize
-    };
     let storage = CudaStorage::new(stream);
     let mem_properties = MemoryDeviceProperties {
         max_page_size: max_memory / 4,
         alignment: CudaStorage::ALIGNMENT,
     };
 
-    let warp_size = unsafe {
-        cudarc::driver::result::device::get_attribute(
-            device_ptr,
-            cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_WARP_SIZE,
-        )
-        .unwrap()
-    };
-    let hardware_props = HardwareProperties {
-        plane_size_min: warp_size as u32,
-        plane_size_max: warp_size as u32,
-        max_bindings: crate::device::CUDA_MAX_BINDINGS,
-        max_shared_memory_size: max_shared,
+    let hardware_props = unsafe {
+        use cudarc::driver::{result::device::get_attribute, sys::CUdevice_attribute::*};
+        let warp_size = get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_WARP_SIZE).unwrap() as u32;
+        let max_shared = get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK)
+            .unwrap() as usize;
+        let max_threads =
+            get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK).unwrap() as u32;
+        let block_dim_x = get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X).unwrap();
+        let block_dim_y = get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y).unwrap();
+        let block_dim_z = get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z).unwrap();
+        let max_cube_dim =
+            CubeDim::new_3d(block_dim_x as u32, block_dim_y as u32, block_dim_z as u32);
+
+        let grid_dim_x = get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X).unwrap();
+        let grid_dim_y = get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y).unwrap();
+        let grid_dim_z = get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z).unwrap();
+        let max_cube_count =
+            CubeDim::new_3d(grid_dim_x as u32, grid_dim_y as u32, grid_dim_z as u32);
+
+        HardwareProperties {
+            plane_size_min: warp_size,
+            plane_size_max: warp_size,
+            max_bindings: crate::device::CUDA_MAX_BINDINGS,
+            max_shared_memory_size: max_shared,
+            max_cube_count,
+            max_units_per_cube: max_threads,
+            max_cube_dim,
+        }
     };
 
     let memory_management =

--- a/crates/cubecl-runtime/src/memory_management/mod.rs
+++ b/crates/cubecl-runtime/src/memory_management/mod.rs
@@ -6,6 +6,7 @@ pub use base::*;
 
 /// Dynamic memory management strategy.
 mod memory_manage;
+use cubecl_common::CubeDim;
 pub use memory_manage::*;
 
 #[cfg(not(feature = "std"))]
@@ -105,6 +106,12 @@ pub struct HardwareProperties {
     pub max_bindings: u32,
     /// Maximum amount of shared memory, in bytes
     pub max_shared_memory_size: usize,
+    /// Maximum `CubeCount` in x, y and z dimensions
+    pub max_cube_count: CubeDim,
+    /// Maximum number of total units in a cube
+    pub max_units_per_cube: u32,
+    /// Maximum `CubeDim` in x, y, and z dimensions
+    pub max_cube_dim: CubeDim,
 }
 
 impl HardwareProperties {

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -1,4 +1,5 @@
 use super::DummyServer;
+use cubecl_common::CubeDim;
 use cubecl_runtime::storage::BytesStorage;
 use cubecl_runtime::tune::LocalTuner;
 use cubecl_runtime::{channel::MutexComputeChannel, memory_management::HardwareProperties};
@@ -40,6 +41,9 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
         plane_size_max: 32,
         max_bindings: 32,
         max_shared_memory_size: 48000,
+        max_cube_count: CubeDim::new_3d(u16::MAX as u32, u16::MAX as u32, u16::MAX as u32),
+        max_units_per_cube: 1024,
+        max_cube_dim: CubeDim::new_3d(1024, 1024, 64),
     };
     let memory_management = MemoryManagement::from_configuration(
         storage,

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -6,7 +6,7 @@ use crate::{
 use cubecl_common::future;
 use cubecl_core::{
     ir::{Elem, FloatKind},
-    AtomicFeature, DeviceId, Feature, Runtime,
+    AtomicFeature, CubeDim, DeviceId, Feature, Runtime,
 };
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
 use cubecl_runtime::{
@@ -182,11 +182,19 @@ pub(crate) fn create_client_on_setup(
         max_page_size: limits.max_storage_buffer_binding_size as u64,
         alignment: WgpuStorage::ALIGNMENT.max(limits.min_storage_buffer_offset_alignment as u64),
     };
+    let max_count = adapter_limits.max_compute_workgroups_per_dimension;
     let hardware_props = HardwareProperties {
         plane_size_min: adapter_limits.min_subgroup_size,
         plane_size_max: adapter_limits.max_subgroup_size,
         max_bindings: limits.max_storage_buffers_per_shader_stage,
         max_shared_memory_size: limits.max_compute_workgroup_storage_size as usize,
+        max_cube_count: CubeDim::new_3d(max_count, max_count, max_count),
+        max_units_per_cube: adapter_limits.max_compute_invocations_per_workgroup,
+        max_cube_dim: CubeDim::new_3d(
+            adapter_limits.max_compute_workgroup_size_x,
+            adapter_limits.max_compute_workgroup_size_y,
+            adapter_limits.max_compute_workgroup_size_z,
+        ),
     };
 
     let mut compilation_options = Default::default();


### PR DESCRIPTION
This adds limits on, `CubeCount`, `CubeDim` and total units per cube to the `HardwareProperties`, queried from the device. The `CubeDim` in particular might not be always intuitive, and can vary between devices. The values for the 5090 for example are `1024` total units, and the max dims are `1024` on `x` and `y`, but only `64` on `z`.