### PR TITLE
Simpler memory management in wgpu stream

### DIFF
--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -182,7 +182,7 @@ impl ComputeServer for CudaServer {
 
     fn empty(&mut self, size: usize) -> server::Handle {
         let ctx = self.get_context();
-        let handle = ctx.memory_management.reserve(size as u64);
+        let handle = ctx.memory_management.reserve(size as u64, None);
         server::Handle::new(handle, None, None, size as u64)
     }
 

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -188,7 +188,7 @@ impl ComputeServer for HipServer {
 
     fn empty(&mut self, size: usize) -> server::Handle {
         let ctx = self.get_context();
-        let handle = ctx.memory_management.reserve(size as u64);
+        let handle = ctx.memory_management.reserve(size as u64, None);
         server::Handle::new(handle, None, None, size as u64)
     }
 

--- a/crates/cubecl-runtime/benches/dynamic.rs
+++ b/crates/cubecl-runtime/benches/dynamic.rs
@@ -21,7 +21,7 @@ fn main() {
         if handles.len() >= 4000 {
             handles.pop_front();
         }
-        let handle = mm.reserve(MB);
+        let handle = mm.reserve(MB, None);
         handles.push_back(handle);
     }
     println!("{:?}", start.elapsed());

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -92,6 +92,11 @@ impl StorageExclude {
     pub fn clear(&mut self) {
         self.ids.clear();
     }
+
+    /// Number of currently excluded storage buffers.
+    pub fn count(&self) -> usize {
+        self.ids.len()
+    }
 }
 
 fn generate_bucket_sizes(

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/base.rs
@@ -1,6 +1,6 @@
 use super::{SliceBinding, SliceHandle, SliceId};
 use crate::{
-    memory_management::MemoryUsage,
+    memory_management::{MemoryUsage, StorageExclude},
     storage::{ComputeStorage, StorageHandle},
 };
 
@@ -39,7 +39,7 @@ pub trait MemoryPool {
 
     fn get(&self, binding: &SliceBinding) -> Option<&StorageHandle>;
 
-    fn try_reserve(&mut self, size: u64) -> Option<SliceHandle>;
+    fn try_reserve(&mut self, size: u64, exclude: Option<&StorageExclude>) -> Option<SliceHandle>;
 
     fn alloc<Storage: ComputeStorage>(&mut self, storage: &mut Storage, size: u64) -> SliceHandle;
 

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
@@ -1,7 +1,7 @@
 use super::index::SearchIndex;
 use super::{MemoryPool, RingBuffer, Slice, SliceBinding, SliceHandle, SliceId};
-use crate::memory_management::MemoryUsage;
 use crate::memory_management::memory_pool::calculate_padding;
+use crate::memory_management::{MemoryUsage, StorageExclude};
 use crate::storage::{ComputeStorage, StorageHandle, StorageId, StorageUtilization};
 use alloc::vec::Vec;
 use hashbrown::HashMap;
@@ -94,8 +94,29 @@ impl MemoryPool for SlicedPool {
     /// a handle to the reserved memory.
     ///
     /// Also clean ups, merging free slices together if permitted by the merging strategy
-    fn try_reserve(&mut self, size: u64) -> Option<SliceHandle> {
-        self.get_free_slice(size)
+    fn try_reserve(&mut self, size: u64, exclude: Option<&StorageExclude>) -> Option<SliceHandle> {
+        let padding = calculate_padding(size, self.alignment);
+        let effective_size = size + padding;
+        let slice_id = self.ring.find_free_slice(
+            effective_size,
+            &mut self.pages,
+            &mut self.slices,
+            exclude,
+        )?;
+
+        let slice = self.slices.get_mut(&slice_id).unwrap();
+        let old_slice_size = slice.effective_size();
+        let offset = slice.storage.utilization.offset;
+        slice.storage.utilization = StorageUtilization { offset, size };
+        let new_padding = old_slice_size - size;
+        slice.padding = new_padding;
+        assert_eq!(
+            slice.effective_size(),
+            old_slice_size,
+            "new and old slice should have the same size"
+        );
+
+        Some(slice.handle.clone())
     }
 
     fn alloc<Storage: ComputeStorage>(&mut self, storage: &mut Storage, size: u64) -> SliceHandle {
@@ -172,30 +193,6 @@ impl SlicedPool {
             page_size,
             max_alloc_size,
         }
-    }
-
-    /// Finds a free slice that can contain the given size
-    fn get_free_slice(&mut self, size: u64) -> Option<SliceHandle> {
-        let padding = calculate_padding(size, self.alignment);
-        let effective_size = size + padding;
-
-        let slice_id =
-            self.ring
-                .find_free_slice(effective_size, &mut self.pages, &mut self.slices)?;
-
-        let slice = self.slices.get_mut(&slice_id).unwrap();
-        let old_slice_size = slice.effective_size();
-        let offset = slice.storage.utilization.offset;
-        slice.storage.utilization = StorageUtilization { offset, size };
-        let new_padding = old_slice_size - size;
-        slice.padding = new_padding;
-        assert_eq!(
-            slice.effective_size(),
-            old_slice_size,
-            "new and old slice should have the same size"
-        );
-
-        Some(slice.handle.clone())
     }
 
     /// Creates a slice of size `size` upon the given page with the given offset.

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -80,7 +80,7 @@ impl ComputeServer for DummyServer {
 
     fn empty(&mut self, size: usize) -> Handle {
         Handle::new(
-            self.memory_management.reserve(size as u64),
+            self.memory_management.reserve(size as u64, None),
             None,
             None,
             size as u64,

--- a/crates/cubecl-wgpu/src/compute/mem_manager.rs
+++ b/crates/cubecl-wgpu/src/compute/mem_manager.rs
@@ -1,0 +1,87 @@
+use cubecl_core::{
+    server::{Binding, Handle},
+    MemoryConfiguration,
+};
+use cubecl_runtime::{
+    memory_management::{MemoryDeviceProperties, MemoryManagement, StorageExclude},
+    storage::ComputeStorage,
+};
+use wgpu::BufferUsages;
+
+use super::{WgpuResource, WgpuStorage};
+
+#[derive(Debug)]
+pub(crate) struct WgpuMemManager {
+    memory_pool: MemoryManagement<WgpuStorage>,
+    pending_operations: StorageExclude,
+}
+
+impl WgpuMemManager {
+    pub(crate) fn new(
+        device: wgpu::Device,
+        memory_properties: MemoryDeviceProperties,
+        memory_config: MemoryConfiguration,
+    ) -> Self {
+        // Allocate storage & memory management for the main memory buffers. Any calls
+        // to empty() or create() with a small enough size will be allocated from this
+        // main memory pool.
+        #[allow(unused_mut)]
+        let mut memory_main = MemoryManagement::from_configuration(
+            WgpuStorage::new(
+                device.clone(),
+                BufferUsages::STORAGE
+                    | BufferUsages::COPY_SRC
+                    | BufferUsages::COPY_DST
+                    | BufferUsages::INDIRECT
+                    | BufferUsages::QUERY_RESOLVE,
+            ),
+            &memory_properties,
+            memory_config.clone(),
+        );
+
+        Self {
+            memory_pool: memory_main,
+            pending_operations: StorageExclude::default(),
+        }
+    }
+
+    pub(crate) fn reserve(&mut self, size: u64, exclude_pending_operations: bool) -> Handle {
+        let exclude = if exclude_pending_operations {
+            Some(&self.pending_operations)
+        } else {
+            None
+        };
+        Handle::new(self.memory_pool.reserve(size, exclude), None, None, size)
+    }
+
+    pub(crate) fn get_resource(&mut self, binding: Binding) -> WgpuResource {
+        let handle = self
+            .memory_pool
+            .get(binding.memory.clone())
+            .expect("Failed to find storage!");
+        let handle = match binding.offset_start {
+            Some(offset) => handle.offset_start(offset),
+            None => handle,
+        };
+        let handle = match binding.offset_end {
+            Some(offset) => handle.offset_end(offset),
+            None => handle,
+        };
+        // Assume this resource is now used for something. That means we can't copy to it anymore,
+        // as any copy will get ordered first.
+        self.pending_operations.exclude_storage(handle.id);
+        self.memory_pool.storage().get(&handle)
+    }
+
+    pub(crate) fn memory_usage(&self) -> cubecl_runtime::memory_management::MemoryUsage {
+        self.memory_pool.memory_usage()
+    }
+
+    pub(crate) fn memory_cleanup(&mut self, explicit: bool) {
+        self.memory_pool.cleanup(explicit);
+    }
+
+    pub(crate) fn clear_pending(&mut self) {
+        self.pending_operations.clear();
+    }
+}

--- a/crates/cubecl-wgpu/src/compute/mem_manager.rs
+++ b/crates/cubecl-wgpu/src/compute/mem_manager.rs
@@ -84,4 +84,8 @@ impl WgpuMemManager {
     pub(crate) fn clear_pending(&mut self) {
         self.pending_operations.clear();
     }
+
+    pub(crate) fn needs_flush(&self, max_pending: usize) -> bool {
+        self.pending_operations.count() > max_pending
+    }
 }

--- a/crates/cubecl-wgpu/src/compute/mem_manager.rs
+++ b/crates/cubecl-wgpu/src/compute/mem_manager.rs
@@ -1,6 +1,6 @@
 use cubecl_core::{
-    server::{Binding, Handle},
     MemoryConfiguration,
+    server::{Binding, Handle},
 };
 use cubecl_runtime::{
     memory_management::{MemoryDeviceProperties, MemoryManagement, StorageExclude},

--- a/crates/cubecl-wgpu/src/compute/mod.rs
+++ b/crates/cubecl-wgpu/src/compute/mod.rs
@@ -1,3 +1,4 @@
+pub(super) mod mem_manager;
 pub(super) mod poll;
 pub(super) mod stream;
 pub(super) mod timestamps;

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -112,7 +112,7 @@ impl ComputeServer for WgpuServer {
     }
 
     fn get_resource(&mut self, binding: Binding) -> BindingResource<WgpuResource> {
-        let resource = self.stream.get_resource(binding.clone());
+        let resource = self.stream.mem_manage.get_resource(binding.clone());
         BindingResource::new(binding, resource)
     }
 
@@ -227,11 +227,11 @@ impl ComputeServer for WgpuServer {
     }
 
     fn memory_usage(&self) -> cubecl_runtime::memory_management::MemoryUsage {
-        self.stream.memory_usage()
+        self.stream.mem_manage.memory_usage()
     }
 
     fn memory_cleanup(&mut self) {
-        self.stream.memory_cleanup();
+        self.stream.mem_manage.memory_cleanup(true);
     }
 
     fn enable_timestamps(&mut self) {

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -350,6 +350,8 @@ impl WgpuStream {
         // - On devices with unified memory, this could skip the staging buffer entirely.
         self.queue
             .write_buffer(resource.buffer(), resource.offset(), data);
+        self.flush_if_needed();
+
         alloc
     }
 
@@ -357,7 +359,7 @@ impl WgpuStream {
         // Flush when there are too many tasks, or when too many handles are locked.
         // Locked handles should only accumulate in rare circumstances (where uniforms
         // are being created but no work is submitted).
-        if self.tasks_count >= self.tasks_max {
+        if self.tasks_count >= self.tasks_max || self.mem_manage.needs_flush(self.tasks_max * 8) {
             self.flush();
         }
     }

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -38,15 +38,18 @@ impl WgpuStream {
     ) -> Self {
         let poll = WgpuPoll::new(device.clone());
 
+        #[allow(unused_mut)]
+        let mut mem_manage = WgpuMemManager::new(device.clone(), memory_properties, memory_config);
+
         // Allocate a small buffer to use for synchronization.
         #[cfg(target_family = "wasm")]
-        let sync_buffer = Some(Handle::new(memory_main.reserve(32), None, None, 32));
+        let sync_buffer = Some(mem_manage.reserve(32, false));
 
         #[cfg(not(target_family = "wasm"))]
         let sync_buffer = None;
 
         Self {
-            mem_manage: WgpuMemManager::new(device.clone(), memory_properties, memory_config),
+            mem_manage,
             compute_pass: None,
             timestamps,
             encoder: {

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -346,7 +346,7 @@ impl WgpuStream {
         let resource = self.mem_manage.get_resource(alloc.clone().binding());
 
         // Nb: using write_buffer_with here has no advantages. It'd only be faster if create() would expose
-        // it's API as a slice to write into.
+        // its API as a slice to write into.
         //
         // write_buffer is the recommended way to write this data, as:
         // - On WebGPU, from WASM, this can save a copy to the JS memory.

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -7,7 +7,7 @@ use web_time::Instant;
 
 use super::{mem_manager::WgpuMemManager, poll::WgpuPoll, timestamps::KernelTimestamps};
 use cubecl_runtime::{
-    memory_management::MemoryDeviceProperties, TimestampsError, TimestampsResult,
+    TimestampsError, TimestampsResult, memory_management::MemoryDeviceProperties,
 };
 use wgpu::ComputePipeline;
 


### PR DESCRIPTION
This might be the 5th flip-flip on this piece of code, but, hopefully 5th time is the charm!

The main goal of this PR is to swap some custom GPU uploading for `queue.write_buffer`. This function is part of the [WebGPU specification ](https://developer.mozilla.org/en-US/docs/Web/API/GPUQueue/writeBuffer), and can be implemented more efficiently on the web. In particular, it saves a copy from WASM memory -> JS memory. See [this thread](https://github.com/gpuweb/gpuweb/discussions/1428) for more info. The second advantage is that on unified memory architectures (eg. macbooks), this implementation CAN skip using a staging buffer all together. I _think_ Chrome actually does this, but `wgpu` doesn't currently.

To do this, this goes back to how we did things a few PR's back: Memory is "excluded" or "locked" from being used for the copy queue, if it has any preceding compute work. This means "re-ordering" the copy operation to the start of the submission is allowed, so we can just use `write_buffer` to write data at the start of the next queue.submit().

While going over this code, I also noticed a particularly gnarly potential bug - Bindings have NO notion of what memory pool they came from. Their ID is just an atomically incremented counter. As such, the current `get_resource` function is wrong - it might find the ID in a different memory pool than it was allocated in. I'm not sure if this really happens in practice, but it seems very sketchy.

This PR merges the memory pools:
- Query resolves don't need a seperate pool, marking buffers as compatible with a QUERY_RESOLVE doesn't seem to have downsides / performance loss.
- The small uniforms buffer is no longer needed, all memory is done just with write_buffer. This does lose the ability to specially mark this memory as usable for 'uniform' buffers, but Cube didn't use this anyway, nor does my code which did use it get any faster from it.

Testing on desktop, I see no performance difference before/after this PR. On WASM, loading a particularly big model that used to OOM now works.
