### PR TITLE
Fix buffer write when < aligned_len

### DIFF
--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -374,7 +374,8 @@ impl WgpuStream {
                     resource.offset(),
                     core::num::NonZeroU64::new(aligned_len).unwrap(),
                 )
-                .map(|mut view| view[0..data.len()].copy_from_slice(data));
+                .unwrap()[0..data.len()]
+                .copy_from_slice(data);
         }
         self.flush_if_needed();
 


### PR DESCRIPTION
Noticed a bunch of SPIR-V tests were failing when running the checks in Burn.

```
In Queue::write_buffer
    Copy size 25 does not respect `COPY_BUFFER_ALIGNMENT`
```

Some recent changes in wgpu stream assume 4-byte alignment which is always valid on wgpu but not necessarily SPIR-V. For example, the failing tests in `burn-vision` tried to allocated a 5x5 u8 tensor (bool).