### PR TITLE
CudaDevice new and small ctx addition

### DIFF
--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -13,12 +13,12 @@ version.workspace = true
 [features]
 compilation-cache = ["cubecl-common/cache"]
 default = [
-    "std",
-    "cubecl-runtime/default",
-    "cubecl-common/default",
-    "cubecl-core/default",
-    "cudarc/cuda-12050",
-    "cudarc/dynamic-loading",
+  "std",
+  "cubecl-runtime/default",
+  "cubecl-common/default",
+  "cubecl-core/default",
+  "cudarc/cuda-12050",
+  "cudarc/dynamic-loading",
 ]
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 ptx-wmma = []
@@ -40,36 +40,36 @@ matmul_tests_f32 = ["cubecl-matmul/matmul_tests_f32"]
 matmul_tests_layouts = ["cubecl-matmul/matmul_tests_layouts"]
 matmul_tests_alt_shapes = ["cubecl-matmul/matmul_tests_alt_shapes"]
 matmul_tests_partition_buffering = [
-    "cubecl-matmul/matmul_tests_partition_buffering",
+  "cubecl-matmul/matmul_tests_partition_buffering",
 ]
 matmul_tests_hypercube = ["cubecl-matmul/matmul_tests_hypercube"]
 matmul_tests_base = [
-    "matmul_tests_plane",
-    "matmul_tests_double",
-    "matmul_tests_simple",
-    "matmul_tests_ordered",
-    "matmul_tests_cyclic",
-    "matmul_tests_f16",
+  "matmul_tests_plane",
+  "matmul_tests_double",
+  "matmul_tests_simple",
+  "matmul_tests_ordered",
+  "matmul_tests_cyclic",
+  "matmul_tests_f16",
 ]
 matmul_tests_all = [
-    "matmul_tests_unit",
-    "matmul_tests_plane",
-    "matmul_tests_tma",
-    "matmul_tests_double",
-    "matmul_tests_simple",
-    "matmul_tests_ordered",
-    "matmul_tests_cyclic",
-    "matmul_tests_strided",
-    "matmul_tests_tilewise",
-    "matmul_tests_hybrid",
-    "matmul_tests_barrier",
-    "matmul_tests_specialized",
-    "matmul_tests_f16",
-    "matmul_tests_f32",
-    "matmul_tests_layouts",
-    "matmul_tests_alt_shapes",
-    "matmul_tests_partition_buffering",
-    "matmul_tests_hypercube",
+  "matmul_tests_unit",
+  "matmul_tests_plane",
+  "matmul_tests_tma",
+  "matmul_tests_double",
+  "matmul_tests_simple",
+  "matmul_tests_ordered",
+  "matmul_tests_cyclic",
+  "matmul_tests_strided",
+  "matmul_tests_tilewise",
+  "matmul_tests_hybrid",
+  "matmul_tests_barrier",
+  "matmul_tests_specialized",
+  "matmul_tests_f16",
+  "matmul_tests_f32",
+  "matmul_tests_layouts",
+  "matmul_tests_alt_shapes",
+  "matmul_tests_partition_buffering",
+  "matmul_tests_hypercube",
 ]
 conv_tests = ["cubecl-convolution/conv_tests"]
 
@@ -77,18 +77,19 @@ conv_tests = ["cubecl-convolution/conv_tests"]
 cubecl-common = { path = "../cubecl-common", version = "0.6.0", default-features = false }
 cubecl-core = { path = "../cubecl-core", version = "0.6.0", default-features = false }
 cubecl-cpp = { path = "../cubecl-cpp", version = "0.6.0", default-features = false, features = [
-    "cuda",
+  "cuda",
 ] }
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.6.0", default-features = false, features = [
-    "channel-mutex",
+  "channel-mutex",
 ] }
 
 bytemuck = { workspace = true }
 cudarc = { version = "0.16.3", features = [
-    "std",
-    "driver",
-    "cuda-version-from-build-system",
-    "dynamic-loading",
+  "std",
+  "driver",
+  "cuda-version-from-build-system",
+  "dynamic-loading",
+  "nccl",
 ], default-features = false }
 
 derive-new = { workspace = true }
