### PR TITLE
Sanitize init element const

### DIFF
--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -335,10 +335,7 @@ pub(crate) fn init_expand_element<E: Into<ExpandElement>>(
 ) -> ExpandElement {
     let elem = element.into();
 
-    if !is_mut && matches!(elem.kind, VariableKind::LocalConst { .. }) {
-        return elem;
-    } else if is_mut && elem.can_mut() {
-        // If the elem is mut, we can check if we can reuse the same register.
+    if !is_mut && (matches!(elem.kind, VariableKind::LocalConst { .. }) || elem.can_mut()) {
         return elem;
     }
 

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -335,8 +335,10 @@ pub(crate) fn init_expand_element<E: Into<ExpandElement>>(
 ) -> ExpandElement {
     let elem = element.into();
 
-    if elem.can_mut() && !is_mut {
-        // Can reuse inplace :)
+    if !is_mut && matches!(elem.kind, VariableKind::LocalConst { .. }) {
+        return elem;
+    } else if is_mut && elem.can_mut() {
+        // If the elem is mut, we can check if we can reuse the same register.
         return elem;
     }
 


### PR DESCRIPTION
It makes it easier to read the generated C++ & WGSL code.