### PR TITLE
Silence warning about MAPPABLE_PRIMARY_BUFFERS

### DIFF
--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -12,7 +12,9 @@ use wgpu::{
 
 pub async fn request_metal_device(adapter: &wgpu::Adapter) -> (wgpu::Device, wgpu::Queue) {
     let limits = adapter.limits();
-    let features = adapter.features();
+    let features = adapter
+        .features()
+        .difference(Features::MAPPABLE_PRIMARY_BUFFERS);
     unsafe {
         adapter.as_hal::<hal::api::Metal, _, _>(|hal_adapter| {
             request_device(adapter, hal_adapter.unwrap(), features, limits)

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -40,7 +40,9 @@ pub fn bindings(repr: &SpirvKernel) -> Vec<(usize, Visibility)> {
 
 pub async fn request_vulkan_device(adapter: &wgpu::Adapter) -> (wgpu::Device, wgpu::Queue) {
     let limits = adapter.limits();
-    let features = adapter.features();
+    let features = adapter
+        .features()
+        .difference(Features::MAPPABLE_PRIMARY_BUFFERS);
     unsafe {
         adapter.as_hal::<hal::api::Vulkan, _, _>(|hal_adapter| {
             request_device(adapter, hal_adapter.unwrap(), features, limits)

--- a/crates/cubecl-wgpu/src/backend/wgsl.rs
+++ b/crates/cubecl-wgpu/src/backend/wgsl.rs
@@ -25,7 +25,9 @@ pub async fn request_device(adapter: &wgpu::Adapter) -> (wgpu::Device, wgpu::Que
     adapter
         .request_device(&wgpu::DeviceDescriptor {
             label: None,
-            required_features: adapter.features(),
+            required_features: adapter
+                .features()
+                .difference(Features::MAPPABLE_PRIMARY_BUFFERS),
             required_limits: limits,
             // The default is MemoryHints::Performance, which tries to do some bigger
             // block allocations. However, we already batch allocations, so we

--- a/crates/cubecl-wgpu/src/backend/wgsl.rs
+++ b/crates/cubecl-wgpu/src/backend/wgsl.rs
@@ -4,6 +4,7 @@ use cubecl_core::{
     ir::{Elem, UIntKind},
 };
 use cubecl_runtime::DeviceProperties;
+use wgpu::Features;
 
 use crate::WgslCompiler;
 

--- a/examples/device_sharing/src/lib.rs
+++ b/examples/device_sharing/src/lib.rs
@@ -15,7 +15,9 @@ mod device_sharing_wgpu {
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 label: Some("Raw"),
-                required_features: adapter.features(),
+                required_features: adapter
+                    .features()
+                    .difference(Features::MAPPABLE_PRIMARY_BUFFERS),
                 required_limits: adapter.limits(),
                 memory_hints: wgpu::MemoryHints::MemoryUsage,
                 trace: wgpu::Trace::Off,


### PR DESCRIPTION
WGPU really doesn't want you to enable this as using it is super slow. Burn/Cube does _not_ use it already so this SHOULD be a no-op but maybe this might inform some behaviour in Windows. Either way it gets rid of a warning on startup.