### PR TITLE
Matmul: specialized double buffering

### DIFF
--- a/crates/cubecl-convolution/src/algorithm/mod.rs
+++ b/crates/cubecl-convolution/src/algorithm/mod.rs
@@ -1,6 +1,6 @@
 use cubecl_matmul::{
     components::{
-        InputIdent, InvalidConfigError, LoadingPlaneCount, MatmulLineSizes, MatmulPrecision,
+        InputIdent, InvalidConfigError, LoadOnlyRoleConfig, MatmulLineSizes, MatmulPrecision,
         global::{args::MatmulArgs, load::LoaderMode},
         stage::{NumStages, PartitionBuffering, StageMatmulFamily, StageVectorization},
         tile::TileMatmulFamily,
@@ -73,8 +73,8 @@ pub trait Algorithm {
         LoaderMode::Relaxed
     }
 
-    fn loading_plane_count() -> LoadingPlaneCount {
-        LoadingPlaneCount::default()
+    fn loading_plane_count() -> LoadOnlyRoleConfig {
+        LoadOnlyRoleConfig::default()
     }
 
     fn partition_buffering_strategy() -> PartitionBuffering {

--- a/crates/cubecl-convolution/src/algorithm/mod.rs
+++ b/crates/cubecl-convolution/src/algorithm/mod.rs
@@ -1,6 +1,6 @@
 use cubecl_matmul::{
     components::{
-        InputIdent, InvalidConfigError, LoadOnlyRoleConfig, MatmulLineSizes, MatmulPrecision,
+        InputIdent, InvalidConfigError, LoadSpecializationConfig, MatmulLineSizes, MatmulPrecision,
         global::{args::MatmulArgs, load::LoaderMode},
         stage::{NumStages, PartitionBuffering, StageMatmulFamily, StageVectorization},
         tile::TileMatmulFamily,
@@ -52,7 +52,7 @@ pub trait Algorithm {
                 partition_buffering,
                 stage_vectorization,
                 num_stages: Self::num_stages(),
-                loading_plane_count: Self::loading_plane_count(),
+                load_specialization: Self::load_specialization(),
             },
             loading_precompute_strategy: Self::loading_precompute_strategy(),
             loader_mode: Self::loader_mode(),
@@ -73,8 +73,8 @@ pub trait Algorithm {
         LoaderMode::Relaxed
     }
 
-    fn loading_plane_count() -> LoadOnlyRoleConfig {
-        LoadOnlyRoleConfig::None
+    fn load_specialization() -> LoadSpecializationConfig {
+        LoadSpecializationConfig::None
     }
 
     fn partition_buffering_strategy() -> PartitionBuffering {

--- a/crates/cubecl-convolution/src/algorithm/mod.rs
+++ b/crates/cubecl-convolution/src/algorithm/mod.rs
@@ -74,7 +74,7 @@ pub trait Algorithm {
     }
 
     fn loading_plane_count() -> LoadOnlyRoleConfig {
-        LoadOnlyRoleConfig::default()
+        LoadOnlyRoleConfig::None
     }
 
     fn partition_buffering_strategy() -> PartitionBuffering {

--- a/crates/cubecl-convolution/src/homogeneous/base.rs
+++ b/crates/cubecl-convolution/src/homogeneous/base.rs
@@ -95,7 +95,7 @@ pub mod config {
     use cubecl_matmul::components::{
         InputIdent, MatmulConfig, MatrixLayout, TilingScheme,
         global::{
-            GlobalConfig, LoadingSets, PlaneRoleConfig, load::LoaderMode,
+            GlobalConfig, SpecializedLoadingSides, PlaneRoleConfig, load::LoaderMode,
             multi_stage::EventLoadingMode,
         },
     };
@@ -180,8 +180,8 @@ pub mod config {
             self.matmul.plane_role_config()
         }
 
-        fn loading_sets(&self) -> LoadingSets {
-            self.matmul.loading_sets()
+        fn specialized_loading_sides(&self) -> SpecializedLoadingSides {
+            self.matmul.specialized_loading_sides()
         }
     }
 

--- a/crates/cubecl-convolution/src/homogeneous/base.rs
+++ b/crates/cubecl-convolution/src/homogeneous/base.rs
@@ -94,7 +94,10 @@ pub mod config {
     use crate::{ConvGemmConfig, base::Dimensionality};
     use cubecl_matmul::components::{
         InputIdent, MatmulConfig, MatrixLayout, TilingScheme,
-        global::{GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode},
+        global::{
+            GlobalConfig, LoadingSets, PlaneRoleConfig, load::LoaderMode,
+            multi_stage::EventLoadingMode,
+        },
     };
 
     use super::*;
@@ -133,8 +136,8 @@ pub mod config {
             self.matmul.matrix_layout(ident)
         }
 
-        fn num_loading_planes(&self) -> u32 {
-            self.matmul.num_loading_planes()
+        fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32 {
+            self.matmul.num_loading_planes(ident)
         }
 
         fn plane_dim(&self) -> u32 {
@@ -175,6 +178,10 @@ pub mod config {
 
         fn plane_role_config(&self) -> PlaneRoleConfig {
             self.matmul.plane_role_config()
+        }
+
+        fn loading_sets(&self) -> LoadingSets {
+            self.matmul.loading_sets()
         }
     }
 

--- a/crates/cubecl-convolution/src/homogeneous/base.rs
+++ b/crates/cubecl-convolution/src/homogeneous/base.rs
@@ -95,7 +95,7 @@ pub mod config {
     use cubecl_matmul::components::{
         InputIdent, MatmulConfig, MatrixLayout, TilingScheme,
         global::{
-            GlobalConfig, SpecializerConfig, load::LoaderMode, multi_stage::EventLoadingMode,
+            GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode,
         },
     };
 
@@ -175,8 +175,8 @@ pub mod config {
             self.matmul.event_loading_mode(ident)
         }
 
-        fn specializer_config(&self) -> SpecializerConfig {
-            self.matmul.specializer_config()
+        fn plane_role_config(&self) -> PlaneRoleConfig {
+            self.matmul.plane_role_config()
         }
     }
 

--- a/crates/cubecl-convolution/src/homogeneous/base.rs
+++ b/crates/cubecl-convolution/src/homogeneous/base.rs
@@ -94,9 +94,7 @@ pub mod config {
     use crate::{ConvGemmConfig, base::Dimensionality};
     use cubecl_matmul::components::{
         InputIdent, MatmulConfig, MatrixLayout, TilingScheme,
-        global::{
-            GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode,
-        },
+        global::{GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode},
     };
 
     use super::*;

--- a/crates/cubecl-convolution/src/homogeneous/base.rs
+++ b/crates/cubecl-convolution/src/homogeneous/base.rs
@@ -95,7 +95,7 @@ pub mod config {
     use cubecl_matmul::components::{
         InputIdent, MatmulConfig, MatrixLayout, TilingScheme,
         global::{
-            GlobalConfig, SpecializedLoadingSides, PlaneRoleConfig, load::LoaderMode,
+            GlobalConfig, PlaneRoleConfig, SpecializedLoadingSides, load::LoaderMode,
             multi_stage::EventLoadingMode,
         },
     };

--- a/crates/cubecl-convolution/src/homogeneous/multi_stage_tma.rs
+++ b/crates/cubecl-convolution/src/homogeneous/multi_stage_tma.rs
@@ -292,7 +292,7 @@ where
         let num_stages = num_stages::<R, MP>(
             client,
             problem,
-            stage_config.num_compute_planes(),
+            stage_config.num_main_flow_planes(),
             &stage_config.tiling_scheme(),
         );
 

--- a/crates/cubecl-convolution/src/loader/im2col.rs
+++ b/crates/cubecl-convolution/src/loader/im2col.rs
@@ -87,7 +87,7 @@ impl SimpleIm2col {
         let line_size = config.global_line_size(ident);
 
         let num_stage_elements = config.tiling_scheme().elements_in_stage(ident);
-        let total_units = comptime!(config.num_loading_planes() * config.plane_dim());
+        let total_units = comptime!(config.num_loading_planes(ident) * config.plane_dim());
         let jump_length = comptime!(total_units * line_size);
         let num_loads_per_unit = num_stage_elements / jump_length;
 

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -6,7 +6,9 @@ use crate::{
         Ident, InputIdent, InvalidConfigError, LoadSpecializationConfig, MatmulConfigFactory,
         MatmulPrecision, MatrixLayout, TilingScheme,
         config::MatmulConfig,
-        global::{LoadingSets, PlaneRoleConfig, multi_stage::EventLoadingMode},
+        global::{
+            PlaneRoleConfig, RoleRuleConfig, SpecializedLoadingSides, multi_stage::EventLoadingMode,
+        },
         stage::{self, StageConfig},
     },
     kernels::matmul::MatmulSelection,
@@ -130,7 +132,10 @@ pub trait GlobalConfig: MatmulConfig {
 
     fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32;
     fn plane_role_config(&self) -> PlaneRoleConfig;
-    fn loading_sets(&self) -> LoadingSets;
+    fn specialized_loading_sides(&self) -> SpecializedLoadingSides;
+    fn role_rule_config(&self) -> RoleRuleConfig {
+        self.plane_role_config().rule
+    }
 
     /// Returns the size of the plane dimension
     fn plane_dim(&self) -> u32;

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -6,8 +6,7 @@ use crate::{
         Ident, InputIdent, InvalidConfigError, LoadSpecializationConfig, MatmulConfigFactory,
         MatmulPrecision, MatrixLayout, TilingScheme,
         config::MatmulConfig,
-        global::PlaneRoleConfig,
-        global::multi_stage::EventLoadingMode,
+        global::{LoadingSets, PlaneRoleConfig, multi_stage::EventLoadingMode},
         stage::{self, StageConfig},
     },
     kernels::matmul::MatmulSelection,
@@ -129,8 +128,9 @@ pub trait GlobalConfig: MatmulConfig {
     /// Returns the [MatrixLayout] for the given ident
     fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout;
 
-    fn num_loading_planes(&self) -> u32;
+    fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32;
     fn plane_role_config(&self) -> PlaneRoleConfig;
+    fn loading_sets(&self) -> LoadingSets;
 
     /// Returns the size of the plane dimension
     fn plane_dim(&self) -> u32;

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 
 use crate::{
     components::{
-        Ident, InputIdent, InvalidConfigError, LoadingPlaneCount, MatmulConfigFactory,
+        Ident, InputIdent, InvalidConfigError, LoadOnlyRoleConfig, MatmulConfigFactory,
         MatmulPrecision, MatrixLayout, TilingScheme,
         config::MatmulConfig,
         global::SpecializerConfig,
@@ -27,7 +27,7 @@ pub trait GlobalMatmulFamily:
 
     fn cube_dim(
         selection: &MatmulSelection,
-        loading_plane_count: LoadingPlaneCount,
+        loading_plane_count: LoadOnlyRoleConfig,
     ) -> Result<CubeDim, InvalidConfigError>;
 }
 

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -3,10 +3,10 @@ use cubecl_core::prelude::*;
 
 use crate::{
     components::{
-        Ident, InputIdent, InvalidConfigError, LoadOnlyRoleConfig, MatmulConfigFactory,
+        Ident, InputIdent, InvalidConfigError, LoadSpecializationConfig, MatmulConfigFactory,
         MatmulPrecision, MatrixLayout, TilingScheme,
         config::MatmulConfig,
-        global::SpecializerConfig,
+        global::PlaneRoleConfig,
         global::multi_stage::EventLoadingMode,
         stage::{self, StageConfig},
     },
@@ -27,7 +27,7 @@ pub trait GlobalMatmulFamily:
 
     fn cube_dim(
         selection: &MatmulSelection,
-        loading_plane_count: LoadOnlyRoleConfig,
+        loading_plane_count: LoadSpecializationConfig,
     ) -> Result<CubeDim, InvalidConfigError>;
 }
 
@@ -130,7 +130,7 @@ pub trait GlobalConfig: MatmulConfig {
     fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout;
 
     fn num_loading_planes(&self) -> u32;
-    fn specializer_config(&self) -> SpecializerConfig;
+    fn plane_role_config(&self) -> PlaneRoleConfig;
 
     /// Returns the size of the plane dimension
     fn plane_dim(&self) -> u32;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_buffer_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_buffer_maximize_slice_length.rs
@@ -79,7 +79,7 @@ impl AsyncBufferLoadingStrategy for LoadingStrategy {
             }
         };
 
-        let unit_count = config.plane_dim() * config.num_loading_planes();
+        let unit_count = config.plane_dim() * config.num_loading_planes(input_ident);
         let num_tasks_per_unit = comptime!(num_slices.div_ceil(unit_count));
 
         Job {

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
@@ -22,7 +22,7 @@ pub struct LoadingStrategy<T: TilingOrder> {
 
 impl<T: TilingOrder> LoadingValidation for LoadingStrategy<T> {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
-        let total_units = config.num_loading_planes() * config.plane_dim();
+        let total_units = config.num_loading_planes(ident) * config.plane_dim();
         let num_slices = config.tiling_scheme().elements_in_tile_row(ident)
             * config.tiling_scheme().tiles_in_stage(ident);
 
@@ -45,7 +45,7 @@ impl<TO: TilingOrder> AsyncFullLoadingStrategy for LoadingStrategy<TO> {
         #[comptime] input_ident: InputIdent,
         #[comptime] config: G,
     ) -> Job {
-        let total_units = config.plane_dim() * config.num_loading_planes();
+        let total_units = config.plane_dim() * config.num_loading_planes(input_ident);
         let line_size = config.global_line_size(input_ident);
 
         let (num_slices_per_tile, slice_length_in_lines) = match config.matrix_layout(input_ident) {

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_slice_length.rs
@@ -39,7 +39,7 @@ impl AsyncFullLoadingStrategy for LoadingStrategy {
             MatrixLayout::RowMajor => config.tiling_scheme().elements_in_stage_row(input_ident),
             MatrixLayout::ColMajor => config.tiling_scheme().elements_in_stage_col(input_ident),
         };
-        let unit_count = config.plane_dim() * config.num_loading_planes();
+        let unit_count = config.plane_dim() * config.num_loading_planes(input_ident);
 
         let num_tasks_per_unit = comptime!(div_ceil(num_slices, unit_count));
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
@@ -32,7 +32,7 @@ impl LoadingValidation for LoadingStrategy {
                 config.tiling_scheme().elements_in_stage_row(ident) / line_size,
             ),
         };
-        let unit_count = config.plane_dim() * config.num_loading_planes();
+        let unit_count = config.plane_dim() * config.num_loading_planes(ident);
 
         if unit_count % num_slices != 0 {
             return Err(Box::new(
@@ -72,7 +72,7 @@ impl AsyncFullLoadingStrategy for LoadingStrategy {
             ),
         };
 
-        let unit_count = config.plane_dim() * config.num_loading_planes();
+        let unit_count = config.plane_dim() * config.num_loading_planes(input_ident);
 
         let units_per_slice = comptime!(unit_count / num_slices);
         let nth_slice = UNIT_POS / units_per_slice;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_cyclic.rs
@@ -27,7 +27,7 @@ impl<TO: TilingOrder> LoadingValidation for LoadingStrategy<TO> {
             let num_tiles_in_buffer = config.tiling_scheme().tiles_in_stage(ident);
             let total_num_lines = num_tiles_in_buffer * num_lines_per_tile;
 
-            let total_units = config.plane_dim() * config.num_loading_planes();
+            let total_units = config.plane_dim() * config.num_loading_planes(ident);
             let jump_length = total_units * line_size;
             let num_tasks_per_unit = total_num_lines.div_ceil(total_units);
 
@@ -65,7 +65,7 @@ impl<TO: TilingOrder> SyncBufferLoadingStrategy for LoadingStrategy<TO> {
         let tile_count_col = config.tiling_scheme().tiles_in_stage_col(input_ident);
 
         let num_lines_per_tile = tile_size / line_size;
-        let total_units = config.plane_dim() * config.num_loading_planes();
+        let total_units = config.plane_dim() * config.num_loading_planes(input_ident);
         let jump_length = total_units * line_size;
 
         let num_tiles_in_buffer = tile_count_row * tile_count_col;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_cyclic.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::components::global::load::SyncBufferLoadingStrategy;
 use crate::components::global::tensor_view::TensorReader;
-use crate::components::global::{GlobalConfig, Quantization};
+use crate::components::global::{GlobalConfig, Quantization, RoleRule};
 use crate::components::stage::{ContiguousTilingLayout, StageMemory, TilingOrder};
 use crate::components::{Ident, InputIdent, InvalidConfigError, MatmulPrecision};
 use cubecl_core as cubecl;
@@ -73,7 +73,10 @@ impl<TO: TilingOrder> SyncBufferLoadingStrategy for LoadingStrategy<TO> {
         let num_tasks_per_unit = total_num_lines.div_ceil(total_units);
         let balanced_workload = num_tasks_per_unit % total_units == 0;
 
-        let unit_id = UNIT_POS_Y * config.plane_dim() + UNIT_POS_X;
+        let unit_id = RoleRule::new(config.role_rule_config())
+            .load_index(input_ident, config.specialized_loading_sides())
+            * config.plane_dim()
+            + UNIT_POS_X;
         let unit_position_base = unit_id * line_size;
 
         Job {

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_tilewise.rs
@@ -31,7 +31,7 @@ pub struct LoadingStrategy<T: TilingOrder> {
 impl<T: TilingOrder> LoadingValidation for LoadingStrategy<T> {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
         let line_size = config.global_line_size(ident);
-        let num_planes = config.num_loading_planes();
+        let num_planes = config.num_loading_planes(ident);
         let num_tiles = config.tiling_scheme().tiles_in_stage(ident);
 
         if num_tiles % num_planes != 0 {
@@ -73,7 +73,7 @@ impl<TO: TilingOrder> SyncBufferLoadingStrategy for LoadingStrategy<TO> {
         #[comptime] config: G,
     ) -> Job {
         let line_size = config.global_line_size(input_ident);
-        let num_planes = config.num_loading_planes();
+        let num_planes = config.num_loading_planes(input_ident);
         let num_tiles = config.tiling_scheme().tiles_in_stage(input_ident);
         let plane_dim = config.plane_dim();
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_tilewise.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::components::global::Quantization;
+use crate::components::global::{Quantization, RoleRule};
 use crate::components::global::load::SyncBufferLoadingStrategy;
 use crate::components::{
     FormattedConfigError, Ident, InputIdent, InvalidConfigError, MatmulPrecision,
@@ -91,7 +91,9 @@ impl<TO: TilingOrder> SyncBufferLoadingStrategy for LoadingStrategy<TO> {
         let row_col_stride = num_stages * stage_width;
         let buffer_offset = stage_width * buffer_index;
 
-        let starting_tile_within_stage = UNIT_POS_Y * num_tiles_per_plane;
+        let starting_tile_within_stage = RoleRule::new(config.role_rule_config())
+            .load_index(input_ident, config.specialized_loading_sides())
+            * num_tiles_per_plane;
         let row_col_index = starting_tile_within_stage / stage_width;
         let inner_offset = starting_tile_within_stage % stage_width;
         let num_tiles_to_skip = row_col_index * row_col_stride + inner_offset + buffer_offset;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_buffer_tilewise.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
-use crate::components::global::{Quantization, RoleRule};
 use crate::components::global::load::SyncBufferLoadingStrategy;
+use crate::components::global::{Quantization, RoleRule};
 use crate::components::{
     FormattedConfigError, Ident, InputIdent, InvalidConfigError, MatmulPrecision,
 };

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_cyclic.rs
@@ -26,7 +26,7 @@ impl<TO: TilingOrder> LoadingValidation for LoadingStrategy<TO> {
             let line_size = config.global_line_size(ident);
 
             let num_stage_lines = config.tiling_scheme().elements_in_stage(ident) / line_size;
-            let total_units = config.num_loading_planes() * config.plane_dim();
+            let total_units = config.num_loading_planes(ident) * config.plane_dim();
 
             if num_stage_lines % total_units != 0 {
                 return Err(Box::new(
@@ -52,7 +52,7 @@ impl<TO: TilingOrder> SyncFullLoadingStrategy for LoadingStrategy<TO> {
         let tile_num_elements = config.tiling_scheme().elements_in_tile(input_ident);
         let line_size = config.global_line_size(input_ident);
         let num_stage_elements = config.tiling_scheme().elements_in_stage(input_ident);
-        let total_units = comptime!(config.num_loading_planes() * config.plane_dim());
+        let total_units = comptime!(config.num_loading_planes(input_ident) * config.plane_dim());
         let jump_length = comptime!(total_units * line_size);
         let num_tasks_per_unit = comptime!(num_stage_elements.div_ceil(jump_length));
         let balanced_workload = num_tasks_per_unit % total_units == 0;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_ordered.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_ordered.rs
@@ -1,3 +1,4 @@
+use crate::components::global::RoleRule;
 use crate::components::global::load::SyncFullLoadingStrategy;
 use crate::components::stage::OrderedTilingOrder;
 use crate::components::{
@@ -90,7 +91,9 @@ impl SyncFullLoadingStrategy for LoadingStrategy {
         let num_lines_per_plane = num_lines_per_tile * num_tiles_per_plane;
         let num_lines_per_unit = num_lines_per_plane / plane_dim;
 
-        let num_tiles_to_skip = UNIT_POS_Y * num_tiles_per_plane;
+        let num_tiles_to_skip = RoleRule::new(config.role_rule_config())
+            .load_index(input_ident, config.specialized_loading_sides())
+            * num_tiles_per_plane;
         let num_lines_to_skip = num_tiles_to_skip * num_lines_per_tile;
 
         // Ordered is just a tilewise loader using the ordered tiling order

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_ordered.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_ordered.rs
@@ -29,7 +29,7 @@ impl LoadingValidation for LoadingStrategy {
         }
 
         let line_size = config.global_line_size(ident);
-        let num_planes = config.num_loading_planes();
+        let num_planes = config.num_loading_planes(ident);
         let num_tiles = config.tiling_scheme().tiles_in_stage(ident);
 
         if num_tiles % num_planes != 0 {
@@ -44,7 +44,7 @@ impl LoadingValidation for LoadingStrategy {
         let num_lines_per_tile =
             comptime!(config.tiling_scheme().elements_in_tile(ident) / line_size);
         let num_lines_per_plane = num_lines_per_tile * num_tiles_per_plane;
-        let num_planes = config.num_loading_planes();
+        let num_planes = config.num_loading_planes(ident);
         let plane_dim = config.plane_dim();
         let rows_per_plane = config.tiling_scheme().tiles_in_stage_row(ident) / num_planes;
 
@@ -80,7 +80,7 @@ impl SyncFullLoadingStrategy for LoadingStrategy {
         #[comptime] config: G,
     ) -> Self::Job<MP> {
         let line_size = config.global_line_size(input_ident);
-        let num_planes = config.num_loading_planes();
+        let num_planes = config.num_loading_planes(input_ident);
         let num_tiles = config.tiling_scheme().tiles_in_stage(input_ident);
         let plane_dim = config.plane_dim();
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_strided.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_strided.rs
@@ -1,7 +1,7 @@
 use crate::components::MatmulPrecision;
 use crate::components::global::load::SyncFullLoadingStrategy;
 use crate::components::global::tensor_view::TensorReader;
-use crate::components::global::{GlobalConfig, Quantization};
+use crate::components::global::{GlobalConfig, Quantization, RoleRule};
 use crate::components::stage::{StageMemory, StridedTilingLayout};
 use crate::components::{Ident, InputIdent, InvalidConfigError};
 use cubecl_core as cubecl;
@@ -47,7 +47,10 @@ impl SyncFullLoadingStrategy for LoadingStrategy {
         let unit_count = config.num_loading_planes(input_ident) * config.plane_dim();
         let num_tasks_per_unit = comptime!(num_stage_lines / unit_count);
 
-        let unit_position_base = UNIT_POS_Y * config.plane_dim() + UNIT_POS_X;
+        let unit_position_base = RoleRule::new(config.role_rule_config())
+            .load_index(input_ident, config.specialized_loading_sides())
+            * config.plane_dim()
+            + UNIT_POS_X;
 
         Job {
             unit_position_base,

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_strided.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_strided.rs
@@ -20,7 +20,7 @@ impl LoadingValidation for LoadingStrategy {
         let line_size = config.global_line_size(ident);
 
         let num_stage_lines = config.tiling_scheme().elements_in_stage(ident) / line_size;
-        let total_units = config.num_loading_planes() * config.plane_dim();
+        let total_units = config.num_loading_planes(ident) * config.plane_dim();
 
         if num_stage_lines % total_units != 0 {
             return Err(Box::new(
@@ -44,7 +44,7 @@ impl SyncFullLoadingStrategy for LoadingStrategy {
     ) -> Self::Job<MP> {
         let line_size = config.global_line_size(input_ident);
         let num_stage_lines = config.tiling_scheme().elements_in_stage(input_ident) / line_size;
-        let unit_count = config.num_loading_planes() * config.plane_dim();
+        let unit_count = config.num_loading_planes(input_ident) * config.plane_dim();
         let num_tasks_per_unit = comptime!(num_stage_lines / unit_count);
 
         let unit_position_base = UNIT_POS_Y * config.plane_dim() + UNIT_POS_X;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_tilewise.rs
@@ -32,7 +32,7 @@ pub struct LoadingStrategy<T: TilingOrder> {
 impl<T: TilingOrder> LoadingValidation for LoadingStrategy<T> {
     fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
         let line_size = config.global_line_size(ident);
-        let num_planes = config.num_loading_planes();
+        let num_planes = config.num_loading_planes(ident);
         let num_tiles = config.tiling_scheme().tiles_in_stage(ident);
 
         if num_tiles % num_planes != 0 {
@@ -71,7 +71,7 @@ impl<TO: TilingOrder> SyncFullLoadingStrategy for LoadingStrategy<TO> {
         #[comptime] config: G,
     ) -> Self::Job<MP> {
         let line_size = config.global_line_size(input_ident);
-        let num_planes = config.num_loading_planes();
+        let num_planes = config.num_loading_planes(input_ident);
         let num_tiles = config.tiling_scheme().tiles_in_stage(input_ident);
         let plane_dim = config.plane_dim();
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_tilewise.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
-use crate::components::global::Quantization;
 use crate::components::global::load::SyncFullLoadingStrategy;
+use crate::components::global::{Quantization, RoleRule};
 use crate::components::{
     FormattedConfigError, Ident, InputIdent, InvalidConfigError, MatmulPrecision,
 };
@@ -81,7 +81,9 @@ impl<TO: TilingOrder> SyncFullLoadingStrategy for LoadingStrategy<TO> {
         let num_lines_per_plane = num_lines_per_tile * num_tiles_per_plane;
         let num_lines_per_unit = num_lines_per_plane / plane_dim;
 
-        let num_tiles_to_skip = UNIT_POS_Y * num_tiles_per_plane;
+        let num_tiles_to_skip = RoleRule::new(config.role_rule_config())
+            .load_index(input_ident, config.specialized_loading_sides())
+            * num_tiles_per_plane;
         let num_lines_to_skip = num_tiles_to_skip * num_lines_per_tile;
 
         Job {

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -2,7 +2,7 @@ use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
         global::{
-            GlobalConfig, SpecializerConfig, load::LoaderMode, multi_stage::EventLoadingMode,
+            GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode,
         },
         stage::{self},
     },
@@ -90,11 +90,11 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
     }
 
     fn num_loading_planes(&self) -> u32 {
-        self.stage_config.specializer_config().loader_count()
+        self.stage_config.plane_role_config().loader_count()
     }
 
-    fn specializer_config(&self) -> SpecializerConfig {
-        self.stage_config.specializer_config()
+    fn plane_role_config(&self) -> PlaneRoleConfig {
+        self.stage_config.plane_role_config()
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -2,7 +2,7 @@ use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
         global::{
-            GlobalConfig, LoadingSet, LoadingSets, PlaneRoleConfig, load::LoaderMode,
+            GlobalConfig, LoadingSides, SpecializedLoadingSides, PlaneRoleConfig, load::LoaderMode,
             multi_stage::EventLoadingMode,
         },
         stage::{self},
@@ -95,18 +95,17 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
     }
 
     fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32 {
-        self.loading_sets().num_loading_planes(
+        self.specialized_loading_sides().num_loading_planes(
             self.plane_role_config().has_specialization(),
             ident.into().as_input_ident(),
             self.plane_role_config().plane_roles,
         )
     }
 
-    fn loading_sets(&self) -> LoadingSets {
-        LoadingSets {
-            specialized_main_flow: LoadingSet::Full,
-            specialized_load_only: LoadingSet::Full,
-            no_specialization: LoadingSet::Full,
+    fn specialized_loading_sides(&self) -> SpecializedLoadingSides {
+        SpecializedLoadingSides {
+            main_flow: LoadingSides::Both,
+            load_only: LoadingSides::Both,
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -1,7 +1,10 @@
 use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
-        global::{GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode},
+        global::{
+            GlobalConfig, LoadingSet, LoadingSets, PlaneRoleConfig, load::LoaderMode,
+            multi_stage::EventLoadingMode,
+        },
         stage::{self},
     },
     kernels::matmul::LoadingPrecomputeStrategy,
@@ -87,12 +90,24 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
         EventLoadingMode::Relaxed
     }
 
-    fn num_loading_planes(&self) -> u32 {
-        self.stage_config.plane_role_config().loader_count()
-    }
-
     fn plane_role_config(&self) -> PlaneRoleConfig {
         self.stage_config.plane_role_config()
+    }
+
+    fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32 {
+        self.loading_sets().num_loading_planes(
+            self.plane_role_config().has_specialization(),
+            ident.into().as_input_ident(),
+            self.plane_role_config().plane_roles,
+        )
+    }
+
+    fn loading_sets(&self) -> LoadingSets {
+        LoadingSets {
+            specialized_main_flow: LoadingSet::Full,
+            specialized_load_only: LoadingSet::Full,
+            no_specialization: LoadingSet::Full,
+        }
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -2,7 +2,7 @@ use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
         global::{
-            GlobalConfig, LoadingSides, SpecializedLoadingSides, PlaneRoleConfig, load::LoaderMode,
+            GlobalConfig, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides, load::LoaderMode,
             multi_stage::EventLoadingMode,
         },
         stage::{self},

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -1,9 +1,7 @@
 use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
-        global::{
-            GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode,
-        },
+        global::{GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode},
         stage::{self},
     },
     kernels::matmul::LoadingPrecomputeStrategy,

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -176,7 +176,7 @@ where
         Self::LhsLoader::fill_stage(&mut lhs_loader, BufferId::A, config);
         Self::RhsLoader::fill_stage(&mut rhs_loader, BufferId::A, config);
 
-        let specializer = Specializer::new(config.plane_role_config(), config.loading_sets());
+        let specializer = Specializer::new(config.plane_role_config(), config.specialized_loading_sides());
 
         sync_cube();
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -176,7 +176,6 @@ where
         Self::LhsLoader::fill_stage(&mut lhs_loader, BufferId::A, config);
         Self::RhsLoader::fill_stage(&mut rhs_loader, BufferId::A, config);
 
-        // TODO builder pattern
         let specializer = Specializer::new(
             config.plane_role_config(),
             LoadingSet::Full,

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -176,7 +176,10 @@ where
         Self::LhsLoader::fill_stage(&mut lhs_loader, BufferId::A, config);
         Self::RhsLoader::fill_stage(&mut rhs_loader, BufferId::A, config);
 
-        let specializer = Specializer::new(config.plane_role_config(), config.specialized_loading_sides());
+        let specializer = Specializer::new(
+            config.plane_role_config(),
+            config.specialized_loading_sides(),
+        );
 
         sync_cube();
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -3,7 +3,7 @@ use crate::components::global::multi_stage::double_buffering::DoubleBufferingGlo
 use crate::components::global::multi_stage::execute::{
     execute_current_and_load_next, execute_last_and_write_results,
 };
-use crate::components::global::{GlobalConfig, LoadingSet, ZeroAccumulatorLoader};
+use crate::components::global::{GlobalConfig, ZeroAccumulatorLoader};
 use crate::components::global::{Quantization, Specializer};
 use crate::components::stage::{BufferStageToTileReader, StageConfig};
 use crate::components::{
@@ -176,12 +176,7 @@ where
         Self::LhsLoader::fill_stage(&mut lhs_loader, BufferId::A, config);
         Self::RhsLoader::fill_stage(&mut rhs_loader, BufferId::A, config);
 
-        let specializer = Specializer::new(
-            config.plane_role_config(),
-            LoadingSet::Full,
-            LoadingSet::Full,
-            LoadingSet::Full,
-        );
+        let specializer = Specializer::new(config.plane_role_config(), config.loading_sets());
 
         sync_cube();
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -315,7 +315,9 @@ fn execute_current_stage_and_load_next_buffer<
     #[comptime] buffer_to_load: BufferId,
     #[comptime] config: DoubleBufferingGlobalConfig<SMM::Config>,
 ) {
+    #[allow(clippy::collapsible_else_if)]
     if specializer.must_check_if_computer() {
+        #[allow(clippy::collapsible_else_if)]
         if specializer.must_check_if_loader() {
             if specializer.is_computer() && specializer.is_loader() {
                 execute_with_listener::<MP, SMM, LL, RL>(
@@ -365,6 +367,7 @@ fn execute_current_stage_and_load_next_buffer<
             }
         }
     } else {
+        #[allow(clippy::collapsible_else_if)]
         if specializer.must_check_if_loader() {
             if specializer.is_loader() {
                 execute_with_listener::<MP, SMM, LL, RL>(
@@ -472,6 +475,7 @@ fn execute_last_stage_and_write_results<MP: MatmulPrecision, SMM: stage::StageMa
     specializer: &Specializer,
     #[comptime] config: DoubleBufferingGlobalConfig<SMM::Config>,
 ) {
+    #[allow(clippy::collapsible_else_if)]
     if specializer.must_check_if_computer() {
         if specializer.is_computer() {
             execute_and_write::<MP, SMM>(

--- a/crates/cubecl-matmul/src/components/global/multi_stage/event_listener.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/event_listener.rs
@@ -94,8 +94,7 @@ impl CubeDebug for EventAnalysis {}
 impl<Lhs: JobExecutor<G>, Rhs: JobExecutor<G>, G: GlobalConfig>
     DoubleBufferingEventListener<Lhs, Rhs, G>
 {
-    // TODO remove pub
-    pub fn new(
+    fn new(
         #[comptime] buffer_id: BufferId,
         loader_lhs: &Lhs,
         loader_rhs: &Rhs,

--- a/crates/cubecl-matmul/src/components/global/multi_stage/execute.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/execute.rs
@@ -1,0 +1,131 @@
+use crate::components::global::GlobalConfig;
+use crate::components::global::RoleRule;
+use crate::components::global::Specializer;
+use crate::components::global::SpecializerKind;
+use crate::components::global::load::BufferId;
+use crate::components::global::multi_stage::DoubleBufferingEventListener;
+use crate::components::global::multi_stage::JobExecutor;
+use crate::components::{MatmulPrecision, stage};
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+#[cube]
+pub fn execute_current_and_load_next<
+    MP: MatmulPrecision,
+    SMM: stage::StageMatmul<MP>,
+    LJ: JobExecutor<G>,
+    RJ: JobExecutor<G>,
+    G: GlobalConfig<StageConfig = SMM::Config>,
+>(
+    lhs_reader: &SMM::LhsReader,
+    rhs_reader: &SMM::RhsReader,
+    lhs_tile: &mut SMM::LhsTile,
+    rhs_tile: &mut SMM::RhsTile,
+    acc: &mut SMM::Accumulator,
+    lhs_loader: &mut LJ,
+    rhs_loader: &mut RJ,
+    specializer: &Specializer,
+    #[comptime] buffer_to_load: BufferId,
+    #[comptime] config: G,
+) {
+    match comptime!(specializer.kind) {
+        SpecializerKind::Specialized {
+            main_flow_loading_set,
+            load_only_loading_set,
+            role_rule_config,
+        } => {
+            let rule = RoleRule::new(role_rule_config);
+            if !rule.is_load_only() {
+                SMM::execute_with_listener::<DoubleBufferingEventListener<LJ, RJ, G>>(
+                    lhs_reader,
+                    rhs_reader,
+                    lhs_tile,
+                    rhs_tile,
+                    acc,
+                    config.stage_config(),
+                    DoubleBufferingEventListener::new(
+                        buffer_to_load,
+                        lhs_loader,
+                        rhs_loader,
+                        config,
+                        main_flow_loading_set,
+                    ),
+                );
+            } else {
+                if load_only_loading_set.should_fill_lhs() {
+                    LJ::execute_whole_job(lhs_loader, buffer_to_load, config);
+                }
+                if load_only_loading_set.should_fill_rhs() {
+                    RJ::execute_whole_job(rhs_loader, buffer_to_load, config);
+                }
+            }
+        }
+        SpecializerKind::NotSpecialized(loading_set) => {
+            SMM::execute_with_listener::<DoubleBufferingEventListener<LJ, RJ, G>>(
+                lhs_reader,
+                rhs_reader,
+                lhs_tile,
+                rhs_tile,
+                acc,
+                config.stage_config(),
+                DoubleBufferingEventListener::new(
+                    buffer_to_load,
+                    lhs_loader,
+                    rhs_loader,
+                    config,
+                    loading_set,
+                ),
+            );
+        }
+    };
+}
+
+#[cube]
+pub fn execute_last_and_write_results<
+    MP: MatmulPrecision,
+    SMM: stage::StageMatmul<MP>,
+    G: GlobalConfig<StageConfig = SMM::Config>,
+>(
+    lhs_reader: &SMM::LhsReader,
+    rhs_reader: &SMM::RhsReader,
+    lhs_tile: &mut SMM::LhsTile,
+    rhs_tile: &mut SMM::RhsTile,
+    acc: &mut SMM::Accumulator,
+    out_writer: &mut SMM::Writer,
+    specializer: &Specializer,
+    #[comptime] config: G,
+) {
+    match comptime!(specializer.kind) {
+        SpecializerKind::Specialized {
+            main_flow_loading_set: _,
+            load_only_loading_set: _,
+            role_rule_config,
+        } => {
+            let rule = RoleRule::new(role_rule_config);
+            if !rule.is_load_only() {
+                SMM::execute(
+                    lhs_reader,
+                    rhs_reader,
+                    lhs_tile,
+                    rhs_tile,
+                    acc,
+                    config.stage_config(),
+                );
+
+                SMM::write_results::<G>(acc, out_writer, config.stage_config(), config);
+            }
+        }
+        SpecializerKind::NotSpecialized(_) => {
+            SMM::execute(
+                lhs_reader,
+                rhs_reader,
+                lhs_tile,
+                rhs_tile,
+                acc,
+                config.stage_config(),
+            );
+
+            SMM::write_results::<G>(acc, out_writer, config.stage_config(), config);
+        }
+    }
+}

--- a/crates/cubecl-matmul/src/components/global/multi_stage/mod.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/mod.rs
@@ -2,5 +2,6 @@ pub mod double_buffering;
 pub mod ordered;
 
 mod event_listener;
+mod execute;
 
 pub use event_listener::*;

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
@@ -1,9 +1,7 @@
 use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
-        global::{
-            GlobalConfig, SpecializerConfig, load::LoaderMode, multi_stage::EventLoadingMode,
-        },
+        global::{GlobalConfig, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode},
         stage::{self},
     },
     kernels::matmul::LoadingPrecomputeStrategy,
@@ -96,11 +94,11 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
     }
 
     fn num_loading_planes(&self) -> u32 {
-        self.stage_config.specializer_config().loader_count()
+        self.stage_config.plane_role_config().loader_count()
     }
 
-    fn specializer_config(&self) -> SpecializerConfig {
-        self.stage_config.specializer_config()
+    fn plane_role_config(&self) -> PlaneRoleConfig {
+        self.stage_config.plane_role_config()
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
@@ -2,7 +2,7 @@ use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
         global::{
-            GlobalConfig, LoadingSet, LoadingSets, PlaneRoleConfig, load::LoaderMode,
+            GlobalConfig, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides, load::LoaderMode,
             multi_stage::EventLoadingMode,
         },
         stage::{self},
@@ -100,16 +100,15 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
         self.stage_config.plane_role_config()
     }
 
-    fn loading_sets(&self) -> LoadingSets {
-        LoadingSets {
-            specialized_main_flow: LoadingSet::Lhs,
-            specialized_load_only: LoadingSet::Rhs,
-            no_specialization: LoadingSet::Full,
+    fn specialized_loading_sides(&self) -> SpecializedLoadingSides {
+        SpecializedLoadingSides {
+            main_flow: LoadingSides::Lhs,
+            load_only: LoadingSides::Rhs,
         }
     }
 
     fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32 {
-        self.loading_sets().num_loading_planes(
+        self.specialized_loading_sides().num_loading_planes(
             self.plane_role_config().has_specialization(),
             ident.into().as_input_ident(),
             self.plane_role_config().plane_roles,

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
@@ -191,7 +191,7 @@ where
 
         Self::LhsLoader::advance_view(&mut lhs_loader, buffer_step);
 
-        let specializer = Specializer::new(config.plane_role_config(), config.loading_sets());
+        let specializer = Specializer::new(config.plane_role_config(), config.specialized_loading_sides());
 
         sync_cube();
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
@@ -5,7 +5,7 @@ use crate::components::global::load::{
 use crate::components::global::multi_stage::execute::{
     execute_current_and_load_next, execute_last_and_write_results,
 };
-use crate::components::global::{self, GlobalConfig, LoadingSet, ZeroAccumulatorLoader};
+use crate::components::global::{self, GlobalConfig, ZeroAccumulatorLoader};
 use crate::components::global::{Quantization, Specializer};
 use crate::components::problem::MatmulLineSizes;
 use crate::components::stage::FullReaderFamily;
@@ -191,12 +191,7 @@ where
 
         Self::LhsLoader::advance_view(&mut lhs_loader, buffer_step);
 
-        let specializer = Specializer::new(
-            config.plane_role_config(),
-            LoadingSet::Lhs,
-            LoadingSet::Rhs,
-            LoadingSet::Full,
-        );
+        let specializer = Specializer::new(config.plane_role_config(), config.loading_sets());
 
         sync_cube();
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
@@ -191,7 +191,10 @@ where
 
         Self::LhsLoader::advance_view(&mut lhs_loader, buffer_step);
 
-        let specializer = Specializer::new(config.plane_role_config(), config.specialized_loading_sides());
+        let specializer = Specializer::new(
+            config.plane_role_config(),
+            config.specialized_loading_sides(),
+        );
 
         sync_cube();
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/config.rs
@@ -1,7 +1,9 @@
 use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
-        global::{self, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode},
+        global::{
+            self, LoadingSets, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode,
+        },
         stage,
     },
     kernels::matmul::LoadingPrecomputeStrategy,
@@ -87,12 +89,19 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         EventLoadingMode::Relaxed
     }
 
-    fn num_loading_planes(&self) -> u32 {
-        self.stage_config.plane_role_config().loader_count()
-    }
-
     fn plane_role_config(&self) -> PlaneRoleConfig {
         self.stage_config.plane_role_config()
+    }
+
+    fn num_loading_planes<I: Into<Ident>>(&self, _ident: I) -> u32 {
+        // Specialized is not available
+        self.stage_config().num_main_flow_planes()
+    }
+
+    fn loading_sets(&self) -> LoadingSets {
+        unimplemented!(
+            "Loading sets not available for simple matmul because specialization is not available"
+        )
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/config.rs
@@ -1,11 +1,8 @@
 use crate::{
     components::{
-        Ident, InputIdent, MatmulConfig, MatrixLayout,
         global::{
-            self, PlaneRoleConfig, SpecializedLoadingSides, load::LoaderMode,
-            multi_stage::EventLoadingMode,
-        },
-        stage,
+            self, load::LoaderMode, multi_stage::EventLoadingMode, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides
+        }, stage, Ident, InputIdent, MatmulConfig, MatrixLayout
     },
     kernels::matmul::LoadingPrecomputeStrategy,
 };
@@ -100,7 +97,11 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
     }
 
     fn specialized_loading_sides(&self) -> SpecializedLoadingSides {
-        unimplemented!("Specialization not available for simple matmul")
+        SpecializedLoadingSides {
+            main_flow: LoadingSides::Both,
+            // Specialized is not available
+            load_only: LoadingSides::None,
+        }
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/config.rs
@@ -2,7 +2,8 @@ use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
         global::{
-            self, LoadingSets, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode,
+            self, PlaneRoleConfig, SpecializedLoadingSides, load::LoaderMode,
+            multi_stage::EventLoadingMode,
         },
         stage,
     },
@@ -98,10 +99,8 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
         self.stage_config().num_main_flow_planes()
     }
 
-    fn loading_sets(&self) -> LoadingSets {
-        unimplemented!(
-            "Loading sets not available for simple matmul because specialization is not available"
-        )
+    fn specialized_loading_sides(&self) -> SpecializedLoadingSides {
+        unimplemented!("Specialization not available for simple matmul")
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/config.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::{
         Ident, InputIdent, MatmulConfig, MatrixLayout,
-        global::{self, SpecializerConfig, load::LoaderMode, multi_stage::EventLoadingMode},
+        global::{self, PlaneRoleConfig, load::LoaderMode, multi_stage::EventLoadingMode},
         stage,
     },
     kernels::matmul::LoadingPrecomputeStrategy,
@@ -88,11 +88,11 @@ impl<S: stage::StageConfig> global::GlobalConfig for Config<S> {
     }
 
     fn num_loading_planes(&self) -> u32 {
-        self.stage_config.specializer_config().loader_count()
+        self.stage_config.plane_role_config().loader_count()
     }
 
-    fn specializer_config(&self) -> SpecializerConfig {
-        self.stage_config.specializer_config()
+    fn plane_role_config(&self) -> PlaneRoleConfig {
+        self.stage_config.plane_role_config()
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
@@ -176,7 +176,7 @@ where
             sync_cube();
 
             if specializer.must_check_if_loader() {
-                if specializer.is_loader(UNIT_POS_Y) {
+                if specializer.is_loader() {
                     Self::LhsLoader::fill_stage(&mut lhs_loader, config);
                     Self::RhsLoader::fill_stage(&mut rhs_loader, config);
                 }
@@ -188,7 +188,7 @@ where
             sync_cube();
 
             if specializer.must_check_if_computer() {
-                if specializer.is_computer(UNIT_POS_Y) {
+                if specializer.is_computer() {
                     SMM::execute(
                         lhs_stage_reader,
                         rhs_stage_reader,
@@ -214,7 +214,7 @@ where
         }
 
         if specializer.must_check_if_computer() {
-            if specializer.is_computer(UNIT_POS_Y) {
+            if specializer.is_computer() {
                 SMM::write_results::<Self::Config>(
                     acc,
                     &mut out_writer,

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::components::InputIdent;
-use crate::components::LoadingPlaneCount;
+use crate::components::LoadOnlyRoleConfig;
 use crate::components::MatmulPrecision;
 use crate::components::global::GlobalMatmul;
 use crate::components::global::Quantization;
@@ -53,13 +53,15 @@ where
 
     fn cube_dim(
         selection: &MatmulSelection,
-        loading_plane_count: LoadingPlaneCount,
+        load_only_role_config: LoadOnlyRoleConfig,
     ) -> Result<CubeDim, InvalidConfigError> {
-        let compute_planes = SMM::computation_resources(&selection.tiling_scheme)?.get_count();
-        let load_only_planes = loading_plane_count.load_only.resolve(compute_planes);
+        let main_flow_planes = SMM::computation_resources(&selection.tiling_scheme)?
+            .as_plane_resources(selection.plane_dim)?
+            .get_count();
+        let load_only_planes = load_only_role_config.resolve(main_flow_planes);
         Ok(CubeDim::new_2d(
             selection.plane_dim,
-            compute_planes + load_only_planes,
+            main_flow_planes + load_only_planes,
         ))
     }
 }

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_barrier.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::components::InputIdent;
-use crate::components::LoadOnlyRoleConfig;
+use crate::components::LoadSpecializationConfig;
 use crate::components::MatmulPrecision;
 use crate::components::global::GlobalMatmul;
 use crate::components::global::Quantization;
@@ -53,16 +53,19 @@ where
 
     fn cube_dim(
         selection: &MatmulSelection,
-        load_only_role_config: LoadOnlyRoleConfig,
+        load_specialization: LoadSpecializationConfig,
     ) -> Result<CubeDim, InvalidConfigError> {
         let main_flow_planes = SMM::computation_resources(&selection.tiling_scheme)?
             .as_plane_resources(selection.plane_dim)?
             .get_count();
-        let load_only_planes = load_only_role_config.resolve(main_flow_planes);
-        Ok(CubeDim::new_2d(
-            selection.plane_dim,
-            main_flow_planes + load_only_planes,
-        ))
+
+        if let LoadSpecializationConfig::None = load_specialization {
+            Ok(CubeDim::new_2d(selection.plane_dim, main_flow_planes))
+        } else {
+            Err(Box::new(
+                "Error: Specialization is unavailable for simple barrier matmul.",
+            ))
+        }
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
@@ -1,5 +1,5 @@
 use crate::components::InputIdent;
-use crate::components::LoadingPlaneCount;
+use crate::components::LoadOnlyRoleConfig;
 use crate::components::MatmulPrecision;
 use crate::components::global::ZeroAccumulatorLoader;
 use crate::components::global::load::TmaLoader;
@@ -42,13 +42,15 @@ where
 
     fn cube_dim(
         selection: &MatmulSelection,
-        loading_plane_count: LoadingPlaneCount,
+        load_only_role_config: LoadOnlyRoleConfig,
     ) -> Result<CubeDim, InvalidConfigError> {
-        let compute_planes = SMM::computation_resources(&selection.tiling_scheme)?.get_count();
-        let load_only_planes = loading_plane_count.load_only.resolve(compute_planes);
+        let main_flow_planes = SMM::computation_resources(&selection.tiling_scheme)?
+            .as_plane_resources(selection.plane_dim)?
+            .get_count();
+        let load_only_planes = load_only_role_config.resolve(main_flow_planes);
         Ok(CubeDim::new_2d(
             selection.plane_dim,
-            compute_planes + load_only_planes,
+            main_flow_planes + load_only_planes,
         ))
     }
 }

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul_tma.rs
@@ -1,5 +1,5 @@
 use crate::components::InputIdent;
-use crate::components::LoadOnlyRoleConfig;
+use crate::components::LoadSpecializationConfig;
 use crate::components::MatmulPrecision;
 use crate::components::global::ZeroAccumulatorLoader;
 use crate::components::global::load::TmaLoader;
@@ -42,16 +42,19 @@ where
 
     fn cube_dim(
         selection: &MatmulSelection,
-        load_only_role_config: LoadOnlyRoleConfig,
+        load_specialization: LoadSpecializationConfig,
     ) -> Result<CubeDim, InvalidConfigError> {
         let main_flow_planes = SMM::computation_resources(&selection.tiling_scheme)?
             .as_plane_resources(selection.plane_dim)?
             .get_count();
-        let load_only_planes = load_only_role_config.resolve(main_flow_planes);
-        Ok(CubeDim::new_2d(
-            selection.plane_dim,
-            main_flow_planes + load_only_planes,
-        ))
+
+        if let LoadSpecializationConfig::None = load_specialization {
+            Ok(CubeDim::new_2d(selection.plane_dim, main_flow_planes))
+        } else {
+            Err(Box::new(
+                "Error: Specialization is unavailable for simple tma matmul.",
+            ))
+        }
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/specialization.rs
+++ b/crates/cubecl-matmul/src/components/global/specialization.rs
@@ -1,4 +1,4 @@
-use crate::components::{LoadingPlaneCount, PlaneRoles};
+use crate::components::{LoadOnlyRoleConfig, PlaneRoles};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
@@ -11,21 +11,21 @@ pub struct SpecializerConfig {
 // remains comptime. is use inside specializer AND to create specializer
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum SpecializerKind {
-    LoadOverlapCompute,
+    LoadOnlyFirst,
     NoSpecialization,
 }
 
 impl SpecializerConfig {
-    pub fn from_loading_plane_count(
-        loading_plane_count: LoadingPlaneCount,
+    pub fn from_plane_roles_config(
+        plane_role_config: LoadOnlyRoleConfig,
         compute_planes: u32,
     ) -> Self {
-        Self::from_plane_roles(loading_plane_count.to_plane_roles(compute_planes))
+        Self::from_plane_roles(plane_role_config.to_plane_roles(compute_planes))
     }
 
     pub fn from_plane_roles(plane_roles: PlaneRoles) -> Self {
         let kind = match plane_roles.has_specialization() {
-            true => SpecializerKind::LoadOverlapCompute,
+            true => SpecializerKind::LoadOnlyFirst,
             false => SpecializerKind::NoSpecialization,
         };
 
@@ -40,16 +40,9 @@ impl SpecializerConfig {
         self.plane_roles.computer_count()
     }
 
-    fn must_check_if_loader(&self) -> bool {
-        match self.kind {
-            SpecializerKind::LoadOverlapCompute => self.plane_roles.compute_only > 0,
-            SpecializerKind::NoSpecialization => false,
-        }
-    }
-
     fn must_check_if_computer(&self) -> bool {
         match self.kind {
-            SpecializerKind::LoadOverlapCompute => self.plane_roles.load_only > 0,
+            SpecializerKind::LoadOnlyFirst => self.plane_roles.load_only > 0,
             SpecializerKind::NoSpecialization => false,
         }
     }
@@ -71,29 +64,13 @@ impl Specializer {
         Specializer { specializer_config }
     }
 
-    pub fn must_check_if_loader(&self) -> comptime_type!(bool) {
-        comptime!(self.specializer_config.must_check_if_loader())
-    }
-
-    pub fn is_loader(&self) -> bool {
-        match comptime!(self.specializer_config.kind) {
-            SpecializerKind::LoadOverlapCompute => {
-                let plane_roles = self.specializer_config.plane_roles;
-                UNIT_POS_Y < comptime!(plane_roles.load_only + plane_roles.overlap)
-            }
-            SpecializerKind::NoSpecialization => {
-                comptime!(unreachable!("Should call must_check_if_loader prior"))
-            }
-        }
-    }
-
-    pub fn must_check_if_computer(&self) -> comptime_type!(bool) {
+    pub fn can_be_load_only(&self) -> comptime_type!(bool) {
         comptime!(self.specializer_config.must_check_if_computer())
     }
 
     pub fn is_computer(&self) -> bool {
         match comptime!(self.specializer_config.kind) {
-            SpecializerKind::LoadOverlapCompute => {
+            SpecializerKind::LoadOnlyFirst => {
                 UNIT_POS_Y >= self.specializer_config.plane_roles.load_only
             }
             SpecializerKind::NoSpecialization => {
@@ -108,7 +85,7 @@ impl Specializer {
 
     pub fn plane_id_to_computer_index(&self) -> u32 {
         match comptime!(self.specializer_config.kind) {
-            SpecializerKind::LoadOverlapCompute => {
+            SpecializerKind::LoadOnlyFirst => {
                 UNIT_POS_Y - self.specializer_config.plane_roles.load_only
             }
             SpecializerKind::NoSpecialization => UNIT_POS_Y,

--- a/crates/cubecl-matmul/src/components/global/specialization.rs
+++ b/crates/cubecl-matmul/src/components/global/specialization.rs
@@ -37,12 +37,12 @@ impl LoadingSides {
     }
 
     pub fn includes(&self, ident: InputIdent) -> bool {
-        match (self, ident) {
+        matches!(
+            (self, ident),
             (LoadingSides::Both, _)
-            | (LoadingSides::Lhs, InputIdent::Lhs)
-            | (LoadingSides::Rhs, InputIdent::Rhs) => true,
-            _ => false,
-        }
+                | (LoadingSides::Lhs, InputIdent::Lhs)
+                | (LoadingSides::Rhs, InputIdent::Rhs)
+        )
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/specialization.rs
+++ b/crates/cubecl-matmul/src/components/global/specialization.rs
@@ -1,94 +1,163 @@
-use crate::components::{LoadOnlyRoleConfig, PlaneRoles};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-pub struct SpecializerConfig {
-    plane_roles: PlaneRoles,
-    kind: SpecializerKind,
+pub struct PlaneRoles {
+    pub main_flow: u32,
+    pub load_only: u32,
 }
 
-// remains comptime. is use inside specializer AND to create specializer
+impl PlaneRoles {
+    pub fn total_count(&self) -> u32 {
+        self.main_flow + self.load_only
+    }
+}
+
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum SpecializerKind {
-    LoadOnlyFirst,
-    NoSpecialization,
+pub enum LoadingSet {
+    // Load both Lhs and Rhs
+    Full,
+    // Load Lhs only
+    Lhs,
+    // Load Rhs only
+    Rhs,
+    // Don't perform loading
+    None,
 }
 
-impl SpecializerConfig {
-    pub fn from_plane_roles_config(
-        plane_role_config: LoadOnlyRoleConfig,
-        compute_planes: u32,
-    ) -> Self {
-        Self::from_plane_roles(plane_role_config.to_plane_roles(compute_planes))
-    }
-
-    pub fn from_plane_roles(plane_roles: PlaneRoles) -> Self {
-        let kind = match plane_roles.has_specialization() {
-            true => SpecializerKind::LoadOnlyFirst,
-            false => SpecializerKind::NoSpecialization,
-        };
-
-        Self { plane_roles, kind }
-    }
-
-    pub fn loader_count(&self) -> u32 {
-        self.plane_roles.loader_count()
-    }
-
-    pub fn computer_count(&self) -> u32 {
-        self.plane_roles.computer_count()
-    }
-
-    fn must_check_if_computer(&self) -> bool {
-        match self.kind {
-            SpecializerKind::LoadOnlyFirst => self.plane_roles.load_only > 0,
-            SpecializerKind::NoSpecialization => false,
+impl LoadingSet {
+    pub fn should_fill_lhs(&self) -> bool {
+        match self {
+            LoadingSet::Full => true,
+            LoadingSet::Lhs => true,
+            LoadingSet::Rhs => false,
+            LoadingSet::None => false,
         }
     }
 
-    pub fn has_specialization(&self) -> bool {
-        self.plane_roles.has_specialization()
+    pub fn should_fill_rhs(&self) -> bool {
+        match self {
+            LoadingSet::Full => true,
+            LoadingSet::Lhs => false,
+            LoadingSet::Rhs => true,
+            LoadingSet::None => false,
+        }
     }
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct PlaneRoleConfig {
+    plane_roles: PlaneRoles,
+    pub rule: RoleRuleConfig,
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum RoleRuleConfig {
+    MainFlowOnly,
+    LoadOnlyFirst { load_only: u32 },
+    LoadOnlyLast { main_flow: u32 },
+}
+
+#[derive(CubeType, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum RoleRule {
+    MainFlowOnly,
+    LoadOnlyFirst(u32),
+    LoadOnlyLast(u32),
+}
+
+impl PlaneRoleConfig {
+    pub fn from_plane_roles(plane_roles: PlaneRoles) -> Self {
+        // TODO make possible to select LoadOnlyLast
+        let rule = match plane_roles.load_only {
+            0 => RoleRuleConfig::MainFlowOnly,
+            _ => RoleRuleConfig::LoadOnlyFirst {
+                load_only: plane_roles.load_only,
+            },
+        };
+
+        Self { plane_roles, rule }
+    }
+
+    pub fn loader_count(&self) -> u32 {
+        self.plane_roles.load_only + self.plane_roles.main_flow
+    }
+
+    pub fn computer_count(&self) -> u32 {
+        self.plane_roles.main_flow
+    }
+
+    pub fn has_specialization(&self) -> bool {
+        self.plane_roles.load_only > 0
+    }
+}
+
+#[cube]
+impl RoleRule {
+    pub fn new(#[comptime] comptime_rule: RoleRuleConfig) -> RoleRule {
+        match comptime!(comptime_rule) {
+            RoleRuleConfig::MainFlowOnly => RoleRule::new_MainFlowOnly(),
+            RoleRuleConfig::LoadOnlyFirst { load_only } => RoleRule::new_LoadOnlyFirst(load_only),
+            RoleRuleConfig::LoadOnlyLast { main_flow } => RoleRule::new_LoadOnlyLast(main_flow),
+        }
+    }
+
+    pub fn is_load_only(self) -> bool {
+        match self {
+            RoleRule::MainFlowOnly => false,
+            RoleRule::LoadOnlyFirst(load_only) => UNIT_POS_Y < load_only,
+            RoleRule::LoadOnlyLast(main_flow) => UNIT_POS_Y >= main_flow,
+        }
+    }
+
+    pub fn compute_index(self) -> u32 {
+        match self {
+            RoleRule::MainFlowOnly => UNIT_POS_Y,
+            RoleRule::LoadOnlyFirst(load_only) => UNIT_POS_Y - load_only,
+            RoleRule::LoadOnlyLast(_) => UNIT_POS_Y,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum SpecializerKind {
+    Specialized {
+        main_flow_loading_set: LoadingSet,
+        load_only_loading_set: LoadingSet,
+        role_rule_config: RoleRuleConfig,
+    },
+    NotSpecialized(LoadingSet),
 }
 
 #[derive(CubeType, Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Specializer {
     #[cube(comptime)]
-    specializer_config: SpecializerConfig,
+    pub kind: SpecializerKind,
 }
 
 #[cube]
 impl Specializer {
-    pub fn new(#[comptime] specializer_config: SpecializerConfig) -> Specializer {
-        Specializer { specializer_config }
-    }
-
-    pub fn can_be_load_only(&self) -> comptime_type!(bool) {
-        comptime!(self.specializer_config.must_check_if_computer())
-    }
-
-    pub fn is_computer(&self) -> bool {
-        match comptime!(self.specializer_config.kind) {
-            SpecializerKind::LoadOnlyFirst => {
-                UNIT_POS_Y >= self.specializer_config.plane_roles.load_only
+    pub fn new(
+        #[comptime] plane_role_config: PlaneRoleConfig,
+        #[comptime] specialized_main_flow: LoadingSet,
+        #[comptime] specialized_load_only: LoadingSet,
+        #[comptime] no_specialization: LoadingSet,
+    ) -> Specializer {
+        if plane_role_config.has_specialization() {
+            Specializer {
+                kind: comptime! {
+                    SpecializerKind::Specialized {
+                        main_flow_loading_set: specialized_main_flow,
+                        load_only_loading_set: specialized_load_only,
+                        role_rule_config: plane_role_config.rule
+                    }
+                },
             }
-            SpecializerKind::NoSpecialization => {
-                comptime!(unreachable!("Should call must_check_if_computer prior"))
+        } else {
+            Specializer {
+                kind: comptime! {SpecializerKind::NotSpecialized(
+                    no_specialization,
+                )},
             }
-        }
-    }
-
-    pub fn plane_id_to_loader_index(&self) -> u32 {
-        UNIT_POS_Y
-    }
-
-    pub fn plane_id_to_computer_index(&self) -> u32 {
-        match comptime!(self.specializer_config.kind) {
-            SpecializerKind::LoadOnlyFirst => {
-                UNIT_POS_Y - self.specializer_config.plane_roles.load_only
-            }
-            SpecializerKind::NoSpecialization => UNIT_POS_Y,
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/global/specialization.rs
+++ b/crates/cubecl-matmul/src/components/global/specialization.rs
@@ -75,11 +75,11 @@ impl Specializer {
         comptime!(self.specializer_config.must_check_if_loader())
     }
 
-    pub fn is_loader(&self, plane_id: u32) -> bool {
+    pub fn is_loader(&self) -> bool {
         match comptime!(self.specializer_config.kind) {
             SpecializerKind::LoadOverlapCompute => {
                 let plane_roles = self.specializer_config.plane_roles;
-                plane_id < comptime!(plane_roles.load_only + plane_roles.overlap)
+                UNIT_POS_Y < comptime!(plane_roles.load_only + plane_roles.overlap)
             }
             SpecializerKind::NoSpecialization => {
                 comptime!(unreachable!("Should call must_check_if_loader prior"))
@@ -91,10 +91,10 @@ impl Specializer {
         comptime!(self.specializer_config.must_check_if_computer())
     }
 
-    pub fn is_computer(&self, plane_id: u32) -> bool {
+    pub fn is_computer(&self) -> bool {
         match comptime!(self.specializer_config.kind) {
             SpecializerKind::LoadOverlapCompute => {
-                plane_id >= self.specializer_config.plane_roles.load_only
+                UNIT_POS_Y >= self.specializer_config.plane_roles.load_only
             }
             SpecializerKind::NoSpecialization => {
                 comptime!(unreachable!("Should call must_check_if_computer prior"))
@@ -102,29 +102,16 @@ impl Specializer {
         }
     }
 
-    pub fn plane_id_to_loader_index(&self, plane_id: u32) -> u32 {
-        plane_id
+    pub fn plane_id_to_loader_index(&self) -> u32 {
+        UNIT_POS_Y
     }
 
-    pub fn plane_id_to_computer_index(&self, plane_id: u32) -> u32 {
+    pub fn plane_id_to_computer_index(&self) -> u32 {
         match comptime!(self.specializer_config.kind) {
             SpecializerKind::LoadOverlapCompute => {
-                plane_id - self.specializer_config.plane_roles.load_only
+                UNIT_POS_Y - self.specializer_config.plane_roles.load_only
             }
-            SpecializerKind::NoSpecialization => plane_id,
-        }
-    }
-
-    pub fn loader_index_to_plane_id(&self, loader_index: u32) -> u32 {
-        loader_index
-    }
-
-    pub fn computer_index_to_plane_id(&self, computer_index: u32) -> u32 {
-        match comptime!(self.specializer_config.kind) {
-            SpecializerKind::LoadOverlapCompute => {
-                self.specializer_config.plane_roles.load_only + computer_index
-            }
-            SpecializerKind::NoSpecialization => computer_index,
+            SpecializerKind::NoSpecialization => UNIT_POS_Y,
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/resource.rs
+++ b/crates/cubecl-matmul/src/components/resource.rs
@@ -58,11 +58,11 @@ impl Default for LoadingPlaneCount {
 impl LoadingPlaneCount {
     pub fn to_plane_roles(&self, compute_planes: u32) -> PlaneRoles {
         let overlap = self.get_overlap_count(compute_planes);
-        PlaneRoles {
-            load_only: self.load_only.resolve(compute_planes),
+        PlaneRoles::new(
+            self.load_only.resolve(compute_planes),
             overlap,
-            compute_only: compute_planes - overlap,
-        }
+            compute_planes - overlap,
+        )
     }
 
     fn get_overlap_count(&self, compute_planes: u32) -> u32 {
@@ -118,6 +118,17 @@ pub struct PlaneRoles {
 }
 
 impl PlaneRoles {
+    pub fn new(load_only: u32, overlap: u32, compute_only: u32) -> Self {
+        assert!(load_only + overlap > 0, "There are no loader planes");
+        assert!(compute_only + overlap > 0, "There are no computer planes");
+
+        Self {
+            load_only,
+            overlap,
+            compute_only,
+        }
+    }
+
     pub fn has_specialization(&self) -> bool {
         self.load_only > 0 || self.compute_only > 0
     }

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -153,11 +153,9 @@ pub trait StageConfig: MatmulConfig {
 
     fn tiling_scheme(&self) -> TilingScheme;
 
-    /// Number of planes that perform computation
-    fn num_compute_planes(&self) -> u32;
-
     fn plane_role_config(&self) -> PlaneRoleConfig;
     fn role_rule_config(&self) -> RoleRuleConfig;
+    fn num_main_flow_planes(&self) -> u32;
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -6,7 +6,7 @@ use crate::components::{
     ComputeResources, Ident, InputIdent, InvalidConfigError, MatmulConfigFactory, MatmulPrecision,
     MatrixLayout, TilingScheme,
     config::MatmulConfig,
-    global::{self, AccumulatorLoader, GlobalWriter, SpecializerConfig},
+    global::{self, AccumulatorLoader, GlobalWriter, PlaneRoleConfig, RoleRuleConfig},
     tile::TileConfig,
 };
 
@@ -156,7 +156,8 @@ pub trait StageConfig: MatmulConfig {
     /// Number of planes that perform computation
     fn num_compute_planes(&self) -> u32;
 
-    fn specializer_config(&self) -> SpecializerConfig;
+    fn plane_role_config(&self) -> PlaneRoleConfig;
+    fn role_rule_config(&self) -> RoleRuleConfig;
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/crates/cubecl-matmul/src/components/stage/layout.rs
+++ b/crates/cubecl-matmul/src/components/stage/layout.rs
@@ -154,7 +154,7 @@ impl TilingOrder for OrderedTilingOrder {
         if Ident::Lhs != ident {
             panic!("Ordered tiling order should be used only on Lhs")
         }
-        if config.specializer_config().has_specialization() {
+        if config.plane_role_config().has_specialization() {
             panic!("Ordered tiling order unimplemented for specialized")
         }
 
@@ -182,7 +182,7 @@ impl TilingOrder for OrderedTilingOrder {
         if Ident::Lhs != ident {
             panic!("Ordered tiling order should be used only on Lhs")
         }
-        if config.specializer_config().has_specialization() {
+        if config.plane_role_config().has_specialization() {
             panic!("Ordered tiling order unimplemented for specialized")
         }
 

--- a/crates/cubecl-matmul/src/components/stage/layout.rs
+++ b/crates/cubecl-matmul/src/components/stage/layout.rs
@@ -154,11 +154,8 @@ impl TilingOrder for OrderedTilingOrder {
         if Ident::Lhs != ident {
             panic!("Ordered tiling order should be used only on Lhs")
         }
-        if config.plane_role_config().has_specialization() {
-            panic!("Ordered tiling order unimplemented for specialized")
-        }
 
-        let group_rows = tile_count_rows / config.num_compute_planes();
+        let group_rows = tile_count_rows / config.num_main_flow_planes();
         let tiles_per_group = group_rows * tile_count_cols;
 
         let group = nth / tiles_per_group;
@@ -182,11 +179,8 @@ impl TilingOrder for OrderedTilingOrder {
         if Ident::Lhs != ident {
             panic!("Ordered tiling order should be used only on Lhs")
         }
-        if config.plane_role_config().has_specialization() {
-            panic!("Ordered tiling order unimplemented for specialized")
-        }
 
-        let group_rows = tile_count_rows / config.num_compute_planes();
+        let group_rows = tile_count_rows / config.num_main_flow_planes();
         let group = row / group_rows;
 
         let local_row = row % group_rows;

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
@@ -131,7 +131,7 @@ impl<TMM: TileMatmulFamily, LRF: ReaderFamily, RRF: ReaderFamily> MatmulConfigFa
                 .as_plane_resources(tile_config.plane_dim())
                 .unwrap_or_else(|e| panic!("{}", e))
                 .get_count();
-        let specializer_config = SpecializerConfig::from_loading_plane_count(
+        let specializer_config = SpecializerConfig::from_plane_roles_config(
             stage_input.loading_plane_count,
             compute_planes,
         );

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
@@ -41,7 +41,7 @@ impl StagePartitioner for PlanePartitioner {
     }
 
     fn position<S: StageConfig>(#[comptime] config: S) -> u32 {
-        Specializer::new(config.specializer_config()).plane_id_to_computer_index(UNIT_POS_Y)
+        Specializer::new(config.specializer_config()).plane_id_to_computer_index()
     }
 
     fn num_primitives<S: StageConfig>(#[comptime] config: S) -> comptime_type!(u32) {

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane.rs
@@ -45,7 +45,7 @@ impl StagePartitioner for PlanePartitioner {
     }
 
     fn num_primitives<S: StageConfig>(#[comptime] config: S) -> comptime_type!(u32) {
-        config.num_compute_planes()
+        config.num_main_flow_planes()
     }
 }
 
@@ -82,7 +82,7 @@ impl<TMM: TileMatmulFamily, LRF: ReaderFamily, RRF: ReaderFamily> MatmulConfigFa
 
     fn check_config(config: &Self::Config) -> Result<(), InvalidConfigError> {
         let num_planes_needed = config.tiling_scheme().stage_partitions_in_stage_mn();
-        let num_compute_planes = config.num_compute_planes();
+        let num_compute_planes = config.num_main_flow_planes();
 
         if num_compute_planes != num_planes_needed {
             return Err(Box::new(format!(

--- a/crates/cubecl-matmul/src/components/stage/matmul/shared.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/shared.rs
@@ -1,6 +1,6 @@
 use crate::components::{
     Ident, InputIdent, MatmulConfig, MatmulPrecision, MatrixLayout, TilingScheme,
-    global::{AccumulatorLoader, SpecializerConfig},
+    global::{AccumulatorLoader, PlaneRoleConfig, RoleRuleConfig},
     stage::{PartitionBuffering, StageConfig},
     tile::{TileConfig, TileMatmul},
 };
@@ -15,7 +15,7 @@ pub struct CommonStageConfig<T: TileConfig> {
     pub quantized: bool,
     pub partition_buffering: PartitionBuffering,
     pub num_stages: NumStages,
-    specializer_config: SpecializerConfig,
+    plane_role_config: PlaneRoleConfig,
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -61,11 +61,15 @@ impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
     }
 
     fn num_compute_planes(&self) -> u32 {
-        self.specializer_config.computer_count()
+        self.plane_role_config.computer_count()
     }
 
-    fn specializer_config(&self) -> SpecializerConfig {
-        self.specializer_config
+    fn plane_role_config(&self) -> PlaneRoleConfig {
+        self.plane_role_config
+    }
+
+    fn role_rule_config(&self) -> RoleRuleConfig {
+        self.plane_role_config.rule
     }
 }
 
@@ -79,7 +83,7 @@ impl<T: TileConfig> CommonStageConfig<T> {
         quantized: bool,
         partition_buffering: PartitionBuffering,
         num_stages: NumStages,
-        specializer_config: SpecializerConfig,
+        plane_role_config: PlaneRoleConfig,
     ) -> Self {
         Self {
             tile_config,
@@ -87,7 +91,7 @@ impl<T: TileConfig> CommonStageConfig<T> {
             quantized,
             partition_buffering,
             num_stages,
-            specializer_config,
+            plane_role_config,
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/stage/matmul/shared.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/shared.rs
@@ -60,8 +60,8 @@ impl<T: TileConfig> StageConfig for CommonStageConfig<T> {
         self.tiling_scheme
     }
 
-    fn num_compute_planes(&self) -> u32 {
-        self.plane_role_config.computer_count()
+    fn num_main_flow_planes(&self) -> u32 {
+        self.plane_role_config.main_flow_count()
     }
 
     fn plane_role_config(&self) -> PlaneRoleConfig {

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
@@ -129,7 +129,7 @@ impl<TMM: TileMatmulFamily, RF: ReaderFamily> MatmulConfigFactory for UnitMatmul
                 .as_plane_resources(tile_config.plane_dim())
                 .unwrap_or_else(|e| panic!("{}", e))
                 .get_count();
-        let specializer_config = SpecializerConfig::from_loading_plane_count(
+        let specializer_config = SpecializerConfig::from_plane_roles_config(
             stage_input.loading_plane_count,
             compute_planes,
         );

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
@@ -42,8 +42,7 @@ impl StagePartitioner for UnitPartitioner {
     }
 
     fn position<S: StageConfig>(#[comptime] config: S) -> u32 {
-        let plane_id =
-            Specializer::new(config.specializer_config()).plane_id_to_computer_index(UNIT_POS_Y);
+        let plane_id = Specializer::new(config.specializer_config()).plane_id_to_computer_index();
 
         UNIT_POS_X + config.plane_dim() * plane_id
     }

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit.rs
@@ -48,7 +48,7 @@ impl StagePartitioner for UnitPartitioner {
     }
 
     fn num_primitives<S: StageConfig>(#[comptime] config: S) -> comptime_type!(u32) {
-        config.num_compute_planes() * config.plane_dim()
+        config.num_main_flow_planes() * config.plane_dim()
     }
 }
 
@@ -81,7 +81,7 @@ impl<TMM: TileMatmulFamily, RF: ReaderFamily> MatmulConfigFactory for UnitMatmul
 
     fn check_config(config: &Self::Config) -> Result<(), InvalidConfigError> {
         let num_units_needed = config.tiling_scheme().stage_partitions_in_stage_mn();
-        let num_units = config.plane_dim() * config.num_compute_planes();
+        let num_units = config.plane_dim() * config.num_main_flow_planes();
 
         if num_units != num_units_needed {
             return Err(Box::new(format!(

--- a/crates/cubecl-matmul/src/components/stage/stage_memory.rs
+++ b/crates/cubecl-matmul/src/components/stage/stage_memory.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
-use crate::components::global::GlobalConfig;
 use crate::components::global::load::BufferId;
+use crate::components::global::{GlobalConfig, RoleRule};
 use crate::components::stage::{StageConfig, TilingLayout};
 use crate::components::tile::Tile;
 use crate::components::{Ident, InputIdent, MatrixLayout};
@@ -98,7 +98,10 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
         let unit_count = config.num_loading_planes(ident) * config.plane_dim();
         let num_writes_per_unit = smem_length.div_ceil(unit_count);
 
-        let unit_base_position = UNIT_POS_Y * config.plane_dim() + UNIT_POS_X;
+        let unit_base_position = RoleRule::new(config.role_rule_config())
+            .load_index(ident, config.specialized_loading_sides())
+            * config.plane_dim()
+            + UNIT_POS_X;
 
         for i in 0..num_writes_per_unit {
             let offset = unit_base_position + i * unit_count;
@@ -134,7 +137,10 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
         let unit_count = config.num_loading_planes(ident) * config.plane_dim();
         let num_writes_per_unit = buffer_length.div_ceil(unit_count);
 
-        let unit_base_position = UNIT_POS_Y * config.plane_dim() + UNIT_POS_X;
+        let unit_base_position = RoleRule::new(config.role_rule_config())
+            .load_index(ident, config.specialized_loading_sides())
+            * config.plane_dim()
+            + UNIT_POS_X;
 
         for i in 0..num_writes_per_unit {
             let unit_position = unit_base_position + i * unit_count;

--- a/crates/cubecl-matmul/src/components/stage/stage_memory.rs
+++ b/crates/cubecl-matmul/src/components/stage/stage_memory.rs
@@ -95,7 +95,7 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
                 / config.stage_config().stage_line_size(ident.into())
         );
 
-        let unit_count = config.num_loading_planes() * config.plane_dim();
+        let unit_count = config.num_loading_planes(ident) * config.plane_dim();
         let num_writes_per_unit = smem_length.div_ceil(unit_count);
 
         let unit_base_position = UNIT_POS_Y * config.plane_dim() + UNIT_POS_X;
@@ -131,7 +131,7 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
 
         let matrix_layout = config.matrix_layout(ident.as_ident());
 
-        let unit_count = config.num_loading_planes() * config.plane_dim();
+        let unit_count = config.num_loading_planes(ident) * config.plane_dim();
         let num_writes_per_unit = buffer_length.div_ceil(unit_count);
 
         let unit_base_position = UNIT_POS_Y * config.plane_dim() + UNIT_POS_X;

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
@@ -1,4 +1,4 @@
-use crate::components::LoadOnlyRoleConfig;
+use crate::components::LoadSpecializationConfig;
 use crate::components::batch::BatchMatmulFamily;
 use crate::components::global::GlobalMatmulFamily;
 use crate::components::global::load::LoaderMode;
@@ -24,7 +24,7 @@ pub struct StageInput {
     pub partition_buffering: stage::PartitionBuffering,
     pub stage_vectorization: StageVectorization,
     pub num_stages: NumStages,
-    pub loading_plane_count: LoadOnlyRoleConfig,
+    pub load_specialization: LoadSpecializationConfig,
 }
 
 pub enum MultiRowStrategy {
@@ -95,7 +95,7 @@ pub trait Algorithm {
                 partition_buffering,
                 stage_vectorization,
                 num_stages: Self::num_stages(),
-                loading_plane_count: Self::plane_role_config(),
+                load_specialization: Self::plane_role_config(),
             },
             loading_precompute_strategy: Self::loading_precompute_strategy(),
             loader_mode: Self::loader_mode(),
@@ -114,8 +114,8 @@ pub trait Algorithm {
         LoaderMode::Relaxed
     }
 
-    fn plane_role_config() -> LoadOnlyRoleConfig {
-        LoadOnlyRoleConfig::None
+    fn plane_role_config() -> LoadSpecializationConfig {
+        LoadSpecializationConfig::None
     }
 
     fn partition_buffering_strategy() -> PartitionBuffering {

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
@@ -1,4 +1,4 @@
-use crate::components::LoadingPlaneCount;
+use crate::components::LoadOnlyRoleConfig;
 use crate::components::batch::BatchMatmulFamily;
 use crate::components::global::GlobalMatmulFamily;
 use crate::components::global::load::LoaderMode;
@@ -24,7 +24,7 @@ pub struct StageInput {
     pub partition_buffering: stage::PartitionBuffering,
     pub stage_vectorization: StageVectorization,
     pub num_stages: NumStages,
-    pub loading_plane_count: LoadingPlaneCount,
+    pub loading_plane_count: LoadOnlyRoleConfig,
 }
 
 pub enum MultiRowStrategy {
@@ -61,7 +61,7 @@ pub trait Algorithm {
     type BatchMatmul: batch::BatchMatmulFamily<Input = GlobalInput<StageInput>>;
 
     fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError> {
-        Self::GlobalMatmul::cube_dim(selection, Self::loading_plane_count())
+        Self::GlobalMatmul::cube_dim(selection, Self::plane_role_config())
     }
 
     fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
@@ -95,7 +95,7 @@ pub trait Algorithm {
                 partition_buffering,
                 stage_vectorization,
                 num_stages: Self::num_stages(),
-                loading_plane_count: Self::loading_plane_count(),
+                loading_plane_count: Self::plane_role_config(),
             },
             loading_precompute_strategy: Self::loading_precompute_strategy(),
             loader_mode: Self::loader_mode(),
@@ -114,8 +114,8 @@ pub trait Algorithm {
         LoaderMode::Relaxed
     }
 
-    fn loading_plane_count() -> LoadingPlaneCount {
-        LoadingPlaneCount::default()
+    fn plane_role_config() -> LoadOnlyRoleConfig {
+        LoadOnlyRoleConfig::None
     }
 
     fn partition_buffering_strategy() -> PartitionBuffering {

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
@@ -61,7 +61,7 @@ pub trait Algorithm {
     type BatchMatmul: batch::BatchMatmulFamily<Input = GlobalInput<StageInput>>;
 
     fn cube_dim(selection: &MatmulSelection) -> Result<CubeDim, InvalidConfigError> {
-        Self::GlobalMatmul::cube_dim(selection, Self::plane_role_config())
+        Self::GlobalMatmul::cube_dim(selection, Self::load_specialization_config())
     }
 
     fn cube_count(selection: &MatmulSelection, problem: &MatmulProblem) -> CubeCount {
@@ -95,7 +95,7 @@ pub trait Algorithm {
                 partition_buffering,
                 stage_vectorization,
                 num_stages: Self::num_stages(),
-                load_specialization: Self::plane_role_config(),
+                load_specialization: Self::load_specialization_config(),
             },
             loading_precompute_strategy: Self::loading_precompute_strategy(),
             loader_mode: Self::loader_mode(),
@@ -114,7 +114,7 @@ pub trait Algorithm {
         LoaderMode::Relaxed
     }
 
-    fn plane_role_config() -> LoadSpecializationConfig {
+    fn load_specialization_config() -> LoadSpecializationConfig {
         LoadSpecializationConfig::None
     }
 

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -2,13 +2,13 @@ use cubecl_core::ir::Elem;
 use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
+use crate::components::MatmulProblem;
 use crate::components::batch::{Partitioner, RowMajorGlobalPartitionMatmul};
 use crate::components::global::load::{sync_buffer_cyclic, sync_buffer_tilewise};
 use crate::components::stage::{
     self, BufferReaderFamily, ColMajorTilingOrder, NumStages, RowMajorTilingOrder,
 };
-use crate::components::{LoadingPlaneCount, MatmulProblem};
-use crate::components::{PlaneCountMode, tile};
+use crate::components::tile;
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -8,7 +8,7 @@ use crate::components::stage::{
     self, BufferReaderFamily, ColMajorTilingOrder, NumStages, RowMajorTilingOrder,
 };
 use crate::components::tile;
-use crate::components::{LoadOnlyRoleConfig, MatmulProblem};
+use crate::components::{LoadSpecializationConfig, MatmulProblem};
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};
@@ -148,8 +148,8 @@ where
         (2, 2).into()
     }
 
-    fn plane_role_config() -> LoadOnlyRoleConfig {
-        LoadOnlyRoleConfig::Mirror
+    fn plane_role_config() -> LoadSpecializationConfig {
+        LoadSpecializationConfig::Mirror
     }
 
     fn selection<R: Runtime>(

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -2,13 +2,13 @@ use cubecl_core::ir::Elem;
 use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
-use crate::components::MatmulProblem;
 use crate::components::batch::{Partitioner, RowMajorGlobalPartitionMatmul};
 use crate::components::global::load::{sync_buffer_cyclic, sync_buffer_tilewise};
 use crate::components::stage::{
     self, BufferReaderFamily, ColMajorTilingOrder, NumStages, RowMajorTilingOrder,
 };
 use crate::components::tile;
+use crate::components::{LoadOnlyRoleConfig, MatmulProblem};
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};
@@ -146,6 +146,10 @@ where
 
     fn num_stages() -> NumStages {
         (2, 2).into()
+    }
+
+    fn plane_role_config() -> LoadOnlyRoleConfig {
+        LoadOnlyRoleConfig::Mirror
     }
 
     fn selection<R: Runtime>(

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -2,13 +2,13 @@ use cubecl_core::ir::Elem;
 use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
+use crate::components::MatmulProblem;
 use crate::components::batch::{Partitioner, RowMajorGlobalPartitionMatmul};
 use crate::components::global::load::{sync_buffer_cyclic, sync_buffer_tilewise};
 use crate::components::stage::{
     self, BufferReaderFamily, ColMajorTilingOrder, NumStages, RowMajorTilingOrder,
 };
 use crate::components::tile;
-use crate::components::{LoadSpecializationConfig, MatmulProblem};
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};
@@ -146,10 +146,6 @@ where
 
     fn num_stages() -> NumStages {
         (2, 2).into()
-    }
-
-    fn plane_role_config() -> LoadSpecializationConfig {
-        LoadSpecializationConfig::Mirror
     }
 
     fn selection<R: Runtime>(

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -2,13 +2,13 @@ use cubecl_core::ir::Elem;
 use cubecl_core::prelude::*;
 use std::marker::PhantomData;
 
-use crate::components::MatmulProblem;
 use crate::components::batch::{Partitioner, RowMajorGlobalPartitionMatmul};
 use crate::components::global::load::{sync_buffer_cyclic, sync_buffer_tilewise};
 use crate::components::stage::{
     self, BufferReaderFamily, ColMajorTilingOrder, NumStages, RowMajorTilingOrder,
 };
-use crate::components::tile;
+use crate::components::{LoadingPlaneCount, MatmulProblem};
+use crate::components::{PlaneCountMode, tile};
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -8,7 +8,7 @@ use crate::components::global::load::sync_buffer_cyclic;
 use crate::components::stage::{
     self, BufferReaderFamily, FullReaderFamily, NumStages, RowMajorTilingOrder,
 };
-use crate::components::tile;
+use crate::components::{tile, LoadSpecializationConfig};
 use crate::components::{InvalidConfigError, MatmulProblem};
 use crate::components::{batch, global};
 
@@ -73,5 +73,9 @@ where
             elem_stage,
             elem_acc,
         )
+    }
+
+    fn plane_role_config() -> LoadSpecializationConfig {
+        LoadSpecializationConfig::Mirror
     }
 }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -45,7 +45,7 @@ where
         if selection.tiling_scheme.stage_partitions_in_stage_n() > 1 {
             return Err(Box::new("Ordered does not support partitions > 1 in n"));
         }
-        Self::GlobalMatmul::cube_dim(selection, Self::loading_plane_count())
+        Self::GlobalMatmul::cube_dim(selection, Self::plane_role_config())
     }
 
     fn num_stages() -> NumStages {

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -8,8 +8,8 @@ use crate::components::global::load::sync_buffer_cyclic;
 use crate::components::stage::{
     self, BufferReaderFamily, FullReaderFamily, NumStages, RowMajorTilingOrder,
 };
+use crate::components::tile;
 use crate::components::{InvalidConfigError, MatmulProblem};
-use crate::components::{LoadSpecializationConfig, tile};
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};
@@ -45,15 +45,11 @@ where
         if selection.tiling_scheme.stage_partitions_in_stage_n() > 1 {
             return Err(Box::new("Ordered does not support partitions > 1 in n"));
         }
-        Self::GlobalMatmul::cube_dim(selection, Self::plane_role_config())
+        Self::GlobalMatmul::cube_dim(selection, Self::load_specialization_config())
     }
 
     fn num_stages() -> NumStages {
         (1, 2).into()
-    }
-
-    fn partition_buffering_strategy() -> stage::PartitionBuffering {
-        stage::PartitionBuffering::Single
     }
 
     fn selection<R: Runtime>(
@@ -73,9 +69,5 @@ where
             elem_stage,
             elem_acc,
         )
-    }
-
-    fn plane_role_config() -> LoadSpecializationConfig {
-        LoadSpecializationConfig::Fixed(2)
     }
 }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -8,8 +8,8 @@ use crate::components::global::load::sync_buffer_cyclic;
 use crate::components::stage::{
     self, BufferReaderFamily, FullReaderFamily, NumStages, RowMajorTilingOrder,
 };
-use crate::components::{tile, LoadSpecializationConfig};
 use crate::components::{InvalidConfigError, MatmulProblem};
+use crate::components::{LoadSpecializationConfig, tile};
 use crate::components::{batch, global};
 
 use super::base::{self, MultiRowStrategy};
@@ -76,6 +76,6 @@ where
     }
 
     fn plane_role_config() -> LoadSpecializationConfig {
-        LoadSpecializationConfig::Mirror
+        LoadSpecializationConfig::Fixed(2)
     }
 }

--- a/crates/cubecl-matmul/src/tests/test_macros/suite/plane_accelerated/algorithm.rs
+++ b/crates/cubecl-matmul/src/tests/test_macros/suite/plane_accelerated/algorithm.rs
@@ -62,25 +62,25 @@ macro_rules! testgen_matmul_plane_accelerated_algorithm {
             $crate::testgen_matmul_accelerated_precision!(SimpleBarrierAlgorithm<TMM, async_full_maximize_unit_count::LoadingStrategy>);
         }
 
-        mod double_buffering_single_row_cyclic {
+        mod double_buffering_cyclic {
             use super::*;
 
             $crate::testgen_matmul_accelerated_precision!(CyclicDoubleBufferingAlgorithm<TMM>);
         }
 
-        mod double_buffering_single_row_tilewise {
+        mod double_buffering_tilewise {
             use super::*;
 
             $crate::testgen_matmul_accelerated_precision!(TilewiseDoubleBufferingAlgorithm<TMM>);
         }
 
-        mod double_buffering_single_row_hybrid {
+        mod double_buffering_hybrid {
             use super::*;
 
             $crate::testgen_matmul_accelerated_precision!(HybridDoubleBufferingAlgorithm<TMM>);
         }
 
-        mod ordered_double_buffering_single_row {
+        mod ordered_double_buffering {
             use super::*;
 
             $crate::testgen_matmul_accelerated_precision!(OrderedDoubleBufferingAlgorithm<TMM>);


### PR DESCRIPTION
Specialized Double Buffering. To enable specialized double buffering, simply adjust the `load_specialization_config` parameter in the `Algorithm`. It will automatically add the wanted number of load only planes. 

Right now it's configured so that
- In double buffering (vanilla), load-only will contribute to loading both loading lhs and rhs but will restrain from computing
- In ordered double buffering, load-only will load Rhs, while main flow planes will load Lhs. But main flow planes could help with Rhs as well, easy to set. 




## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
