### PR TITLE
Fix edge case for `calculate_cube_count_elemwise`

### DIFF
--- a/crates/cubecl-core/src/lib.rs
+++ b/crates/cubecl-core/src/lib.rs
@@ -60,7 +60,10 @@ pub fn calculate_cube_count_elemwise(num_elems: usize, cube_dim: CubeDim) -> Cub
     let num_elems_per_cube = cube_dim.num_elems();
     let cube_counts = f32::max(1.0, f32::ceil(num_elems as f32 / num_elems_per_cube as f32));
     let cube_count_x = f32::ceil(f32::sqrt(cube_counts));
-    let cube_count_y = f32::ceil(num_elems as f32 / (cube_count_x * num_elems_per_cube as f32));
+    let cube_count_y = f32::max(
+        1.0,
+        f32::ceil(num_elems as f32 / (cube_count_x * num_elems_per_cube as f32)),
+    );
 
     CubeCount::Static(cube_count_x as u32, cube_count_y as u32, 1)
 }


### PR DESCRIPTION
Fixes oversight in `calculate_cube_count_elemwise` that caused `cube_count_y` to be 0 if `num_elems == cube_dim.num_elems()`.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
