### PR TITLE
Fix compiling without `autotune_persistent_cache`

### DIFF
--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -2,6 +2,7 @@
 use super::AutotuneOutcome;
 #[cfg(autotune_persistent_cache)]
 use cubecl_common::cache::Cache;
+#[cfg(autotune_persistent_cache)]
 use cubecl_common::cache::CacheError;
 #[cfg(autotune_persistent_cache)]
 use serde::{Deserialize, Serialize};

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -62,7 +62,8 @@ impl WgpuStream {
         // Allocate storage & memory management for the main memory buffers. Any calls
         // to empty() or create() with a small enough size will be allocated from this
         // main memory pool.
-        let memory_main = MemoryManagement::from_configuration(
+        #[allow(unused_mut)]
+        let mut memory_main = MemoryManagement::from_configuration(
             WgpuStorage::new(
                 device.clone(),
                 BufferUsages::STORAGE
@@ -96,8 +97,7 @@ impl WgpuStream {
         // Allocate a separate storage & memory management for 'uniforms' (small bits of data
         // that need to be uploaded quickly). We allocate these with the BufferUsages::UNIFORM flag
         // to allow binding them as uniforms.
-        #[allow(unused_mut)]
-        let mut memory_uniforms = MemoryManagement::from_configuration(
+        let memory_uniforms = MemoryManagement::from_configuration(
             WgpuStorage::new(
                 device.clone(),
                 BufferUsages::STORAGE


### PR DESCRIPTION
Necesarry for WASM

Also fix an error for allocating the sync buffer.