### PR TITLE
Fixes for naive matmul kernel

### DIFF
--- a/crates/cubecl-linalg/src/matmul/kernels/naive.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/naive.rs
@@ -159,10 +159,6 @@ pub fn launch<R: Runtime, E: Numeric>(
         false => 1,
     };
 
-    println!("lhs handle: {:?}", lhs);
-    println!("rhs handle: {:?}", rhs);
-    println!("out handle: {:?}", out);
-
     unsafe {
         matmul_kernel::launch_unchecked::<E, R>(
             client,

--- a/crates/cubecl-linalg/src/matmul/tune_key.rs
+++ b/crates/cubecl-linalg/src/matmul/tune_key.rs
@@ -129,7 +129,7 @@ mod tests {
 
         assert!(!key.round);
         assert!(key.broadcast);
-        assert_eq!(key.m, 256);
+        assert_eq!(key.m, 512);
         assert_eq!(key.k, 512);
         assert_eq!(key.n, 512);
         assert_eq!(key.batch, 4);

--- a/crates/cubecl-linalg/src/matmul/tune_key.rs
+++ b/crates/cubecl-linalg/src/matmul/tune_key.rs
@@ -132,7 +132,7 @@ mod tests {
         assert_eq!(key.m, 512);
         assert_eq!(key.k, 512);
         assert_eq!(key.n, 1024);
-        assert_eq!(key.batch, 4);
+        assert_eq!(key.batch, 8);
     }
 
     #[test]

--- a/crates/cubecl-linalg/src/matmul/tune_key.rs
+++ b/crates/cubecl-linalg/src/matmul/tune_key.rs
@@ -131,7 +131,7 @@ mod tests {
         assert!(key.broadcast);
         assert_eq!(key.m, 512);
         assert_eq!(key.k, 512);
-        assert_eq!(key.n, 512);
+        assert_eq!(key.n, 1024);
         assert_eq!(key.batch, 4);
     }
 

--- a/crates/cubecl-runtime/src/tune/util.rs
+++ b/crates/cubecl-runtime/src/tune/util.rs
@@ -3,7 +3,7 @@
 /// Useful when creating autotune keys.
 pub fn anchor(x: usize, max: Option<usize>, min: Option<usize>, base: Option<usize>) -> usize {
     let base = base.unwrap_or(2);
-    let exp = usize::ilog(x, base);
+    let exp = (x as f64).log(base as f64).ceil() as u32;
     let power = base.pow(exp);
 
     let result = if let Some(max) = max {


### PR DESCRIPTION
Fixes two bugs in naive_matmul:
One was introduced by the recent TensorMap PR, it used `rhs.stride(rank - 2)`, but the correct stride to use is actually `rhs.stride(rank - 1)`.
This was hidden by the second bug:
The kernel ensures the rhs tensor is always transposed, so k is the contiguous dimension. However, it never swaps back the strides. So for contiguous rhs matrices, strides are passed as `NK`, but for matrices that are already transposed and don't need to be corrected the strides are `KN`. This breaks every assumption about strides we make, so I fixed it by swapping the strides back to the normal order after the correction.

Also includes a fix for anchoring that prevents it from rounding down the value. This was breaking some of the convolution tests by producing invalid convolution sizes.

# Testing

This fixes the burn tests.