### PR TITLE
fix: timestamp_query_inside_passes should be supported for metal

### DIFF
--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -239,14 +239,13 @@ pub(crate) fn create_client_on_setup(
     let mut compilation_options = Default::default();
 
     let features = setup.adapter.features();
-    let time_measurement = match setup
-        .device
-        .features()
-        .contains(wgpu::Features::TIMESTAMP_QUERY)
-    {
-        true => TimeMeasurement::Device,
-        false => TimeMeasurement::System,
-    };
+    let time_measurement =
+        match setup.device.features().contains(
+            wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES,
+        ) {
+            true => TimeMeasurement::Device,
+            false => TimeMeasurement::System,
+        };
 
     let mut device_props =
         DeviceProperties::new(&[], mem_props.clone(), hardware_props, time_measurement);


### PR DESCRIPTION
See https://github.com/tracel-ai/cubecl/issues/693

On Apple M2 Metal, the profiling breaks for TIMESTAMP_QUERY. This solves the issue by checking for the TIMESTAMP_QUERY_INSIDE_PASS feature as well. Maybe there is a better approach. I would be happy to discuss.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
