### PR TITLE
Fix/spirv various

### DIFF
--- a/crates/cubecl-ir/src/branch.rs
+++ b/crates/cubecl-ir/src/branch.rs
@@ -39,8 +39,12 @@ impl OperationReflect for Branch {
 impl Display for Branch {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Branch::If(if_) => write!(f, "if({})", if_.cond),
-            Branch::IfElse(if_else) => write!(f, "if({})", if_else.cond),
+            Branch::If(if_) => write!(f, "if({}) {}", if_.cond, if_.scope),
+            Branch::IfElse(if_else) => write!(
+                f,
+                "if({}) {} else {}",
+                if_else.cond, if_else.scope_if, if_else.scope_else
+            ),
             Branch::Switch(switch) => write!(
                 f,
                 "switch({}) {:?}",
@@ -53,13 +57,14 @@ impl Display for Branch {
             ),
             Branch::RangeLoop(range_loop) => write!(
                 f,
-                "for({} in {}{}{})",
+                "for({} in {}{}{}) {}",
                 range_loop.i,
                 range_loop.start,
                 if range_loop.inclusive { "..=" } else { ".." },
-                range_loop.end
+                range_loop.end,
+                range_loop.scope
             ),
-            Branch::Loop(_) => write!(f, "loop{{}}"),
+            Branch::Loop(loop_) => write!(f, "loop {}", loop_.scope),
             Branch::Return => write!(f, "return"),
             Branch::Break => write!(f, "break"),
         }

--- a/crates/cubecl-ir/src/scope.rs
+++ b/crates/cubecl-ir/src/scope.rs
@@ -1,5 +1,5 @@
-use alloc::{borrow::Cow, boxed::Box, rc::Rc, vec::Vec};
-use core::{any::TypeId, cell::RefCell};
+use alloc::{borrow::Cow, boxed::Box, rc::Rc, string::ToString, vec::Vec};
+use core::{any::TypeId, cell::RefCell, fmt::Display};
 use hashbrown::{HashMap, HashSet};
 
 use crate::{BarrierLevel, CubeFnSource, ExpandElement, Matrix, Processor, SourceLoc, TypeHash};
@@ -352,5 +352,24 @@ impl Scope {
                 .borrow_mut()
                 .insert(variable, name.into());
         }
+    }
+}
+
+impl Display for Scope {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "{{")?;
+        for instruction in self.instructions.iter() {
+            let instruction_str = instruction.to_string();
+            if !instruction_str.is_empty() {
+                writeln!(
+                    f,
+                    "{}{}",
+                    "    ".repeat(self.depth as usize + 1),
+                    instruction_str,
+                )?;
+            }
+        }
+        write!(f, "{}}}", "    ".repeat(self.depth as usize))?;
+        Ok(())
     }
 }

--- a/crates/cubecl-opt/src/passes/expression_merge.rs
+++ b/crates/cubecl-opt/src/passes/expression_merge.rs
@@ -140,7 +140,10 @@ fn check_op(
         return None;
     }
     for rhs_idx in indices.iter().skip(i + 1) {
-        if op.operation == ops.borrow()[*rhs_idx].operation {
+        // Type needs to be checked because versioned variable can have the same expression, but different output
+        if op.operation == ops.borrow()[*rhs_idx].operation
+            && out.item == ops.borrow()[*rhs_idx].out().item
+        {
             ops.borrow_mut()[*rhs_idx].operation = Operation::Copy(out);
             changes.inc();
         }

--- a/crates/cubecl-spirv/src/lookups.rs
+++ b/crates/cubecl-spirv/src/lookups.rs
@@ -164,13 +164,9 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         item: Item,
         insert: impl FnOnce(&mut Self) -> Word,
     ) -> Word {
-        if let Some(id) = self.state.constants.get(&(value, item.clone())) {
-            *id
-        } else {
-            let id = insert(self);
-            self.state.constants.insert((value, item), id);
-            id
-        }
+        let id = insert(self);
+        self.state.constants.insert((value, item), id);
+        id
     }
 
     pub fn get_or_insert_global(
@@ -178,17 +174,13 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         global: Globals,
         insert: impl FnOnce(&mut Self) -> Word,
     ) -> Word {
-        if let Some(id) = self.state.globals.get(&global) {
-            *id
-        } else {
-            let current_block = self.selected_block();
-            let setup = self.setup_block;
-            self.select_block(Some(setup)).unwrap();
-            let id = insert(self);
-            self.select_block(current_block).unwrap();
-            self.state.globals.insert(global, id);
-            id
-        }
+        let current_block = self.selected_block();
+        let setup = self.setup_block;
+        self.select_block(Some(setup)).unwrap();
+        let id = insert(self);
+        self.select_block(current_block).unwrap();
+        self.state.globals.insert(global, id);
+        id
     }
 
     pub fn get_local(&mut self, id: Id, item: &Item, var: ir::Variable) -> Word {

--- a/crates/cubecl-spirv/src/target.rs
+++ b/crates/cubecl-spirv/src/target.rs
@@ -68,6 +68,7 @@ impl SpirvTarget for GLCompute {
         b.capability(Capability::Shader);
         b.capability(Capability::VulkanMemoryModel);
         b.capability(Capability::VulkanMemoryModelDeviceScope);
+        b.capability(Capability::GroupNonUniform);
 
         let caps: Vec<_> = b.capabilities.iter().copied().collect();
         for cap in caps.iter() {


### PR DESCRIPTION
This PR contains fix to avoid segfault in burn notably:
- Merge same expression could merge expression that doesn't share the same out type.
- get_or_insert_global would not generate the necessary instruction when it is already cached. Removing the repetition of constant should be done in cubecl-opt not in spir-v.

It also introduce a printer for CubeCL IR by implementing Display for Scope.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [X] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [X] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [X] Fix any broken tests or compilation errors in burn.
- [X] Submit a PR in burn with your fixes and link it here.
