### PR TITLE
Fix: matmul lower precision

### DIFF
--- a/crates/cubecl-core/src/frontend/container/slice.rs
+++ b/crates/cubecl-core/src/frontend/container/slice.rs
@@ -36,7 +36,7 @@ pub struct SliceMut<E> {
 mod metadata {
     use core::num::NonZero;
 
-    use cubecl_ir::{Item, NonSemantic};
+    use cubecl_ir::{Elem, FloatKind, Item, NonSemantic};
 
     use crate::prelude::cube_comment;
 
@@ -149,7 +149,15 @@ mod metadata {
             T: CubePrimitive,
         {
             if T::as_elem(scope) != E::as_elem(scope) && !is_tf32::<E, T>(scope) {
-                panic!("Try cast unchecked should only be used to satisfy the rust type system.")
+                let elems = [T::as_elem(scope), E::as_elem(scope)];
+                let is_flex32_cast = elems.contains(&Elem::Float(FloatKind::F32))
+                    && elems.contains(&Elem::Float(FloatKind::Flex32));
+
+                if !is_flex32_cast {
+                    panic!(
+                        "Try cast unchecked should only be used to satisfy the rust type system."
+                    )
+                }
             }
 
             self.expand.into()

--- a/crates/cubecl-linalg/src/matmul/components/spec.rs
+++ b/crates/cubecl-linalg/src/matmul/components/spec.rs
@@ -53,10 +53,10 @@ impl MatmulPrecision for f16 {
 
 impl MatmulPrecision for flex32 {
     const QUANTIZED: bool = false;
-    type EI = flex32;
+    type EI = f32;
     type ES = f16;
     type EA = f32;
-    type EO = flex32;
+    type EO = f32;
 }
 
 impl MatmulPrecision for bf16 {

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/base.rs
@@ -205,7 +205,7 @@ fn matmul_launch_kernel<R: Runtime, MP: MatmulPrecision, A: Algorithm>(
     plane_dim: u32,
 ) -> Result<(), MatmulLaunchError> {
     if <A::TileMatmul as TileMatmulFamily>::requires_tensor_cores()
-        && TypeId::of::<MP::EI>() == TypeId::of::<f32>()
+        && TypeId::of::<MP::ES>() == TypeId::of::<f32>()
         && tf32::is_supported(client)
     {
         select_kernel_concrete::<ReplaceES<MP, tf32>, R, A>(
@@ -282,7 +282,7 @@ pub fn matmul_cmma_tma_ref_no_check<R: Runtime, MP: MatmulPrecision, A: Algorith
         }
     };
 
-    if TypeId::of::<MP::EI>() == TypeId::of::<f32>() && tf32::is_supported(client) {
+    if TypeId::of::<MP::ES>() == TypeId::of::<f32>() && tf32::is_supported(client) {
         select_kernel_concrete::<(ReplaceES<MP, tf32>, TensorMapArgs), R, A>(
             client, lhs, rhs, out, problem, plane_dim,
         )

--- a/crates/cubecl-linalg/src/matmul/kernels/matmul/base.rs
+++ b/crates/cubecl-linalg/src/matmul/kernels/matmul/base.rs
@@ -58,28 +58,24 @@ pub fn launch_ref<R: Runtime, MP: MatmulPrecision, A: Algorithm>(
     let (rhs_make_contiguous, rhs_transposed) = check_layout(rhs);
 
     match (lhs_make_contiguous, rhs_make_contiguous) {
-        (false, false) => matmul_cmma_ref_no_check::<R, MP, A>(
-            client,
-            lhs,
-            rhs,
-            out,
-            (lhs_transposed, rhs_transposed),
-        ),
-        (false, true) => matmul_cmma_ref_no_check::<R, MP, A>(
+        (false, false) => {
+            matmul_cmma_ref::<R, MP, A>(client, lhs, rhs, out, (lhs_transposed, rhs_transposed))
+        }
+        (false, true) => matmul_cmma_ref::<R, MP, A>(
             client,
             lhs,
             &into_contiguous_pitched::<R, MP::EI>(client, rhs).as_ref(),
             out,
             (lhs_transposed, rhs_transposed),
         ),
-        (true, false) => matmul_cmma_ref_no_check::<R, MP, A>(
+        (true, false) => matmul_cmma_ref::<R, MP, A>(
             client,
             &into_contiguous_pitched::<R, MP::EI>(client, lhs).as_ref(),
             rhs,
             out,
             (lhs_transposed, rhs_transposed),
         ),
-        (true, true) => matmul_cmma_ref_no_check::<R, MP, A>(
+        (true, true) => matmul_cmma_ref::<R, MP, A>(
             client,
             &into_contiguous_pitched::<R, MP::EI>(client, lhs).as_ref(),
             &into_contiguous_pitched::<R, MP::EI>(client, rhs).as_ref(),
@@ -90,7 +86,7 @@ pub fn launch_ref<R: Runtime, MP: MatmulPrecision, A: Algorithm>(
 }
 
 #[allow(clippy::result_large_err)]
-fn matmul_cmma_ref_no_check<R: Runtime, MP: MatmulPrecision, A: Algorithm>(
+fn matmul_cmma_ref<R: Runtime, MP: MatmulPrecision, A: Algorithm>(
     client: &ComputeClient<R::Server, R::Channel>,
     lhs: &TensorHandleRef<'_, R>,
     rhs: &TensorHandleRef<'_, R>,
@@ -210,16 +206,11 @@ fn matmul_launch_kernel<R: Runtime, MP: MatmulPrecision, A: Algorithm>(
 ) -> Result<(), MatmulLaunchError> {
     if <A::TileMatmul as TileMatmulFamily>::requires_tensor_cores()
         && TypeId::of::<MP::EI>() == TypeId::of::<f32>()
+        && tf32::is_supported(client)
     {
-        if tf32::is_supported(client) {
-            select_kernel_concrete::<ReplaceES<MP, tf32>, R, A>(
-                client, lhs, rhs, out, problem, plane_dim,
-            )
-        } else {
-            select_kernel_concrete::<ReplaceES<MP, half::f16>, R, A>(
-                client, lhs, rhs, out, problem, plane_dim,
-            )
-        }
+        select_kernel_concrete::<ReplaceES<MP, tf32>, R, A>(
+            client, lhs, rhs, out, problem, plane_dim,
+        )
     } else {
         select_kernel_concrete::<MP, R, A>(client, lhs, rhs, out, problem, plane_dim)
     }
@@ -291,7 +282,7 @@ pub fn matmul_cmma_tma_ref_no_check<R: Runtime, MP: MatmulPrecision, A: Algorith
         }
     };
 
-    if TypeId::of::<MP::EI>() == TypeId::of::<f32>() {
+    if TypeId::of::<MP::EI>() == TypeId::of::<f32>() && tf32::is_supported(client) {
         select_kernel_concrete::<(ReplaceES<MP, tf32>, TensorMapArgs), R, A>(
             client, lhs, rhs, out, problem, plane_dim,
         )

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -129,12 +129,13 @@ fn run_benches<R: Runtime, MP: MatmulPrecision>() {
 fn main() {
     #[cfg(feature = "wgpu")]
     {
-        run_benches::<cubecl::wgpu::WgpuRuntime, f32>();
+        // run_benches::<cubecl::wgpu::WgpuRuntime, f32>();
     }
 
     #[cfg(feature = "wgpu-spirv")]
     {
-        run_benches::<cubecl::wgpu::WgpuRuntime, half::f16>();
+        // run_benches::<cubecl::wgpu::WgpuRuntime, half::f16>();
+        run_benches::<cubecl::wgpu::WgpuRuntime, cubecl::flex32>();
     }
 
     #[cfg(all(feature = "hip", target_os = "linux"))]
@@ -145,7 +146,7 @@ fn main() {
     #[cfg(feature = "cuda")]
     {
         // run_benches::<cubecl::cuda::CudaRuntime, f32>();
-        run_benches::<cubecl::cuda::CudaRuntime, half::f16>();
+        run_benches::<cubecl::cuda::CudaRuntime, cubecl::flex32>();
         //run_benches::<cubecl::cuda::CudaRuntime, SymQ8>();
         // run_benches::<cubecl::cuda::CudaRuntime, (i8, i8, i32, i32)>();
         // run_benches::<cubecl::cuda::CudaRuntime, (i8, i8, i32, i8)>();


### PR DESCRIPTION
On Vulkan we use matmul stage size in f16 instead of f32/tf32 to leverage tensor cores, but we shouldn't since the precision is very impacted by this.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.

https://github.com/tracel-ai/burn/pull/3059
