### PR TITLE
Fix deadlock by really properly not capturing locks

### DIFF
--- a/crates/cubecl-common/src/future.rs
+++ b/crates/cubecl-common/src/future.rs
@@ -1,4 +1,9 @@
-use core::future::Future;
+use alloc::boxed::Box;
+use core::{future::Future, pin::Pin};
+
+/// A dynamically typed, boxed, future. Useful for futures that need to ensure they
+/// are not capturing any of their inputs.
+pub type DynFut<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 
 /// Block until the [future](Future) is completed and returns the result.
 pub fn block_on<O>(fut: impl Future<Output = O>) -> O {

--- a/crates/cubecl-runtime/src/channel/base.rs
+++ b/crates/cubecl-runtime/src/channel/base.rs
@@ -1,5 +1,4 @@
-use core::future::Future;
-use cubecl_common::{ExecutionMode, benchmark::ProfileDuration};
+use cubecl_common::{ExecutionMode, benchmark::ProfileDuration, future::DynFut};
 
 use crate::{
     server::{Binding, BindingWithMeta, Bindings, ComputeServer, CubeCount, Handle},
@@ -11,13 +10,13 @@ use alloc::vec::Vec;
 /// while ensuring thread-safety
 pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send + Sync {
     /// Given bindings, returns owned resources as bytes
-    fn read(&self, bindings: Vec<Binding>) -> impl Future<Output = Vec<Vec<u8>>> + Send;
+    fn read(&self, bindings: Vec<Binding>) -> DynFut<Vec<Vec<u8>>>;
 
     /// Given bindings, returns owned resources as bytes
-    fn read_tensor(
-        &self,
-        bindings: Vec<BindingWithMeta>,
-    ) -> impl Future<Output = Vec<Vec<u8>>> + Send;
+    fn read_tensor(&self, bindings: Vec<BindingWithMeta>) -> DynFut<Vec<Vec<u8>>>;
+
+    /// Wait for the completion of every task in the server.
+    fn sync(&self) -> DynFut<()>;
 
     /// Given a resource handle, return the storage resource.
     fn get_resource(
@@ -53,9 +52,6 @@ pub trait ComputeChannel<Server: ComputeServer>: Clone + core::fmt::Debug + Send
 
     /// Flush outstanding work of the server.
     fn flush(&self);
-
-    /// Wait for the completion of every task in the server.
-    fn sync(&self) -> impl Future<Output = ()> + Send;
 
     /// Get the current memory usage of the server.
     fn memory_usage(&self) -> crate::memory_management::MemoryUsage;

--- a/crates/cubecl-runtime/src/channel/cell.rs
+++ b/crates/cubecl-runtime/src/channel/cell.rs
@@ -5,6 +5,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use cubecl_common::ExecutionMode;
 use cubecl_common::benchmark::ProfileDuration;
+use cubecl_common::future::DynFut;
 
 /// A channel using a [ref cell](core::cell::RefCell) to access the server with mutability.
 ///
@@ -44,20 +45,19 @@ impl<Server> ComputeChannel<Server> for RefCellComputeChannel<Server>
 where
     Server: ComputeServer + Send,
 {
-    async fn read(&self, bindings: Vec<Binding>) -> Vec<Vec<u8>> {
-        let future = {
-            let mut server = self.server.borrow_mut();
-            server.read(bindings)
-        };
-        future.await
+    fn read(&self, bindings: Vec<Binding>) -> DynFut<Vec<Vec<u8>>> {
+        let mut server = self.server.borrow_mut();
+        server.read(bindings)
     }
 
-    async fn read_tensor(&self, bindings: Vec<BindingWithMeta>) -> Vec<Vec<u8>> {
-        let future = {
-            let mut server = self.server.borrow_mut();
-            server.read_tensor(bindings)
-        };
-        future.await
+    fn read_tensor(&self, bindings: Vec<BindingWithMeta>) -> DynFut<Vec<Vec<u8>>> {
+        let mut server = self.server.borrow_mut();
+        server.read_tensor(bindings)
+    }
+
+    fn sync(&self) -> DynFut<()> {
+        let mut server = self.server.borrow_mut();
+        server.sync()
     }
 
     fn get_resource(
@@ -106,14 +106,6 @@ where
 
     fn flush(&self) {
         self.server.borrow_mut().flush()
-    }
-
-    async fn sync(&self) {
-        let future = {
-            let mut server = self.server.borrow_mut();
-            server.sync()
-        };
-        future.await
     }
 
     fn memory_usage(&self) -> crate::memory_management::MemoryUsage {

--- a/crates/cubecl-runtime/src/channel/mutex.rs
+++ b/crates/cubecl-runtime/src/channel/mutex.rs
@@ -5,6 +5,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use cubecl_common::ExecutionMode;
 use cubecl_common::benchmark::ProfileDuration;
+use cubecl_common::future::DynFut;
 use spin::Mutex;
 
 /// The MutexComputeChannel ensures thread-safety by locking the server
@@ -37,24 +38,19 @@ impl<Server> ComputeChannel<Server> for MutexComputeChannel<Server>
 where
     Server: ComputeServer,
 {
-    async fn read(&self, bindings: Vec<Binding>) -> Vec<Vec<u8>> {
-        // Nb: The order here is really important - the mutex guard has to be dropped before
-        // the future is polled. Just calling lock().read().await can deadlock.
-        let fut = {
-            let mut server = self.server.lock();
-            server.read(bindings)
-        };
-        fut.await
+    fn read(&self, bindings: Vec<Binding>) -> DynFut<Vec<Vec<u8>>> {
+        let mut server = self.server.lock();
+        server.read(bindings)
     }
 
-    async fn read_tensor(&self, bindings: Vec<BindingWithMeta>) -> Vec<Vec<u8>> {
-        // Nb: The order here is really important - the mutex guard has to be dropped before
-        // the future is polled. Just calling lock().read().await can deadlock.
-        let fut = {
-            let mut server = self.server.lock();
-            server.read_tensor(bindings)
-        };
-        fut.await
+    fn read_tensor(&self, bindings: Vec<BindingWithMeta>) -> DynFut<Vec<Vec<u8>>> {
+        let mut server = self.server.lock();
+        server.read_tensor(bindings)
+    }
+
+    fn sync(&self) -> DynFut<()> {
+        let mut server = self.server.lock();
+        server.sync()
     }
 
     fn get_resource(
@@ -97,16 +93,6 @@ where
 
     fn flush(&self) {
         self.server.lock().flush();
-    }
-
-    async fn sync(&self) {
-        // Nb: The order here is really important - the mutex guard has to be dropped before
-        // the future is polled. Just calling lock().sync().await can deadlock.
-        let fut = {
-            let mut server = self.server.lock();
-            server.sync()
-        };
-        fut.await
     }
 
     fn memory_usage(&self) -> crate::memory_management::MemoryUsage {

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -63,8 +63,11 @@ where
     }
 
     /// Given bindings, returns owned resources as bytes.
-    pub async fn read_async(&self, bindings: Vec<Binding>) -> Vec<Vec<u8>> {
-        self.channel.read(bindings).await
+    pub fn read_async(
+        &self,
+        bindings: Vec<Binding>,
+    ) -> impl Future<Output = Vec<Vec<u8>>> + Send + use<Server, Channel> {
+        self.channel.read(bindings)
     }
 
     /// Given bindings, returns owned resources as bytes.
@@ -74,11 +77,6 @@ where
     /// Panics if the read operation fails.
     pub fn read(&self, bindings: Vec<Binding>) -> Vec<Vec<u8>> {
         cubecl_common::reader::read_sync(self.channel.read(bindings))
-    }
-
-    /// Given a binding, returns owned resource as bytes.
-    pub async fn read_one_async(&self, binding: Binding) -> Vec<u8> {
-        self.channel.read([binding].into()).await.remove(0)
     }
 
     /// Given a binding, returns owned resource as bytes.

--- a/crates/cubecl-runtime/src/server.rs
+++ b/crates/cubecl-runtime/src/server.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use core::{fmt::Debug, future::Future};
-use cubecl_common::{ExecutionMode, benchmark::ProfileDuration};
+use core::fmt::Debug;
+use cubecl_common::{ExecutionMode, benchmark::ProfileDuration, future::DynFut};
 use cubecl_ir::Elem;
 
 /// The compute server is responsible for handling resources and computations over resources.
@@ -30,16 +30,13 @@ where
     type Feature: Ord + Copy + Debug + Send + Sync;
 
     /// Given bindings, returns the owned resources as bytes.
-    fn read(
-        &mut self,
-        bindings: Vec<Binding>,
-    ) -> impl Future<Output = Vec<Vec<u8>>> + Send + 'static;
+    fn read(&mut self, bindings: Vec<Binding>) -> DynFut<Vec<Vec<u8>>>;
 
     /// Given tensor handles, returns the owned resources as bytes.
-    fn read_tensor(
-        &mut self,
-        bindings: Vec<BindingWithMeta>,
-    ) -> impl Future<Output = Vec<Vec<u8>>> + Send + 'static;
+    fn read_tensor(&mut self, bindings: Vec<BindingWithMeta>) -> DynFut<Vec<Vec<u8>>>;
+
+    /// Wait for the completion of every task in the server.
+    fn sync(&mut self) -> DynFut<()>;
 
     /// Given a resource handle, returns the storage resource.
     fn get_resource(
@@ -86,9 +83,6 @@ where
 
     /// Flush all outstanding tasks in the server.
     fn flush(&mut self);
-
-    /// Wait for the completion of every task in the server.
-    fn sync(&mut self) -> impl Future<Output = ()> + Send + 'static;
 
     /// The current memory usage of the server.
     fn memory_usage(&self) -> MemoryUsage;

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, time::Duration};
+use std::time::Duration;
 
 use super::WgpuResource;
 use super::{WgpuStorage, stream::WgpuStream};
@@ -6,6 +6,7 @@ use crate::AutoCompiler;
 use alloc::sync::Arc;
 use cubecl_common::future;
 use cubecl_core::benchmark::ProfileDuration;
+use cubecl_core::future::DynFut;
 use cubecl_core::{
     Feature, KernelId, MemoryConfiguration, WgpuCompilationOptions,
     compute::DebugInformation,
@@ -126,10 +127,7 @@ impl ComputeServer for WgpuServer {
     type Feature = Feature;
     type Info = wgpu::Backend;
 
-    fn read(
-        &mut self,
-        bindings: Vec<Binding>,
-    ) -> impl Future<Output = Vec<Vec<u8>>> + Send + 'static {
+    fn read(&mut self, bindings: Vec<Binding>) -> DynFut<Vec<Vec<u8>>> {
         self.stream.read_buffers(bindings)
     }
 
@@ -221,7 +219,7 @@ impl ComputeServer for WgpuServer {
     }
 
     /// Returns the total time of GPU work this sync completes.
-    fn sync(&mut self) -> impl Future<Output = ()> + 'static {
+    fn sync(&mut self) -> DynFut<()> {
         self.logger.profile_summary();
         self.stream.sync()
     }
@@ -252,10 +250,7 @@ impl ComputeServer for WgpuServer {
         self.stream.mem_manage.memory_cleanup(true);
     }
 
-    fn read_tensor(
-        &mut self,
-        bindings: Vec<BindingWithMeta>,
-    ) -> impl Future<Output = Vec<Vec<u8>>> + Send + 'static {
+    fn read_tensor(&mut self, bindings: Vec<BindingWithMeta>) -> DynFut<Vec<Vec<u8>>> {
         let bindings = bindings.into_iter().map(|it| it.binding).collect();
         self.read(bindings)
     }


### PR DESCRIPTION
I was experiencing a deadlock on WASM. I'm guessing other platforms might hit this but usually don't use an actual async runtime  or if they do a multi threaded one.

The problem is mixing async code and regular locks. It's important to _not_ hold a lock across await points. We tried doing this by marking futures as 'static but that's not quite what you want. This would still allow capturing &self as long as &self was 'static (eg. by cloning an arc). The fusion client was incorrectly capturing things leading to a deadlock.

The proper thing to do is `use<>` bounds. I've annotated futures where possible. However, `use<>` bounds in traits are still unstable. There I've gone back to a boxed future, which also doesn't capture parameters by default. Rust 1.88 stabilizes this so maybe can then remove the unneeeded boxing again.

This is only the cubecl changes, burn has the more changes, see https://github.com/tracel-ai/burn/pull/3123