### PR TITLE
Pool query sets to fix metal

### DIFF
--- a/crates/cubecl-matmul/src/components/global/single_stage/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/config.rs
@@ -1,8 +1,11 @@
 use crate::{
     components::{
+        Ident, InputIdent, MatmulConfig, MatrixLayout,
         global::{
-            self, load::LoaderMode, multi_stage::EventLoadingMode, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides
-        }, stage, Ident, InputIdent, MatmulConfig, MatrixLayout
+            self, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides, load::LoaderMode,
+            multi_stage::EventLoadingMode,
+        },
+        stage,
     },
     kernels::matmul::LoadingPrecomputeStrategy,
 };


### PR DESCRIPTION
Mac Currently trips over Cube creating query sets and crashing with:

```
[2025-06-14T03:48:01Z ERROR wgpu_hal::metal::device] Failed to create counter sample buffer: "Cannot allocate sample buffer"
[2025-06-14T03:48:01Z ERROR wgpu::backend::wgpu_core] Handling wgpu errors as fatal by default

thread 'tokio-runtime-worker' panicked at /Users/arthurbrussee/.cargo/git/checkouts/wgpu-50febe783b343bfe/6bf4985/wgpu/src/backend/wgpu_core.rs:1582:18:
wgpu error: Validation Error

Caused by:
  In Device::create_query_set
    Creation of a resource failed for a reason other than running out of memory.
```


I'm not sure why this is happening now but atm seems to break WGPU on macOS pretty badly. This pools query sets which seems to fix things, even if its not the best workaround, I guess in theory it's also faster.