### PR TITLE
Fix wasm by always using cfg(std_io)

### DIFF
--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -41,7 +41,7 @@ serde = { workspace = true }
 toml = { workspace = true, optional = true }
 dirs = { workspace = true, optional = true }
 
-# Persistent cache deps - has to match the autotune_persistent_cache cfg.
+# Persistent cache deps - has to match the cfg(std_desktop_platform) cfg.
 [target.'cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))'.dependencies]
 cubecl-common = { path = "../cubecl-common", version = "0.6.0", default-features = false, features = [
     "cache",

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -41,7 +41,7 @@ serde = { workspace = true }
 toml = { workspace = true, optional = true }
 dirs = { workspace = true, optional = true }
 
-# Persistent cache deps - has to match the cfg(std_desktop_platform) cfg.
+# Persistent cache deps - has to match the cfg(std_io) cfg.
 [target.'cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))'.dependencies]
 cubecl-common = { path = "../cubecl-common", version = "0.6.0", default-features = false, features = [
     "cache",

--- a/crates/cubecl-runtime/build.rs
+++ b/crates/cubecl-runtime/build.rs
@@ -5,7 +5,7 @@ fn main() {
     cfg_aliases! {
         // Some features like autotune caching, compilation caching, and config loading rely on files/environment variables,
         // which are only applicable on "standard desktop platforms".
-        std_desktop_platform: { all(feature = "std", any(target_os = "windows", target_os = "linux", target_os = "macos")) },
+        std_io: { all(feature = "std", any(target_os = "windows", target_os = "linux", target_os = "macos")) },
         exclusive_memory_only: { any(feature = "exclusive-memory-only", target_family = "wasm") },
     }
 }

--- a/crates/cubecl-runtime/build.rs
+++ b/crates/cubecl-runtime/build.rs
@@ -3,7 +3,9 @@ use cfg_aliases::cfg_aliases;
 fn main() {
     // Setup cfg aliases
     cfg_aliases! {
-        autotune_persistent_cache: { all(feature = "std", any(target_os = "windows", target_os = "linux", target_os = "macos")) },
+        // Some features like autotune caching, compilation caching, and config loading rely on files/environment variables,
+        // which are only applicable on "standard desktop platforms".
+        std_desktop_platform: { all(feature = "std", any(target_os = "windows", target_os = "linux", target_os = "macos")) },
         exclusive_memory_only: { any(feature = "exclusive-memory-only", target_family = "wasm") },
     }
 }

--- a/crates/cubecl-runtime/src/config/autotune.rs
+++ b/crates/cubecl-runtime/src/config/autotune.rs
@@ -1,4 +1,4 @@
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 use super::cache::CacheConfig;
 use super::logger::{LogLevel, LoggerConfig};
 
@@ -15,7 +15,7 @@ pub struct AutotuneConfig {
 
     /// Cache location for storing autotune results.
     #[serde(default)]
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     pub cache: CacheConfig,
 }
 

--- a/crates/cubecl-runtime/src/config/autotune.rs
+++ b/crates/cubecl-runtime/src/config/autotune.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "std")]
+#[cfg(std_desktop_platform)]
 use super::cache::CacheConfig;
 use super::logger::{LogLevel, LoggerConfig};
 
@@ -15,7 +15,7 @@ pub struct AutotuneConfig {
 
     /// Cache location for storing autotune results.
     #[serde(default)]
-    #[cfg(feature = "std")]
+    #[cfg(std_desktop_platform)]
     pub cache: CacheConfig,
 }
 

--- a/crates/cubecl-runtime/src/config/base.rs
+++ b/crates/cubecl-runtime/src/config/base.rs
@@ -40,19 +40,22 @@ impl GlobalConfig {
     pub fn get() -> Arc<Self> {
         let mut state = CUBE_GLOBAL_CONFIG.lock();
         if state.as_ref().is_none() {
-            #[cfg(feature = "std")]
-            let config = Self::from_current_dir();
-            #[cfg(feature = "std")]
-            let config = config.override_from_env();
-            #[cfg(not(feature = "std"))]
-            let config = Self::default();
+            cfg_if::cfg_if! {
+                if #[cfg(std_desktop_platform)]  {
+                    let config = Self::from_current_dir();
+                    let config = config.override_from_env();
+                } else {
+                    let config = Self::default();
+                }
+            }
+
             *state = Some(Arc::new(config));
         }
 
         state.as_ref().cloned().unwrap()
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(std_desktop_platform)]
     /// Save the default configuration to the provided file path.
     pub fn save_default<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<()> {
         use std::io::Write;
@@ -82,7 +85,7 @@ impl GlobalConfig {
         *state = Some(Arc::new(config));
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(std_desktop_platform)]
     /// Overrides configuration fields based on environment variables.
     pub fn override_from_env(mut self) -> Self {
         use super::compilation::CompilationLogLevel;
@@ -176,7 +179,7 @@ impl GlobalConfig {
     //
     // Traverses up the directory tree until a valid configuration file is found or the root is reached.
     // Returns a default configuration if no file is found.
-    #[cfg(feature = "std")]
+    #[cfg(std_desktop_platform)]
     fn from_current_dir() -> Self {
         let mut dir = std::env::current_dir().unwrap();
 
@@ -198,7 +201,7 @@ impl GlobalConfig {
     }
 
     // Loads configuration from a specified file path.
-    #[cfg(feature = "std")]
+    #[cfg(std_desktop_platform)]
     fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Self> {
         let content = std::fs::read_to_string(path)?;
         let config: Self = match toml::from_str(&content) {

--- a/crates/cubecl-runtime/src/config/base.rs
+++ b/crates/cubecl-runtime/src/config/base.rs
@@ -41,7 +41,7 @@ impl GlobalConfig {
         let mut state = CUBE_GLOBAL_CONFIG.lock();
         if state.as_ref().is_none() {
             cfg_if::cfg_if! {
-                if #[cfg(std_desktop_platform)]  {
+                if #[cfg(std_io)]  {
                     let config = Self::from_current_dir();
                     let config = config.override_from_env();
                 } else {
@@ -55,7 +55,7 @@ impl GlobalConfig {
         state.as_ref().cloned().unwrap()
     }
 
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     /// Save the default configuration to the provided file path.
     pub fn save_default<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<()> {
         use std::io::Write;
@@ -85,7 +85,7 @@ impl GlobalConfig {
         *state = Some(Arc::new(config));
     }
 
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     /// Overrides configuration fields based on environment variables.
     pub fn override_from_env(mut self) -> Self {
         use super::compilation::CompilationLogLevel;
@@ -179,7 +179,7 @@ impl GlobalConfig {
     //
     // Traverses up the directory tree until a valid configuration file is found or the root is reached.
     // Returns a default configuration if no file is found.
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     fn from_current_dir() -> Self {
         let mut dir = std::env::current_dir().unwrap();
 
@@ -201,7 +201,7 @@ impl GlobalConfig {
     }
 
     // Loads configuration from a specified file path.
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Self> {
         let content = std::fs::read_to_string(path)?;
         let config: Self = match toml::from_str(&content) {

--- a/crates/cubecl-runtime/src/config/compilation.rs
+++ b/crates/cubecl-runtime/src/config/compilation.rs
@@ -1,4 +1,4 @@
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 use super::cache::CacheConfig;
 use super::logger::{BinaryLogLevel, LoggerConfig};
 
@@ -10,7 +10,7 @@ pub struct CompilationConfig {
     pub logger: LoggerConfig<CompilationLogLevel>,
     /// Cache location for storing compiled kernels.
     #[serde(default)]
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     pub cache: Option<CacheConfig>,
 }
 

--- a/crates/cubecl-runtime/src/config/compilation.rs
+++ b/crates/cubecl-runtime/src/config/compilation.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "std")]
+#[cfg(std_desktop_platform)]
 use super::cache::CacheConfig;
 use super::logger::{BinaryLogLevel, LoggerConfig};
 
@@ -10,7 +10,7 @@ pub struct CompilationConfig {
     pub logger: LoggerConfig<CompilationLogLevel>,
     /// Cache location for storing compiled kernels.
     #[serde(default)]
-    #[cfg(feature = "std")]
+    #[cfg(std_desktop_platform)]
     pub cache: Option<CacheConfig>,
 }
 

--- a/crates/cubecl-runtime/src/config/logger.rs
+++ b/crates/cubecl-runtime/src/config/logger.rs
@@ -6,7 +6,7 @@ use alloc::{string::ToString, sync::Arc, vec::Vec};
 use core::fmt::Display;
 use hashbrown::HashMap;
 
-#[cfg(feature = "std")]
+#[cfg(std_desktop_platform)]
 use std::{
     fs::{File, OpenOptions},
     io::{BufWriter, Write},
@@ -21,7 +21,7 @@ use std::{
 pub struct LoggerConfig<L: LogLevel> {
     /// Path to the log file, if file logging is enabled (requires `std` feature).
     #[serde(default)]
-    #[cfg(feature = "std")]
+    #[cfg(std_desktop_platform)]
     pub file: Option<PathBuf>,
 
     /// Whether to append to the log file (true) or overwrite it (false). Defaults to true.
@@ -123,11 +123,11 @@ impl Logger {
 
         #[derive(Hash, PartialEq, Eq)]
         enum LoggerId {
-            #[cfg(feature = "std")]
+            #[cfg(std_desktop_platform)]
             File(PathBuf),
-            #[cfg(feature = "std")]
+            #[cfg(std_desktop_platform)]
             Stdout,
-            #[cfg(feature = "std")]
+            #[cfg(std_desktop_platform)]
             Stderr,
             LogCrate(LogCrateLevel),
         }

--- a/crates/cubecl-runtime/src/config/logger.rs
+++ b/crates/cubecl-runtime/src/config/logger.rs
@@ -125,9 +125,9 @@ impl Logger {
         enum LoggerId {
             #[cfg(std_desktop_platform)]
             File(PathBuf),
-            #[cfg(std_desktop_platform)]
+            #[cfg(feature = "std")]
             Stdout,
-            #[cfg(std_desktop_platform)]
+            #[cfg(feature = "std")]
             Stderr,
             LogCrate(LogCrateLevel),
         }
@@ -163,7 +163,7 @@ impl Logger {
             loggers: &mut Vec<LoggerKind>,
             logger2index: &mut HashMap<LoggerId, usize>,
         ) {
-            #[cfg(feature = "std")]
+            #[cfg(std_desktop_platform)]
             if let Some(file) = &kind.file {
                 new_logger(
                     setting_index,
@@ -340,7 +340,7 @@ impl LogLevel for BinaryLogLevel {}
 #[derive(Debug)]
 enum LoggerKind {
     /// Logs to a file.
-    #[cfg(feature = "std")]
+    #[cfg(std_desktop_platform)]
     File(FileLogger),
 
     /// Logs to standard output.
@@ -358,7 +358,7 @@ enum LoggerKind {
 impl LoggerKind {
     fn log<S: Display>(&mut self, msg: &S) {
         match self {
-            #[cfg(feature = "std")]
+            #[cfg(std_desktop_platform)]
             LoggerKind::File(file_logger) => file_logger.log(msg),
             #[cfg(feature = "std")]
             LoggerKind::Stdout => println!("{msg}"),
@@ -375,12 +375,12 @@ impl LoggerKind {
 
 /// Logger that writes messages to a file.
 #[derive(Debug)]
-#[cfg(feature = "std")]
+#[cfg(std_desktop_platform)]
 struct FileLogger {
     writer: BufWriter<File>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(std_desktop_platform)]
 impl FileLogger {
     // Creates a new file logger.
     fn new(path: &PathBuf, append: bool) -> Self {

--- a/crates/cubecl-runtime/src/config/logger.rs
+++ b/crates/cubecl-runtime/src/config/logger.rs
@@ -6,7 +6,7 @@ use alloc::{string::ToString, sync::Arc, vec::Vec};
 use core::fmt::Display;
 use hashbrown::HashMap;
 
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 use std::{
     fs::{File, OpenOptions},
     io::{BufWriter, Write},
@@ -21,7 +21,7 @@ use std::{
 pub struct LoggerConfig<L: LogLevel> {
     /// Path to the log file, if file logging is enabled (requires `std` feature).
     #[serde(default)]
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     pub file: Option<PathBuf>,
 
     /// Whether to append to the log file (true) or overwrite it (false). Defaults to true.
@@ -123,7 +123,7 @@ impl Logger {
 
         #[derive(Hash, PartialEq, Eq)]
         enum LoggerId {
-            #[cfg(std_desktop_platform)]
+            #[cfg(std_io)]
             File(PathBuf),
             #[cfg(feature = "std")]
             Stdout,
@@ -163,7 +163,7 @@ impl Logger {
             loggers: &mut Vec<LoggerKind>,
             logger2index: &mut HashMap<LoggerId, usize>,
         ) {
-            #[cfg(std_desktop_platform)]
+            #[cfg(std_io)]
             if let Some(file) = &kind.file {
                 new_logger(
                     setting_index,
@@ -340,7 +340,7 @@ impl LogLevel for BinaryLogLevel {}
 #[derive(Debug)]
 enum LoggerKind {
     /// Logs to a file.
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     File(FileLogger),
 
     /// Logs to standard output.
@@ -358,7 +358,7 @@ enum LoggerKind {
 impl LoggerKind {
     fn log<S: Display>(&mut self, msg: &S) {
         match self {
-            #[cfg(std_desktop_platform)]
+            #[cfg(std_io)]
             LoggerKind::File(file_logger) => file_logger.log(msg),
             #[cfg(feature = "std")]
             LoggerKind::Stdout => println!("{msg}"),
@@ -375,12 +375,12 @@ impl LoggerKind {
 
 /// Logger that writes messages to a file.
 #[derive(Debug)]
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 struct FileLogger {
     writer: BufWriter<File>,
 }
 
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 impl FileLogger {
     // Creates a new file logger.
     fn new(path: &PathBuf, append: bool) -> Self {

--- a/crates/cubecl-runtime/src/config/mod.rs
+++ b/crates/cubecl-runtime/src/config/mod.rs
@@ -6,7 +6,7 @@ pub mod compilation;
 pub mod profiling;
 
 mod base;
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 pub(crate) mod cache;
 mod logger;
 

--- a/crates/cubecl-runtime/src/config/mod.rs
+++ b/crates/cubecl-runtime/src/config/mod.rs
@@ -6,7 +6,7 @@ pub mod compilation;
 pub mod profiling;
 
 mod base;
-#[cfg(feature = "std")]
+#[cfg(std_desktop_platform)]
 pub(crate) mod cache;
 mod logger;
 

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -103,7 +103,7 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             let mut fastest = tuner.fastest(&key);
 
             // If the cache checksum hasn't been checked, do so now, and retry.
-            #[cfg(std_desktop_platform)]
+            #[cfg(std_io)]
             if matches!(fastest, TuneCacheResult::Unchecked) {
                 let checksum = operations.compute_checksum();
                 tuner.validate_checksum(&key, &checksum);

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -103,7 +103,7 @@ impl<AK: AutotuneKey + 'static, ID: Hash + PartialEq + Eq + Clone + Display> Loc
             let mut fastest = tuner.fastest(&key);
 
             // If the cache checksum hasn't been checked, do so now, and retry.
-            #[cfg(autotune_persistent_cache)]
+            #[cfg(std_desktop_platform)]
             if matches!(fastest, TuneCacheResult::Unchecked) {
                 let checksum = operations.compute_checksum();
                 tuner.validate_checksum(&key, &checksum);

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -11,7 +11,7 @@ use super::{
 };
 
 /// Default checksum for an operation set
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 pub fn compute_checksum<In: Clone + Send + 'static, Out: 'static>(
     autotunables: &[Arc<dyn Tunable<Inputs = In, Output = Out>>],
 ) -> String {
@@ -91,7 +91,7 @@ impl<K: AutotuneKey, Inputs: Clone + Send + 'static, Output: 'static>
     }
 
     /// Compute a checksum that can invalidate outdated cached auto-tune results.
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     pub fn compute_checksum(&self) -> String {
         if let Some(checksum_override) = &self.checksum_override {
             checksum_override(self)
@@ -152,7 +152,7 @@ impl<T: Tunable> IntoTunable<T::Inputs, T::Output, IsIdentity> for T {
     }
 }
 
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 /// Trait alias with support for persistent caching
 pub trait AutotuneKey:
     Clone
@@ -168,7 +168,7 @@ pub trait AutotuneKey:
     + 'static
 {
 }
-#[cfg(not(std_desktop_platform))]
+#[cfg(not(std_io))]
 /// Trait alias
 pub trait AutotuneKey:
     Clone + Debug + PartialEq + Eq + Hash + Display + Send + Sync + 'static

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -11,7 +11,7 @@ use super::{
 };
 
 /// Default checksum for an operation set
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 pub fn compute_checksum<In: Clone + Send + 'static, Out: 'static>(
     autotunables: &[Arc<dyn Tunable<Inputs = In, Output = Out>>],
 ) -> String {
@@ -91,7 +91,7 @@ impl<K: AutotuneKey, Inputs: Clone + Send + 'static, Output: 'static>
     }
 
     /// Compute a checksum that can invalidate outdated cached auto-tune results.
-    #[cfg(autotune_persistent_cache)]
+    #[cfg(std_desktop_platform)]
     pub fn compute_checksum(&self) -> String {
         if let Some(checksum_override) = &self.checksum_override {
             checksum_override(self)
@@ -152,7 +152,7 @@ impl<T: Tunable> IntoTunable<T::Inputs, T::Output, IsIdentity> for T {
     }
 }
 
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 /// Trait alias with support for persistent caching
 pub trait AutotuneKey:
     Clone
@@ -168,7 +168,7 @@ pub trait AutotuneKey:
     + 'static
 {
 }
-#[cfg(not(autotune_persistent_cache))]
+#[cfg(not(std_desktop_platform))]
 /// Trait alias
 pub trait AutotuneKey:
     Clone + Debug + PartialEq + Eq + Hash + Display + Send + Sync + 'static

--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -1,10 +1,10 @@
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 use super::AutotuneOutcome;
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 use cubecl_common::cache::Cache;
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 use cubecl_common::cache::CacheError;
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 use serde::{Deserialize, Serialize};
 
 use super::AutotuneKey;
@@ -30,7 +30,7 @@ pub(crate) enum ChecksumState {
 }
 
 /// Persistent cache key
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Hash)]
 pub(crate) struct PersistentCacheKey<K> {
     key: K,
@@ -38,7 +38,7 @@ pub(crate) struct PersistentCacheKey<K> {
 }
 
 /// Persistent cache entry
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub(crate) struct PersistentCacheValue {
     fastest_index: usize,
@@ -49,7 +49,7 @@ pub(crate) struct PersistentCacheValue {
 #[derive(Debug)]
 pub(crate) struct TuneCache<K> {
     in_memory_cache: HashMap<K, CacheEntry>,
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     persistent_cache: Cache<PersistentCacheKey<K>, PersistentCacheValue>,
 }
 
@@ -71,10 +71,10 @@ pub enum TuneCacheResult {
 
 impl<K: AutotuneKey> TuneCache<K> {
     pub(crate) fn new(
-        #[cfg_attr(not(std_desktop_platform), allow(unused_variables))] name: &str,
-        #[cfg_attr(not(std_desktop_platform), allow(unused_variables))] device_id: &str,
+        #[cfg_attr(not(std_io), allow(unused_variables))] name: &str,
+        #[cfg_attr(not(std_io), allow(unused_variables))] device_id: &str,
     ) -> Self {
-        #[cfg(std_desktop_platform)]
+        #[cfg(std_io)]
         {
             let root = crate::config::GlobalConfig::get().autotune.cache.root();
             let options = cubecl_common::cache::CacheOption::default();
@@ -89,7 +89,7 @@ impl<K: AutotuneKey> TuneCache<K> {
             cache
         }
 
-        #[cfg(not(std_desktop_platform))]
+        #[cfg(not(std_io))]
         {
             TuneCache {
                 in_memory_cache: HashMap::new(),
@@ -109,7 +109,7 @@ impl<K: AutotuneKey> TuneCache<K> {
                 checksum,
                 fastest_index,
             } => {
-                if cfg!(std_desktop_platform) {
+                if cfg!(std_io) {
                     match checksum {
                         ChecksumState::ToBeVerified(..) => TuneCacheResult::Unchecked, // Don't know yet.
                         ChecksumState::NoMatch => TuneCacheResult::Miss, // Can't use this.
@@ -129,7 +129,7 @@ impl<K: AutotuneKey> TuneCache<K> {
         }
     }
 
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     pub fn validate_checksum(&mut self, key: &K, checksum: &str) {
         let result = self.in_memory_cache.get_mut(key);
         let Some(val) = result else {
@@ -167,7 +167,7 @@ impl<K: AutotuneKey> TuneCache<K> {
     }
 }
 
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 impl<K: AutotuneKey> TuneCache<K> {
     pub(crate) fn persistent_cache_insert(
         &mut self,

--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -1,10 +1,10 @@
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 use super::AutotuneOutcome;
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 use cubecl_common::cache::Cache;
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 use cubecl_common::cache::CacheError;
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 use serde::{Deserialize, Serialize};
 
 use super::AutotuneKey;
@@ -30,7 +30,7 @@ pub(crate) enum ChecksumState {
 }
 
 /// Persistent cache key
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Hash)]
 pub(crate) struct PersistentCacheKey<K> {
     key: K,
@@ -38,7 +38,7 @@ pub(crate) struct PersistentCacheKey<K> {
 }
 
 /// Persistent cache entry
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub(crate) struct PersistentCacheValue {
     fastest_index: usize,
@@ -49,7 +49,7 @@ pub(crate) struct PersistentCacheValue {
 #[derive(Debug)]
 pub(crate) struct TuneCache<K> {
     in_memory_cache: HashMap<K, CacheEntry>,
-    #[cfg(autotune_persistent_cache)]
+    #[cfg(std_desktop_platform)]
     persistent_cache: Cache<PersistentCacheKey<K>, PersistentCacheValue>,
 }
 
@@ -71,10 +71,10 @@ pub enum TuneCacheResult {
 
 impl<K: AutotuneKey> TuneCache<K> {
     pub(crate) fn new(
-        #[cfg_attr(not(autotune_persistent_cache), allow(unused_variables))] name: &str,
-        #[cfg_attr(not(autotune_persistent_cache), allow(unused_variables))] device_id: &str,
+        #[cfg_attr(not(std_desktop_platform), allow(unused_variables))] name: &str,
+        #[cfg_attr(not(std_desktop_platform), allow(unused_variables))] device_id: &str,
     ) -> Self {
-        #[cfg(autotune_persistent_cache)]
+        #[cfg(std_desktop_platform)]
         {
             let root = crate::config::GlobalConfig::get().autotune.cache.root();
             let options = cubecl_common::cache::CacheOption::default();
@@ -89,7 +89,7 @@ impl<K: AutotuneKey> TuneCache<K> {
             cache
         }
 
-        #[cfg(not(autotune_persistent_cache))]
+        #[cfg(not(std_desktop_platform))]
         {
             TuneCache {
                 in_memory_cache: HashMap::new(),
@@ -109,7 +109,7 @@ impl<K: AutotuneKey> TuneCache<K> {
                 checksum,
                 fastest_index,
             } => {
-                if cfg!(autotune_persistent_cache) {
+                if cfg!(std_desktop_platform) {
                     match checksum {
                         ChecksumState::ToBeVerified(..) => TuneCacheResult::Unchecked, // Don't know yet.
                         ChecksumState::NoMatch => TuneCacheResult::Miss, // Can't use this.
@@ -129,7 +129,7 @@ impl<K: AutotuneKey> TuneCache<K> {
         }
     }
 
-    #[cfg(autotune_persistent_cache)]
+    #[cfg(std_desktop_platform)]
     pub fn validate_checksum(&mut self, key: &K, checksum: &str) {
         let result = self.in_memory_cache.get_mut(key);
         let Some(val) = result else {
@@ -167,7 +167,7 @@ impl<K: AutotuneKey> TuneCache<K> {
     }
 }
 
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 impl<K: AutotuneKey> TuneCache<K> {
     pub(crate) fn persistent_cache_insert(
         &mut self,

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -1,7 +1,6 @@
 use alloc::format;
 use alloc::vec::Vec;
 use async_channel::{Receiver, Sender};
-use cubecl_common::future;
 use hashbrown::HashSet;
 
 use core::time::Duration;
@@ -328,7 +327,7 @@ impl<K: AutotuneKey> Tuner<K> {
                     // - Benchmarks would need a "warmup" time until a good kernel is selected.
                     // - Tuning could be less precise, as it's possible that other operations are
                     //   submitted while tuning, which might skew results.
-                    future::block_on(fut_result)
+                    cubecl_common::future::block_on(fut_result)
                 }
             }
         };

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -26,10 +26,7 @@ pub struct Tuner<K: AutotuneKey> {
 }
 
 /// The measured outcome for a given autotune invocation.
-#[cfg_attr(
-    std_desktop_platform,
-    derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)
-)]
+#[cfg_attr(std_io, derive(serde::Serialize, serde::Deserialize, PartialEq, Eq))]
 #[derive(new, Debug, Clone)]
 pub struct AutotuneOutcome {
     name: String,
@@ -52,7 +49,7 @@ enum AutotuneMessage<K> {
         key: K,
         fastest_index: usize,
         results: Vec<Result<AutotuneOutcome, String>>,
-        #[cfg(std_desktop_platform)]
+        #[cfg(std_io)]
         checksum: String,
         #[cfg(feature = "autotune-checks")]
         autotune_checks: alloc::boxed::Box<dyn FnOnce() + Send>,
@@ -94,7 +91,7 @@ impl<K: AutotuneKey> Tuner<K> {
     }
 
     /// Fetch the fastest autotune operation index for an autotune key and validate the checksum.
-    #[cfg(std_desktop_platform)]
+    #[cfg(std_io)]
     pub fn validate_checksum(&mut self, key: &K, checksum: &str) {
         if let AutotuneLogLevel::Full = self.logger.log_level_autotune() {
             self.logger
@@ -113,9 +110,9 @@ impl<K: AutotuneKey> Tuner<K> {
                 key,
                 fastest_index,
                 results,
-                #[cfg(std_desktop_platform)]
+                #[cfg(std_io)]
                 checksum,
-                #[cfg(std_desktop_platform)]
+                #[cfg(std_io)]
                 #[cfg(feature = "autotune-checks")]
                     autotune_checks: check,
             } => {
@@ -173,7 +170,7 @@ impl<K: AutotuneKey> Tuner<K> {
                 #[cfg(feature = "autotune-checks")]
                 check();
 
-                #[cfg(std_desktop_platform)]
+                #[cfg(std_io)]
                 {
                     self.tune_cache
                         .persistent_cache_insert(key, checksum, fastest_index, results);
@@ -221,14 +218,14 @@ impl<K: AutotuneKey> Tuner<K> {
                     key,
                     fastest_index: autotunables[0].0,
                     results: Vec::new(),
-                    #[cfg(std_desktop_platform)]
+                    #[cfg(std_io)]
                     checksum: tunables.compute_checksum(),
                     #[cfg(feature = "autotune-checks")]
                     autotune_checks: Box::new(|| {}),
                 };
             }
 
-            #[cfg(std_desktop_platform)]
+            #[cfg(std_io)]
             let checksum = tunables.compute_checksum();
             let test_inputs = tunables.generate_inputs(&key, inputs);
 
@@ -302,7 +299,7 @@ impl<K: AutotuneKey> Tuner<K> {
                     key: key_clone,
                     fastest_index: result.index,
                     results: bench_results,
-                    #[cfg(std_desktop_platform)]
+                    #[cfg(std_io)]
                     checksum,
                     #[cfg(feature = "autotune-checks")]
                     autotune_checks: Box::new(|| {

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -28,7 +28,7 @@ pub struct Tuner<K: AutotuneKey> {
 
 /// The measured outcome for a given autotune invocation.
 #[cfg_attr(
-    autotune_persistent_cache,
+    std_desktop_platform,
     derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)
 )]
 #[derive(new, Debug, Clone)]
@@ -53,7 +53,7 @@ enum AutotuneMessage<K> {
         key: K,
         fastest_index: usize,
         results: Vec<Result<AutotuneOutcome, String>>,
-        #[cfg(autotune_persistent_cache)]
+        #[cfg(std_desktop_platform)]
         checksum: String,
         #[cfg(feature = "autotune-checks")]
         autotune_checks: alloc::boxed::Box<dyn FnOnce() + Send>,
@@ -95,7 +95,7 @@ impl<K: AutotuneKey> Tuner<K> {
     }
 
     /// Fetch the fastest autotune operation index for an autotune key and validate the checksum.
-    #[cfg(autotune_persistent_cache)]
+    #[cfg(std_desktop_platform)]
     pub fn validate_checksum(&mut self, key: &K, checksum: &str) {
         if let AutotuneLogLevel::Full = self.logger.log_level_autotune() {
             self.logger
@@ -114,9 +114,9 @@ impl<K: AutotuneKey> Tuner<K> {
                 key,
                 fastest_index,
                 results,
-                #[cfg(autotune_persistent_cache)]
+                #[cfg(std_desktop_platform)]
                 checksum,
-                #[cfg(autotune_persistent_cache)]
+                #[cfg(std_desktop_platform)]
                 #[cfg(feature = "autotune-checks")]
                     autotune_checks: check,
             } => {
@@ -174,7 +174,7 @@ impl<K: AutotuneKey> Tuner<K> {
                 #[cfg(feature = "autotune-checks")]
                 check();
 
-                #[cfg(autotune_persistent_cache)]
+                #[cfg(std_desktop_platform)]
                 {
                     self.tune_cache
                         .persistent_cache_insert(key, checksum, fastest_index, results);
@@ -222,14 +222,14 @@ impl<K: AutotuneKey> Tuner<K> {
                     key,
                     fastest_index: autotunables[0].0,
                     results: Vec::new(),
-                    #[cfg(autotune_persistent_cache)]
+                    #[cfg(std_desktop_platform)]
                     checksum: tunables.compute_checksum(),
                     #[cfg(feature = "autotune-checks")]
                     autotune_checks: Box::new(|| {}),
                 };
             }
 
-            #[cfg(autotune_persistent_cache)]
+            #[cfg(std_desktop_platform)]
             let checksum = tunables.compute_checksum();
             let test_inputs = tunables.generate_inputs(&key, inputs);
 
@@ -303,7 +303,7 @@ impl<K: AutotuneKey> Tuner<K> {
                     key: key_clone,
                     fastest_index: result.index,
                     results: bench_results,
-                    #[cfg(autotune_persistent_cache)]
+                    #[cfg(std_desktop_platform)]
                     checksum,
                     #[cfg(feature = "autotune-checks")]
                     autotune_checks: Box::new(|| {

--- a/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
@@ -1,4 +1,4 @@
-#[cfg(autotune_persistent_cache)]
+#[cfg(std_desktop_platform)]
 use rand::{Rng, distr::Alphanumeric};
 use std::sync::Arc;
 

--- a/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
@@ -1,4 +1,4 @@
-#[cfg(std_desktop_platform)]
+#[cfg(std_io)]
 use rand::{Rng, distr::Alphanumeric};
 use std::sync::Arc;
 


### PR DESCRIPTION
WASM is currently broken, as some code assumes feature = "std" means there is a filesystem and env variables are available. This is not true on WASM and on mobile platforms.

This fixes things by standardizing on a std_desktop_platform cfg already in use for autotune caching.

I've left logging with stdout and stderr as cfg(std) as that _does_ have functionality on WASM/mobile platforms. It might be easier to put things through the `log` crate though as that has cross platform configuration options of it's own