### PR TITLE
Perf: double buffering event cleanup

### DIFF
--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -347,7 +347,7 @@ where
     let git_hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
     let durations = benchmark.run(TimingMethod::Full);
 
-    BenchmarkResult {
+    let result = BenchmarkResult {
         raw: durations.clone(),
         computed: BenchmarkComputations::new(&durations),
         git_hash,
@@ -355,7 +355,10 @@ where
         options: benchmark.options(),
         shapes: benchmark.shapes(),
         timestamp,
-    }
+    };
+
+    println!("{result}");
+    result
 }
 
 #[cfg(test)]

--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -347,7 +347,7 @@ where
     let git_hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
     let durations = benchmark.run(TimingMethod::Full);
 
-    let result = BenchmarkResult {
+    BenchmarkResult {
         raw: durations.clone(),
         computed: BenchmarkComputations::new(&durations),
         git_hash,
@@ -355,10 +355,7 @@ where
         options: benchmark.options(),
         shapes: benchmark.shapes(),
         timestamp,
-    };
-
-    println!("{result}");
-    result
+    }
 }
 
 #[cfg(test)]

--- a/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-linalg/src/matmul/components/global/multi_stage/double_buffering/matmul.rs
@@ -344,40 +344,21 @@ impl<Lhs: LoaderEventListener, Rhs: LoaderEventListener, G: GlobalConfig>
 /// How events are handled for double buffering.
 ///
 /// The goal is to overlap computation instructions with memory instructions.
-enum EventListenerMode {
-    /// We execute memory instructions based on the given ratio (between 0 and 1) of the
-    /// computation that is completed.
-    Full {
-        /// The ratio to be waited for with LHS.
-        ratio_lhs: f32,
-        /// The ratio to be waited for with RHS.
-        ratio_rhs: f32,
-    },
-    /// We execute memory instructions for each [STEP] after [START] compute tasks are executed.
-    Splitted {
-        /// The event number to execute the next LHS task.
-        event_lhs: u32,
-        /// If no more tasks need to be executed for LHS.
-        event_lhs_completed: bool,
-        /// The event number to execute the next RHS task.
-        event_rhs: u32,
-        /// If no more tasks need to be executed for RHS.
-        event_rhs_completed: bool,
-    },
+struct Event {
+    /// We execute memory instructions for each [STEP] compute tasks are executed.
+    /// The event number to execute the next LHS task.
+    lhs: u32,
+    /// If no more tasks need to be executed for LHS.
+    lhs_completed: bool,
+    /// The event number to execute the next RHS task.
+    rhs: u32,
+    /// If no more tasks need to be executed for RHS.
+    rhs_completed: bool,
 }
 
-impl CubeDebug for EventListenerMode {}
+impl CubeDebug for Event {}
 
-const STEP: u32 = 2;
-const START: u32 = 1;
-
-fn should_handle_event(expected_event: u32, current_event: u32, total: u32) -> bool {
-    current_event == expected_event || (total <= expected_event && current_event + 1 == total)
-}
-
-fn should_handle_event_ratio(ratio: f32, current_event: u32, total: u32) -> bool {
-    should_handle_event(f32::ceil(ratio * total as f32) as u32, current_event, total)
-}
+const STEP: u32 = 1;
 
 #[cube]
 impl<
@@ -394,28 +375,28 @@ impl<
                 this.init();
             }
 
-            let mode = this.mode(total);
+            let event = this.create_event(total);
+            this.on_event(event, current);
+        }
 
-            match comptime!(mode) {
-                EventListenerMode::Full {
-                    ratio_lhs,
-                    ratio_rhs,
-                } => this.on_full_event(ratio_lhs, ratio_rhs, current, total),
-                EventListenerMode::Splitted {
-                    event_lhs,
-                    event_lhs_completed,
-                    event_rhs,
-                    event_rhs_completed,
-                } => this.on_splitted_event(
-                    event_lhs,
-                    event_lhs_completed,
-                    event_rhs,
-                    event_rhs_completed,
-                    current,
-                    total,
-                ),
+        // Cleanup remaining tasks if any.
+        if let StageEvent::Finish = event {
+            let lhs_job = this.state_lhs.index_mut(0);
+            let lhs_num_task_executed = lhs_job.current.read().counter;
+
+            #[unroll]
+            for _ in lhs_num_task_executed..lhs_job.num_tasks {
+                SyncBufferLoader::execute_task(&mut this.loader_lhs, lhs_job, this.config);
             }
-        };
+
+            let rhs_job = this.state_rhs.index_mut(0);
+            let rhs_num_task_executed = rhs_job.current.read().counter;
+
+            #[unroll]
+            for _ in rhs_num_task_executed..rhs_job.num_tasks {
+                SyncBufferLoader::execute_task(&mut this.loader_rhs, rhs_job, this.config);
+            }
+        }
     }
 }
 
