### PR TITLE
Reinterpret read

### DIFF
--- a/crates/cubecl-core/src/frontend/comptime_error.rs
+++ b/crates/cubecl-core/src/frontend/comptime_error.rs
@@ -1,0 +1,5 @@
+use cubecl_ir::Scope;
+
+pub fn expand<T>(_scope: &mut Scope, content: &str) -> T {
+    panic!("{content}")
+}

--- a/crates/cubecl-core/src/frontend/container/line/base.rs
+++ b/crates/cubecl-core/src/frontend/container/line/base.rs
@@ -2,7 +2,7 @@ use std::num::NonZero;
 
 use crate::frontend::{CubePrimitive, CubeType, ExpandElementBaseInit, ExpandElementTyped};
 use crate::{
-    ir::{Arithmetic, BinaryOperator, ConstantScalarValue, Elem, Instruction, Item, Scope},
+    ir::{Arithmetic, BinaryOperator, Elem, Instruction, Item, Scope},
     prelude::{Dot, Numeric, binary_expand_fixed_output},
     unexpanded,
 };
@@ -102,23 +102,21 @@ mod empty {
         }
 
         /// Expand function of [empty](Self::empty).
-        pub fn __expand_empty(
-            scope: &mut Scope,
-            length: ExpandElementTyped<u32>,
-        ) -> ExpandElementTyped<Self> {
-            let length = match length.expand.as_const() {
-                Some(val) => match val {
-                    ConstantScalarValue::Int(val, _) => NonZero::new(val)
-                        .map(|val| val.get() as u8)
-                        .map(|val| NonZero::new(val).unwrap()),
-                    ConstantScalarValue::Float(val, _) => NonZero::new(val as i64)
-                        .map(|val| val.get() as u8)
-                        .map(|val| NonZero::new(val).unwrap()),
-                    ConstantScalarValue::UInt(val, _) => NonZero::new(val as u8),
-                    ConstantScalarValue::Bool(_) => None,
-                },
-                None => None,
-            };
+        pub fn __expand_empty(scope: &mut Scope, length: u32) -> ExpandElementTyped<Self> {
+            // let length = match length {
+            // Some(val) => match val {
+            // ConstantScalarValue::Int(val, _) => NonZero::new(val)
+            //     .map(|val| val.get() as u8)
+            //     .map(|val| NonZero::new(val).unwrap()),
+            // ConstantScalarValue::Float(val, _) => NonZero::new(val as i64)
+            //     .map(|val| val.get() as u8)
+            //     .map(|val| NonZero::new(val).unwrap()),
+            // ConstantScalarValue::UInt(val, _) => NonZero::new(val as u8),
+            // ConstantScalarValue::Bool(_) => None,
+            // // },
+            // None => panic!("line size must be known at compile time"),
+            // };
+            let length = NonZero::new(length as u8);
             scope
                 .create_local_mut(Item::vectorized(Self::as_elem(scope), length))
                 .into()

--- a/crates/cubecl-core/src/frontend/container/line/base.rs
+++ b/crates/cubecl-core/src/frontend/container/line/base.rs
@@ -103,19 +103,6 @@ mod empty {
 
         /// Expand function of [empty](Self::empty).
         pub fn __expand_empty(scope: &mut Scope, length: u32) -> ExpandElementTyped<Self> {
-            // let length = match length {
-            // Some(val) => match val {
-            // ConstantScalarValue::Int(val, _) => NonZero::new(val)
-            //     .map(|val| val.get() as u8)
-            //     .map(|val| NonZero::new(val).unwrap()),
-            // ConstantScalarValue::Float(val, _) => NonZero::new(val as i64)
-            //     .map(|val| val.get() as u8)
-            //     .map(|val| NonZero::new(val).unwrap()),
-            // ConstantScalarValue::UInt(val, _) => NonZero::new(val as u8),
-            // ConstantScalarValue::Bool(_) => None,
-            // // },
-            // None => panic!("line size must be known at compile time"),
-            // };
             let length = NonZero::new(length as u8);
             scope
                 .create_local_mut(Item::vectorized(Self::as_elem(scope), length))

--- a/crates/cubecl-core/src/frontend/container/registry/base.rs
+++ b/crates/cubecl-core/src/frontend/container/registry/base.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
 use cubecl_ir::Scope;
 
-use crate::prelude::{CubeDebug, CubeType, ExpandElementTyped, Init};
+use crate::prelude::{CubeDebug, CubeType, Init};
 
 /// It is similar to a map, but where the keys are stored at comptime, but the values can be runtime
 /// variables.
@@ -21,13 +21,6 @@ pub trait RegistryQuery<K>: Into<K> {}
 
 // We provide default implementations for some types.
 impl RegistryQuery<u32> for u32 {}
-// impl RegistryQuery<u32> for ExpandElementTyped<u32> {}
-
-// impl From<ExpandElementTyped<u32>> for u32 {
-//     fn from(val: ExpandElementTyped<u32>) -> Self {
-//         val.constant().unwrap().as_u32()
-//     }
-// }
 
 impl<K: PartialOrd + Ord + core::fmt::Debug, V: CubeType + Clone> Registry<K, V> {
     /// Create a new registry.

--- a/crates/cubecl-core/src/frontend/container/registry/base.rs
+++ b/crates/cubecl-core/src/frontend/container/registry/base.rs
@@ -21,13 +21,13 @@ pub trait RegistryQuery<K>: Into<K> {}
 
 // We provide default implementations for some types.
 impl RegistryQuery<u32> for u32 {}
-impl RegistryQuery<u32> for ExpandElementTyped<u32> {}
+// impl RegistryQuery<u32> for ExpandElementTyped<u32> {}
 
-impl From<ExpandElementTyped<u32>> for u32 {
-    fn from(val: ExpandElementTyped<u32>) -> Self {
-        val.constant().unwrap().as_u32()
-    }
-}
+// impl From<ExpandElementTyped<u32>> for u32 {
+//     fn from(val: ExpandElementTyped<u32>) -> Self {
+//         val.constant().unwrap().as_u32()
+//     }
+// }
 
 impl<K: PartialOrd + Ord + core::fmt::Debug, V: CubeType + Clone> Registry<K, V> {
     /// Create a new registry.

--- a/crates/cubecl-core/src/frontend/element/cast.rs
+++ b/crates/cubecl-core/src/frontend/element/cast.rs
@@ -34,16 +34,15 @@ impl<P: CubePrimitive> Cast for P {
     }
 }
 
-/// Enables reinterpet-casting/bitcasting from any floating point value to any integer value and vice
-/// versa
-pub trait BitCast: CubePrimitive {
+/// Enables reinterpetring the bits from any value to any other type of the same size.
+pub trait Reinterpret: CubePrimitive {
     /// Reinterpret the bits of another primitive as this primitive without conversion.
     #[allow(unused_variables)]
-    fn bitcast_from<From: CubePrimitive>(value: From) -> Self {
+    fn reinterpret<From: CubePrimitive>(value: From) -> Self {
         unexpanded!()
     }
 
-    fn __expand_bitcast_from<From: CubePrimitive>(
+    fn __expand_reinterpret<From: CubePrimitive>(
         scope: &mut Scope,
         value: ExpandElementTyped<From>,
     ) -> <Self as CubeType>::ExpandType {
@@ -68,4 +67,4 @@ pub trait BitCast: CubePrimitive {
     }
 }
 
-impl<P: CubePrimitive> BitCast for P {}
+impl<P: CubePrimitive> Reinterpret for P {}

--- a/crates/cubecl-core/src/frontend/list.rs
+++ b/crates/cubecl-core/src/frontend/list.rs
@@ -52,10 +52,28 @@ pub trait ListMutExpand<T: CubeType> {
     );
 }
 
-// Automatic implementation for references to List.
+// Automatic implementation for mutable references to List.
 impl<'a, T: CubeType, L: List<T>> List<T> for &'a L
 where
     &'a L: CubeType<ExpandType = L::ExpandType>,
+{
+    fn read(&self, index: u32) -> T {
+        L::read(self, index)
+    }
+
+    fn __expand_read(
+        scope: &mut Scope,
+        this: Self::ExpandType,
+        index: ExpandElementTyped<u32>,
+    ) -> <T as CubeType>::ExpandType {
+        L::__expand_read(scope, this, index)
+    }
+}
+
+// Automatic implementation for mutable references to List.
+impl<'a, T: CubeType, L: List<T>> List<T> for &'a mut L
+where
+    &'a mut L: CubeType<ExpandType = L::ExpandType>,
 {
     fn read(&self, index: u32) -> T {
         L::read(self, index)
@@ -74,6 +92,25 @@ where
 impl<'a, T: CubeType, L: ListMut<T>> ListMut<T> for &'a L
 where
     &'a L: CubeType<ExpandType = L::ExpandType>,
+{
+    fn write(&self, index: u32, value: T) {
+        L::write(self, index, value);
+    }
+
+    fn __expand_write(
+        scope: &mut Scope,
+        this: Self::ExpandType,
+        index: ExpandElementTyped<u32>,
+        value: T::ExpandType,
+    ) {
+        L::__expand_write(scope, this, index, value);
+    }
+}
+
+// Automatic implementation for references to ListMut.
+impl<'a, T: CubeType, L: ListMut<T>> ListMut<T> for &'a mut L
+where
+    &'a mut L: CubeType<ExpandType = L::ExpandType>,
 {
     fn write(&self, index: u32, value: T) {
         L::write(self, index, value);

--- a/crates/cubecl-core/src/frontend/list.rs
+++ b/crates/cubecl-core/src/frontend/list.rs
@@ -14,7 +14,7 @@ pub trait List<T: CubeType>: CubeType<ExpandType: ListExpand<T>> {
         scope: &mut Scope,
         this: Self::ExpandType,
         index: ExpandElementTyped<u32>,
-    ) -> ExpandElementTyped<T>;
+    ) -> T::ExpandType;
 }
 
 /// Expand version of [CubeRead].
@@ -23,7 +23,7 @@ pub trait ListExpand<T: CubeType> {
         self,
         scope: &mut Scope,
         index: ExpandElementTyped<u32>,
-    ) -> ExpandElementTyped<T>;
+    ) -> T::ExpandType;
 }
 
 /// Type for which we can read and write values in cube functions.
@@ -38,7 +38,7 @@ pub trait ListMut<T: CubeType>: CubeType<ExpandType: ListMutExpand<T>> + List<T>
         scope: &mut Scope,
         this: Self::ExpandType,
         index: ExpandElementTyped<u32>,
-        value: ExpandElementTyped<T>,
+        value: T::ExpandType,
     );
 }
 
@@ -48,6 +48,43 @@ pub trait ListMutExpand<T: CubeType> {
         self,
         scope: &mut Scope,
         index: ExpandElementTyped<u32>,
-        value: ExpandElementTyped<T>,
+        value: T::ExpandType,
     );
+}
+
+// Automatic implementation for references to List.
+impl<'a, T: CubeType, L: List<T>> List<T> for &'a L
+where
+    &'a L: CubeType<ExpandType = L::ExpandType>,
+{
+    fn read(&self, index: u32) -> T {
+        L::read(self, index)
+    }
+
+    fn __expand_read(
+        scope: &mut Scope,
+        this: Self::ExpandType,
+        index: ExpandElementTyped<u32>,
+    ) -> <T as CubeType>::ExpandType {
+        L::__expand_read(scope, this, index)
+    }
+}
+
+// Automatic implementation for references to ListMut.
+impl<'a, T: CubeType, L: ListMut<T>> ListMut<T> for &'a L
+where
+    &'a L: CubeType<ExpandType = L::ExpandType>,
+{
+    fn write(&self, index: u32, value: T) {
+        L::write(self, index, value);
+    }
+
+    fn __expand_write(
+        scope: &mut Scope,
+        this: Self::ExpandType,
+        index: ExpandElementTyped<u32>,
+        value: T::ExpandType,
+    ) {
+        L::__expand_write(scope, this, index, value);
+    }
 }

--- a/crates/cubecl-core/src/frontend/mod.rs
+++ b/crates/cubecl-core/src/frontend/mod.rs
@@ -6,6 +6,7 @@ pub mod synchronization;
 
 mod base;
 mod comment;
+pub mod comptime_error;
 mod const_expand;
 mod container;
 mod debug;

--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -53,5 +53,8 @@ cubecl-linalg = { path = "../cubecl-linalg", version = "0.5.0", features = [
 cubecl-reduce = { path = "../cubecl-reduce", version = "0.5.0", features = [
     "export_tests",
 ] }
+cubecl-std= { path = "../cubecl-std", version = "0.5.0", features = [
+    "export_tests",
+] }
 paste = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/cubecl-cuda/src/lib.rs
+++ b/crates/cubecl-cuda/src/lib.rs
@@ -16,6 +16,9 @@ mod tests {
     pub use half::{bf16, f16};
 
     cubecl_core::testgen_all!(f32: [f16, bf16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
+
+    cubecl_std::testgen!();
+
     cubecl_linalg::testgen_matmul_accelerated!([f16]);
     cubecl_linalg::testgen_matmul_quantized!();
     cubecl_linalg::testgen_matmul_simple!([f16, bf16, f32]);

--- a/crates/cubecl-linalg/src/matmul/components/global/args.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/args.rs
@@ -599,7 +599,7 @@ impl MatmulArgs for TensorMapArgs {
     ) -> Line<EI> {
         comptime!(unimplemented!("Can't directly read from TensorMap"));
         #[allow(unreachable_code)]
-        Line::empty(1)
+        Line::empty(1_u32)
     }
 
     fn read_rhs<EI: Numeric, EO: Numeric>(
@@ -608,7 +608,7 @@ impl MatmulArgs for TensorMapArgs {
     ) -> Line<EI> {
         comptime!(unimplemented!("Can't directly read from TensorMap"));
         #[allow(unreachable_code)]
-        Line::empty(1)
+        Line::empty(1_u32)
     }
 
     #[allow(unused)]

--- a/crates/cubecl-linalg/src/matmul/components/global/quantization.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/quantization.rs
@@ -97,7 +97,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
         1 => {
             // Each item is a 1 byte value, we need four of them.
             let start = index * 4;
-            let mut bytes = Line::empty(4);
+            let mut bytes = Line::empty(4_u32);
             #[unroll]
             for k in 0..4 {
                 bytes[k] = slice[start + k][0];
@@ -107,7 +107,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
         2 => {
             // Each item is a 2 bytes value, we need two of them.
             let start = index * 2;
-            let mut bytes = Line::empty(2); // This is either a line of two lines of u8 / i8 or a line of two f16 / u16 / i16.
+            let mut bytes = Line::empty(2_u32); // This is either a line of two lines of u8 / i8 or a line of two f16 / u16 / i16.
             #[unroll]
             for k in 0..2 {
                 bytes[k] = slice[start + k][0];
@@ -119,7 +119,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
             // Each item is a 8 bytes value, we need half of one.
             let outer = index / 2;
             let inner = index % 2;
-            let mut bytes = Line::empty(line_size / 2);
+            let mut bytes = Line::empty(comptime!(line_size / 2));
             #[unroll]
             for k in 0..line_size / 2 {
                 bytes[k] = slice[outer][inner + k];
@@ -130,7 +130,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
             // Each item is a 16 bytes value, we need a quarter of one.
             let outer = index / 4;
             let inner = index % 4;
-            let mut bytes = Line::empty(line_size / 4);
+            let mut bytes = Line::empty(comptime!(line_size / 4));
             #[unroll]
             for k in 0..line_size / 4 {
                 bytes[k] = slice[outer][inner + k];
@@ -141,7 +141,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
             // Each item is a 32 bytes value, we need an eight of one.
             let outer = index / 8;
             let inner = index % 8;
-            let mut bytes = Line::empty(line_size / 8);
+            let mut bytes = Line::empty(comptime!(line_size / 8));
             #[unroll]
             for k in 0..line_size / 8 {
                 bytes[k] = slice[outer][inner + k];
@@ -180,7 +180,7 @@ fn write_f32<EG: Numeric>(
             #[unroll]
             for k in 0..2 {
                 // We build a line from the first / last two bytes.
-                let mut line = Line::<EG>::empty(2);
+                let mut line = Line::<EG>::empty(2_u32);
                 line[0] = bytes[2 * k];
                 line[1] = bytes[2 * k + 1];
 

--- a/crates/cubecl-linalg/src/matmul/components/global/quantization.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/quantization.rs
@@ -102,7 +102,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
             for k in 0..4 {
                 bytes[k] = slice[start + k][0];
             }
-            f32::bitcast_from(bytes)
+            f32::reinterpret(bytes)
         }
         2 => {
             // Each item is a 2 bytes value, we need two of them.
@@ -112,9 +112,9 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
             for k in 0..2 {
                 bytes[k] = slice[start + k][0];
             }
-            f32::bitcast_from(bytes)
+            f32::reinterpret(bytes)
         }
-        4 => f32::bitcast_from(slice[index]), // Each item is a 4 bytes value, we need one of them.
+        4 => f32::reinterpret(slice[index]), // Each item is a 4 bytes value, we need one of them.
         8 => {
             // Each item is a 8 bytes value, we need half of one.
             let outer = index / 2;
@@ -124,7 +124,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
             for k in 0..line_size / 2 {
                 bytes[k] = slice[outer][inner + k];
             }
-            f32::bitcast_from(bytes)
+            f32::reinterpret(bytes)
         }
         16 => {
             // Each item is a 16 bytes value, we need a quarter of one.
@@ -135,7 +135,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
             for k in 0..line_size / 4 {
                 bytes[k] = slice[outer][inner + k];
             }
-            f32::bitcast_from(bytes)
+            f32::reinterpret(bytes)
         }
         32 => {
             // Each item is a 32 bytes value, we need an eight of one.
@@ -146,7 +146,7 @@ fn read_f32<EG: Numeric>(slice: Slice<Line<EG>>, index: u32, #[comptime] line_si
             for k in 0..line_size / 8 {
                 bytes[k] = slice[outer][inner + k];
             }
-            f32::bitcast_from(bytes)
+            f32::reinterpret(bytes)
         }
         _ => comptime!(panic!("invalid number of bytes")), // unreachable
     }
@@ -163,7 +163,7 @@ fn write_f32<EG: Numeric>(
     value: f32,
     #[comptime] line_size: u32,
 ) {
-    let bytes = Line::<EG>::bitcast_from(value);
+    let bytes = Line::<EG>::reinterpret(value);
     let num_bytes_line_eg = comptime!(core::mem::size_of::<EG>() as u32) * line_size;
     match num_bytes_line_eg {
         1 => {
@@ -184,10 +184,10 @@ fn write_f32<EG: Numeric>(
                 line[0] = bytes[2 * k];
                 line[1] = bytes[2 * k + 1];
 
-                slice[start + k] = Line::<EG>::bitcast_from(line);
+                slice[start + k] = Line::<EG>::reinterpret(line);
             }
         }
-        4 => slice[index] = Line::<EG>::bitcast_from(value), // Each item is a 4 bytes value, we need one of them.
+        4 => slice[index] = Line::<EG>::reinterpret(value), // Each item is a 4 bytes value, we need one of them.
         8 => {
             // Each item is a 8 bytes value, we need half of one.
             let outer = index / 2;
@@ -196,9 +196,9 @@ fn write_f32<EG: Numeric>(
             // We convert the item to a pair of f32.
             // Then we overwrite one of the two f32 by the given value.
             // Finally, we convert back to a Line<EG> that we write in the slice.
-            let mut line = Line::<f32>::bitcast_from(slice[outer]);
+            let mut line = Line::<f32>::reinterpret(slice[outer]);
             line[inner] = value;
-            slice[outer] = Line::<EG>::bitcast_from(line);
+            slice[outer] = Line::<EG>::reinterpret(line);
         }
         16 => {
             // Each item is a 16 bytes value, we need a quarter of one.
@@ -208,9 +208,9 @@ fn write_f32<EG: Numeric>(
             // We convert the item to four f32.
             // Then we overwrite one of the four f32 by the given value.
             // Finally, we convert back to a Line<EG> that we write in the slice.
-            let mut line = Line::<f32>::bitcast_from(slice[outer]);
+            let mut line = Line::<f32>::reinterpret(slice[outer]);
             line[inner] = value;
-            slice[outer] = Line::<EG>::bitcast_from(line);
+            slice[outer] = Line::<EG>::reinterpret(line);
         }
         32 => {
             // Each item is a 32 bytes value, we need an eight of one.
@@ -220,9 +220,9 @@ fn write_f32<EG: Numeric>(
             // We convert the item to eight f32.
             // Then we overwrite one of the eight f32 by the given value.
             // Finally, we convert back to a Line<EG> that we write in the slice.
-            let mut line = Line::<f32>::bitcast_from(slice[outer]);
+            let mut line = Line::<f32>::reinterpret(slice[outer]);
             line[inner] = value;
-            slice[outer] = Line::<EG>::bitcast_from(line);
+            slice[outer] = Line::<EG>::reinterpret(line);
         }
         _ => comptime!(panic!("invalid number of bytes")), // unreachable
     }

--- a/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/loader.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/tiling2d/tile/loader.rs
@@ -175,7 +175,7 @@ pub(crate) fn load_plain<N: Numeric, L: BlockLoader<N>>(
     let mut sm = load_info.shared_memory;
 
     if write_row < sm_dim_vertical {
-        if comment![line_size == tile_size] {
+        if comptime![line_size == tile_size] {
             L::load_tile_plain::<MatchingVectorization>(
                 tensor,
                 &mut sm,

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -156,6 +156,10 @@ pub enum Expression {
     Comment {
         content: LitStr,
     },
+    RustMacro {
+        ident: Ident,
+        tokens: TokenStream,
+    },
     Terminate,
 }
 
@@ -209,6 +213,7 @@ impl Expression {
             Expression::CompilerIntrinsic { .. } => None,
             Expression::Match { .. } => None,
             Expression::Comment { .. } => None,
+            Expression::RustMacro { .. } => None,
             Expression::Terminate => None,
         }
     }
@@ -271,6 +276,13 @@ impl Expression {
             Expression::MethodCall { .. } if self.is_const() => Some(self.to_tokens(context)),
             _ => None,
         }
+    }
+
+    pub fn is_verbatim(&self) -> bool {
+        matches!(
+            self,
+            Expression::Verbatim { .. } | Expression::VerbatimTerminated { .. }
+        )
     }
 
     pub fn as_index(&self) -> Option<(&Expression, &Expression)> {

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -521,6 +521,9 @@ impl Expression {
                 let frontend_path = frontend_path();
                 quote![#frontend_path::cube_comment::expand(context, #content)]
             }
+            Expression::RustMacro { ident, tokens } => {
+                quote![#ident!(#tokens)]
+            }
             Expression::Terminate => {
                 quote![cubecl::frontend::branch::return_expand(context);]
             }
@@ -625,7 +628,11 @@ impl Block {
         let ret = if let Some(ret) = self.ret.as_ref() {
             let as_const = ret.as_const(context);
             if let Some(as_const) = as_const {
-                quote![#as_const.__expand_runtime_method(context)]
+                if ret.is_verbatim() {
+                    quote![panic!()]
+                } else {
+                    quote![#as_const.__expand_runtime_method(context)]
+                }
             } else {
                 ret.to_tokens(context)
             }

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -202,6 +202,7 @@ pub fn terminate(input: TokenStream) -> TokenStream {
     let tokens: proc_macro2::TokenStream = input.into();
     quote![{ #tokens }].into()
 }
+
 /// Implements display and initialization for autotune keys.
 ///
 /// # Helper

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -502,4 +502,3 @@ fn fn_associated_type(path: &Expression) -> Option<(Path, PathSegment)> {
         _ => None,
     }
 }
-

--- a/crates/cubecl-macros/src/parse/statement.rs
+++ b/crates/cubecl-macros/src/parse/statement.rs
@@ -1,4 +1,4 @@
-use quote::format_ident;
+use quote::{format_ident, quote};
 use syn::{ExprArray, LitStr, Macro, Pat, Stmt, Type, TypeReference, parse_quote};
 
 use crate::{
@@ -90,10 +90,20 @@ pub fn parse_pat(pat: Pat) -> syn::Result<Pattern> {
 
 pub fn parse_macros(mac: Macro, context: &mut Context) -> syn::Result<Expression> {
     if mac.path.is_ident("comptime") {
-        Ok(Expression::Verbatim { tokens: mac.tokens })
-    } else if ["panic", "assert", "assert_eq", "assert_ne"]
-        .into_iter()
-        .any(|target| mac.path.is_ident(&target))
+        let tokens = &mac.tokens;
+        Ok(Expression::Verbatim {
+            tokens: quote![{#tokens}],
+        })
+    } else if [
+        "panic",
+        "assert",
+        "assert_eq",
+        "assert_ne",
+        "todo",
+        "unimplemented",
+    ]
+    .into_iter()
+    .any(|target| mac.path.is_ident(&target))
     {
         Ok(Expression::RustMacro {
             ident: mac.path.segments.last().unwrap().ident.clone(),

--- a/crates/cubecl-std/Cargo.toml
+++ b/crates/cubecl-std/Cargo.toml
@@ -14,7 +14,11 @@ readme.workspace = true
 repository = "https://github.com/tracel-ai/cubecl/tree/main/crates/cubecl-std"
 version.workspace = true
 
+[features]
+export_tests = []
+
 [dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.5.0", default-features = false }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.5.0", default-features = false }
+half.workspace = true
 serde = { workspace = true }

--- a/crates/cubecl-std/src/lib.rs
+++ b/crates/cubecl-std/src/lib.rs
@@ -1,5 +1,8 @@
 //! Cubecl standard library.
 
+mod reinterpret_list;
+pub use reinterpret_list::*;
+
 mod quantization;
 pub use quantization::*;
 
@@ -10,6 +13,9 @@ pub mod tensor;
 
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
+
+#[cfg(feature = "export_tests")]
+pub mod tests;
 
 #[cube]
 #[allow(clippy::manual_div_ceil)]

--- a/crates/cubecl-std/src/reinterpret_list.rs
+++ b/crates/cubecl-std/src/reinterpret_list.rs
@@ -1,0 +1,116 @@
+use core::{cmp::Ordering, marker::PhantomData};
+
+use cubecl::prelude::*;
+use cubecl_core as cubecl;
+
+#[derive(CubeType)]
+pub struct ReinterpretList<From: CubePrimitive, To: CubePrimitive, L: List<Line<From>>> {
+    list: L,
+
+    #[cube(comptime)]
+    line_size: u32,
+
+    #[cube(comptime)]
+    num_bytes_line_from: u32,
+
+    #[cube(comptime)]
+    num_bytes_to: u32,
+
+    #[cube(comptime)]
+    _phantom: PhantomData<(From, To)>,
+}
+
+#[cube]
+impl<From: CubePrimitive, To: CubePrimitive, L: List<Line<From>>> ReinterpretList<From, To, L> {
+    pub fn new(list: L, #[comptime] line_size: u32) -> ReinterpretList<From, To, L> {
+        let num_bytes_line_from = comptime!(core::mem::size_of::<From>() as u32 * line_size);
+        let num_bytes_to = comptime!(core::mem::size_of::<To>() as u32);
+        // panic!("FROM {num_bytes_line_from} TO {num_bytes_to}");
+
+        comptime! {
+            match num_bytes_line_from.cmp(&num_bytes_to) {
+                Ordering::Equal => {}
+                Ordering::Less => {
+                    // TODO: Support fractional encoding (e.g. 3 lines encode 2 values)
+                    if num_bytes_to % num_bytes_line_from != 0 {
+                        panic!("incompatible number of bytes");
+                    }
+                }
+                Ordering::Greater => {
+                    // TODO: Support fractional encoding (e.g. 3 lines encode 4 values)
+                    if num_bytes_line_from % num_bytes_to != 0 {
+                        panic!("incompatible number of bytes");
+                    }
+                }
+            }
+        }
+
+        ReinterpretList::<From, To, L> {
+            list,
+            line_size,
+            num_bytes_line_from,
+            num_bytes_to,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[allow(clippy::comparison_chain)]
+    pub fn read(&self, index: u32) -> To {
+        if comptime!(self.num_bytes_line_from == self.num_bytes_to) {
+            // panic!("PATH 1");
+            To::bitcast_from(self.list.read(index))
+        } else if comptime!(self.num_bytes_line_from < self.num_bytes_to) {
+            self.read_smaller_lines(index)
+        } else {
+            self.read_larger_lines(index)
+        }
+    }
+
+    pub fn read_smaller_lines(&self, index: u32) -> To {
+        let num_lines_to_read = comptime!(self.num_bytes_to / self.num_bytes_line_from);
+
+        // This will contains the content of `num_lines_to_read` lines merged
+        // into a single larger line.
+        let target_line_size = comptime!(num_lines_to_read * self.line_size);
+        let mut merged_lines = Line::<From>::empty(target_line_size);
+
+        let first = index * num_lines_to_read;
+        #[unroll]
+        for i in 0..num_lines_to_read {
+            let line = self.list.read(first + i);
+            #[unroll]
+            for j in 0..self.line_size {
+                merged_lines[i * self.line_size + j] = line[j]
+            }
+        }
+        To::bitcast_from(merged_lines)
+    }
+
+    pub fn read_larger_lines(&self, index: u32) -> To {
+        let num_outputs_per_line = comptime!(self.num_bytes_line_from / self.num_bytes_to);
+
+        if comptime!(num_outputs_per_line > self.line_size) {
+            panic!(
+                "the number of bytes in To ({}) must be a non-zero multiple of the number of bytes in From ({})-> {}, {}",
+                self.num_bytes_to,
+                self.num_bytes_line_from / self.line_size,
+                self.num_bytes_line_from,
+                num_outputs_per_line
+            );
+        }
+
+        let num_elems_to_read = comptime!(self.line_size / num_outputs_per_line);
+
+        let line = self.list.read(index / num_outputs_per_line);
+        let index_in_line = index % num_outputs_per_line;
+
+        // A sub-segment of the total line.
+        let mut line_segment = Line::empty(num_elems_to_read);
+
+        #[unroll]
+        for j in 0..num_elems_to_read {
+            line_segment[j] = line[index_in_line * num_elems_to_read + j]
+        }
+        To::bitcast_from(line_segment)
+    }
+}

--- a/crates/cubecl-std/src/reinterpret_list.rs
+++ b/crates/cubecl-std/src/reinterpret_list.rs
@@ -28,7 +28,6 @@ impl<From: CubePrimitive, To: CubePrimitive, L: List<Line<From>>> ReinterpretLis
     pub fn new(list: L, #[comptime] line_size: u32) -> ReinterpretList<From, To, L> {
         let num_bytes_line_from = comptime!(core::mem::size_of::<From>() as u32 * line_size);
         let num_bytes_to = comptime!(core::mem::size_of::<To>() as u32);
-        // panic!("FROM {num_bytes_line_from} TO {num_bytes_to}");
 
         comptime! {
             match num_bytes_line_from.cmp(&num_bytes_to) {

--- a/crates/cubecl-std/src/reinterpret_list.rs
+++ b/crates/cubecl-std/src/reinterpret_list.rs
@@ -60,7 +60,7 @@ impl<From: CubePrimitive, To: CubePrimitive, L: List<Line<From>>> ReinterpretLis
     #[allow(clippy::comparison_chain)]
     pub fn read(&self, index: u32) -> To {
         if comptime!(self.num_bytes_line_from == self.num_bytes_to) {
-            To::bitcast_from(self.list.read(index))
+            To::reinterpret(self.list.read(index))
         } else if comptime!(self.num_bytes_line_from < self.num_bytes_to) {
             self.read_smaller_lines(index)
         } else {
@@ -85,7 +85,7 @@ impl<From: CubePrimitive, To: CubePrimitive, L: List<Line<From>>> ReinterpretLis
                 merged_lines[i * self.line_size + j] = line[j]
             }
         }
-        To::bitcast_from(merged_lines)
+        To::reinterpret(merged_lines)
     }
 
     fn read_larger_lines(&self, index: u32) -> To {
@@ -113,6 +113,6 @@ impl<From: CubePrimitive, To: CubePrimitive, L: List<Line<From>>> ReinterpretLis
         for j in 0..num_elems_to_read {
             line_segment[j] = line[index_in_line * num_elems_to_read + j]
         }
-        To::bitcast_from(line_segment)
+        To::reinterpret(line_segment)
     }
 }

--- a/crates/cubecl-std/src/tests/mod.rs
+++ b/crates/cubecl-std/src/tests/mod.rs
@@ -1,0 +1,12 @@
+pub mod reinterpret_list;
+
+#[macro_export]
+macro_rules! testgen {
+    () => {
+        mod test_cubecl_std {
+            use super::*;
+
+            cubecl_std::testgen_reinterpret_list!();
+        }
+    };
+}

--- a/crates/cubecl-std/src/tests/reinterpret_list.rs
+++ b/crates/cubecl-std/src/tests/reinterpret_list.rs
@@ -1,0 +1,60 @@
+use cubecl::prelude::*;
+use cubecl_core as cubecl;
+
+use crate::ReinterpretList;
+use half::f16;
+
+#[cube(launch)]
+fn kernel(input: &Array<Line<i8>>, output: &mut Array<f16>) {
+    let line_size = input.line_size();
+    let list = ReinterpretList::<i8, f16, &Array<Line<i8>>>::new(input, line_size);
+    output[UNIT_POS] = list.read(UNIT_POS);
+}
+
+pub fn run_test<R: Runtime>(client: ComputeClient<R::Server, R::Channel>, line_size: usize) {
+    let target = [f16::from_f32(1.0), f16::from_f32(-8.5)];
+    let casted: [i8; 4] = unsafe { std::mem::transmute(target) };
+
+    let input = client.create(i8::as_bytes(&casted));
+    let output = client.empty(4);
+
+    kernel::launch::<R>(
+        &client,
+        CubeCount::new_single(),
+        CubeDim::new(2, 1, 1),
+        unsafe { ArrayArg::from_raw_parts::<i8>(&input, 4 / line_size, line_size as u8) },
+        unsafe { ArrayArg::from_raw_parts::<f16>(&output, 2, 1) },
+    );
+
+    let actual = client.read_one(output.binding());
+    let actual = f16::from_bytes(&actual);
+
+    assert_eq!(actual, target);
+}
+
+#[macro_export]
+macro_rules! testgen_reinterpret_list {
+    () => {
+        mod reinterpret_list_f16 {
+            use super::*;
+
+            #[test]
+            fn from_i8x1() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_std::tests::reinterpret_list::run_test::<TestRuntime>(client, 1);
+            }
+
+            #[test]
+            fn from_i8x2() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_std::tests::reinterpret_list::run_test::<TestRuntime>(client, 2);
+            }
+
+            #[test]
+            fn from_i8x4() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_std::tests::reinterpret_list::run_test::<TestRuntime>(client, 4);
+            }
+        }
+    };
+}

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -66,9 +66,6 @@ cubecl-linalg = { path = "../cubecl-linalg", version = "0.5.0", features = [
 cubecl-reduce = { path = "../cubecl-reduce", version = "0.5.0", features = [
     "export_tests",
 ] }
-cubecl-std = { path = "../cubecl-std", version = "0.5.0", features = [
-    "export_tests",
-] }
 half = { workspace = true }
 paste = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -66,6 +66,9 @@ cubecl-linalg = { path = "../cubecl-linalg", version = "0.5.0", features = [
 cubecl-reduce = { path = "../cubecl-reduce", version = "0.5.0", features = [
     "export_tests",
 ] }
+cubecl-std = { path = "../cubecl-std", version = "0.5.0", features = [
+    "export_tests",
+] }
 half = { workspace = true }
 paste = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -28,7 +28,6 @@ mod tests {
     pub type TestRuntime = crate::WgpuRuntime;
 
     cubecl_core::testgen_all!();
-    cubecl_std::testgen!();
     cubecl_linalg::testgen_matmul_plane!([f32]);
     cubecl_linalg::testgen_matmul_tiling2d!([flex32, f32]);
     cubecl_linalg::testgen_matmul_simple!([flex32, f32]);

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -28,6 +28,7 @@ mod tests {
     pub type TestRuntime = crate::WgpuRuntime;
 
     cubecl_core::testgen_all!();
+    cubecl_std::testgen!();
     cubecl_linalg::testgen_matmul_plane!([f32]);
     cubecl_linalg::testgen_matmul_tiling2d!([flex32, f32]);
     cubecl_linalg::testgen_matmul_simple!([flex32, f32]);


### PR DESCRIPTION
I introduce a new data type in `cubecl-std`. A `ReinterpretList` allows to read a list of some input type as if it was a list of some other type. This is semantically equivalent to bitcasting the original list, but the bitcast is done while reading. This is particularly useful to read metadata at the end of a Tensor or Array buffer. For example, this is done for quantization.

I also added the support for common rust macros such as `panic`, `todo`, `assert` and it is now trivial to add more macros that can be evaluated at comptime. (simply add its name to a list somewhere in `cubecl-macros`)

However, note that since the macros are evaluated at comptime, we have to be careful about their behavior with control flow.

For example, the following will always panic as the control flow is evaluated at runtime, but the panic is generated at comptime.

```rust
#[cube]
fn something(array: Array<i32>) {
   if array[0] < 0 { // you need a comptime condition for panic to work as expected.
     panic!("first element must be positive");
   }
   // rest of the kernel
}
```

However, we can now do the following without being yelled at by the compiler and using flaky comptime tricks.

```rust
#[cube]
fn something(#[comptime] fancy_feature: bool) {
  if comptime!(fancy_feature) {
    todo!("the fancy feature is not yet supported") 
  } else {
    // normal execution
  } 
}
``` 

Finally, I fixed some issues with vectorization of lines created by `Line::empty`.

## burn

There is a branch in burn to add those changes, but since burn is currently broken with cuda, I can't test. But it compiles.

https://github.com/tracel-ai/burn/tree/update-cubecl. 
