### PR TITLE
Add availability check for conv

### DIFF
--- a/crates/cubecl-linalg/src/convolution/base.rs
+++ b/crates/cubecl-linalg/src/convolution/base.rs
@@ -1,7 +1,10 @@
-use crate::matmul::components::{
-    global::{AccumulatorLoader, OutputLoader},
-    stage::{StageMatmul, StageMatmulFamily},
-    InvalidConfigError, MatmulPrecision, MatmulProblem, MatrixLayout,
+use crate::matmul::{
+    components::{
+        global::{AccumulatorLoader, OutputLoader},
+        stage::{StageMatmul, StageMatmulFamily},
+        InvalidConfigError, MatmulPrecision, MatmulProblem, MatrixLayout,
+    },
+    kernels::MatmulAvailabilityError,
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -92,6 +95,11 @@ pub trait ConvolutionConfigFactory: Send + Sync + 'static {
         cube_dim: &CubeDim,
         cube_count: &CubeCount,
     ) -> Self::Config;
+
+    fn check_availability<R: Runtime, CS: MatmulPrecision>(
+        client: &ComputeClient<R::Server, R::Channel>,
+        config: &Self::Config,
+    ) -> Result<(), MatmulAvailabilityError>;
 }
 
 /// Provides launch entry point to solve a matmul

--- a/crates/cubecl-linalg/src/convolution/homogeneous/base.rs
+++ b/crates/cubecl-linalg/src/convolution/homogeneous/base.rs
@@ -232,6 +232,13 @@ where
             problem.has_bias,
         )
     }
+
+    fn check_availability<R: Runtime, CS: MatmulPrecision>(
+        client: &ComputeClient<R::Server, R::Channel>,
+        config: &Self::Config,
+    ) -> Result<(), crate::matmul::kernels::MatmulAvailabilityError> {
+        SMM::check_availability::<R, CS>(client, &config.to_smm_config())
+    }
 }
 
 impl<SMM: StageMatmulFamily<LhsReader = LhsReaderFamily, RhsReader = RhsReaderFamily>>

--- a/crates/cubecl-linalg/src/convolution/launch.rs
+++ b/crates/cubecl-linalg/src/convolution/launch.rs
@@ -8,7 +8,10 @@ use crate::matmul::kernels::MatmulLaunchError;
 use crate::{convolution::base::ConvolutionLaunch, matmul::components::MatmulPrecision};
 
 use super::{
-    algorithm::Algorithm, base::ConvolutionProblem, selection::ConvSelector, ConvLaunchError,
+    algorithm::Algorithm,
+    base::{ConvolutionConfigFactory, ConvolutionProblem},
+    selection::ConvSelector,
+    ConvLaunchError,
 };
 
 /// Perform a 2D convolution using the implicit GEMM (im2col) algorithm, using cubecl tiling matmul
@@ -41,6 +44,10 @@ where
 
     let config = Alg::make_config(config_input, &problem, &cube_dim, &cube_count)
         .map_err(MatmulLaunchError::InvalidConfig)?;
+
+    <Alg::GlobalConvolution as ConvolutionConfigFactory>::check_availability::<R, SP>(
+        client, &config,
+    )?;
 
     unsafe {
         Alg::GlobalConvolution::launch_unchecked::<SP, R>(


### PR DESCRIPTION
Follow-up on #516 and https://github.com/tracel-ai/burn/pull/2908.

Turns out hanging macos tests were caused by an actual issue (had to debug this through the CI in https://github.com/tracel-ai/burn/pull/2922)

```
thread 'tests::cube::autodiff::f32_ty::ad_conv1d::tests::test_conv1d_groups' panicked at /Users/admin/.cargo/git/checkouts/cubecl-058c47895211d464/1a59333/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs:325:17:
Cooperative matrix-multiply and accumulate not supported.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

@wingertge looks like the check was in Burn before but removed in the migration to the cubecl repo

/edit: tests pass locally but we need to either fix the dependency issue, change MSRV or move to edition 2024 😅 