### PR TITLE
[Perf] Rework `into_contiguous` to improve performance

### DIFF
--- a/crates/cubecl-linalg/src/tensor/contiguous.rs
+++ b/crates/cubecl-linalg/src/tensor/contiguous.rs
@@ -74,7 +74,7 @@ pub fn index_offset_contiguous_fastdivmod<N: CubePrimitive>(
         offset += ogwl * stride.index(dim);
         remainder = rem;
 
-        comptime![dim -= 1;]
+        comptime![dim = dim.saturating_sub(1);]
     }
 
     offset / tensor.line_size()


### PR DESCRIPTION
Adds several new optimizations to significantly speed up `into_contiguous` while also reducing its compute load.
Improves perfomance by approximately 35% while lowering compute load between 20% and 80% depending on how many dimensions are powers of two (which have a special fast path in `FastDivmod`).

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
