### PR TITLE
Get number of SMs and tensor cores from device

### DIFF
--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -160,16 +160,9 @@ fn create_client(device: &CudaDevice, options: RuntimeOptions) -> ComputeClient<
 
 fn tensor_cores_per_sm(version: u32) -> Option<u32> {
     match version {
-        70 => Some(8),   // Volta (SM 7.0)
-        75 => Some(8),   // Turing (SM 7.5)
-        80 => Some(4),   // Ampere A100 (SM 8.0)
-        86 => Some(16),  // Ampere GA10x (SM 8.6)
-        89 => Some(16),  // Ampere GA10B (SM 8.9, Jetson Orin)
-        90 => Some(64),  // Hopper H100 (SM 9.0)
-        91 => Some(64),  // Hopper L40S (SM 9.1)
-        92 => Some(64),  // Hopper H200 (SM 9.2)
-        100 => Some(64), // Blackwell (SM 10.0, est.)
-        _ => None,       // Unknown or unsupported architecture
+        70 | 75 => Some(8),                           // Volta, Turing
+        80 | 86 | 89 | 90 | 91 | 92 | 100 => Some(4), // Ampere, Hopper, Blackwell
+        _ => None,                                    // Unknown or unsupported architecture
     }
 }
 

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -99,8 +99,9 @@ fn create_client(device: &CudaDevice, options: RuntimeOptions) -> ComputeClient<
         let max_cube_count =
             CubeDim::new_3d(grid_dim_x as u32, grid_dim_y as u32, grid_dim_z as u32);
 
-        let num_streaming_multiprocessors =
-            Some(get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT).unwrap() as u32);
+        let num_streaming_multiprocessors = Some(
+            get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT).unwrap() as u32,
+        );
         let num_tensor_cores = tensor_cores_per_sm(arch.version);
 
         comp_opts.warp_size = warp_size;
@@ -114,7 +115,7 @@ fn create_client(device: &CudaDevice, options: RuntimeOptions) -> ComputeClient<
             max_units_per_cube: max_threads,
             max_cube_dim,
             num_streaming_multiprocessors,
-            num_tensor_cores
+            num_tensor_cores,
         }
     };
 

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -127,6 +127,8 @@ fn create_client<M: DialectWmmaCompiler<HipDialect<M>>>(
         max_cube_count,
         max_units_per_cube: prop_max_threads,
         max_cube_dim,
+        num_streaming_multiprocessors: None,
+        num_tensor_cores: None,
     };
     let memory_management =
         MemoryManagement::from_configuration(storage, &mem_properties, options.memory_config);

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/algorithm/selector.rs
@@ -11,8 +11,8 @@ use crate::matmul::{
 
 use super::Algorithm;
 
-const NUM_SM_APPROX: usize = 50;
-const NUM_TENSOR_CORES_APPROX: usize = 8;
+const NUM_SM_APPROX: u32 = 50;
+const NUM_TENSOR_CORES_APPROX: u32 = 8;
 
 /// Select which kernel to launch for the given Algorithm.
 #[allow(clippy::result_large_err)]
@@ -142,8 +142,16 @@ pub(crate) fn matmul_selection<TMM: TileMatmulFamily, MS: MatmulSpec, R: Runtime
         problem.m,
         problem.n,
         problem.num_batches(),
-        NUM_SM_APPROX,
-        NUM_TENSOR_CORES_APPROX,
+        client
+            .properties()
+            .hardware_properties()
+            .num_streaming_multiprocessors
+            .unwrap_or(NUM_SM_APPROX) as usize,
+        client
+            .properties()
+            .hardware_properties()
+            .num_tensor_cores
+            .unwrap_or(NUM_TENSOR_CORES_APPROX) as usize,
         instruction_m,
         instruction_n,
     );

--- a/crates/cubecl-runtime/src/memory_management/mod.rs
+++ b/crates/cubecl-runtime/src/memory_management/mod.rs
@@ -112,6 +112,10 @@ pub struct HardwareProperties {
     pub max_units_per_cube: u32,
     /// Maximum `CubeDim` in x, y, and z dimensions
     pub max_cube_dim: CubeDim,
+    /// Number of streaming multiprocessors (SM), if available
+    pub num_streaming_multiprocessors: Option<u32>,
+    /// Number of tensor cores per SM, if any
+    pub num_tensor_cores: Option<u32>,
 }
 
 impl HardwareProperties {

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -44,6 +44,8 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
         max_cube_count: CubeDim::new_3d(u16::MAX as u32, u16::MAX as u32, u16::MAX as u32),
         max_units_per_cube: 1024,
         max_cube_dim: CubeDim::new_3d(1024, 1024, 64),
+        num_streaming_multiprocessors: None,
+        num_tensor_cores: None,
     };
     let memory_management = MemoryManagement::from_configuration(
         storage,

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -202,6 +202,8 @@ pub(crate) fn create_client_on_setup(
             adapter_limits.max_compute_workgroup_size_y,
             adapter_limits.max_compute_workgroup_size_z,
         ),
+        num_streaming_multiprocessors: None,
+        num_tensor_cores: None,
     };
 
     let mut compilation_options = Default::default();


### PR DESCRIPTION
Feature available for CUDA only, otherwise falls back to the approx consts we had. Not benchmarked yet. 