### PR TITLE
Matmul: invert compute resource dependancy

### DIFF
--- a/crates/cubecl-convolution/src/algorithm/mod.rs
+++ b/crates/cubecl-convolution/src/algorithm/mod.rs
@@ -28,15 +28,14 @@ pub trait Algorithm {
     type TileMatmul: TileMatmulFamily;
     type StageMatmul: StageMatmulFamily<Input = StageInput>;
     type GlobalConvolution: ConvolutionFamily<Input = GlobalInput<StageInput>>;
-    type MatmulSelection: MatmulSelection;
 
     type Args: MatmulArgs;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim;
-    fn cube_count(selection: &Self::MatmulSelection, problem: &ConvolutionProblem) -> CubeCount;
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim;
+    fn cube_count(selection: &MatmulSelection, problem: &ConvolutionProblem) -> CubeCount;
 
-    fn global_input(selection: &Self::MatmulSelection) -> GlobalInput<StageInput> {
-        let partition_buffering = if selection.tiling_scheme().tiles_in_partition_n() > 1 {
+    fn global_input(selection: &MatmulSelection) -> GlobalInput<StageInput> {
+        let partition_buffering = if selection.tiling_scheme.tiles_in_partition_n() > 1 {
             Self::partition_buffering_strategy()
         } else {
             PartitionBuffering::Single
@@ -49,7 +48,7 @@ pub trait Algorithm {
 
         GlobalInput {
             stage_input: StageInput {
-                tiling_scheme: *selection.tiling_scheme(),
+                tiling_scheme: selection.tiling_scheme.clone(),
                 partition_buffering,
                 stage_vectorization,
                 num_stages: Self::num_stages(),
@@ -115,7 +114,7 @@ pub trait Algorithm {
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection;
+    ) -> MatmulSelection;
 
     fn line_sizes(
         problem: &ConvolutionProblem,

--- a/crates/cubecl-convolution/src/algorithm/simple.rs
+++ b/crates/cubecl-convolution/src/algorithm/simple.rs
@@ -12,16 +12,13 @@ use crate::{
     selection::convolution_matmul_selection,
 };
 use cubecl_matmul::components::stage::NumStages;
-use cubecl_matmul::kernels::matmul::MatmulSelection;
-use cubecl_matmul::{
-    components::{
-        InputIdent,
-        global::args::TensorArgs,
-        stage::{FullReaderFamily, plane_matmul::PlaneMatmulFamily},
-        tile::TileMatmulFamily,
-    },
-    kernels::matmul::PlaneMatmulSelection,
+use cubecl_matmul::components::{
+    InputIdent,
+    global::args::TensorArgs,
+    stage::{FullReaderFamily, plane_matmul::PlaneMatmulFamily},
+    tile::TileMatmulFamily,
 };
+use cubecl_matmul::kernels::matmul::MatmulSelection;
 
 use cubecl_std::tensor::{TensorHandle, into_contiguous};
 
@@ -36,21 +33,20 @@ impl<TMM: TileMatmulFamily> Algorithm for SimpleConvAlgorithm<TMM> {
     type TileMatmul = TMM;
     type StageMatmul = PlaneMatmulFamily<Self::TileMatmul, FullReaderFamily, FullReaderFamily>;
     type GlobalConvolution = SimpleConvolutionFamily<Self::StageMatmul>;
-    type MatmulSelection = PlaneMatmulSelection;
 
     type Args = TensorArgs;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
         CubeDim::new(
             selection.plane_dim,
-            selection.tiling_scheme().tiles_in_stage_m(),
+            selection.tiling_scheme.tiles_in_stage_m(),
             1,
         )
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &ConvolutionProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &ConvolutionProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_needed_m = (problem.m as u32).div_ceil(m_stage);
         let cubes_needed_n = (problem.n as u32).div_ceil(n_stage);
 
@@ -91,7 +87,7 @@ impl<TMM: TileMatmulFamily> Algorithm for SimpleConvAlgorithm<TMM> {
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         convolution_matmul_selection::<TMM, R>(client, problem, plane_dim, elem_stage, elem_acc)
     }
 }

--- a/crates/cubecl-convolution/src/algorithm/simple_tma.rs
+++ b/crates/cubecl-convolution/src/algorithm/simple_tma.rs
@@ -22,7 +22,6 @@ use cubecl_matmul::{
         stage::{FullReaderFamily, plane_matmul::PlaneMatmulFamily},
         tile::TileMatmulFamily,
     },
-    kernels::matmul::PlaneMatmulSelection,
 };
 
 use cubecl_std::tensor::{TensorHandle, into_contiguous_pitched};
@@ -40,21 +39,20 @@ impl<TMM: TileMatmulFamily> Algorithm for SimpleTmaConvAlgorithm<TMM> {
     type TileMatmul = TMM;
     type StageMatmul = PlaneMatmulFamily<Self::TileMatmul, FullReaderFamily, FullReaderFamily>;
     type GlobalConvolution = SimpleTmaConvolutionFamily<Self::StageMatmul>;
-    type MatmulSelection = PlaneMatmulSelection;
 
     type Args = TensorMapArgs;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
         CubeDim::new(
             selection.plane_dim,
-            selection.tiling_scheme().tiles_in_stage_m(),
+            selection.tiling_scheme.tiles_in_stage_m(),
             1,
         )
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &ConvolutionProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &ConvolutionProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_needed_m = (problem.m as u32).div_ceil(m_stage);
         let cubes_needed_n = (problem.n as u32).div_ceil(n_stage);
 
@@ -116,7 +114,7 @@ impl<TMM: TileMatmulFamily> Algorithm for SimpleTmaConvAlgorithm<TMM> {
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         convolution_matmul_selection::<TMM, R>(client, problem, plane_dim, elem_stage, elem_acc)
     }
 }

--- a/crates/cubecl-convolution/src/algorithm/simple_tma.rs
+++ b/crates/cubecl-convolution/src/algorithm/simple_tma.rs
@@ -14,15 +14,13 @@ use crate::{
 };
 use cubecl_matmul::components::MatmulLineSizes;
 use cubecl_matmul::components::stage::NumStages;
-use cubecl_matmul::kernels::matmul::MatmulSelection;
-use cubecl_matmul::{
-    components::{
-        InputIdent, InvalidConfigError, MatmulPrecision,
-        global::args::TensorMapArgs,
-        stage::{FullReaderFamily, plane_matmul::PlaneMatmulFamily},
-        tile::TileMatmulFamily,
-    },
+use cubecl_matmul::components::{
+    InputIdent, InvalidConfigError, MatmulPrecision,
+    global::args::TensorMapArgs,
+    stage::{FullReaderFamily, plane_matmul::PlaneMatmulFamily},
+    tile::TileMatmulFamily,
 };
+use cubecl_matmul::kernels::matmul::MatmulSelection;
 
 use cubecl_std::tensor::{TensorHandle, into_contiguous_pitched};
 

--- a/crates/cubecl-convolution/src/args.rs
+++ b/crates/cubecl-convolution/src/args.rs
@@ -13,20 +13,20 @@ use cubecl_matmul::kernels::matmul::MatmulSelection;
 use super::base::ConvolutionProblem;
 
 pub trait ConvInputsLaunch: LaunchArg {
-    fn create<'a, M: MatmulSelection, R: Runtime>(
+    fn create<'a, R: Runtime>(
         lhs: &'a TensorHandleRef<'a, R>,
         rhs: &'a TensorHandleRef<'a, R>,
-        selection: &M,
+        selection: &MatmulSelection,
         problem: &ConvolutionProblem,
         line_sizes: &MatmulLineSizes,
     ) -> Self::RuntimeArg<'a, R>;
 }
 
 impl<EI: Numeric> ConvInputsLaunch for TensorInputs<EI> {
-    fn create<'a, M: MatmulSelection, R: Runtime>(
+    fn create<'a, R: Runtime>(
         lhs: &'a TensorHandleRef<'a, R>,
         rhs: &'a TensorHandleRef<'a, R>,
-        _selection: &M,
+        _selection: &MatmulSelection,
         _problem: &ConvolutionProblem,
         line_sizes: &MatmulLineSizes,
     ) -> Self::RuntimeArg<'a, R> {
@@ -40,14 +40,14 @@ impl<EI: Numeric> ConvInputsLaunch for TensorInputs<EI> {
 }
 
 impl<EI: Numeric> ConvInputsLaunch for TensorMapInputs<EI> {
-    fn create<'a, M: MatmulSelection, R: Runtime>(
+    fn create<'a, R: Runtime>(
         lhs: &'a TensorHandleRef<'a, R>,
         rhs: &'a TensorHandleRef<'a, R>,
-        selection: &M,
+        selection: &MatmulSelection,
         problem: &ConvolutionProblem,
         line_sizes: &MatmulLineSizes,
     ) -> Self::RuntimeArg<'a, R> {
-        let tiling_scheme = selection.tiling_scheme();
+        let tiling_scheme = selection.tiling_scheme;
         let stage_m = tiling_scheme.elements_in_stage_m();
         let stage_n = tiling_scheme.elements_in_stage_n();
         let tile_size_k = tiling_scheme.elements_in_tile_k();

--- a/crates/cubecl-convolution/src/launch.rs
+++ b/crates/cubecl-convolution/src/launch.rs
@@ -1,6 +1,7 @@
 use std::any::TypeId;
 
 use cubecl_core::{Runtime, client::ComputeClient, prelude::*};
+use cubecl_matmul::kernels::matmul::MatmulSelection;
 use half::f16;
 
 use crate::base::ConvolutionLaunch;
@@ -174,7 +175,7 @@ pub fn launch_kernel<R: Runtime, MP: MatmulPrecision, Alg: Algorithm>(
     out: &TensorHandleRef<'_, R>,
     problem: ConvolutionProblem,
     line_sizes: &MatmulLineSizes,
-    selection: Alg::MatmulSelection,
+    selection: MatmulSelection,
 ) -> Result<(), ConvLaunchError>
 where
     Input<Alg, MP>: ConvInputsLaunch,

--- a/crates/cubecl-convolution/src/selection.rs
+++ b/crates/cubecl-convolution/src/selection.rs
@@ -5,7 +5,7 @@ use cubecl_matmul::components::TilingScheme;
 use cubecl_matmul::{
     components::tile::TileMatmulFamily,
     kernels::matmul::{
-        NUM_SM_APPROX, NUM_TENSOR_CORES_APPROX, PlaneMatmulSelection, find_instruction_size,
+        NUM_SM_APPROX, NUM_TENSOR_CORES_APPROX, MatmulSelection, find_instruction_size,
     },
 };
 
@@ -80,7 +80,7 @@ pub fn convolution_matmul_selection<TMM: TileMatmulFamily, R: Runtime>(
     plane_dim: u32,
     elem_stage: Elem,
     elem_acc: Elem,
-) -> PlaneMatmulSelection {
+) -> MatmulSelection {
     // rough heuristic based on previous bench results where 512 channels with a 3x3 kernel seemed
     // to be the rough cutoff for the k=4 size.
     let stage_k = if problem.k >= 4096 { 4 } else { 2 };
@@ -118,7 +118,7 @@ pub fn convolution_matmul_selection<TMM: TileMatmulFamily, R: Runtime>(
         .build()
         .unwrap();
 
-    PlaneMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }

--- a/crates/cubecl-convolution/src/selection.rs
+++ b/crates/cubecl-convolution/src/selection.rs
@@ -5,7 +5,7 @@ use cubecl_matmul::components::TilingScheme;
 use cubecl_matmul::{
     components::tile::TileMatmulFamily,
     kernels::matmul::{
-        NUM_SM_APPROX, NUM_TENSOR_CORES_APPROX, MatmulSelection, find_instruction_size,
+        MatmulSelection, NUM_SM_APPROX, NUM_TENSOR_CORES_APPROX, find_instruction_size,
     },
 };
 

--- a/crates/cubecl-convolution/src/tests/convolution_test_launcher.rs
+++ b/crates/cubecl-convolution/src/tests/convolution_test_launcher.rs
@@ -1,5 +1,6 @@
 use cubecl_core::CubeElement;
 use cubecl_core::prelude::*;
+use cubecl_matmul::kernels::matmul::MatmulSelection;
 
 use crate::algorithm::Algorithm;
 use crate::base::ConvolutionLaunch;
@@ -22,7 +23,7 @@ pub fn test_convolution_algorithm<A, Args, P, R>(
     client: ComputeClient<R::Server, R::Channel>,
     problem: ConvolutionProblem,
     input: <A::GlobalConvolution as ConvolutionConfigFactory>::Input,
-    selection: A::MatmulSelection,
+    selection: MatmulSelection,
 ) where
     A: Algorithm,
     Args: MatmulArgs,

--- a/crates/cubecl-convolution/src/tests/test_macros/suite.rs
+++ b/crates/cubecl-convolution/src/tests/test_macros/suite.rs
@@ -8,7 +8,7 @@ use cubecl_core::Runtime;
 use cubecl_matmul::components::global::args::ConcreteOutputFactory;
 use cubecl_matmul::components::global::args::MatmulArgs;
 use cubecl_matmul::components::{MatrixLayout, PartitionSize, StageSize, TileSize, TilingScheme};
-use cubecl_matmul::kernels::matmul::PlaneMatmulSelection;
+use cubecl_matmul::kernels::matmul::MatmulSelection;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ConvolutionSize {
@@ -20,7 +20,7 @@ pub struct ConvolutionSize {
 }
 
 pub fn test_algo<
-    A: Algorithm<MatmulSelection = PlaneMatmulSelection>,
+    A: Algorithm,
     Args: MatmulArgs,
     P: TestPrecision,
     R: Runtime,
@@ -88,7 +88,7 @@ pub fn test_algo<
         .build()
         .unwrap();
 
-    let selection = PlaneMatmulSelection {
+    let selection = MatmulSelection {
         plane_dim,
         tiling_scheme: tiling_scheme.clone(),
     };

--- a/crates/cubecl-convolution/src/tests/test_macros/suite.rs
+++ b/crates/cubecl-convolution/src/tests/test_macros/suite.rs
@@ -19,12 +19,7 @@ pub struct ConvolutionSize {
     pub out_c: usize,
 }
 
-pub fn test_algo<
-    A: Algorithm,
-    Args: MatmulArgs,
-    P: TestPrecision,
-    R: Runtime,
->(
+pub fn test_algo<A: Algorithm, Args: MatmulArgs, P: TestPrecision, R: Runtime>(
     tile_size: TileSize,
     partition_size: PartitionSize,
     stage_size: StageSize,

--- a/crates/cubecl-matmul/src/components/batch/base.rs
+++ b/crates/cubecl-matmul/src/components/batch/base.rs
@@ -1,10 +1,13 @@
-use crate::components::{
-    MatmulLaunch, MatmulPrecision, Quantized, TilingScheme,
-    config::MatmulConfig,
-    global::{
-        self, GlobalConfig as _, Quantization,
-        args::{self, MatmulArgs, TensorInput, TensorOutput},
+use crate::{
+    components::{
+        MatmulLaunch, MatmulPrecision, MatmulProblem, Quantized, TilingScheme,
+        config::MatmulConfig,
+        global::{
+            self, GlobalConfig as _, Quantization,
+            args::{self, MatmulArgs, TensorInput, TensorOutput},
+        },
     },
+    kernels::matmul::MatmulSelection,
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -16,6 +19,8 @@ use cubecl_std::{
 /// A family of [matmuls](BatchMatmul) working with any [precision](MatmulPrecision).
 pub trait BatchMatmulFamily: 'static + Send + Sync + MatmulLaunch<Config: BatchConfig> {
     type Matmul<MP: MatmulPrecision>: BatchMatmul<MP, Config = Self::Config>;
+
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount;
 }
 
 #[cube]

--- a/crates/cubecl-matmul/src/components/batch/cube_dispatch.rs
+++ b/crates/cubecl-matmul/src/components/batch/cube_dispatch.rs
@@ -8,10 +8,10 @@ use crate::components::batch::shared::swizzle;
 #[cube]
 /// Distributes cube instances across the tensor, assigning each to compute data in distinct regions.
 pub trait CubeDispatch: Clone + Copy + 'static + Send + Sync + Debug + Hash + Eq {
-    fn x_y_indices() -> (u32, u32);
+    fn m_n_indices() -> (u32, u32);
     fn batch_index() -> u32;
-    fn max_x(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32);
-    fn max_y(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32);
+    fn max_m(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32);
+    fn max_n(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32);
     fn max_batches(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32);
     fn cube_count(
         #[comptime] cubes_for_m: u32,
@@ -46,7 +46,7 @@ pub struct SwizzleTransposedDispatch<const W: u32>;
 
 #[cube]
 impl CubeDispatch for NaturalDispatch {
-    fn x_y_indices() -> (u32, u32) {
+    fn m_n_indices() -> (u32, u32) {
         (CUBE_POS_X, CUBE_POS_Y)
     }
 
@@ -54,11 +54,11 @@ impl CubeDispatch for NaturalDispatch {
         CUBE_POS_Z
     }
 
-    fn max_x(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
+    fn max_m(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.0
     }
 
-    fn max_y(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
+    fn max_n(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.1
     }
 
@@ -77,7 +77,7 @@ impl CubeDispatch for NaturalDispatch {
 
 #[cube]
 impl CubeDispatch for TransposedDispatch {
-    fn x_y_indices() -> (u32, u32) {
+    fn m_n_indices() -> (u32, u32) {
         (CUBE_POS_Y, CUBE_POS_X)
     }
 
@@ -85,11 +85,11 @@ impl CubeDispatch for TransposedDispatch {
         CUBE_POS_Z
     }
 
-    fn max_x(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
+    fn max_m(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.1
     }
 
-    fn max_y(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
+    fn max_n(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.0
     }
 
@@ -108,7 +108,7 @@ impl CubeDispatch for TransposedDispatch {
 
 #[cube]
 impl<const W: u32> CubeDispatch for SwizzleNaturalDispatch<W> {
-    fn x_y_indices() -> (u32, u32) {
+    fn m_n_indices() -> (u32, u32) {
         let height = CUBE_COUNT_X;
         let nth_cube = CUBE_POS_Y * height + CUBE_POS_X;
         swizzle(nth_cube, height, W)
@@ -118,11 +118,11 @@ impl<const W: u32> CubeDispatch for SwizzleNaturalDispatch<W> {
         CUBE_POS_Z
     }
 
-    fn max_x(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
+    fn max_m(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.0
     }
 
-    fn max_y(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
+    fn max_n(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.1
     }
 
@@ -141,7 +141,7 @@ impl<const W: u32> CubeDispatch for SwizzleNaturalDispatch<W> {
 
 #[cube]
 impl<const W: u32> CubeDispatch for SwizzleTransposedDispatch<W> {
-    fn x_y_indices() -> (u32, u32) {
+    fn m_n_indices() -> (u32, u32) {
         let height = CUBE_COUNT_Y;
         let nth_cube = CUBE_POS_X * height + CUBE_POS_Y;
         swizzle(nth_cube, height, W)
@@ -151,11 +151,11 @@ impl<const W: u32> CubeDispatch for SwizzleTransposedDispatch<W> {
         CUBE_POS_Z
     }
 
-    fn max_x(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
+    fn max_m(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.1
     }
 
-    fn max_y(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
+    fn max_n(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.0
     }
 

--- a/crates/cubecl-matmul/src/components/batch/cube_dispatch.rs
+++ b/crates/cubecl-matmul/src/components/batch/cube_dispatch.rs
@@ -13,10 +13,11 @@ pub trait CubeDispatch: Clone + Copy + 'static + Send + Sync + Debug + Hash + Eq
     fn max_x(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32);
     fn max_y(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32);
     fn max_batches(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32);
-}
-
-pub trait CubeCountDispatch {
-    fn cube_count(cubes_for_m: u32, cubes_for_n: u32, cubes_for_batches: u32) -> CubeCount;
+    fn cube_count(
+        #[comptime] cubes_for_m: u32,
+        #[comptime] cubes_for_n: u32,
+        #[comptime] cubes_for_batches: u32,
+    ) -> comptime_type!(CubeCount);
 }
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
@@ -64,11 +65,13 @@ impl CubeDispatch for NaturalDispatch {
     fn max_batches(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.2
     }
-}
 
-impl CubeCountDispatch for NaturalDispatch {
-    fn cube_count(cubes_for_m: u32, cubes_for_n: u32, cubes_for_batches: u32) -> CubeCount {
-        CubeCount::Static(cubes_for_m, cubes_for_n, cubes_for_batches)
+    fn cube_count(
+        #[comptime] cubes_for_m: u32,
+        #[comptime] cubes_for_n: u32,
+        #[comptime] cubes_for_batches: u32,
+    ) -> comptime_type!(CubeCount) {
+        comptime! {CubeCount::Static(cubes_for_m, cubes_for_n, cubes_for_batches)}
     }
 }
 
@@ -93,11 +96,13 @@ impl CubeDispatch for TransposedDispatch {
     fn max_batches(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.2
     }
-}
 
-impl CubeCountDispatch for TransposedDispatch {
-    fn cube_count(cubes_for_m: u32, cubes_for_n: u32, cubes_for_batches: u32) -> CubeCount {
-        CubeCount::Static(cubes_for_n, cubes_for_m, cubes_for_batches)
+    fn cube_count(
+        #[comptime] cubes_for_m: u32,
+        #[comptime] cubes_for_n: u32,
+        #[comptime] cubes_for_batches: u32,
+    ) -> comptime_type!(CubeCount) {
+        comptime! {CubeCount::Static(cubes_for_n, cubes_for_m, cubes_for_batches)}
     }
 }
 
@@ -124,11 +129,13 @@ impl<const W: u32> CubeDispatch for SwizzleNaturalDispatch<W> {
     fn max_batches(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.2
     }
-}
 
-impl<const W: u32> CubeCountDispatch for SwizzleNaturalDispatch<W> {
-    fn cube_count(cubes_for_m: u32, cubes_for_n: u32, cubes_for_batches: u32) -> CubeCount {
-        CubeCount::Static(cubes_for_m, cubes_for_n, cubes_for_batches)
+    fn cube_count(
+        #[comptime] cubes_for_m: u32,
+        #[comptime] cubes_for_n: u32,
+        #[comptime] cubes_for_batches: u32,
+    ) -> comptime_type!(CubeCount) {
+        comptime! {CubeCount::Static(cubes_for_m, cubes_for_n, cubes_for_batches)}
     }
 }
 
@@ -155,10 +162,12 @@ impl<const W: u32> CubeDispatch for SwizzleTransposedDispatch<W> {
     fn max_batches(#[comptime] cube_count: (u32, u32, u32)) -> comptime_type!(u32) {
         cube_count.2
     }
-}
 
-impl<const W: u32> CubeCountDispatch for SwizzleTransposedDispatch<W> {
-    fn cube_count(cubes_for_m: u32, cubes_for_n: u32, cubes_for_batches: u32) -> CubeCount {
-        CubeCount::Static(cubes_for_n, cubes_for_m, cubes_for_batches)
+    fn cube_count(
+        #[comptime] cubes_for_m: u32,
+        #[comptime] cubes_for_n: u32,
+        #[comptime] cubes_for_batches: u32,
+    ) -> comptime_type!(CubeCount) {
+        comptime! {CubeCount::Static(cubes_for_n, cubes_for_m, cubes_for_batches)}
     }
 }

--- a/crates/cubecl-matmul/src/components/batch/one_to_many.rs
+++ b/crates/cubecl-matmul/src/components/batch/one_to_many.rs
@@ -9,6 +9,7 @@ use crate::components::{
 };
 use crate::components::{MatmulConfigFactory, MatmulLaunch, batch, config::MatmulConfig, global};
 use crate::kernels::MatmulAvailabilityError;
+use crate::kernels::matmul::MatmulSelection;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::CubeOption;
@@ -26,6 +27,10 @@ impl<GMM: GlobalMatmulFamily, S: SpanMatmul, C: CubeDispatch> BatchMatmulFamily
     for OneToManyMatmulFamily<GMM, S, C>
 {
     type Matmul<MP: MatmulPrecision> = OneToManyMatmul<MP, GMM::Matmul<MP>, S, C>;
+
+    fn cube_count(_selection: &MatmulSelection, _problem: &MatmulProblem) -> CubeCount {
+        todo!()
+    }
 }
 
 impl<GMM: GlobalMatmulFamily, S: SpanMatmul, C: CubeDispatch> MatmulConfigFactory

--- a/crates/cubecl-matmul/src/components/batch/one_to_many.rs
+++ b/crates/cubecl-matmul/src/components/batch/one_to_many.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::components::batch::span::{GlobalPartitionMatmul, Span, SpanDim};
+use crate::components::batch::span::{GlobalPartitionMatmul, PartitionSpan, SpanDim};
 use crate::components::global::GlobalMatmulFamily;
 use crate::components::global::Quantization;
 use crate::components::{
@@ -152,7 +152,7 @@ impl<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>, S: GlobalPartitionMatmu
         let (m_index, n_index) = C::m_n_indices();
         let batch_index = C::batch_index();
 
-        let span = Span::new(
+        let span = PartitionSpan::new(
             SpanDim::new(problem_m, stage_m, m_index, cubes_m),
             SpanDim::new(problem_n, stage_n, n_index, cubes_n),
             SpanDim::new(shape_b, stage_b, batch_index, cubes_b),

--- a/crates/cubecl-matmul/src/components/batch/one_to_one.rs
+++ b/crates/cubecl-matmul/src/components/batch/one_to_one.rs
@@ -6,6 +6,7 @@ use crate::components::{
     batch::{self, shared::gmm_execute},
     config::MatmulConfig,
     global::{self, GlobalMatmul, GlobalMatmulFamily, Quantization},
+    resource::ResourceDemand,
 };
 use crate::kernels::MatmulAvailabilityError;
 use batch::{BatchMatmul, BatchMatmulFamily};
@@ -59,6 +60,10 @@ impl<GMM: GlobalMatmulFamily, C: CubeDispatch> MatmulConfigFactory
         };
 
         Config::<GMM::Config, C>::new(global_config, cube_count, quantized)
+    }
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        let cube_dim_demand = GMM::resource_demand(config.global_config());
     }
 }
 

--- a/crates/cubecl-matmul/src/components/batch/one_to_one.rs
+++ b/crates/cubecl-matmul/src/components/batch/one_to_one.rs
@@ -1,9 +1,17 @@
 use std::marker::PhantomData;
 
-use crate::{components::{
-    batch::{self, shared::gmm_execute}, config::MatmulConfig, global::{self, GlobalMatmul, GlobalMatmulFamily, Quantization}, Args, InputRuntimeArg, InvalidConfigError, MatmulConfigFactory, MatmulLaunch, MatmulLineSizes, MatmulPrecision, MatmulProblem, MatmulSpec, OutputRuntimeArg, EA, EI, EO, ES
-}, kernels::matmul::MatmulSelection};
 use crate::kernels::MatmulAvailabilityError;
+use crate::{
+    components::{
+        Args, EA, EI, EO, ES, InputRuntimeArg, InvalidConfigError, MatmulConfigFactory,
+        MatmulLaunch, MatmulLineSizes, MatmulPrecision, MatmulProblem, MatmulSpec,
+        OutputRuntimeArg,
+        batch::{self, shared::gmm_execute},
+        config::MatmulConfig,
+        global::{self, GlobalMatmul, GlobalMatmulFamily, Quantization},
+    },
+    kernels::matmul::MatmulSelection,
+};
 use batch::{BatchMatmul, BatchMatmulFamily};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;

--- a/crates/cubecl-matmul/src/components/batch/span.rs
+++ b/crates/cubecl-matmul/src/components/batch/span.rs
@@ -16,7 +16,7 @@ use super::shared::gmm_execute;
 #[derive(CubeType)]
 /// Area of a tensor a cube is responsible of performing matmul
 /// Similar to the concept of tensor slice, but specialized for matmul constraints
-pub struct Span {
+pub struct PartitionSpan {
     row: SpanDim,
     col: SpanDim,
     batch: SpanDim,
@@ -37,7 +37,7 @@ pub trait GlobalPartitionMatmul: 'static + Send + Sync {
         lhs: VirtualTensor<MP::EI>,
         rhs: VirtualTensor<MP::EI>,
         out: VirtualTensor<MP::EO, ReadWrite>,
-        span: Span,
+        span: PartitionSpan,
         acc: GMM::Accumulator,
         k_range: (u32, u32),
         quantization: CubeOption<Quantization<MP>>,
@@ -62,9 +62,9 @@ pub struct ColMajorSpanMatmul {}
 pub struct SwizzleSpanMatmul<const W: u32> {}
 
 #[cube]
-impl Span {
-    pub fn new(row: SpanDim, col: SpanDim, batch: SpanDim) -> Span {
-        Span { row, col, batch }
+impl PartitionSpan {
+    pub fn new(row: SpanDim, col: SpanDim, batch: SpanDim) -> PartitionSpan {
+        PartitionSpan { row, col, batch }
     }
 }
 
@@ -95,7 +95,7 @@ impl GlobalPartitionMatmul for RowMajorSpanMatmul {
         lhs: VirtualTensor<MP::EI>,
         rhs: VirtualTensor<MP::EI>,
         out: VirtualTensor<MP::EO, ReadWrite>,
-        span: Span,
+        span: PartitionSpan,
         mut acc: GMM::Accumulator,
         k_range: (u32, u32),
         quantization: CubeOption<Quantization<MP>>,
@@ -129,7 +129,7 @@ impl GlobalPartitionMatmul for ColMajorSpanMatmul {
         lhs: VirtualTensor<MP::EI>,
         rhs: VirtualTensor<MP::EI>,
         out: VirtualTensor<MP::EO, ReadWrite>,
-        span: Span,
+        span: PartitionSpan,
         mut acc: GMM::Accumulator,
         k_range: (u32, u32),
         quantization: CubeOption<Quantization<MP>>,
@@ -163,7 +163,7 @@ impl<const W: u32> GlobalPartitionMatmul for SwizzleSpanMatmul<W> {
         lhs: VirtualTensor<MP::EI>,
         rhs: VirtualTensor<MP::EI>,
         out: VirtualTensor<MP::EO, ReadWrite>,
-        span: Span,
+        span: PartitionSpan,
         mut acc: GMM::Accumulator,
         k_range: (u32, u32),
         quantization: CubeOption<Quantization<MP>>,

--- a/crates/cubecl-matmul/src/components/batch/span.rs
+++ b/crates/cubecl-matmul/src/components/batch/span.rs
@@ -32,7 +32,7 @@ pub struct SpanDim {
 
 #[cube]
 /// Iterates on several global matmul across a span
-pub trait SpanMatmul: 'static + Send + Sync {
+pub trait GlobalPartitionMatmul: 'static + Send + Sync {
     fn execute<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>>(
         lhs: VirtualTensor<MP::EI>,
         rhs: VirtualTensor<MP::EI>,
@@ -90,7 +90,7 @@ impl SpanDim {
 }
 
 #[cube]
-impl SpanMatmul for RowMajorSpanMatmul {
+impl GlobalPartitionMatmul for RowMajorSpanMatmul {
     fn execute<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>>(
         lhs: VirtualTensor<MP::EI>,
         rhs: VirtualTensor<MP::EI>,
@@ -124,7 +124,7 @@ impl SpanMatmul for RowMajorSpanMatmul {
 }
 
 #[cube]
-impl SpanMatmul for ColMajorSpanMatmul {
+impl GlobalPartitionMatmul for ColMajorSpanMatmul {
     fn execute<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>>(
         lhs: VirtualTensor<MP::EI>,
         rhs: VirtualTensor<MP::EI>,
@@ -158,7 +158,7 @@ impl SpanMatmul for ColMajorSpanMatmul {
 }
 
 #[cube]
-impl<const W: u32> SpanMatmul for SwizzleSpanMatmul<W> {
+impl<const W: u32> GlobalPartitionMatmul for SwizzleSpanMatmul<W> {
     fn execute<MP: MatmulPrecision, GMM: global::GlobalMatmul<MP>>(
         lhs: VirtualTensor<MP::EI>,
         rhs: VirtualTensor<MP::EI>,

--- a/crates/cubecl-matmul/src/components/config.rs
+++ b/crates/cubecl-matmul/src/components/config.rs
@@ -3,7 +3,6 @@ use cubecl_core::prelude::*;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
-use crate::components::resource::ResourceDemand;
 use crate::kernels::MatmulAvailabilityError;
 
 use super::problem::MatmulLineSizes;
@@ -56,8 +55,6 @@ pub trait MatmulConfigFactory: Send + Sync + 'static {
         cube_count: &CubeCount,
         quantized: bool,
     ) -> Self::Config;
-
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError>;
 }
 
 /// A config for a matmul

--- a/crates/cubecl-matmul/src/components/config.rs
+++ b/crates/cubecl-matmul/src/components/config.rs
@@ -3,6 +3,7 @@ use cubecl_core::prelude::*;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
+use crate::components::resource::ResourceDemand;
 use crate::kernels::MatmulAvailabilityError;
 
 use super::problem::MatmulLineSizes;
@@ -55,6 +56,8 @@ pub trait MatmulConfigFactory: Send + Sync + 'static {
         cube_count: &CubeCount,
         quantized: bool,
     ) -> Self::Config;
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError>;
 }
 
 /// A config for a matmul

--- a/crates/cubecl-matmul/src/components/global/args.rs
+++ b/crates/cubecl-matmul/src/components/global/args.rs
@@ -16,12 +16,12 @@ use crate::{
 /// Create the input runtime arguments for a matmul kernel that works on concrete inputs and
 /// output (not fused).
 pub trait ConcreteInputsFactory: LaunchArg {
-    fn create<'a, M: MatmulSelection, R: Runtime>(
+    fn create<'a, R: Runtime>(
         lhs: &'a TensorHandleRef<'a, R>,
         lhs_scale: &'a Option<TensorHandleRef<'a, R>>,
         rhs: &'a TensorHandleRef<'a, R>,
         rhs_scale: &'a Option<TensorHandleRef<'a, R>>,
-        selection: &M,
+        selection: &MatmulSelection,
         problem: &MatmulProblem,
         line_sizes: &MatmulLineSizes,
     ) -> Self::RuntimeArg<'a, R>;
@@ -30,9 +30,9 @@ pub trait ConcreteInputsFactory: LaunchArg {
 /// Create the output runtime argument for a matmul kernel that works on concrete inputs and
 /// output (not fused).
 pub trait ConcreteOutputFactory: LaunchArg {
-    fn create<'a, M: MatmulSelection, R: Runtime>(
+    fn create<'a, R: Runtime>(
         out: &'a TensorHandleRef<'a, R>,
-        selection: &M,
+        selection: &MatmulSelection,
         problem: &MatmulProblem,
         line_sizes: &MatmulLineSizes,
     ) -> Self::RuntimeArg<'a, R>;
@@ -455,12 +455,12 @@ pub struct TensorInputs<EG: Numeric> {
 }
 
 impl<EG: Numeric> ConcreteInputsFactory for TensorInputs<EG> {
-    fn create<'a, M: MatmulSelection, R: Runtime>(
+    fn create<'a, R: Runtime>(
         lhs: &'a TensorHandleRef<'a, R>,
         lhs_scale: &'a Option<TensorHandleRef<'a, R>>,
         rhs: &'a TensorHandleRef<'a, R>,
         rhs_scale: &'a Option<TensorHandleRef<'a, R>>,
-        _selection: &M,
+        _selection: &MatmulSelection,
         _problem: &MatmulProblem,
         line_sizes: &MatmulLineSizes,
     ) -> Self::RuntimeArg<'a, R> {
@@ -474,9 +474,9 @@ impl<EG: Numeric> ConcreteInputsFactory for TensorInputs<EG> {
 }
 
 impl<EG: Numeric> ConcreteOutputFactory for Tensor<Line<EG>> {
-    fn create<'a, M: MatmulSelection, R: Runtime>(
+    fn create<'a, R: Runtime>(
         out: &'a TensorHandleRef<'a, R>,
-        _selection: &M,
+        _selection: &MatmulSelection,
         _problem: &MatmulProblem,
         line_sizes: &MatmulLineSizes,
     ) -> Self::RuntimeArg<'a, R> {
@@ -653,16 +653,16 @@ pub struct TensorMapInputs<EG: Numeric> {
 }
 
 impl<EG: Numeric> ConcreteInputsFactory for TensorMapInputs<EG> {
-    fn create<'a, M: MatmulSelection, R: Runtime>(
+    fn create<'a, R: Runtime>(
         lhs: &'a TensorHandleRef<'a, R>,
         _lhs_scale: &'a Option<TensorHandleRef<'a, R>>,
         rhs: &'a TensorHandleRef<'a, R>,
         _rhs_scale: &'a Option<TensorHandleRef<'a, R>>,
-        selection: &M,
+        selection: &MatmulSelection,
         problem: &MatmulProblem,
         line_sizes: &MatmulLineSizes,
     ) -> Self::RuntimeArg<'a, R> {
-        let tiling_scheme = selection.tiling_scheme();
+        let tiling_scheme = selection.tiling_scheme;
         let stage_m = tiling_scheme.elements_in_stage_m();
         let stage_n = tiling_scheme.elements_in_stage_n();
         let stage_k = tiling_scheme.elements_in_stage_k();

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -2,8 +2,10 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::components::{
-    Ident, InputIdent, MatmulConfigFactory, MatmulPrecision, MatrixLayout, TilingScheme,
+    Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
+    TilingScheme,
     config::MatmulConfig,
+    resource::ResourceDemand,
     stage::{self, StageConfig},
 };
 use cubecl_std::{
@@ -18,6 +20,8 @@ pub trait GlobalMatmulFamily:
     MatmulConfigFactory<Config: GlobalConfig> + Send + Sync + 'static
 {
     type Matmul<MP: MatmulPrecision>: GlobalMatmul<MP, Config = Self::Config>;
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError>;
 }
 
 #[cube]

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -1,12 +1,14 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use crate::components::{
-    Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
-    TilingScheme,
-    config::MatmulConfig,
-    resource::ResourceDemand,
-    stage::{self, StageConfig},
+use crate::{
+    components::{
+        Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
+        TilingScheme,
+        config::MatmulConfig,
+        stage::{self, StageConfig},
+    },
+    kernels::matmul::MatmulSelection,
 };
 use cubecl_std::{
     CubeOption,
@@ -21,7 +23,7 @@ pub trait GlobalMatmulFamily:
 {
     type Matmul<MP: MatmulPrecision>: GlobalMatmul<MP, Config = Self::Config>;
 
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError>;
+    fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError>;
 }
 
 #[cube]

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -40,6 +40,10 @@ where
 {
     type Matmul<MP: MatmulPrecision> =
         DoubleBufferingMatmul<MP, SMM::Matmul<MP, LL::TilingLayout, RL::TilingLayout>, LL, RL>;
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    }
 }
 
 impl<SMM, LL, RL> MatmulConfigFactory for DoubleBufferingMatmulFamily<SMM, LL, RL>
@@ -98,10 +102,6 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
-    }
-
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -4,6 +4,7 @@ use crate::components::global::load::{
 };
 use crate::components::global::multi_stage::double_buffering::DoubleBufferingGlobalConfig;
 use crate::components::global::{GlobalConfig, ZeroAccumulatorLoader};
+use crate::components::resource::ResourceDemand;
 use crate::components::stage::StageEvent;
 use crate::components::stage::StageEventListener;
 use crate::components::stage::{BufferStageToTileReader, StageConfig};
@@ -97,6 +98,10 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
+    }
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -4,7 +4,6 @@ use crate::components::global::load::{
 };
 use crate::components::global::multi_stage::double_buffering::DoubleBufferingGlobalConfig;
 use crate::components::global::{GlobalConfig, ZeroAccumulatorLoader};
-use crate::components::resource::ResourceDemand;
 use crate::components::stage::StageEvent;
 use crate::components::stage::StageEventListener;
 use crate::components::stage::{BufferStageToTileReader, StageConfig};
@@ -15,7 +14,7 @@ use crate::components::{
 use crate::components::{MatmulLineSizes, global};
 use crate::components::{global::GlobalMatmulFamily, stage::BufferReaderFamily};
 use crate::kernels::MatmulAvailabilityError;
-use crate::kernels::matmul::GlobalInput;
+use crate::kernels::matmul::{GlobalInput, MatmulSelection};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
@@ -41,8 +40,8 @@ where
     type Matmul<MP: MatmulPrecision> =
         DoubleBufferingMatmul<MP, SMM::Matmul<MP, LL::TilingLayout, RL::TilingLayout>, LL, RL>;
 
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError> {
+        SMM::resource_demand(selection)?.to_cube_dim(selection.plane_dim)
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
@@ -5,6 +5,7 @@ use crate::components::global::load::{
 };
 use crate::components::global::{self, GlobalConfig, ZeroAccumulatorLoader};
 use crate::components::problem::MatmulLineSizes;
+use crate::components::resource::ResourceDemand;
 use crate::components::stage::{BufferStageToTileReader, StageConfig};
 use crate::components::stage::{FullReaderFamily, StageEventListener};
 use crate::components::stage::{FullStageToTileReader, StageEvent};
@@ -103,6 +104,10 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
+    }
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
@@ -47,6 +47,10 @@ where
         SMM::Matmul<MP, <LL as SyncFullLoadingStrategy>::TilingLayout, RL::TilingLayout>,
         RL,
     >;
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    }
 }
 
 impl<SMM, RL> MatmulConfigFactory for OrderedDoubleBufferingMatmulFamily<SMM, RL>
@@ -104,10 +108,6 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
-    }
-
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
@@ -5,7 +5,6 @@ use crate::components::global::load::{
 };
 use crate::components::global::{self, GlobalConfig, ZeroAccumulatorLoader};
 use crate::components::problem::MatmulLineSizes;
-use crate::components::resource::ResourceDemand;
 use crate::components::stage::{BufferStageToTileReader, StageConfig};
 use crate::components::stage::{FullReaderFamily, StageEventListener};
 use crate::components::stage::{FullStageToTileReader, StageEvent};
@@ -15,7 +14,7 @@ use crate::components::{
 };
 use crate::components::{global::GlobalMatmulFamily, stage::BufferReaderFamily};
 use crate::kernels::MatmulAvailabilityError;
-use crate::kernels::matmul::GlobalInput;
+use crate::kernels::matmul::{GlobalInput, MatmulSelection};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
@@ -48,8 +47,8 @@ where
         RL,
     >;
 
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError> {
+        SMM::resource_demand(selection)?.to_cube_dim(selection.plane_dim)
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
@@ -45,6 +45,10 @@ where
 {
     type Matmul<MP: MatmulPrecision> =
         SimpleMatmul<MP, SMM::Matmul<MP, LL::TilingLayout, RL::TilingLayout>, LL, RL>;
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    }
 }
 
 impl<SMM, LL, RL> MatmulConfigFactory for SimpleMatmulFamily<SMM, LL, RL>
@@ -103,10 +107,6 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
-    }
-
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
@@ -7,10 +7,9 @@ use crate::{
             single_stage::Config,
         },
         problem::MatmulLineSizes,
-        resource::ResourceDemand,
         stage::{FullStageToTileReader, StageConfig, StageMatmul},
     },
-    kernels::matmul::GlobalInput,
+    kernels::matmul::{GlobalInput, MatmulSelection},
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -46,8 +45,8 @@ where
     type Matmul<MP: MatmulPrecision> =
         SimpleMatmul<MP, SMM::Matmul<MP, LL::TilingLayout, RL::TilingLayout>, LL, RL>;
 
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError> {
+        SMM::resource_demand(selection)?.to_cube_dim(selection.plane_dim)
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
@@ -7,6 +7,7 @@ use crate::{
             single_stage::Config,
         },
         problem::MatmulLineSizes,
+        resource::ResourceDemand,
         stage::{FullStageToTileReader, StageConfig, StageMatmul},
     },
     kernels::matmul::GlobalInput,
@@ -102,6 +103,10 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
+    }
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
@@ -9,11 +9,11 @@ use crate::components::global::load::AsyncFullLoadingStrategy;
 use crate::components::global::load::AsyncLoader;
 use crate::components::global::single_stage::Config;
 use crate::components::problem::MatmulLineSizes;
-use crate::components::resource::ResourceDemand;
 use crate::components::stage::StageConfig;
 use crate::components::stage::StageMatmul;
 use crate::components::stage::{FullReaderFamily, FullStageToTileReader};
 use crate::kernels::matmul::GlobalInput;
+use crate::kernels::matmul::MatmulSelection;
 use crate::{
     components::{
         Ident, InvalidConfigError, MatmulConfigFactory, MatmulProblem,
@@ -50,8 +50,8 @@ where
     type Matmul<MP: MatmulPrecision> =
         SimpleBarrierMatmul<MP, SMM::Matmul<MP, LL::TilingLayout, RL::TilingLayout>, LL, RL>;
 
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError> {
+        SMM::resource_demand(selection)?.to_cube_dim(selection.plane_dim)
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
@@ -49,6 +49,10 @@ where
 {
     type Matmul<MP: MatmulPrecision> =
         SimpleBarrierMatmul<MP, SMM::Matmul<MP, LL::TilingLayout, RL::TilingLayout>, LL, RL>;
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    }
 }
 
 impl<SMM, LL, RL> MatmulConfigFactory for SimpleBarrierMatmulFamily<SMM, LL, RL>
@@ -113,10 +117,6 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
-    }
-
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
@@ -9,6 +9,7 @@ use crate::components::global::load::AsyncFullLoadingStrategy;
 use crate::components::global::load::AsyncLoader;
 use crate::components::global::single_stage::Config;
 use crate::components::problem::MatmulLineSizes;
+use crate::components::resource::ResourceDemand;
 use crate::components::stage::StageConfig;
 use crate::components::stage::StageMatmul;
 use crate::components::stage::{FullReaderFamily, FullStageToTileReader};
@@ -112,6 +113,10 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
+    }
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
@@ -7,6 +7,7 @@ use crate::components::global::single_stage::Config;
 use crate::components::global::{GlobalMatmul, load::TmaTiling};
 use crate::components::global::{Quantization, load::TmaReader};
 use crate::components::problem::MatmulLineSizes;
+use crate::components::resource::ResourceDemand;
 use crate::components::stage::StageConfig;
 use crate::components::stage::StageMatmul;
 use crate::kernels::matmul::GlobalInput;
@@ -125,6 +126,10 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
+    }
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
@@ -7,11 +7,9 @@ use crate::components::global::single_stage::Config;
 use crate::components::global::{GlobalMatmul, load::TmaTiling};
 use crate::components::global::{Quantization, load::TmaReader};
 use crate::components::problem::MatmulLineSizes;
-use crate::components::resource::ResourceDemand;
 use crate::components::stage::StageConfig;
 use crate::components::stage::StageMatmul;
-use crate::kernels::matmul::GlobalInput;
-
+use crate::kernels::matmul::{GlobalInput, MatmulSelection};
 use barrier::Barrier;
 use cubecl_core::prelude::{barrier::BarrierLevel, *};
 use cubecl_core::{self as cubecl};
@@ -41,8 +39,8 @@ where
 {
     type Matmul<MP: MatmulPrecision> = SimpleTmaMatmul<MP, SMM::Matmul<MP, TmaTiling, TmaTiling>>;
 
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError> {
+        SMM::resource_demand(selection)?.to_cube_dim(selection.plane_dim)
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
@@ -40,6 +40,10 @@ where
     SMM: stage::StageMatmulFamily<LhsReader = FullReaderFamily, RhsReader = FullReaderFamily>,
 {
     type Matmul<MP: MatmulPrecision> = SimpleTmaMatmul<MP, SMM::Matmul<MP, TmaTiling, TmaTiling>>;
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
+    }
 }
 
 impl<SMM> MatmulConfigFactory for SimpleTmaMatmulFamily<SMM>
@@ -126,10 +130,6 @@ where
             input.loading_precompute_strategy,
             input.loader_mode,
         )
-    }
-
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        SMM::resource_demand(config.stage_config())?.as_planes_resource(config.plane_dim())
     }
 }
 

--- a/crates/cubecl-matmul/src/components/mod.rs
+++ b/crates/cubecl-matmul/src/components/mod.rs
@@ -6,7 +6,6 @@ pub mod tile;
 mod base;
 mod config;
 mod problem;
-mod resource;
 mod size;
 mod spec;
 mod tiling_scheme;

--- a/crates/cubecl-matmul/src/components/mod.rs
+++ b/crates/cubecl-matmul/src/components/mod.rs
@@ -6,6 +6,7 @@ pub mod tile;
 mod base;
 mod config;
 mod problem;
+mod resource;
 mod size;
 mod spec;
 mod tiling_scheme;

--- a/crates/cubecl-matmul/src/components/resource.rs
+++ b/crates/cubecl-matmul/src/components/resource.rs
@@ -5,6 +5,7 @@ use crate::components::InvalidConfigError;
 pub enum ResourceDemand {
     Units(u32),
     Planes(u32),
+    // TODO cube, cubes
 }
 
 impl ResourceDemand {

--- a/crates/cubecl-matmul/src/components/resource.rs
+++ b/crates/cubecl-matmul/src/components/resource.rs
@@ -1,0 +1,33 @@
+use cubecl_core::CubeDim;
+
+use crate::components::InvalidConfigError;
+
+pub enum ResourceDemand {
+    Units(u32),
+    Planes(u32),
+}
+
+impl ResourceDemand {
+    pub fn as_planes_resource(self, plane_dim: u32) -> Result<Self, InvalidConfigError> {
+        match self {
+            ResourceDemand::Units(units) => {
+                if units % plane_dim == 0 {
+                    Ok(ResourceDemand::Planes(units / plane_dim))
+                } else {
+                    Err(Box::new(format!(
+                        "Number of units {:?} should be divisible by plane_dim {:?}",
+                        units, plane_dim
+                    )))
+                }
+            }
+            ResourceDemand::Planes(_) => Ok(self),
+        }
+    }
+
+    pub fn to_cube_dim(self, plane_dim: u32) -> Result<CubeDim, InvalidConfigError> {
+        match self {
+            ResourceDemand::Units(_) => self.as_planes_resource(plane_dim)?.to_cube_dim(plane_dim),
+            ResourceDemand::Planes(num_planes) => Ok(CubeDim::new_2d(plane_dim, num_planes)),
+        }
+    }
+}

--- a/crates/cubecl-matmul/src/components/size.rs
+++ b/crates/cubecl-matmul/src/components/size.rs
@@ -120,3 +120,17 @@ impl_from_tuple!(MatmulProblemSize, u32, u32);
 impl_from_tuple!(MatmulProblemSize, u32, i32);
 impl_from_tuple!(MatmulProblemSize, u32, u16);
 impl_from_tuple!(MatmulProblemSize, u32, usize);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+/// Number of global matmuls for one cube
+pub struct GlobalPartitionSize {
+    pub m: u32,
+    pub n: u32,
+    pub batches: u32,
+}
+
+impl GlobalPartitionSize {
+    pub fn new(m: u32, n: u32, batches: u32) -> Self {
+        Self { m, n, batches }
+    }
+}

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -2,13 +2,15 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
 
-use crate::components::{
-    Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
-    TilingScheme,
-    config::MatmulConfig,
-    global::{self, AccumulatorLoader, GlobalWriter},
-    resource::ResourceDemand,
-    tile::TileConfig,
+use crate::{
+    components::{
+        Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
+        TilingScheme,
+        config::MatmulConfig,
+        global::{self, AccumulatorLoader, GlobalWriter},
+        tile::{ComputeResources, TileConfig},
+    },
+    kernels::matmul::MatmulSelection,
 };
 
 use super::{StageEventListener, StageToTileReader, TilingLayout};
@@ -30,7 +32,7 @@ pub trait StageMatmulFamily:
             RhsReader = <Self::RhsReader as ReaderFamily>::Reader<MP::ES, TR>,
         >;
 
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError>;
+    fn resource_demand(selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError>;
 }
 
 #[cube]

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -32,7 +32,8 @@ pub trait StageMatmulFamily:
             RhsReader = <Self::RhsReader as ReaderFamily>::Reader<MP::ES, TR>,
         >;
 
-    fn resource_demand(selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError>;
+    fn resource_demand(selection: &MatmulSelection)
+    -> Result<ComputeResources, InvalidConfigError>;
 }
 
 #[cube]

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -3,9 +3,11 @@ use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
 
 use crate::components::{
-    Ident, InputIdent, MatmulConfigFactory, MatmulPrecision, MatrixLayout, TilingScheme,
+    Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
+    TilingScheme,
     config::MatmulConfig,
     global::{self, AccumulatorLoader, GlobalWriter},
+    resource::ResourceDemand,
     tile::TileConfig,
 };
 
@@ -27,6 +29,8 @@ pub trait StageMatmulFamily:
             LhsReader = <Self::LhsReader as ReaderFamily>::Reader<MP::ES, TL>,
             RhsReader = <Self::RhsReader as ReaderFamily>::Reader<MP::ES, TR>,
         >;
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError>;
 }
 
 #[cube]

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
@@ -58,7 +58,9 @@ impl<TMM: TileMatmulFamily, LRF: ReaderFamily, RRF: ReaderFamily> StageMatmulFam
     type Matmul<MP: MatmulPrecision, TL: TilingLayout, TR: TilingLayout> =
         PlaneMatmul<MP, TMM::Matmul<MP>, LRF::Reader<MP::ES, TL>, RRF::Reader<MP::ES, TR>>;
 
-    fn resource_demand(selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError> {
+    fn resource_demand(
+        selection: &MatmulSelection,
+    ) -> Result<ComputeResources, InvalidConfigError> {
         if let ComputeResources::Planes(planes) = TMM::resource_demand(selection)? {
             Ok(ComputeResources::Planes(
                 planes * selection.tiling_scheme.partitions_in_stage_mn(),

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
@@ -1,5 +1,6 @@
 use crate::components::MatmulProblem;
 use crate::components::global::PlaneWriter;
+use crate::components::resource::ResourceDemand;
 use crate::components::stage::PartitionBuffering;
 use crate::components::stage::ReaderFamily;
 use crate::components::stage::shared::CommonStageConfig;
@@ -116,5 +117,15 @@ impl<TMM: TileMatmulFamily, LRF: ReaderFamily, RRF: ReaderFamily> MatmulConfigFa
             stage_input.partition_buffering,
             stage_input.num_stages,
         )
+    }
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        if let ResourceDemand::Planes(planes) = TMM::resource_demand(config.tile_config())? {
+            Ok(ResourceDemand::Planes(
+                planes * config.tiling_scheme().partitions_in_stage_mn(),
+            ))
+        } else {
+            unreachable!("Units should never occur here")
+        }
     }
 }

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
@@ -57,7 +57,9 @@ impl<TMM: TileMatmulFamily, RF: ReaderFamily> StageMatmulFamily for UnitMatmulFa
     type Matmul<MP: MatmulPrecision, TL: TilingLayout, TR: TilingLayout> =
         UnitMatmul<MP, TMM::Matmul<MP>, RF::Reader<MP::ES, TL>, RF::Reader<MP::ES, TR>>;
 
-    fn resource_demand(selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError> {
+    fn resource_demand(
+        selection: &MatmulSelection,
+    ) -> Result<ComputeResources, InvalidConfigError> {
         if let ComputeResources::Units(units) = TMM::resource_demand(selection)? {
             Ok(ComputeResources::Units(
                 units * selection.tiling_scheme.partitions_in_stage_mn(),

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
@@ -1,5 +1,6 @@
 use crate::components::MatmulProblem;
 use crate::components::global::UnitWriter;
+use crate::components::resource::ResourceDemand;
 use crate::components::stage::PartitionBuffering;
 use crate::components::stage::ReaderFamily;
 use crate::components::stage::shared::CommonStageConfig;
@@ -112,5 +113,15 @@ impl<TMM: TileMatmulFamily, RF: ReaderFamily> MatmulConfigFactory for UnitMatmul
             stage_input.partition_buffering,
             stage_input.num_stages,
         )
+    }
+
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        if let ResourceDemand::Units(units) = TMM::resource_demand(config.tile_config())? {
+            Ok(ResourceDemand::Units(
+                units * config.tiling_scheme().partitions_in_stage_mn(),
+            ))
+        } else {
+            unreachable!("Planes should never occur here")
+        }
     }
 }

--- a/crates/cubecl-matmul/src/components/tile/accelerated_matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated_matmul.rs
@@ -1,11 +1,12 @@
 use crate::components::config::MatmulConfig;
-use crate::components::resource::ResourceDemand;
+use crate::components::tile::compute_resource::ComputeResources;
 use crate::components::tile::{TileConfig, TileMatmul, TileMatmulFamily};
 use crate::components::{
     Ident, InvalidConfigError, MatmulConfigFactory, MatmulLineSizes, MatmulPrecision,
     MatmulProblem, MatrixLayout, TileSize, as_cmma_layout,
 };
 use crate::kernels::MatmulAvailabilityError;
+use crate::kernels::matmul::MatmulSelection;
 use cubecl_core::ir::{Elem, FloatKind};
 use cubecl_core::{self as cubecl, Feature};
 use cubecl_core::{cmma, prelude::*};
@@ -21,8 +22,8 @@ impl TileMatmulFamily for AcceleratedMatmul {
         true
     }
 
-    fn resource_demand(_config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        Ok(ResourceDemand::Planes(1))
+    fn resource_demand(_selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError> {
+        Ok(ComputeResources::Planes(1))
     }
 }
 

--- a/crates/cubecl-matmul/src/components/tile/accelerated_matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated_matmul.rs
@@ -20,6 +20,10 @@ impl TileMatmulFamily for AcceleratedMatmul {
     fn requires_tensor_cores() -> bool {
         true
     }
+
+    fn resource_demand(_config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        Ok(ResourceDemand::Planes(1))
+    }
 }
 
 #[cube]
@@ -205,10 +209,6 @@ impl MatmulConfigFactory for AcceleratedMatmul {
             rhs_line_size,
             line_sizes.out as u32,
         )
-    }
-
-    fn resource_demand(_config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        Ok(ResourceDemand::Planes(1))
     }
 }
 

--- a/crates/cubecl-matmul/src/components/tile/accelerated_matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated_matmul.rs
@@ -22,7 +22,9 @@ impl TileMatmulFamily for AcceleratedMatmul {
         true
     }
 
-    fn resource_demand(_selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError> {
+    fn resource_demand(
+        _selection: &MatmulSelection,
+    ) -> Result<ComputeResources, InvalidConfigError> {
         Ok(ComputeResources::Planes(1))
     }
 }

--- a/crates/cubecl-matmul/src/components/tile/accelerated_matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated_matmul.rs
@@ -1,4 +1,5 @@
 use crate::components::config::MatmulConfig;
+use crate::components::resource::ResourceDemand;
 use crate::components::tile::{TileConfig, TileMatmul, TileMatmulFamily};
 use crate::components::{
     Ident, InvalidConfigError, MatmulConfigFactory, MatmulLineSizes, MatmulPrecision,
@@ -204,6 +205,10 @@ impl MatmulConfigFactory for AcceleratedMatmul {
             rhs_line_size,
             line_sizes.out as u32,
         )
+    }
+
+    fn resource_demand(_config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        Ok(ResourceDemand::Planes(1))
     }
 }
 

--- a/crates/cubecl-matmul/src/components/tile/base.rs
+++ b/crates/cubecl-matmul/src/components/tile/base.rs
@@ -2,8 +2,8 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::components::{
-    Ident, InputIdent, MatmulConfigFactory, MatmulPrecision, MatrixLayout, TileSize,
-    config::MatmulConfig, stage::StageVectorization,
+    Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
+    TileSize, config::MatmulConfig, resource::ResourceDemand, stage::StageVectorization,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -16,6 +16,7 @@ pub trait TileMatmulFamily:
     MatmulConfigFactory<Input = TileMatmulConfigInput, Config: TileConfig>
 {
     fn requires_tensor_cores() -> bool;
+    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError>;
 
     type Matmul<MP: MatmulPrecision>: TileMatmul<MP, Config = Self::Config>;
 }

--- a/crates/cubecl-matmul/src/components/tile/base.rs
+++ b/crates/cubecl-matmul/src/components/tile/base.rs
@@ -1,9 +1,12 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use crate::components::{
-    Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
-    TileSize, config::MatmulConfig, resource::ResourceDemand, stage::StageVectorization,
+use crate::{
+    components::{
+        Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
+        TileSize, config::MatmulConfig, stage::StageVectorization, tile::compute_resource::ComputeResources,
+    },
+    kernels::matmul::MatmulSelection,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -16,7 +19,7 @@ pub trait TileMatmulFamily:
     MatmulConfigFactory<Input = TileMatmulConfigInput, Config: TileConfig>
 {
     fn requires_tensor_cores() -> bool;
-    fn resource_demand(config: Self::Config) -> Result<ResourceDemand, InvalidConfigError>;
+    fn resource_demand(selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError>;
 
     type Matmul<MP: MatmulPrecision>: TileMatmul<MP, Config = Self::Config>;
 }

--- a/crates/cubecl-matmul/src/components/tile/base.rs
+++ b/crates/cubecl-matmul/src/components/tile/base.rs
@@ -4,7 +4,8 @@ use cubecl_core::prelude::*;
 use crate::{
     components::{
         Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatrixLayout,
-        TileSize, config::MatmulConfig, stage::StageVectorization, tile::compute_resource::ComputeResources,
+        TileSize, config::MatmulConfig, stage::StageVectorization,
+        tile::compute_resource::ComputeResources,
     },
     kernels::matmul::MatmulSelection,
 };
@@ -19,7 +20,8 @@ pub trait TileMatmulFamily:
     MatmulConfigFactory<Input = TileMatmulConfigInput, Config: TileConfig>
 {
     fn requires_tensor_cores() -> bool;
-    fn resource_demand(selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError>;
+    fn resource_demand(selection: &MatmulSelection)
+    -> Result<ComputeResources, InvalidConfigError>;
 
     type Matmul<MP: MatmulPrecision>: TileMatmul<MP, Config = Self::Config>;
 }

--- a/crates/cubecl-matmul/src/components/tile/compute_resource.rs
+++ b/crates/cubecl-matmul/src/components/tile/compute_resource.rs
@@ -2,18 +2,17 @@ use cubecl_core::CubeDim;
 
 use crate::components::InvalidConfigError;
 
-pub enum ResourceDemand {
+pub enum ComputeResources {
     Units(u32),
     Planes(u32),
-    // TODO cube, cubes
 }
 
-impl ResourceDemand {
-    pub fn as_planes_resource(self, plane_dim: u32) -> Result<Self, InvalidConfigError> {
+impl ComputeResources {
+    pub fn as_plane_resources(self, plane_dim: u32) -> Result<Self, InvalidConfigError> {
         match self {
-            ResourceDemand::Units(units) => {
+            ComputeResources::Units(units) => {
                 if units % plane_dim == 0 {
-                    Ok(ResourceDemand::Planes(units / plane_dim))
+                    Ok(ComputeResources::Planes(units / plane_dim))
                 } else {
                     Err(Box::new(format!(
                         "Number of units {:?} should be divisible by plane_dim {:?}",
@@ -21,14 +20,16 @@ impl ResourceDemand {
                     )))
                 }
             }
-            ResourceDemand::Planes(_) => Ok(self),
+            ComputeResources::Planes(_) => Ok(self),
         }
     }
 
     pub fn to_cube_dim(self, plane_dim: u32) -> Result<CubeDim, InvalidConfigError> {
         match self {
-            ResourceDemand::Units(_) => self.as_planes_resource(plane_dim)?.to_cube_dim(plane_dim),
-            ResourceDemand::Planes(num_planes) => Ok(CubeDim::new_2d(plane_dim, num_planes)),
+            ComputeResources::Units(_) => {
+                self.as_plane_resources(plane_dim)?.to_cube_dim(plane_dim)
+            }
+            ComputeResources::Planes(num_planes) => Ok(CubeDim::new_2d(plane_dim, num_planes)),
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/tile/mod.rs
+++ b/crates/cubecl-matmul/src/components/tile/mod.rs
@@ -2,5 +2,7 @@ pub mod accelerated_matmul;
 pub mod register_matmul;
 
 mod base;
+mod compute_resource;
 
 pub use base::*;
+pub use compute_resource::*;

--- a/crates/cubecl-matmul/src/components/tile/register_matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/register_matmul.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use crate::components::config::MatmulConfig;
 use crate::components::problem::MatmulLineSizes;
+use crate::components::resource::ResourceDemand;
 use crate::components::tile::{TileConfig, TileMatmul, TileMatmulFamily};
 use crate::components::{
     Ident, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatmulProblem, MatrixLayout,
@@ -458,6 +459,10 @@ impl MatmulConfigFactory for RegisterMatmul {
             rhs_line_size,
             line_sizes.out as u32,
         )
+    }
+
+    fn resource_demand(_config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        Ok(ResourceDemand::Units(1))
     }
 }
 

--- a/crates/cubecl-matmul/src/components/tile/register_matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/register_matmul.rs
@@ -8,8 +8,8 @@ use crate::components::{
     Ident, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatmulProblem, MatrixLayout,
     TileSize,
 };
-use crate::kernels::matmul::MatmulSelection;
 use crate::kernels::MatmulAvailabilityError;
+use crate::kernels::matmul::MatmulSelection;
 use cubecl_core::ir::{Elem, FloatKind};
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl, Feature};
@@ -35,7 +35,9 @@ impl TileMatmulFamily for RegisterMatmul {
         false
     }
 
-    fn resource_demand(_selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError> {
+    fn resource_demand(
+        _selection: &MatmulSelection,
+    ) -> Result<ComputeResources, InvalidConfigError> {
         Ok(ComputeResources::Units(1))
     }
 }

--- a/crates/cubecl-matmul/src/components/tile/register_matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/register_matmul.rs
@@ -2,12 +2,13 @@ use std::fmt::Display;
 
 use crate::components::config::MatmulConfig;
 use crate::components::problem::MatmulLineSizes;
-use crate::components::resource::ResourceDemand;
+use crate::components::tile::compute_resource::ComputeResources;
 use crate::components::tile::{TileConfig, TileMatmul, TileMatmulFamily};
 use crate::components::{
     Ident, InvalidConfigError, MatmulConfigFactory, MatmulPrecision, MatmulProblem, MatrixLayout,
     TileSize,
 };
+use crate::kernels::matmul::MatmulSelection;
 use crate::kernels::MatmulAvailabilityError;
 use cubecl_core::ir::{Elem, FloatKind};
 use cubecl_core::prelude::*;
@@ -34,8 +35,8 @@ impl TileMatmulFamily for RegisterMatmul {
         false
     }
 
-    fn resource_demand(_config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        Ok(ResourceDemand::Units(1))
+    fn resource_demand(_selection: &MatmulSelection) -> Result<ComputeResources, InvalidConfigError> {
+        Ok(ComputeResources::Units(1))
     }
 }
 

--- a/crates/cubecl-matmul/src/components/tile/register_matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/register_matmul.rs
@@ -33,6 +33,10 @@ impl TileMatmulFamily for RegisterMatmul {
     fn requires_tensor_cores() -> bool {
         false
     }
+
+    fn resource_demand(_config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
+        Ok(ResourceDemand::Units(1))
+    }
 }
 
 #[derive(CubeType)]
@@ -459,10 +463,6 @@ impl MatmulConfigFactory for RegisterMatmul {
             rhs_line_size,
             line_sizes.out as u32,
         )
-    }
-
-    fn resource_demand(_config: Self::Config) -> Result<ResourceDemand, InvalidConfigError> {
-        Ok(ResourceDemand::Units(1))
     }
 }
 

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
@@ -1,9 +1,10 @@
 use crate::components::batch::BatchMatmulFamily;
+use crate::components::global::GlobalMatmulFamily;
 use crate::components::global::load::LoaderMode;
 use crate::components::stage::{NumStages, PartitionBuffering, StageVectorization};
 use crate::components::{
-    MatmulConfigFactory, MatmulLineSizes, MatmulPrecision, MatmulProblem, TilingScheme, batch,
-    global, stage, tile,
+    InvalidConfigError, MatmulConfigFactory, MatmulLineSizes, MatmulPrecision, MatmulProblem,
+    TilingScheme, batch, global, stage, tile,
 };
 use crate::kernels::{MatmulAvailabilityError, MatmulLaunchError};
 use cubecl_core::ir::Elem;
@@ -57,7 +58,10 @@ pub trait Algorithm {
     type GlobalMatmul: global::GlobalMatmulFamily<Input = GlobalInput<StageInput>>;
     type BatchMatmul: batch::BatchMatmulFamily<Input = GlobalInput<StageInput>>;
 
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim;
+    fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError> {
+        Self::GlobalMatmul::cube_dim(selection)
+    }
+
     fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
         Self::BatchMatmul::cube_count(selection, problem)
     }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
@@ -1,3 +1,4 @@
+use crate::components::batch::BatchMatmulFamily;
 use crate::components::global::load::LoaderMode;
 use crate::components::stage::{NumStages, PartitionBuffering, StageVectorization};
 use crate::components::{
@@ -55,22 +56,23 @@ pub trait Algorithm {
     type StageMatmul: stage::StageMatmulFamily<Input = StageInput>;
     type GlobalMatmul: global::GlobalMatmulFamily<Input = GlobalInput<StageInput>>;
     type BatchMatmul: batch::BatchMatmulFamily<Input = GlobalInput<StageInput>>;
-    type MatmulSelection: MatmulSelection;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim;
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount;
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim;
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
+        Self::BatchMatmul::cube_count(selection, problem)
+    }
 
     fn line_sizes(
         problem: &MatmulProblem,
         in_available: impl Iterator<Item = u8> + Clone,
         out_available: impl Iterator<Item = u8> + Clone,
-        _selection: &Self::MatmulSelection,
+        _selection: &MatmulSelection,
     ) -> MatmulLineSizes {
         MatmulLineSizes::new_maximized(problem, in_available, out_available)
     }
 
-    fn global_input(selection: &Self::MatmulSelection) -> GlobalInput<StageInput> {
-        let partition_buffering = if selection.tiling_scheme().tiles_in_partition_n() > 1 {
+    fn global_input(selection: &MatmulSelection) -> GlobalInput<StageInput> {
+        let partition_buffering = if selection.tiling_scheme.tiles_in_partition_n() > 1 {
             Self::partition_buffering_strategy()
         } else {
             PartitionBuffering::Single
@@ -83,7 +85,7 @@ pub trait Algorithm {
 
         GlobalInput {
             stage_input: StageInput {
-                tiling_scheme: *selection.tiling_scheme(),
+                tiling_scheme: selection.tiling_scheme.clone(),
                 partition_buffering,
                 stage_vectorization,
                 num_stages: Self::num_stages(),
@@ -148,5 +150,5 @@ pub trait Algorithm {
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection;
+    ) -> MatmulSelection;
 }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
 use crate::components::MatmulProblem;
-use crate::components::batch::{CubeCountDispatch, CubeDispatch};
+use crate::components::batch::CubeDispatch;
 use crate::components::global::load::{sync_buffer_cyclic, sync_buffer_tilewise};
 use crate::components::stage::{
     self, BufferReaderFamily, ColMajorTilingOrder, NumStages, RowMajorTilingOrder,
@@ -12,7 +12,7 @@ use crate::components::tile;
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};
-use super::{MatmulSelection, PlaneMatmulSelection, plane_matmul_selection};
+use super::{MatmulSelection, plane_matmul_selection};
 
 pub struct CyclicDoubleBufferingAlgorithm<TMM, Dispatch = batch::TransposedDispatch> {
     pub _phantom: PhantomData<(TMM, Dispatch)>,
@@ -29,7 +29,7 @@ pub struct HybridDoubleBufferingAlgorithm<TMM, Dispatch = batch::TransposedDispa
 impl<TMM, Dispatch> base::Algorithm for CyclicDoubleBufferingAlgorithm<TMM, Dispatch>
 where
     TMM: tile::TileMatmulFamily,
-    Dispatch: CubeDispatch + CubeCountDispatch,
+    Dispatch: CubeDispatch,
 {
     type TileMatmul = TMM;
     type StageMatmul = stage::plane_matmul::PlaneMatmulFamily<
@@ -44,16 +44,15 @@ where
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-    type MatmulSelection = PlaneMatmulSelection;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme().partitions_in_stage_m();
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
+        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 
@@ -70,7 +69,7 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         plane_matmul_selection::<Self::TileMatmul, R>(
             client,
             problem,
@@ -87,7 +86,7 @@ where
 impl<TMM, Dispatch> base::Algorithm for TilewiseDoubleBufferingAlgorithm<TMM, Dispatch>
 where
     TMM: tile::TileMatmulFamily,
-    Dispatch: CubeDispatch + CubeCountDispatch,
+    Dispatch: CubeDispatch,
 {
     type TileMatmul = TMM;
     type StageMatmul = stage::plane_matmul::PlaneMatmulFamily<
@@ -103,16 +102,15 @@ where
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-    type MatmulSelection = PlaneMatmulSelection;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme().partitions_in_stage_m();
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
+        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 
@@ -129,7 +127,7 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         plane_matmul_selection::<Self::TileMatmul, R>(
             client,
             problem,
@@ -146,7 +144,7 @@ where
 impl<TMM, Dispatch> base::Algorithm for HybridDoubleBufferingAlgorithm<TMM, Dispatch>
 where
     TMM: tile::TileMatmulFamily,
-    Dispatch: CubeDispatch + CubeCountDispatch,
+    Dispatch: CubeDispatch,
 {
     type TileMatmul = TMM;
     type StageMatmul = stage::plane_matmul::PlaneMatmulFamily<
@@ -161,16 +159,15 @@ where
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-    type MatmulSelection = PlaneMatmulSelection;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme().partitions_in_stage_m();
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
+        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 
@@ -187,7 +184,7 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         plane_matmul_selection::<Self::TileMatmul, R>(
             client,
             problem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -45,11 +45,6 @@ where
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
 
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
     fn num_stages() -> NumStages {
         (2, 2).into()
     }
@@ -94,11 +89,6 @@ where
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
 
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
     fn num_stages() -> NumStages {
         (2, 2).into()
     }
@@ -141,11 +131,6 @@ where
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
 
     fn num_stages() -> NumStages {
         (2, 2).into()

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -50,15 +50,6 @@ where
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme.elements_in_stage_m();
-        let n_stage = selection.tiling_scheme.elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
-    }
-
     fn num_stages() -> NumStages {
         (2, 2).into()
     }
@@ -108,15 +99,6 @@ where
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme.elements_in_stage_m();
-        let n_stage = selection.tiling_scheme.elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
-    }
-
     fn num_stages() -> NumStages {
         (2, 2).into()
     }
@@ -163,15 +145,6 @@ where
     fn cube_dim(selection: &MatmulSelection) -> CubeDim {
         let num_planes = selection.tiling_scheme.partitions_in_stage_m();
         CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
-    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme.elements_in_stage_m();
-        let n_stage = selection.tiling_scheme.elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
     }
 
     fn num_stages() -> NumStages {

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_unit.rs
@@ -66,13 +66,6 @@ where
         }
     }
 
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_units_needed = selection.tiling_scheme.partitions_in_stage_mn();
-        let num_planes = num_units_needed.div_ceil(selection.plane_dim);
-
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
     fn selection<R: Runtime>(
         _client: &ComputeClient<R::Server, R::Channel>,
         problem: &MatmulProblem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_unit.rs
@@ -73,15 +73,6 @@ where
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme.elements_in_stage_m();
-        let n_stage = selection.tiling_scheme.elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
-    }
-
     fn selection<R: Runtime>(
         _client: &ComputeClient<R::Server, R::Channel>,
         problem: &MatmulProblem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_unit.rs
@@ -1,10 +1,10 @@
-use super::{MatmulSelection, UnitMatmulSelection, base, unit_matmul_selection};
+use super::{MatmulSelection, base, unit_matmul_selection};
 use cubecl_core::{ir::Elem, prelude::*};
 use std::marker::PhantomData;
 
 use crate::components::{
     MatmulLineSizes, MatmulProblem, MatrixLayout,
-    batch::{self, CubeCountDispatch, CubeDispatch},
+    batch::{self, CubeDispatch},
     global::{self, load::sync_buffer_cyclic},
     stage::{self, BufferReaderFamily, NumStages, RowMajorTilingOrder},
     tile,
@@ -16,7 +16,7 @@ pub struct DoubleUnitAlgorithm<Dispatch = batch::TransposedDispatch> {
 
 impl<Dispatch> base::Algorithm for DoubleUnitAlgorithm<Dispatch>
 where
-    Dispatch: CubeDispatch + CubeCountDispatch,
+    Dispatch: CubeDispatch,
 {
     type TileMatmul = tile::register_matmul::RegisterMatmul;
     type StageMatmul = stage::unit_matmul::UnitMatmulFamily<Self::TileMatmul, BufferReaderFamily>;
@@ -27,7 +27,6 @@ where
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-    type MatmulSelection = UnitMatmulSelection;
 
     fn num_stages() -> NumStages {
         (2, 2).into()
@@ -37,17 +36,17 @@ where
         problem: &MatmulProblem,
         in_available: impl Iterator<Item = u8> + Clone,
         out_available: impl Iterator<Item = u8> + Clone,
-        selection: &Self::MatmulSelection,
+        selection: &MatmulSelection,
     ) -> MatmulLineSizes {
         let max_lhs = match problem.lhs_layout {
-            MatrixLayout::RowMajor => selection.tiling_scheme().elements_in_tile_k(),
-            MatrixLayout::ColMajor => selection.tiling_scheme().elements_in_tile_m(),
+            MatrixLayout::RowMajor => selection.tiling_scheme.elements_in_tile_k(),
+            MatrixLayout::ColMajor => selection.tiling_scheme.elements_in_tile_m(),
         };
         let max_rhs = match problem.rhs_layout {
-            MatrixLayout::RowMajor => selection.tiling_scheme().elements_in_tile_n(),
-            MatrixLayout::ColMajor => selection.tiling_scheme().elements_in_tile_k(),
+            MatrixLayout::RowMajor => selection.tiling_scheme.elements_in_tile_n(),
+            MatrixLayout::ColMajor => selection.tiling_scheme.elements_in_tile_k(),
         };
-        let max_out = selection.tiling_scheme().elements_in_tile_n();
+        let max_out = selection.tiling_scheme.elements_in_tile_n();
 
         MatmulLineSizes {
             lhs: MatmulLineSizes::maximize_lhs(
@@ -67,16 +66,16 @@ where
         }
     }
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
-        let num_units_needed = selection.tiling_scheme().partitions_in_stage_mn();
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
+        let num_units_needed = selection.tiling_scheme.partitions_in_stage_mn();
         let num_planes = num_units_needed.div_ceil(selection.plane_dim);
 
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 
@@ -89,7 +88,7 @@ where
         plane_dim: u32,
         _elem_stage: Elem,
         _elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         unit_matmul_selection(problem, plane_dim)
     }
 }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -36,11 +36,6 @@ where
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
 
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
     fn num_stages() -> NumStages {
         (1, 2).into()
     }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -3,6 +3,7 @@ use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
 use crate::components::batch::CubeDispatch;
+use crate::components::global::GlobalMatmulFamily;
 use crate::components::global::load::sync_buffer_cyclic;
 use crate::components::stage::{
     self, BufferReaderFamily, FullReaderFamily, NumStages, RowMajorTilingOrder,
@@ -10,7 +11,6 @@ use crate::components::stage::{
 use crate::components::tile;
 use crate::components::{InvalidConfigError, MatmulProblem};
 use crate::components::{batch, global};
-use crate::kernels::matmul::Algorithm;
 
 use super::base::{self, MultiRowStrategy};
 use super::{MatmulSelection, plane_matmul_selection};
@@ -41,7 +41,7 @@ where
         if selection.tiling_scheme.partitions_in_stage_n() > 1 {
             return Err(Box::new("Ordered does not support partitions > 1 in n"));
         }
-        <Self as Algorithm>::cube_dim(selection)
+        Self::GlobalMatmul::cube_dim(selection)
     }
 
     fn num_stages() -> NumStages {

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -41,15 +41,6 @@ where
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme.elements_in_stage_m();
-        let n_stage = selection.tiling_scheme.elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
-    }
-
     fn num_stages() -> NumStages {
         (1, 2).into()
     }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
 use crate::components::MatmulProblem;
-use crate::components::batch::{CubeCountDispatch, CubeDispatch};
+use crate::components::batch::CubeDispatch;
 use crate::components::global::load::sync_buffer_cyclic;
 use crate::components::stage::{
     self, BufferReaderFamily, FullReaderFamily, NumStages, RowMajorTilingOrder,
@@ -12,7 +12,7 @@ use crate::components::tile;
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};
-use super::{MatmulSelection, PlaneMatmulSelection, plane_matmul_selection};
+use super::{MatmulSelection, plane_matmul_selection};
 
 pub struct OrderedDoubleBufferingAlgorithm<TMM, Dispatch = batch::TransposedDispatch> {
     pub _phantom: PhantomData<(TMM, Dispatch)>,
@@ -21,7 +21,7 @@ pub struct OrderedDoubleBufferingAlgorithm<TMM, Dispatch = batch::TransposedDisp
 impl<TMM, Dispatch> base::Algorithm for OrderedDoubleBufferingAlgorithm<TMM, Dispatch>
 where
     TMM: tile::TileMatmulFamily,
-    Dispatch: CubeDispatch + CubeCountDispatch,
+    Dispatch: CubeDispatch,
 {
     type TileMatmul = TMM;
     type StageMatmul = stage::plane_matmul::PlaneMatmulFamily<
@@ -35,16 +35,15 @@ where
     >;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-    type MatmulSelection = PlaneMatmulSelection;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme().partitions_in_stage_m();
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
+        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 
@@ -65,7 +64,7 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         plane_matmul_selection::<Self::TileMatmul, R>(
             client,
             problem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/selector/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/selector/base.rs
@@ -14,8 +14,10 @@ use crate::{
 };
 use cubecl_core::frontend::CubePrimitive;
 
-pub trait MatmulSelection {
-    fn tiling_scheme(&self) -> &TilingScheme;
+#[derive(Debug)]
+pub struct MatmulSelection {
+    pub plane_dim: u32,
+    pub tiling_scheme: TilingScheme,
 }
 
 /// Select which kernel to launch for the given Algorithm.

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/selector/plane.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/selector/plane.rs
@@ -14,18 +14,6 @@ pub const NUM_SM_APPROX: u32 = 50;
 pub const NUM_TENSOR_CORES_APPROX: u32 = 4;
 const NUM_PLANES_PER_TENSOR_CORES: u32 = 2;
 
-#[derive(Debug)]
-pub struct PlaneMatmulSelection {
-    pub plane_dim: u32,
-    pub tiling_scheme: TilingScheme,
-}
-
-impl MatmulSelection for PlaneMatmulSelection {
-    fn tiling_scheme(&self) -> &TilingScheme {
-        &self.tiling_scheme
-    }
-}
-
 pub fn plane_matmul_selection<TMM: TileMatmulFamily, R: Runtime>(
     client: &ComputeClient<R::Server, R::Channel>,
     problem: &MatmulProblem,
@@ -33,7 +21,7 @@ pub fn plane_matmul_selection<TMM: TileMatmulFamily, R: Runtime>(
     multi_row_strategy: MultiRowStrategy,
     elem_stage: Elem,
     elem_acc: Elem,
-) -> PlaneMatmulSelection {
+) -> MatmulSelection {
     let tile_size = find_instruction_size(
         if TMM::requires_tensor_cores() {
             Some((client.properties(), (elem_stage, elem_stage, elem_acc)))
@@ -90,7 +78,7 @@ pub fn plane_matmul_selection<TMM: TileMatmulFamily, R: Runtime>(
         .build()
         .unwrap();
 
-    PlaneMatmulSelection {
+    MatmulSelection {
         tiling_scheme,
         plane_dim,
     }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/selector/unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/selector/unit.rs
@@ -6,19 +6,7 @@ const NUM_PLANES_APPROX: u32 = 2;
 const TILE_DIM: u32 = 4;
 const PARTITION_K_APPROX: u32 = 4;
 
-#[derive(Debug, Clone)]
-pub struct UnitMatmulSelection {
-    pub plane_dim: u32,
-    pub tiling_scheme: TilingScheme,
-}
-
-impl MatmulSelection for UnitMatmulSelection {
-    fn tiling_scheme(&self) -> &TilingScheme {
-        &self.tiling_scheme
-    }
-}
-
-pub fn unit_matmul_selection(problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+pub fn unit_matmul_selection(problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     match Into::<MatmulKind>::into(problem) {
         MatmulKind::General => general_unit_selector(problem, plane_dim),
         MatmulKind::MatVec => matvec_unit_selector(problem, plane_dim),
@@ -32,7 +20,7 @@ pub fn unit_matmul_selection(problem: &MatmulProblem, plane_dim: u32) -> UnitMat
 }
 
 /// (M, K) @ (K, N) → (M, N), with M, K, N > 1
-fn general_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+fn general_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     let num_units = NUM_PLANES_APPROX * plane_dim;
     let (stage_size_m, stage_size_n) = closest_factor_pair(num_units);
     let tiling_scheme = TilingScheme::builder()
@@ -42,14 +30,14 @@ fn general_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmul
         .build()
         .unwrap();
 
-    UnitMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }
 }
 
 /// (M, K) @ (K, 1) → (M, 1)
-fn matvec_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+fn matvec_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     let num_units = NUM_PLANES_APPROX * plane_dim;
     let tiling_scheme = TilingScheme::builder()
         .with_tile_size((TILE_DIM, 1, TILE_DIM).into())
@@ -58,14 +46,14 @@ fn matvec_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulS
         .build()
         .unwrap();
 
-    UnitMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }
 }
 
 /// (1, K) @ (K, N) → (1, N)
-fn vecmat_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+fn vecmat_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     let num_units = NUM_PLANES_APPROX * plane_dim;
     let tiling_scheme = TilingScheme::builder()
         .with_tile_size((1, TILE_DIM, TILE_DIM).into())
@@ -74,14 +62,14 @@ fn vecmat_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulS
         .build()
         .unwrap();
 
-    UnitMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }
 }
 
 /// (1, 1) @ (1, N) → (1, N)
-fn scalarvec_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+fn scalarvec_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     let num_units = NUM_PLANES_APPROX * plane_dim;
     let tiling_scheme = TilingScheme::builder()
         .with_tile_size((1, TILE_DIM, 1).into())
@@ -90,14 +78,14 @@ fn scalarvec_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatm
         .build()
         .unwrap();
 
-    UnitMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }
 }
 
 /// (M, 1) @ (1, 1) → (M, 1)
-fn vecscalar_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+fn vecscalar_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     let num_units = NUM_PLANES_APPROX * plane_dim;
     let tiling_scheme = TilingScheme::builder()
         .with_tile_size((TILE_DIM, 1, 1).into())
@@ -106,14 +94,14 @@ fn vecscalar_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatm
         .build()
         .unwrap();
 
-    UnitMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }
 }
 
 /// (1, K) @ (K, 1) → (1, 1)
-fn inner_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+fn inner_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     let tiling_scheme = TilingScheme::builder()
         .with_tile_size((1, 1, TILE_DIM).into())
         .with_partition_size((1, 1, PARTITION_K_APPROX).into())
@@ -121,14 +109,14 @@ fn inner_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> Unit
         .build()
         .unwrap();
 
-    UnitMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }
 }
 
 /// (M, 1) @ (1, N) → (M, N)
-fn outer_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+fn outer_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     let num_units = NUM_PLANES_APPROX * plane_dim;
     let (stage_size_m, stage_size_n) = closest_factor_pair(num_units);
     let tiling_scheme = TilingScheme::builder()
@@ -138,14 +126,14 @@ fn outer_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> Unit
         .build()
         .unwrap();
 
-    UnitMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }
 }
 
 /// (1, 1) @ (1, 1) → (1, 1)
-fn scalar_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> UnitMatmulSelection {
+fn scalar_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> MatmulSelection {
     let tiling_scheme = TilingScheme::builder()
         .with_tile_size((1, 1, 1).into())
         .with_partition_size((1, 1, 1).into())
@@ -153,7 +141,7 @@ fn scalar_product_unit_selector(_problem: &MatmulProblem, plane_dim: u32) -> Uni
         .build()
         .unwrap();
 
-    UnitMatmulSelection {
+    MatmulSelection {
         plane_dim,
         tiling_scheme,
     }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple.rs
@@ -39,13 +39,7 @@ where
         FullReaderFamily,
     >;
     type GlobalMatmul = global::single_stage::simple::SimpleMatmulFamily<Self::StageMatmul, LL, RL>;
-
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
 
     fn selection<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple.rs
@@ -1,12 +1,10 @@
-use super::{
-    MatmulSelection, MultiRowStrategy, PlaneMatmulSelection, base, plane_matmul_selection,
-};
+use super::{MatmulSelection, MultiRowStrategy, base, plane_matmul_selection};
 use cubecl_core::{ir::Elem, prelude::*};
 use std::marker::PhantomData;
 
 use crate::components::{
     MatmulProblem,
-    batch::{self, CubeCountDispatch, CubeDispatch},
+    batch::{self, CubeDispatch},
     global::{
         self,
         load::{SyncFullLoadingStrategy, sync_full_cyclic},
@@ -32,7 +30,7 @@ where
     TMM: tile::TileMatmulFamily,
     LL: SyncFullLoadingStrategy,
     RL: SyncFullLoadingStrategy,
-    Dispatch: CubeDispatch + CubeCountDispatch,
+    Dispatch: CubeDispatch,
 {
     type TileMatmul = TMM;
     type StageMatmul = stage::plane_matmul::PlaneMatmulFamily<
@@ -43,20 +41,10 @@ where
     type GlobalMatmul = global::single_stage::simple::SimpleMatmulFamily<Self::StageMatmul, LL, RL>;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-    type MatmulSelection = PlaneMatmulSelection;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme().partitions_in_stage_m();
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
+        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
         CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
     }
 
     fn selection<R: Runtime>(
@@ -65,7 +53,7 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         plane_matmul_selection::<Self::TileMatmul, R>(
             client,
             problem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_barrier.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_barrier.rs
@@ -37,11 +37,6 @@ where
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
 
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
     fn selection<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
         problem: &MatmulProblem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_barrier.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_barrier.rs
@@ -42,15 +42,6 @@ where
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme.elements_in_stage_m();
-        let n_stage = selection.tiling_scheme.elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
-    }
-
     fn selection<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
         problem: &MatmulProblem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_barrier.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_barrier.rs
@@ -1,12 +1,10 @@
-use super::{
-    MatmulSelection, MultiRowStrategy, PlaneMatmulSelection, base, plane_matmul_selection,
-};
+use super::{MatmulSelection, MultiRowStrategy, base, plane_matmul_selection};
 use cubecl_core::{ir::Elem, prelude::*};
 use std::marker::PhantomData;
 
 use crate::components::{
     MatmulProblem,
-    batch::{self, CubeCountDispatch, CubeDispatch},
+    batch::{self, CubeDispatch},
     global::{self, load::AsyncFullLoadingStrategy},
     stage::{self, FullReaderFamily},
     tile,
@@ -26,7 +24,7 @@ impl<TMM, L, Dispatch> base::Algorithm for SimpleBarrierAlgorithm<TMM, L, Dispat
 where
     TMM: tile::TileMatmulFamily,
     L: AsyncFullLoadingStrategy,
-    Dispatch: CubeDispatch + CubeCountDispatch,
+    Dispatch: CubeDispatch,
 {
     type TileMatmul = TMM;
     type StageMatmul = stage::plane_matmul::PlaneMatmulFamily<
@@ -38,16 +36,15 @@ where
         global::single_stage::simple::SimpleBarrierMatmulFamily<Self::StageMatmul, L, L>;
 
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-    type MatmulSelection = PlaneMatmulSelection;
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme().partitions_in_stage_m();
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
+        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 
@@ -60,7 +57,7 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         plane_matmul_selection::<Self::TileMatmul, R>(
             client,
             problem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_tma.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_tma.rs
@@ -48,15 +48,6 @@ where
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme.elements_in_stage_m();
-        let n_stage = selection.tiling_scheme.elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
-    }
-
     fn selection<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
         problem: &MatmulProblem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_tma.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_tma.rs
@@ -43,11 +43,6 @@ where
         }
     }
 
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_planes = selection.tiling_scheme.partitions_in_stage_m();
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
     fn selection<R: Runtime>(
         client: &ComputeClient<R::Server, R::Channel>,
         problem: &MatmulProblem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_unit.rs
@@ -1,10 +1,10 @@
-use super::{MatmulSelection, UnitMatmulSelection, base, unit_matmul_selection};
+use super::{MatmulSelection, base, unit_matmul_selection};
 use cubecl_core::{ir::Elem, prelude::*};
 use std::marker::PhantomData;
 
 use crate::components::{
     MatmulLineSizes, MatmulProblem, MatrixLayout,
-    batch::{self, CubeCountDispatch, CubeDispatch},
+    batch::{self, CubeDispatch},
     global::{
         self,
         load::{SyncFullLoadingStrategy, sync_full_cyclic},
@@ -27,29 +27,28 @@ impl<LL, RL, Dispatch> base::Algorithm for SimpleUnitAlgorithm<LL, RL, Dispatch>
 where
     LL: SyncFullLoadingStrategy,
     RL: SyncFullLoadingStrategy,
-    Dispatch: CubeDispatch + CubeCountDispatch,
+    Dispatch: CubeDispatch,
 {
     type TileMatmul = tile::register_matmul::RegisterMatmul;
     type StageMatmul = stage::unit_matmul::UnitMatmulFamily<Self::TileMatmul, FullReaderFamily>;
     type GlobalMatmul = global::single_stage::simple::SimpleMatmulFamily<Self::StageMatmul, LL, RL>;
     type BatchMatmul = batch::one_to_one::OneToOneMatmulFamily<Self::GlobalMatmul, Dispatch>;
-    type MatmulSelection = UnitMatmulSelection;
 
     fn line_sizes(
         problem: &MatmulProblem,
         in_available: impl Iterator<Item = u8> + Clone,
         out_available: impl Iterator<Item = u8> + Clone,
-        selection: &Self::MatmulSelection,
+        selection: &MatmulSelection,
     ) -> MatmulLineSizes {
         let max_lhs = match problem.lhs_layout {
-            MatrixLayout::RowMajor => selection.tiling_scheme().elements_in_tile_k(),
-            MatrixLayout::ColMajor => selection.tiling_scheme().elements_in_tile_m(),
+            MatrixLayout::RowMajor => selection.tiling_scheme.elements_in_tile_k(),
+            MatrixLayout::ColMajor => selection.tiling_scheme.elements_in_tile_m(),
         };
         let max_rhs = match problem.rhs_layout {
-            MatrixLayout::RowMajor => selection.tiling_scheme().elements_in_tile_n(),
-            MatrixLayout::ColMajor => selection.tiling_scheme().elements_in_tile_k(),
+            MatrixLayout::RowMajor => selection.tiling_scheme.elements_in_tile_n(),
+            MatrixLayout::ColMajor => selection.tiling_scheme.elements_in_tile_k(),
         };
-        let max_out = selection.tiling_scheme().elements_in_tile_n();
+        let max_out = selection.tiling_scheme.elements_in_tile_n();
 
         MatmulLineSizes {
             lhs: MatmulLineSizes::maximize_lhs(
@@ -69,16 +68,16 @@ where
         }
     }
 
-    fn cube_dim(selection: &Self::MatmulSelection) -> CubeDim {
-        let num_units_needed = selection.tiling_scheme().partitions_in_stage_mn();
+    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
+        let num_units_needed = selection.tiling_scheme.partitions_in_stage_mn();
         let num_planes = num_units_needed.div_ceil(selection.plane_dim);
 
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &Self::MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme().elements_in_stage_m();
-        let n_stage = selection.tiling_scheme().elements_in_stage_n();
+    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
+        let m_stage = selection.tiling_scheme.elements_in_stage_m();
+        let n_stage = selection.tiling_scheme.elements_in_stage_n();
         let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
         let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
 
@@ -91,7 +90,7 @@ where
         plane_dim: u32,
         _elem_stage: Elem,
         _elem_acc: Elem,
-    ) -> Self::MatmulSelection {
+    ) -> MatmulSelection {
         unit_matmul_selection(problem, plane_dim)
     }
 

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_unit.rs
@@ -75,15 +75,6 @@ where
         CubeDim::new(selection.plane_dim, num_planes, 1)
     }
 
-    fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
-        let m_stage = selection.tiling_scheme.elements_in_stage_m();
-        let n_stage = selection.tiling_scheme.elements_in_stage_n();
-        let cubes_for_m = (problem.m as u32 + m_stage - 1) / m_stage;
-        let cubes_for_n = (problem.n as u32 + n_stage - 1) / n_stage;
-
-        Dispatch::cube_count(cubes_for_m, cubes_for_n, problem.num_batches() as u32)
-    }
-
     fn selection<R: Runtime>(
         _client: &ComputeClient<R::Server, R::Channel>,
         problem: &MatmulProblem,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_unit.rs
@@ -68,13 +68,6 @@ where
         }
     }
 
-    fn cube_dim(selection: &MatmulSelection) -> CubeDim {
-        let num_units_needed = selection.tiling_scheme.partitions_in_stage_mn();
-        let num_planes = num_units_needed.div_ceil(selection.plane_dim);
-
-        CubeDim::new(selection.plane_dim, num_planes, 1)
-    }
-
     fn selection<R: Runtime>(
         _client: &ComputeClient<R::Server, R::Channel>,
         problem: &MatmulProblem,

--- a/crates/cubecl-matmul/src/kernels/matmul/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/base.rs
@@ -3,6 +3,7 @@ use crate::components::{
     MatmulProblem, MatmulSpec, MatrixLayout, OutputRuntimeArg, ReplaceES,
 };
 use crate::components::{global::args::TensorMapArgs, tile::TileMatmulFamily};
+use crate::kernels::matmul::MatmulSelection;
 use crate::kernels::{MatmulAvailabilityError, MatmulLaunchError};
 use core::any::TypeId;
 use cubecl_core::{Feature, prelude::*};
@@ -286,7 +287,7 @@ pub fn matmul_cube_preparation<'a, MS: MatmulSpec, R: Runtime, A: Algorithm>(
     problem: MatmulProblem,
     line_sizes: &MatmulLineSizes,
     config_input: <A::BatchMatmul as MatmulConfigFactory>::Input,
-    selection: A::MatmulSelection,
+    selection: MatmulSelection,
 ) -> Result<(), MatmulLaunchError> {
     let cube_dim = A::cube_dim(&selection);
     let cube_count = A::cube_count(&selection, &problem);

--- a/crates/cubecl-matmul/src/kernels/matmul/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/base.rs
@@ -289,7 +289,7 @@ pub fn matmul_cube_preparation<'a, MS: MatmulSpec, R: Runtime, A: Algorithm>(
     config_input: <A::BatchMatmul as MatmulConfigFactory>::Input,
     selection: MatmulSelection,
 ) -> Result<(), MatmulLaunchError> {
-    let cube_dim = A::cube_dim(&selection);
+    let cube_dim = A::cube_dim(&selection)?;
     let cube_count = A::cube_count(&selection, &problem);
 
     launch_matmul::<MS, R, A>(

--- a/crates/cubecl-matmul/src/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-matmul/src/tests/cmma_matmul/matmul_test_launcher.rs
@@ -54,7 +54,19 @@ pub fn test_matmul_algorithm<A, P, R>(
         &selection,
     );
 
-    let cube_dim = A::cube_dim(&selection);
+    let cube_dim = match A::cube_dim(&selection) {
+        Ok(cube_dim) => cube_dim,
+        Err(err) => {
+            let msg = format!("Can't launch the test: {err}");
+            if panic_on_launch_err {
+                panic!("{msg}");
+            } else {
+                println!("{msg}");
+                return;
+            }
+        }
+    };
+
     let cube_count = A::cube_count(&selection, &problem);
 
     let config = match A::make_config(

--- a/crates/cubecl-matmul/src/tests/cmma_matmul/matmul_test_launcher.rs
+++ b/crates/cubecl-matmul/src/tests/cmma_matmul/matmul_test_launcher.rs
@@ -7,7 +7,7 @@ use crate::components::MatmulLaunch;
 use crate::components::MatmulProblem;
 use crate::components::MatrixLayout;
 use crate::components::global::args::TensorInputsLaunch;
-use crate::kernels::matmul::Algorithm;
+use crate::kernels::matmul::{Algorithm, MatmulSelection};
 use crate::tests::test_utils::Sample;
 use crate::tests::test_utils::TestPrecision;
 
@@ -27,7 +27,7 @@ pub fn test_matmul_algorithm<A, P, R>(
     client: ComputeClient<R::Server, R::Channel>,
     problem: MatmulProblem,
     input: <A::BatchMatmul as MatmulConfigFactory>::Input,
-    selection: A::MatmulSelection,
+    selection: MatmulSelection,
 ) where
     A: Algorithm,
     P: TestPrecision,

--- a/crates/cubecl-matmul/src/tests/cmma_matmul/tma_test_launcher.rs
+++ b/crates/cubecl-matmul/src/tests/cmma_matmul/tma_test_launcher.rs
@@ -51,7 +51,18 @@ pub fn test_tma_matmul_algorithm<A, P, R>(
         &selection,
     );
 
-    let cube_dim = A::cube_dim(&selection);
+    let cube_dim = match A::cube_dim(&selection) {
+        Ok(cube_dim) => cube_dim,
+        Err(err) => {
+            let msg = format!("Can't launch the test: {err}");
+            if panic_on_launch_err {
+                panic!("{msg}");
+            } else {
+                println!("{msg}");
+                return;
+            }
+        }
+    };
     let cube_count = A::cube_count(&selection, &problem);
 
     let config = match A::make_config(

--- a/crates/cubecl-matmul/src/tests/cmma_matmul/tma_test_launcher.rs
+++ b/crates/cubecl-matmul/src/tests/cmma_matmul/tma_test_launcher.rs
@@ -12,6 +12,7 @@ use crate::components::{
     global::args::{ConcreteInputsFactory, TensorMapInputs},
 };
 use crate::kernels::matmul::Algorithm;
+use crate::kernels::matmul::MatmulSelection;
 use crate::tests::test_utils::Sample;
 use crate::tests::test_utils::TestPrecision;
 
@@ -23,7 +24,7 @@ pub fn test_tma_matmul_algorithm<A, P, R>(
     client: ComputeClient<R::Server, R::Channel>,
     problem: MatmulProblem,
     input: <A::BatchMatmul as MatmulConfigFactory>::Input,
-    selection: A::MatmulSelection,
+    selection: MatmulSelection,
 ) where
     A: Algorithm,
     P: TestPrecision,

--- a/crates/cubecl-matmul/src/tests/test_macros/suite/plane_accelerated/launch.rs
+++ b/crates/cubecl-matmul/src/tests/test_macros/suite/plane_accelerated/launch.rs
@@ -1,15 +1,11 @@
 use crate::components::{MatmulProblem, MatrixLayout, PartitionSize, StageSize, TileSize};
 use crate::components::{MatmulProblemSize, TilingScheme};
-use crate::kernels::matmul::{Algorithm, PlaneMatmulSelection};
+use crate::kernels::matmul::{Algorithm, MatmulSelection};
 use crate::tests::cmma_matmul::matmul_test_launcher::test_matmul_algorithm;
 use crate::tests::test_utils::TestPrecision;
 use cubecl_core::Runtime;
 
-pub fn test_algo<
-    A: Algorithm<MatmulSelection = PlaneMatmulSelection>,
-    P: TestPrecision,
-    R: Runtime,
->(
+pub fn test_algo<A: Algorithm, P: TestPrecision, R: Runtime>(
     layouts: (MatrixLayout, MatrixLayout),
     tile_size: TileSize,
     tiles_per_partition: PartitionSize,
@@ -41,7 +37,7 @@ pub fn test_algo<
         .build()
         .unwrap();
 
-    let selection = PlaneMatmulSelection {
+    let selection = MatmulSelection {
         tiling_scheme: tiling_scheme.clone(),
         plane_dim,
     };

--- a/crates/cubecl-matmul/src/tests/test_macros/suite/tma/launch.rs
+++ b/crates/cubecl-matmul/src/tests/test_macros/suite/tma/launch.rs
@@ -1,15 +1,11 @@
 use crate::components::{MatmulProblem, MatrixLayout, PartitionSize, StageSize, TileSize};
 use crate::components::{MatmulProblemSize, TilingScheme};
-use crate::kernels::matmul::{Algorithm, PlaneMatmulSelection};
+use crate::kernels::matmul::{Algorithm, MatmulSelection};
 use crate::tests::cmma_matmul::tma_test_launcher::test_tma_matmul_algorithm;
 use crate::tests::test_utils::TestPrecision;
 use cubecl_core::Runtime;
 
-pub fn test_algo<
-    A: Algorithm<MatmulSelection = PlaneMatmulSelection>,
-    P: TestPrecision,
-    R: Runtime,
->(
+pub fn test_algo<A: Algorithm, P: TestPrecision, R: Runtime>(
     layouts: (MatrixLayout, MatrixLayout),
     tile_size: TileSize,
     partition_size: PartitionSize,
@@ -41,7 +37,7 @@ pub fn test_algo<
         .build()
         .unwrap();
 
-    let selection = PlaneMatmulSelection {
+    let selection = MatmulSelection {
         tiling_scheme: tiling_scheme.clone(),
         plane_dim,
     };

--- a/crates/cubecl-matmul/src/tests/test_macros/suite/unit/launch.rs
+++ b/crates/cubecl-matmul/src/tests/test_macros/suite/unit/launch.rs
@@ -1,15 +1,11 @@
 use crate::components::{MatmulProblem, MatrixLayout, PartitionSize, StageSize, TileSize};
 use crate::components::{MatmulProblemSize, TilingScheme};
-use crate::kernels::matmul::{Algorithm, UnitMatmulSelection};
+use crate::kernels::matmul::{Algorithm, MatmulSelection};
 use crate::tests::cmma_matmul::matmul_test_launcher::test_matmul_algorithm;
 use crate::tests::test_utils::TestPrecision;
 use cubecl_core::Runtime;
 
-pub fn test_algo<
-    A: Algorithm<MatmulSelection = UnitMatmulSelection>,
-    P: TestPrecision,
-    R: Runtime,
->(
+pub fn test_algo<A: Algorithm, P: TestPrecision, R: Runtime>(
     layouts: (MatrixLayout, MatrixLayout),
     tile_size: TileSize,
     partition_size: PartitionSize,
@@ -41,7 +37,7 @@ pub fn test_algo<
         .build()
         .unwrap();
 
-    let selection = UnitMatmulSelection {
+    let selection = MatmulSelection {
         plane_dim,
         tiling_scheme: tiling_scheme.clone(),
     };


### PR DESCRIPTION
Instead of having the Algorithm choose its CubeDim and CubeCount and "hope" that the inner matmul levels work with these, have the inner matmul level specify their resource needs. 

Also, introduce the concept of GlobalPartition as part of the TilingScheme, because now the selector decides if it will perform a one_to_many batch matmul. 

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
