### PR TITLE
Fix cubecl standard library feature flag

### DIFF
--- a/crates/cubecl-std/src/lib.rs
+++ b/crates/cubecl-std/src/lib.rs
@@ -1,5 +1,7 @@
 //! Cubecl standard library.
 
+extern crate alloc;
+
 mod reinterpret_slice;
 pub use reinterpret_slice::*;
 mod fast_math;

--- a/crates/cubecl-std/src/tensor/handle.rs
+++ b/crates/cubecl-std/src/tensor/handle.rs
@@ -1,9 +1,9 @@
+use core::marker::PhantomData;
 use cubecl_core::calculate_cube_count_elemwise;
 use cubecl_core::prelude::*;
 use cubecl_core::tensor_line_size_parallel;
 use cubecl_core::{Runtime, server};
 use cubecl_runtime::server::Handle;
-use std::marker::PhantomData;
 
 /// Tensor representation containing a [server handle](Handle) as well as basic tensor metadata.,
 pub struct TensorHandle<R, E>
@@ -24,7 +24,7 @@ where
     R: Runtime,
     E: CubePrimitive,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!(
             "Tensor {{ shape: {:?}, strides: {:?}, dtype: {}}}",
             self.shape,

--- a/crates/cubecl-std/src/tensor/virtual.rs
+++ b/crates/cubecl-std/src/tensor/virtual.rs
@@ -1,6 +1,7 @@
+use alloc::sync::Arc;
+use core::marker::PhantomData;
 use cubecl::prelude::{CubeType, Scope, *};
 use cubecl_core::{self as cubecl, unexpanded};
-use std::{marker::PhantomData, sync::Arc};
 
 /// The read tag for [virtual tensor](VirtualTensor).
 #[derive(Clone)]

--- a/crates/cubecl-std/src/tests/reinterpret_slice.rs
+++ b/crates/cubecl-std/src/tests/reinterpret_slice.rs
@@ -23,7 +23,7 @@ pub fn run_test_read_global<R: Runtime>(
     }
 
     let target = [f16::from_f32(1.0), f16::from_f32(-8.5)];
-    let casted: [i8; 4] = unsafe { std::mem::transmute(target) };
+    let casted: [i8; 4] = unsafe { core::mem::transmute(target) };
 
     let input = client.create(i8::as_bytes(&casted));
     let output = client.empty(4);
@@ -61,7 +61,7 @@ pub fn run_test_write_global<R: Runtime>(
         return; // can't run test
     }
     let source = [f16::from_f32(1.0), f16::from_f32(-8.5)];
-    let casted: [i8; 4] = unsafe { std::mem::transmute(source) };
+    let casted: [i8; 4] = unsafe { core::mem::transmute(source) };
 
     let output = client.empty(4);
     let input = client.create(f16::as_bytes(&source));
@@ -143,7 +143,7 @@ pub fn run_test_write_shared_memory<R: Runtime>(client: ComputeClient<R::Server,
     }
 
     let source = [f16::from_f32(1.0), f16::from_f32(-8.5)];
-    let casted: [i8; 4] = unsafe { std::mem::transmute(source) };
+    let casted: [i8; 4] = unsafe { core::mem::transmute(source) };
 
     let output = client.empty(4);
     let input = client.create(f16::as_bytes(&source));

--- a/crates/cubecl-std/src/tests/tensor/identity.rs
+++ b/crates/cubecl-std/src/tests/tensor/identity.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use core::fmt::Display;
 
 use cubecl_core::{
     CubeElement,

--- a/crates/cubecl/Cargo.toml
+++ b/crates/cubecl/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 autotune-checks = ["cubecl-runtime/autotune-checks"]
 default = [
     "std",
+    "stdlib",
     "matmul",
     "convolution",
     "cubecl-core/default",
@@ -27,6 +28,7 @@ convolution = ["dep:cubecl-convolution"]
 reduce = ["dep:cubecl-reduce"]
 random = ["dep:cubecl-random"]
 std = ["cubecl-core/std", "cubecl-wgpu?/std", "cubecl-cuda?/std"]
+stdlib = ["cubecl-std"] # CubeCL standard library
 template = ["cubecl-core/template"]
 
 # Runtimes
@@ -52,7 +54,7 @@ cubecl-matmul = { path = "../cubecl-matmul", version = "0.6.0", default-features
 cubecl-random = { path = "../cubecl-random", version = "0.6.0", default-features = false, optional = true }
 cubecl-reduce = { path = "../cubecl-reduce", version = "0.6.0", default-features = false, optional = true }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.6.0", default-features = false }
-cubecl-std = { version = "0.6.0", path = "../cubecl-std" }
+cubecl-std = { path = "../cubecl-std", version = "0.6.0", optional = true }
 cubecl-wgpu = { path = "../cubecl-wgpu", version = "0.6.0", default-features = false, optional = true }
 half = { workspace = true }
 

--- a/crates/cubecl/src/lib.rs
+++ b/crates/cubecl/src/lib.rs
@@ -17,7 +17,7 @@ pub use cubecl_matmul as matmul;
 #[cfg(feature = "convolution")]
 pub use cubecl_convolution as convolution;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "stdlib")]
 pub use cubecl_std as std;
 
 #[cfg(feature = "reduce")]


### PR DESCRIPTION
Feature gating `cubecl::std` under the `std` feature flag conflicts with the standard practice for std/no-std.

I added an additional `stdlib` feature flag to the root `cubecl` crate instead, and changed the std imports to core/alloc stuff.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