@@ -435,74 +416,33 @@ impl<
         self.state_rhs.push(job_rhs);
     }
 
-    fn mode(&self, #[comptime] total: u32) -> comptime_type!(EventListenerMode) {
+    fn create_event(&self, #[comptime] total: u32) -> comptime_type!(Event) {
         let lhs_job = self.state_lhs.index(0);
         let rhs_job = self.state_rhs.index(0);
         let num_tasks_total = comptime!(lhs_job.num_tasks + rhs_job.num_tasks);
 
-        if comptime!(num_tasks_total * STEP + (START) >= total) {
-            comptime! {
-                EventListenerMode::Full {
-                    ratio_lhs: 0.1,
-                    ratio_rhs: 0.3,
-                }
-            }
-        } else {
-            let lhs_num_task_executed = lhs_job.current.read().counter;
-            let rhs_num_task_executed = rhs_job.current.read().counter;
+        let lhs_num_task_executed = lhs_job.current.read().counter;
+        let rhs_num_task_executed = rhs_job.current.read().counter;
 
-            comptime! {
-                EventListenerMode::Splitted {
-                    event_lhs: lhs_num_task_executed  * STEP + START,
-                    event_lhs_completed: lhs_num_task_executed >= lhs_job.num_tasks,
-                    event_rhs: rhs_num_task_executed  * STEP + (lhs_job.num_tasks * STEP) + START,
-                    event_rhs_completed: rhs_num_task_executed >= rhs_job.num_tasks,
-                }
+        comptime! {
+            let start = total - (STEP * num_tasks_total);
+            Event {
+                lhs: lhs_num_task_executed  * STEP + start,
+                lhs_completed: lhs_num_task_executed >= lhs_job.num_tasks,
+                rhs: rhs_num_task_executed  * STEP + (lhs_job.num_tasks * STEP) + start,
+                rhs_completed: rhs_num_task_executed >= rhs_job.num_tasks,
             }
         }
     }
 
-    fn on_full_event(
-        &mut self,
-        #[comptime] ratio_lhs: f32,
-        #[comptime] ratio_rhs: f32,
-        #[comptime] current: u32,
-        #[comptime] total: u32,
-    ) {
-        if comptime![should_handle_event_ratio(ratio_lhs, current, total)] {
-            let lhs_job = self.state_lhs.index_mut(0);
-
-            #[unroll]
-            for _ in 0..lhs_job.num_tasks {
-                SyncBufferLoader::execute_task(&mut self.loader_lhs, lhs_job, self.config);
-            }
-        }
-        if comptime![should_handle_event_ratio(ratio_rhs, current, total)] {
-            let rhs_job = self.state_rhs.index_mut(0);
-
-            #[unroll]
-            for _ in 0..rhs_job.num_tasks {
-                SyncBufferLoader::execute_task(&mut self.loader_rhs, rhs_job, self.config);
-            }
-        }
-    }
-
-    fn on_splitted_event(
-        &mut self,
-        #[comptime] event_lhs: u32,
-        #[comptime] event_lhs_completed: bool,
-        #[comptime] event_rhs: u32,
-        #[comptime] event_rhs_completed: bool,
-        #[comptime] current: u32,
-        #[comptime] total: u32,
-    ) {
-        if comptime![!event_lhs_completed && should_handle_event(event_lhs, current, total)] {
+    fn on_event(&mut self, #[comptime] event: Event, #[comptime] current: u32) {
+        if comptime![!event.lhs_completed && event.lhs == current] {
             let lhs_job = self.state_lhs.index_mut(0);
 
             SyncBufferLoader::execute_task(&mut self.loader_lhs, lhs_job, self.config);
         }
 
-        if comptime![!event_rhs_completed && should_handle_event(event_rhs, current, total)] {
+        if comptime![!event.rhs_completed && event.rhs == current] {
             let rhs_job = self.state_rhs.index_mut(0);
 
             SyncBufferLoader::execute_task(&mut self.loader_rhs, rhs_job, self.config);


### PR DESCRIPTION
It seems like putting loading events at the end of the stage MMA execution is faster than at the beginning, even if it reduces the gap between the loading of global memory to shared memory. That's probably because we're doing so much stuff when we start executing: waiting for sync_units, loading fragments from shared memory (LHS and RHS), etc. If we wait until all LHS fragments are loaded before starting to fill the smem, it's probably a better balance. We then only fill RHS fragments from the smem and have tasks to load global memory into smem as well.

