### PR TITLE
Matmul: remove matmul layouts redundancy

### DIFF
--- a/crates/cubecl-matmul/src/components/line_size.rs
+++ b/crates/cubecl-matmul/src/components/line_size.rs
@@ -17,12 +17,6 @@ pub struct AvailableLineSizes {
     pub out: Vec<u8>,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct MatmulLayouts {
-    pub lhs: MatrixLayout,
-    pub rhs: MatrixLayout,
-}
-
 impl AvailableLineSizes {
     pub fn from_elem_types<R: Runtime>(elem_in: &Elem, elem_out: &Elem) -> Self {
         let in_available: Vec<u8> = R::line_size_elem(elem_in).collect();

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/base.rs
@@ -2,9 +2,7 @@ use crate::components::batch::BatchMatmulFamily;
 use crate::components::global::GlobalMatmulFamily;
 use crate::components::stage::StageMatmulFamily;
 use crate::components::tile::TileMatmulFamily;
-use crate::components::{
-    AvailableLineSizes, MatmulLayouts, MatmulLineSizes, MatmulPrecision, MatmulProblem,
-};
+use crate::components::{AvailableLineSizes, MatmulLineSizes, MatmulPrecision, MatmulProblem};
 use crate::kernels::MatmulSetupError;
 use cubecl_core::ir::Elem;
 use cubecl_core::prelude::*;
@@ -60,7 +58,6 @@ pub trait Algorithm {
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-        layouts: MatmulLayouts,
     ) -> MatmulSelection;
 
     fn filter_line_sizes(available_line_sizes: AvailableLineSizes) -> AvailableLineSizes {

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_buffering.rs
@@ -11,7 +11,7 @@ use crate::components::global::load::{sync_buffer_cyclic, sync_buffer_tilewise};
 use crate::components::stage::{
     BufferReaderFamily, ColMajorTilingOrder, PlaneMatmulFamily, RowMajorTilingOrder,
 };
-use crate::components::{MatmulLayouts, MatmulProblem, tile};
+use crate::components::{MatmulProblem, tile};
 use crate::components::{batch, global};
 
 use super::{MatmulSelection, MultiRowStrategy, base, plane_matmul_selection};
@@ -49,7 +49,6 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-        _layouts: MatmulLayouts,
     ) -> MatmulSelection {
         plane_matmul_selection::<TMM, R>(
             client,
@@ -86,7 +85,6 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-        _layouts: MatmulLayouts,
     ) -> MatmulSelection {
         plane_matmul_selection::<TMM, R>(
             client,
@@ -122,7 +120,6 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-        _layouts: MatmulLayouts,
     ) -> MatmulSelection {
         plane_matmul_selection::<TMM, R>(
             client,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/double_unit.rs
@@ -4,7 +4,7 @@ use cubecl_core::{Runtime, client::ComputeClient, ir::Elem};
 
 use crate::{
     components::{
-        MatmulLayouts, MatmulProblem,
+        MatmulProblem,
         batch::{self, PartitionedBatchMatmulFamily, Partitioner, RowMajorGlobalPartitionMatmul},
         global::{
             load::sync_buffer_cyclic, multi_stage::double_buffering::DoubleBufferingMatmulFamily,
@@ -41,8 +41,7 @@ where
         plane_dim: u32,
         _elem_stage: Elem,
         _elem_acc: Elem,
-        layouts: MatmulLayouts,
     ) -> MatmulSelection {
-        unit_matmul_selection(problem, layouts, plane_dim, true)
+        unit_matmul_selection(problem, plane_dim, true)
     }
 }

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/ordered_double_buffering.rs
@@ -13,7 +13,7 @@ use crate::components::stage::{
     BufferReaderFamily, FullReaderFamily, PlaneMatmulFamily, RowMajorTilingOrder,
 };
 use crate::components::tile;
-use crate::components::{MatmulLayouts, MatmulProblem, batch};
+use crate::components::{MatmulProblem, batch};
 
 use super::{MatmulSelection, MultiRowStrategy, base, plane_matmul_selection};
 
@@ -41,7 +41,6 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-        _layouts: MatmulLayouts,
     ) -> MatmulSelection {
         plane_matmul_selection::<TMM, R>(
             client,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/selector/select_kernel.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/selector/select_kernel.rs
@@ -1,8 +1,6 @@
 use super::MatmulSelection;
 use crate::components::batch::BatchConfig;
-use crate::components::{
-    InputRuntimeArg, MatmulLayouts, MatmulLineSizes, MatmulPrecision, OutputRuntimeArg,
-};
+use crate::components::{InputRuntimeArg, MatmulLineSizes, MatmulPrecision, OutputRuntimeArg};
 use crate::kernels::matmul::{Algorithm, launch_with_config};
 use crate::{
     components::{
@@ -30,7 +28,6 @@ pub fn launch_kernel_concrete<MS: MatmulSpec, R: Runtime, A: Algorithm>(
     line_sizes: MatmulLineSizes,
     plane_dim: u32,
     selection: &Option<MatmulSelection>,
-    layout: MatmulLayouts,
 ) -> Result<(), MatmulSetupError>
 where
     InputArg<MS>: ConcreteInputsFactory,
@@ -41,7 +38,7 @@ where
 
     let selection = match selection {
         Some(selection) => selection.clone(),
-        None => A::selection::<R>(client, &problem, plane_dim, elem_stage, elem_acc, layout),
+        None => A::selection::<R>(client, &problem, plane_dim, elem_stage, elem_acc),
     };
     let config = A::setup::<MS::Precision, R>(client, &problem, &selection, &line_sizes)?;
 
@@ -72,13 +69,12 @@ pub fn launch_kernel_virtual<'a, MS: MatmulSpec, R: Runtime, A: Algorithm>(
     output: OutputRuntimeArg<'a, MS, R>,
     problem: MatmulProblem,
     line_sizes: MatmulLineSizes,
-    layouts: MatmulLayouts,
     plane_dim: u32,
 ) -> Result<(), MatmulSetupError> {
     let elem_stage = <MS::Precision as MatmulPrecision>::ES::as_elem_native_unchecked();
     let elem_acc = <MS::Precision as MatmulPrecision>::EA::as_elem_native_unchecked();
 
-    let selection = A::selection::<R>(client, &problem, plane_dim, elem_stage, elem_acc, layouts);
+    let selection = A::selection::<R>(client, &problem, plane_dim, elem_stage, elem_acc);
     let config = A::setup::<MS::Precision, R>(client, &problem, &selection, &line_sizes)?;
 
     launch_with_config::<MS, R, A>(

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple.rs
@@ -4,7 +4,7 @@ use super::{MatmulSelection, MultiRowStrategy, base, plane_matmul_selection};
 use std::marker::PhantomData;
 
 use crate::components::{
-    MatmulLayouts, MatmulProblem,
+    MatmulProblem,
     batch::{self, PartitionedBatchMatmulFamily, Partitioner, RowMajorGlobalPartitionMatmul},
     global::{
         load::{SyncFullLoadingStrategy, sync_full_cyclic},
@@ -45,7 +45,6 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-        _layouts: MatmulLayouts,
     ) -> MatmulSelection {
         plane_matmul_selection::<TMM, R>(
             client,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_barrier.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_barrier.rs
@@ -4,7 +4,7 @@ use super::{MatmulSelection, MultiRowStrategy, base, plane_matmul_selection};
 use std::marker::PhantomData;
 
 use crate::components::{
-    MatmulLayouts, MatmulProblem,
+    MatmulProblem,
     batch::{self, PartitionedBatchMatmulFamily, Partitioner, RowMajorGlobalPartitionMatmul},
     global::{load::AsyncFullLoadingStrategy, single_stage::barrier::SimpleBarrierMatmulFamily},
     stage::{FullReaderFamily, PlaneMatmulFamily},
@@ -40,7 +40,6 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-        _layouts: MatmulLayouts,
     ) -> MatmulSelection {
         plane_matmul_selection::<TMM, R>(
             client,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_tma.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_tma.rs
@@ -4,7 +4,7 @@ use cubecl_core::{Runtime, client::ComputeClient, ir::Elem};
 
 use crate::{
     components::{
-        MatmulLayouts, MatmulProblem,
+        MatmulProblem,
         batch::{self, PartitionedBatchMatmulFamily, Partitioner, RowMajorGlobalPartitionMatmul},
         global::single_stage::tma::SimpleTmaMatmulFamily,
         stage::{FullReaderFamily, PlaneMatmulFamily},
@@ -37,7 +37,6 @@ where
         plane_dim: u32,
         elem_stage: Elem,
         elem_acc: Elem,
-        _layouts: MatmulLayouts,
     ) -> MatmulSelection {
         plane_matmul_selection::<TMM, R>(
             client,

--- a/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_unit.rs
+++ b/crates/cubecl-matmul/src/kernels/matmul/algorithm/simple_unit.rs
@@ -4,7 +4,7 @@ use super::{MatmulSelection, base, unit_matmul_selection};
 use std::marker::PhantomData;
 
 use crate::components::{
-    MatmulLayouts, MatmulProblem,
+    MatmulProblem,
     batch::{self, PartitionedBatchMatmulFamily, Partitioner, RowMajorGlobalPartitionMatmul},
     global::{
         load::{SyncFullLoadingStrategy, sync_full_cyclic},
@@ -43,8 +43,7 @@ where
         plane_dim: u32,
         _elem_stage: Elem,
         _elem_acc: Elem,
-        layouts: MatmulLayouts,
     ) -> MatmulSelection {
-        unit_matmul_selection(problem, layouts, plane_dim, false)
+        unit_matmul_selection(problem, plane_dim, false)
     }
 }


### PR DESCRIPTION
Matmul layouts was added to selector, but it was already contained in problem. 

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
