### PR TITLE
Assert element type match for random

### DIFF
--- a/crates/cubecl-random/src/bernoulli.rs
+++ b/crates/cubecl-random/src/bernoulli.rs
@@ -70,6 +70,12 @@ pub fn random_bernoulli<R: Runtime, E: CubeElement + Numeric>(
     probability: f32,
     out: TensorHandleRef<R>,
 ) {
+    assert_eq!(
+        out.elem_size as u32,
+        E::elem_size(),
+        "Tensor element type must be the same as type E"
+    );
+
     random(
         client,
         Bernoulli::<E> {

--- a/crates/cubecl-random/src/normal.rs
+++ b/crates/cubecl-random/src/normal.rs
@@ -93,5 +93,11 @@ pub fn random_normal<R: Runtime, E: CubeElement + Numeric>(
     std: E,
     out: TensorHandleRef<R>,
 ) {
+    assert_eq!(
+        out.elem_size as u32,
+        E::elem_size(),
+        "Tensor element type must be the same as type E"
+    );
+
     random(client, Normal { mean, std }, out)
 }

--- a/crates/cubecl-random/src/uniform.rs
+++ b/crates/cubecl-random/src/uniform.rs
@@ -78,6 +78,12 @@ pub fn random_uniform<R: Runtime, E: CubeElement + Numeric>(
     upper_bound: E,
     out: TensorHandleRef<R>,
 ) {
+    assert_eq!(
+        out.elem_size as u32,
+        E::elem_size(),
+        "Tensor element type must be the same as type E"
+    );
+
     random(
         client,
         Uniform {


### PR DESCRIPTION
To avoid situations when calling a cubecl::random function, when the infered type E is not the element type of the given tensor.