@@ -98,22 +99,22 @@ serde = { workspace = true }
 
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.6.0", features = [
-    "export_tests",
+  "export_tests",
 ] }
 cubecl-matmul = { path = "../cubecl-matmul", version = "0.6.0", features = [
-    "export_tests",
+  "export_tests",
 ] }
 cubecl-convolution = { path = "../cubecl-convolution", version = "0.6.0", features = [
-    "export_tests",
+  "export_tests",
 ] }
 cubecl-reduce = { path = "../cubecl-reduce", version = "0.6.0", features = [
-    "export_tests",
+  "export_tests",
 ] }
 cubecl-random = { path = "../cubecl-random", version = "0.6.0", features = [
-    "export_tests",
+  "export_tests",
 ] }
 cubecl-std = { path = "../cubecl-std", version = "0.6.0", features = [
-    "export_tests",
+  "export_tests",
 ] }
 paste = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/cubecl-cuda/src/device.rs
+++ b/crates/cubecl-cuda/src/device.rs
@@ -4,13 +4,61 @@
 // so it's 'safe' to store only this many bindings.
 pub const CUDA_MAX_BINDINGS: u32 = 1024;
 
-#[derive(new, Clone, PartialEq, Eq, Default, Hash)]
-pub struct CudaDevice {
-    pub index: usize,
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum CudaDevice {
+    Device {
+        id: usize,
+    },
+    Remote {
+        id: usize,
+        host: String,
+    },
+    Linked {
+        id: usize,
+        group: usize,
+    },
+    LinkedRemote {
+        id: usize,
+        group: usize,
+        host: String,
+    },
 }
 
-impl core::fmt::Debug for CudaDevice {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Cuda({})", self.index)
+pub struct CudaDeviceInfo {
+    pub id: usize,
+    pub group: usize,
+    pub host: Option<String>,
+}
+
+impl CudaDeviceInfo {
+    fn new(id: usize, group: usize, host: Option<String>) -> Self {
+        CudaDeviceInfo {
+            id, group, host,
+        }
+    }
+}
+
+impl CudaDevice {
+    pub fn id(&self) -> usize {
+        match self {
+            CudaDevice::Device { id } => *id,
+            CudaDevice::Remote { id, .. } => *id,
+            CudaDevice::Linked { id, .. } => *id,
+            CudaDevice::LinkedRemote { id, .. } => *id,
+        }
+    }
+
+    pub fn info(&self) -> CudaDeviceInfo {
+        match self {
+            CudaDevice::Device { id } => CudaDeviceInfo::new(*id, 0, None),
+            CudaDevice::Remote { id, host } => CudaDeviceInfo::new(*id, 0, Some(host.clone())),
+            CudaDevice::Linked { id, group } => CudaDeviceInfo::new(*id, *group, None),
+            CudaDevice::LinkedRemote { id, group, host } => CudaDeviceInfo::new(*id, *group, Some(host.clone())),
+        }
+    }
+}
+impl Default for CudaDevice {
+    fn default() -> Self {
+        CudaDevice::Device { id: 0 }
     }
 }

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -47,7 +47,7 @@ fn create_client<M: DialectWmmaCompiler<CudaDialect<M>>>(
 ) -> ComputeClient<Server, Channel> {
     // To get the supported WMMA features, and memory properties, we have to initialize the server immediately.
     cudarc::driver::result::init().unwrap();
-    let device_ptr = cudarc::driver::result::device::get(device.index as i32).unwrap();
+    let device_ptr = cudarc::driver::result::device::get(device.id() as i32).unwrap();
     let arch_major;
     let arch_version = unsafe {
         arch_major = cudarc::driver::result::device::get_attribute(
@@ -231,7 +231,9 @@ impl Runtime for CudaRuntime {
     }
 
     fn device_id(device: &Self::Device) -> DeviceId {
-        DeviceId::new(0, device.index as u32)
+        let device_info = device.info();
+
+        DeviceId::new(device_info.group as u16, device_info.id as u32)
     }
 
     fn name(_client: &ComputeClient<Self::Server, Self::Channel>) -> &'static str {


### PR DESCRIPTION
Here we got `CudaDevice` as enum and added an `Option<ncclComm_t>` to the Context. Would add functions in the ctx implementation so it's easy to initialize a comm if you guys allow these changes in `cubecl-cuda`. 