### PR TITLE
feat: Add native Metal backend (cubecl-metal)

### DIFF
--- a/crates/cubecl-metal/Cargo.toml
+++ b/crates/cubecl-metal/Cargo.toml
@@ -1,0 +1,112 @@
+[package]
+name = "cubecl-metal"
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[features]
+default = [
+    "cubecl-runtime/default",
+    "cubecl-common/default",
+    "cubecl-core/default",
+]
+
+std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
+
+
+matmul_tests_unit = ["cubecl-matmul/matmul_tests_unit"]
+matmul_tests_plane = ["cubecl-matmul/matmul_tests_plane"]
+matmul_tests_tma = ["cubecl-matmul/matmul_tests_tma"]
+matmul_tests_double = ["cubecl-matmul/matmul_tests_double"]
+matmul_tests_simple = ["cubecl-matmul/matmul_tests_simple"]
+matmul_tests_ordered = ["cubecl-matmul/matmul_tests_ordered"]
+matmul_tests_cyclic = ["cubecl-matmul/matmul_tests_cyclic"]
+matmul_tests_strided = ["cubecl-matmul/matmul_tests_strided"]
+matmul_tests_tilewise = ["cubecl-matmul/matmul_tests_tilewise"]
+matmul_tests_hybrid = ["cubecl-matmul/matmul_tests_hybrid"]
+matmul_tests_barrier = ["cubecl-matmul/matmul_tests_barrier"]
+matmul_tests_specialized = ["cubecl-matmul/matmul_tests_specialized"]
+matmul_tests_f16 = ["cubecl-matmul/matmul_tests_f16"]
+matmul_tests_f32 = ["cubecl-matmul/matmul_tests_f32"]
+matmul_tests_layouts = ["cubecl-matmul/matmul_tests_layouts"]
+matmul_tests_alt_shapes = ["cubecl-matmul/matmul_tests_alt_shapes"]
+matmul_tests_partition_buffering = [
+    "cubecl-matmul/matmul_tests_partition_buffering",
+]
+matmul_tests_hypercube = ["cubecl-matmul/matmul_tests_hypercube"]
+matmul_tests_base = [
+    "matmul_tests_plane",
+    "matmul_tests_double",
+    "matmul_tests_simple",
+    "matmul_tests_ordered",
+    "matmul_tests_cyclic",
+    "matmul_tests_f16",
+]
+matmul_tests_all = [
+    "matmul_tests_unit",
+    "matmul_tests_plane",
+    "matmul_tests_tma",
+    "matmul_tests_double",
+    "matmul_tests_simple",
+    "matmul_tests_ordered",
+    "matmul_tests_cyclic",
+    "matmul_tests_strided",
+    "matmul_tests_tilewise",
+    "matmul_tests_hybrid",
+    "matmul_tests_barrier",
+    "matmul_tests_specialized",
+    "matmul_tests_f16",
+    "matmul_tests_f32",
+    "matmul_tests_layouts",
+    "matmul_tests_alt_shapes",
+    "matmul_tests_partition_buffering",
+    "matmul_tests_hypercube",
+]
+conv_tests = ["cubecl-convolution/conv_tests"]
+
+
+[dependencies]
+cubecl-common = { path = "../cubecl-common", version = "0.6.0", default-features = false }
+cubecl-core = { path = "../cubecl-core", version = "0.6.0", default-features = false }
+cubecl-runtime = { path = "../cubecl-runtime", version = "0.6.0", default-features = false, features = [
+    "channel-mutex",
+] }
+cubecl-cpp = { path = "../cubecl-cpp", version = "0.6.0", features = [
+    "metal",
+] }
+
+bytemuck = { workspace = true }
+async-channel = { workspace = true }
+half = "2.6.0"
+log = { workspace = true }
+paste = { workspace = true }
+serde = { workspace = true, optional = true }
+objc2 = "0.6.1"
+objc2-foundation = "0.3.1"
+objc2-metal = "0.3.1"
+block2 = "0.6.1"
+
+
+
+[dev-dependencies]
+cubecl-core = { path = "../cubecl-core", version = "0.6.0", features = [
+    "export_tests",
+] }
+cubecl-std = { path = "../cubecl-std", version = "0.6.0", features = [
+    "export_tests",
+] }
+cubecl-matmul = { path = "../cubecl-matmul", version = "0.6.0", features = [
+    "export_tests",
+] }
+cubecl-convolution = { path = "../cubecl-convolution", version = "0.6.0", features = [
+    "export_tests",
+] }
+cubecl-reduce = { path = "../cubecl-reduce", version = "0.6.0", features = [
+    "export_tests",
+] }
+cubecl-random = { path = "../cubecl-random", version = "0.6.0", features = [
+    "export_tests",
+] }
+pretty_assertions = { workspace = true }

--- a/crates/cubecl-metal/src/compute/mod.rs
+++ b/crates/cubecl-metal/src/compute/mod.rs
@@ -1,0 +1,5 @@
+mod server;
+mod storage;
+mod stream;
+
+pub use server::*;

--- a/crates/cubecl-metal/src/compute/server.rs
+++ b/crates/cubecl-metal/src/compute/server.rs
@@ -1,0 +1,290 @@
+use super::storage::MetalStorage;
+use crate::compute::stream::MetalStream;
+use crate::{METAL_DISPATCH_LIMIT, METAL_MEMORY_ALIGNMENT};
+use cubecl_common::{CubeDim, future, profile};
+use cubecl_core::compute::{CubeTask, DebugInformation};
+use cubecl_core::future::DynFut;
+use cubecl_core::server::{Bindings, ComputeServer, Handle, ProfilingToken};
+use cubecl_core::{CubeCount, ExecutionMode, Feature, MemoryUsage, server};
+use cubecl_cpp::MslCompiler;
+use cubecl_cpp::formatter::format_cpp;
+use cubecl_cpp::shared::CompilationOptions;
+use cubecl_runtime::id::KernelId;
+use cubecl_runtime::logging::ServerLogger;
+use cubecl_runtime::memory_management::{
+    MemoryConfiguration, MemoryDeviceProperties, offset_handles,
+};
+use cubecl_runtime::storage::{BindingResource, ComputeStorage};
+use cubecl_runtime::timestamp_profiler::TimestampProfiler;
+use objc2::rc::{Retained, autoreleasepool};
+use objc2::runtime::ProtocolObject;
+use objc2_foundation::NSString;
+use objc2_metal::{
+    MTLCompileOptions, MTLComputePipelineState, MTLDevice, MTLLibrary, MTLLibraryOptimizationLevel,
+    MTLMathMode,
+};
+use profile::ProfileDuration;
+use server::ProfileError;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct MetalCompiledKernel {
+    cube_dim: CubeDim,
+    pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
+}
+
+#[derive(Debug)]
+pub struct MetalServer {
+    device: Retained<ProtocolObject<dyn MTLDevice>>,
+    stream: MetalStream,
+    pipelines: HashMap<KernelId, MetalCompiledKernel>,
+    compilation_options: CompilationOptions,
+    timestamps: TimestampProfiler,
+}
+
+unsafe impl Send for MetalServer {}
+unsafe impl Sync for MetalServer {}
+
+impl MetalServer {
+    pub fn new(
+        device: Retained<ProtocolObject<dyn MTLDevice>>,
+        compilation_options: CompilationOptions,
+        memory_properties: MemoryDeviceProperties,
+        memory_config: MemoryConfiguration,
+    ) -> Self {
+        let stream = MetalStream::new(device.clone(), memory_properties, memory_config);
+
+        Self {
+            device,
+            stream,
+            pipelines: HashMap::with_capacity(METAL_DISPATCH_LIMIT),
+            compilation_options,
+            timestamps: TimestampProfiler::default(),
+        }
+    }
+
+    fn compile_new_kernel(
+        &mut self,
+        kernel: Box<dyn CubeTask<MslCompiler>>,
+        mode: ExecutionMode,
+        logger: Arc<ServerLogger>,
+        kernel_id: &KernelId,
+    ) -> MetalCompiledKernel {
+        let _is_atomic = kernel_id.stable_format().contains("atomic");
+
+        let mut jit_kernel =
+            kernel.compile(&mut Default::default(), &self.compilation_options, mode);
+        let cube_dim = jit_kernel.cube_dim;
+
+        if logger.compilation_activated() {
+            jit_kernel.debug_info = Some(DebugInformation::new("cpp", kernel_id.clone()));
+
+            if let Ok(formatted) = format_cpp(&jit_kernel.source) {
+                jit_kernel.source = formatted;
+            }
+        }
+        logger.log_compilation(&jit_kernel);
+
+        autoreleasepool(|_| {
+            let compile_options = MTLCompileOptions::new();
+
+            unsafe {
+                compile_options.setMathMode(MTLMathMode::Fast);
+                compile_options.setOptimizationLevel(MTLLibraryOptimizationLevel::Default);
+            }
+            let library = self
+                .device
+                .newLibraryWithSource_options_error(
+                    &NSString::from_str(&jit_kernel.source),
+                    Some(&compile_options),
+                )
+                .expect("Failed to create Metal library");
+
+            let function = library
+                .newFunctionWithName(&NSString::from_str(&jit_kernel.entrypoint_name))
+                .expect("Failed to find function in library");
+
+            let pipeline_state = self
+                .device
+                .newComputePipelineStateWithFunction_error(&function)
+                .expect("Failed to create compute pipeline state");
+
+            MetalCompiledKernel {
+                cube_dim,
+                pipeline: pipeline_state,
+            }
+        })
+    }
+
+    pub(crate) fn pipeline(
+        &mut self,
+        kernel: Box<dyn CubeTask<MslCompiler>>,
+        mode: ExecutionMode,
+        logger: Arc<ServerLogger>,
+    ) -> MetalCompiledKernel {
+        let mut kernel_id = kernel.id();
+
+        kernel_id.mode(mode);
+
+        if let Some(cached_kernel) = self.pipelines.get(&kernel_id) {
+            return cached_kernel.clone();
+        }
+
+        let compiled_kernel = self.compile_new_kernel(kernel, mode, logger, &kernel_id);
+
+        self.pipelines
+            .insert(kernel_id.clone(), compiled_kernel.clone());
+
+        compiled_kernel
+    }
+}
+
+impl ComputeServer for MetalServer {
+    type Kernel = Box<dyn CubeTask<MslCompiler>>;
+    type Info = ();
+    type Storage = MetalStorage;
+    type Feature = Feature;
+
+    fn read(&mut self, bindings: Vec<server::Binding>) -> DynFut<Vec<Vec<u8>>> {
+        self.stream.read_buffers(bindings)
+    }
+
+    fn read_tensor(&mut self, bindings: Vec<server::BindingWithMeta>) -> DynFut<Vec<Vec<u8>>> {
+        let (expected_sizes, bindings): (Vec<_>, Vec<_>) = bindings
+            .into_iter()
+            .map(|it| {
+                (
+                    it.shape.iter().product::<usize>() * it.elem_size,
+                    it.binding,
+                )
+            })
+            .unzip();
+        let data = self.read(bindings);
+
+        Box::pin(async move {
+            let mut data = data.await;
+
+            for (data, expected_size) in data.iter_mut().zip(expected_sizes) {
+                data.truncate(expected_size);
+            }
+
+            data
+        })
+    }
+
+    fn sync(&mut self) -> DynFut<()> {
+        self.stream.sync()
+    }
+
+    fn get_resource(
+        &mut self,
+        binding: server::Binding,
+    ) -> BindingResource<<Self::Storage as ComputeStorage>::Resource> {
+        let resource = self.stream.get_resource(binding.clone());
+
+        BindingResource::new(binding, resource)
+    }
+
+    fn create(&mut self, data: &[u8]) -> Handle {
+        let handle = self.empty(data.len());
+
+        self.stream.copy_to_handle(handle.clone(), data);
+
+        handle
+    }
+
+    fn create_tensors(
+        &mut self,
+        data: Vec<&[u8]>,
+        shapes: Vec<&[usize]>,
+        elem_sizes: Vec<usize>,
+    ) -> Vec<(Handle, Vec<usize>)> {
+        let handles_strides: Vec<(Handle, Vec<usize>)> =
+            self.empty_tensors(shapes.clone(), elem_sizes);
+
+        for (data_slice, (handle, _)) in data.iter().zip(handles_strides.iter()) {
+            self.stream.copy_to_handle(handle.clone(), data_slice);
+        }
+
+        handles_strides
+    }
+
+    fn empty(&mut self, size: usize) -> Handle {
+        self.stream.empty(size)
+    }
+
+    fn empty_tensors(
+        &mut self,
+        shapes: Vec<&[usize]>,
+        elem_sizes: Vec<usize>,
+    ) -> Vec<(Handle, Vec<usize>)> {
+        let strides = shapes
+            .iter()
+            .map(|shape| contiguous_strides(shape))
+            .collect::<Vec<_>>();
+        let sizes = shapes
+            .iter()
+            .map(|it| it.iter().product::<usize>())
+            .zip(elem_sizes)
+            .map(|(size, elem_size)| (size * elem_size).next_multiple_of(METAL_MEMORY_ALIGNMENT))
+            .collect::<Vec<_>>();
+
+        let total_size = sizes.iter().sum::<usize>();
+
+        let mem_handle = self.empty(total_size);
+        let handles = offset_handles(mem_handle, &sizes);
+
+        handles.into_iter().zip(strides).collect()
+    }
+
+    unsafe fn execute(
+        &mut self,
+        kernel: Self::Kernel,
+        count: CubeCount,
+        bindings: Bindings,
+        kind: ExecutionMode,
+        logger: Arc<ServerLogger>,
+    ) {
+        let cached_kernel = self.pipeline(kernel, kind, logger);
+        let pipeline = cached_kernel.pipeline.clone();
+        let cube_dim = cached_kernel.cube_dim;
+
+        self.stream.register(pipeline, cube_dim, bindings, &count);
+    }
+
+    fn flush(&mut self) {
+        self.stream.flush()
+    }
+
+    fn memory_usage(&self) -> MemoryUsage {
+        self.stream.memory_management.memory_usage()
+    }
+
+    fn memory_cleanup(&mut self) {
+        self.stream.memory_management.cleanup(true);
+    }
+
+    fn start_profile(&mut self) -> ProfilingToken {
+        future::block_on(self.sync());
+
+        self.timestamps.start()
+    }
+
+    fn end_profile(&mut self, token: ProfilingToken) -> Result<ProfileDuration, ProfileError> {
+        future::block_on(self.sync());
+
+        self.timestamps.stop(token)
+    }
+}
+
+pub(crate) fn contiguous_strides(shape: &[usize]) -> Vec<usize> {
+    let rank = shape.len();
+    let mut strides = vec![1; rank];
+
+    for i in (0..rank - 1).rev() {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+
+    strides
+}

--- a/crates/cubecl-metal/src/compute/storage.rs
+++ b/crates/cubecl-metal/src/compute/storage.rs
@@ -1,0 +1,153 @@
+use crate::METAL_DISPATCH_LIMIT;
+use cubecl_runtime::memory_management::MemoryDeviceProperties;
+use cubecl_runtime::storage::{ComputeStorage, StorageHandle, StorageId, StorageUtilization};
+use objc2::rc::{Retained, autoreleasepool};
+use objc2::runtime::ProtocolObject;
+use objc2_metal::{
+    MTLBuffer, MTLCPUCacheMode, MTLDevice, MTLHazardTrackingMode, MTLHeap, MTLHeapDescriptor,
+    MTLResourceOptions, MTLStorageMode,
+};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct MetalResource {
+    buffer: Retained<ProtocolObject<dyn MTLBuffer>>,
+    offset: usize,
+    size: usize,
+}
+
+unsafe impl Send for MetalResource {}
+unsafe impl Sync for MetalResource {}
+
+impl MetalResource {
+    pub fn new(
+        buffer: Retained<ProtocolObject<dyn MTLBuffer>>,
+        offset: usize,
+        size: usize,
+    ) -> Self {
+        Self {
+            buffer,
+            offset,
+            size,
+        }
+    }
+    pub fn buffer(&self) -> &Retained<ProtocolObject<dyn MTLBuffer>> {
+        &self.buffer
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+pub struct MetalStorage {
+    device: Retained<ProtocolObject<dyn MTLDevice>>,
+    heap: Retained<ProtocolObject<dyn MTLHeap>>,
+    memory: HashMap<StorageId, MetalResource>,
+    mem_alignment: usize,
+}
+
+unsafe impl Send for MetalStorage {}
+unsafe impl Sync for MetalStorage {}
+
+impl MetalStorage {
+    pub fn new(
+        device: Retained<ProtocolObject<dyn MTLDevice>>,
+        memory_properties: MemoryDeviceProperties,
+    ) -> Self {
+        let heap = autoreleasepool(|_| unsafe {
+            let heap_descriptor = MTLHeapDescriptor::new();
+            let heap_size = memory_properties.max_page_size.next_multiple_of(4096);
+
+            heap_descriptor.setSize(heap_size as usize);
+            heap_descriptor.setStorageMode(MTLStorageMode::Shared);
+            heap_descriptor.setCpuCacheMode(MTLCPUCacheMode::WriteCombined);
+            heap_descriptor.setHazardTrackingMode(MTLHazardTrackingMode::Untracked);
+
+            device.newHeapWithDescriptor(&heap_descriptor)
+        })
+        .expect("Failed to create heap");
+        let mem_alignment = memory_properties.alignment as usize;
+
+        Self {
+            device,
+            heap,
+            mem_alignment,
+            memory: HashMap::with_capacity(METAL_DISPATCH_LIMIT),
+        }
+    }
+}
+
+impl ComputeStorage for MetalStorage {
+    type Resource = MetalResource;
+
+    fn alignment(&self) -> usize {
+        self.mem_alignment
+    }
+
+    fn get(&mut self, handle: &StorageHandle) -> Self::Resource {
+        let resource = self.memory.get(&handle.id).expect("Failed to get buffer");
+        MetalResource::new(
+            resource.buffer().clone(),
+            handle.offset() as usize,
+            handle.size() as usize,
+        )
+    }
+
+    fn alloc(&mut self, size: u64) -> StorageHandle {
+        let size = size as usize;
+        let available_size = self.heap.maxAvailableSizeWithAlignment(self.alignment());
+
+        let resource_options = MTLResourceOptions::StorageModeShared
+            | MTLResourceOptions::HazardTrackingModeUntracked
+            | MTLResourceOptions::CPUCacheModeWriteCombined;
+
+        // Try heap allocation first if there's enough space
+        let buffer = if available_size >= size {
+            // Attempt heap allocation
+            match self
+                .heap
+                .newBufferWithLength_options(size, resource_options)
+            {
+                Some(buf) => buf,
+                None => {
+                    // Heap allocation failed despite available space, fallback to device
+                    self.device
+                        .newBufferWithLength_options(size, resource_options)
+                        .expect("Failed to allocate buffer from device")
+                }
+            }
+        } else {
+            // Not enough heap space, allocate directly from device
+            self.device
+                .newBufferWithLength_options(size, resource_options)
+                .expect("Failed to allocate buffer from device")
+        };
+
+        // Create storage handle and resource
+        let storage_id = StorageId::new();
+        let resource = MetalResource {
+            buffer,
+            offset: 0,
+            size,
+        };
+
+        self.memory.insert(storage_id, resource);
+
+        StorageHandle::new(
+            storage_id,
+            StorageUtilization {
+                offset: 0,
+                size: size as u64,
+            },
+        )
+    }
+
+    fn dealloc(&mut self, id: StorageId) {
+        self.memory.remove(&id);
+    }
+}

--- a/crates/cubecl-metal/src/compute/stream.rs
+++ b/crates/cubecl-metal/src/compute/stream.rs
@@ -1,0 +1,310 @@
+use super::storage::{MetalResource, MetalStorage};
+use crate::METAL_DISPATCH_LIMIT;
+use block2::RcBlock;
+use cubecl_common::CubeDim;
+use cubecl_core::future::DynFut;
+use cubecl_core::server::Handle;
+use cubecl_runtime::memory_management::{
+    MemoryConfiguration, MemoryDeviceProperties, MemoryManagement,
+};
+use cubecl_runtime::server;
+use cubecl_runtime::server::{Bindings, CubeCount};
+use objc2::__framework_prelude::{ProtocolObject, Retained};
+use objc2::rc::autoreleasepool;
+use objc2_metal::{
+    MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue, MTLComputeCommandEncoder,
+    MTLComputePipelineState, MTLDevice, MTLSharedEvent, MTLSharedEventListener, MTLSize,
+};
+use std::collections::VecDeque;
+use std::ptr::NonNull;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+#[derive(Debug)]
+pub(crate) struct MetalStream {
+    command_queue: Retained<ProtocolObject<dyn MTLCommandQueue>>,
+    current_buffer: Option<Retained<ProtocolObject<dyn MTLCommandBuffer>>>,
+    current_encoder: Option<Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>>,
+    pending_operations: VecDeque<(u64, Retained<ProtocolObject<dyn MTLCommandBuffer>>)>,
+    pub memory_management: MemoryManagement<MetalStorage>,
+
+    event: Retained<ProtocolObject<dyn MTLSharedEvent>>,
+    event_counter: Arc<AtomicU64>,
+
+    tasks_count: usize,
+}
+
+impl MetalStream {
+    pub(crate) fn new(
+        device: Retained<ProtocolObject<dyn MTLDevice>>,
+        memory_properties: MemoryDeviceProperties,
+        memory_config: MemoryConfiguration,
+    ) -> Self {
+        let command_queue = device
+            .newCommandQueue()
+            .expect("Failed to create Metal command queue");
+
+        let event = device
+            .newSharedEvent()
+            .expect("Failed to create Metal shared event");
+
+        let storage = MetalStorage::new(device.clone(), memory_properties.clone());
+        let memory_management =
+            MemoryManagement::from_configuration(storage, &memory_properties, memory_config);
+
+        Self {
+            command_queue,
+            current_buffer: None,
+            current_encoder: None,
+            pending_operations: VecDeque::with_capacity(METAL_DISPATCH_LIMIT),
+            memory_management,
+            event,
+            event_counter: Arc::new(AtomicU64::new(0)),
+            tasks_count: 0,
+        }
+    }
+
+    pub(crate) fn get_resource(&mut self, binding: server::Binding) -> MetalResource {
+        self.memory_management
+            .get_resource(
+                binding.memory.clone(),
+                binding.offset_start,
+                binding.offset_end,
+            )
+            .expect("Failed to find resource")
+    }
+
+    pub(crate) fn copy_to_handle(&mut self, handle: Handle, data: &[u8]) {
+        let resource = self.get_resource(handle.binding());
+
+        unsafe {
+            let contents = resource.buffer().contents();
+            let dst_slice = std::slice::from_raw_parts_mut(
+                (contents.as_ptr() as *mut u8).add(resource.offset()),
+                data.len(),
+            );
+            dst_slice.copy_from_slice(data);
+        }
+    }
+
+    pub fn read_buffers(&mut self, bindings: Vec<server::Binding>) -> DynFut<Vec<Vec<u8>>> {
+        if bindings.is_empty() {
+            return Box::pin(async move { Vec::new() });
+        }
+
+        self.flush();
+
+        autoreleasepool(|_| {
+            let command_buffer = self
+                .command_queue
+                .commandBuffer()
+                .expect("Failed to create command buffer for read");
+
+            let (sender, receiver) = async_channel::bounded(1);
+
+            let resources: Vec<_> = bindings
+                .iter()
+                .map(|binding| {
+                    self.memory_management
+                        .get_resource(
+                            binding.memory.clone(),
+                            binding.offset_start,
+                            binding.offset_end,
+                        )
+                        .expect("Failed to get resource")
+                })
+                .collect();
+
+            let completion_handler = RcBlock::new({
+                move |_buffer| {
+                    let results: Vec<Vec<u8>> = resources
+                        .iter()
+                        .map(|resource| unsafe {
+                            let contents = resource.buffer().contents();
+                            let data_ptr = (contents.as_ptr() as *const u8).add(resource.offset());
+                            let data = std::slice::from_raw_parts(data_ptr, resource.size());
+                            data.to_vec()
+                        })
+                        .collect();
+
+                    let _ = sender.try_send(results);
+                }
+            });
+            let block: *const _ = &*completion_handler;
+
+            unsafe {
+                command_buffer.addCompletedHandler(block.cast_mut());
+            }
+            command_buffer.commit();
+
+            Box::pin(async move { receiver.recv().await.expect("Failed to receive data") })
+        })
+    }
+
+    pub fn sync(&mut self) -> DynFut<()> {
+        self.flush();
+
+        if let Some(&(fence, _)) = self.pending_operations.back() {
+            let (sender, receiver) = async_channel::bounded(1);
+            let listener = MTLSharedEventListener::new();
+            let handler = RcBlock::new(
+                move |_evt: NonNull<ProtocolObject<dyn MTLSharedEvent>>, value: u64| {
+                    if value >= fence {
+                        let _ = sender.try_send(());
+                    }
+                },
+            );
+            let block: *const _ = &*handler;
+
+            unsafe {
+                self.event
+                    .notifyListener_atValue_block(&listener, fence, block.cast_mut());
+            }
+            self.pending_operations.clear();
+
+            return Box::pin(async move {
+                receiver.recv().await.unwrap();
+            });
+        }
+
+        Box::pin(async move {})
+    }
+
+    pub fn empty(&mut self, size: usize) -> Handle {
+        let handle = self.memory_management.reserve(size as u64, None);
+
+        Handle::new(handle, None, None, size as u64)
+    }
+
+    pub fn register(
+        &mut self,
+        pipeline: Retained<ProtocolObject<dyn MTLComputePipelineState>>,
+        cube_dim: CubeDim,
+        bindings: Bindings,
+        dispatch: &CubeCount,
+    ) {
+        // --- Phase 1: Prepare all resources (single pass optimization) ---
+        let has_metadata = !bindings.metadata.data.is_empty();
+
+        // Pre-calculate capacity with a single pass through scalars
+        let mut scalar_count = 0;
+        let mut non_empty_scalars = Vec::new();
+        for (elem, scalar) in &bindings.scalars {
+            if !scalar.data().is_empty() {
+                scalar_count += 1;
+                non_empty_scalars.push((*elem, scalar));
+            }
+        }
+
+        let total_resources = bindings.buffers.len() + has_metadata as usize + scalar_count;
+        let mut all_resources = Vec::with_capacity(total_resources);
+
+        // Add buffer resources
+        for binding in bindings.buffers {
+            all_resources.push(self.get_resource(binding));
+        }
+
+        // Add metadata if needed
+        if has_metadata {
+            let info_data: &[u8] = bytemuck::cast_slice(&bindings.metadata.data);
+            let handle = self.empty(info_data.len());
+            self.copy_to_handle(handle.clone(), info_data);
+            all_resources.push(self.get_resource(handle.binding()));
+        }
+
+        // Add scalar resources (already filtered in single pass above)
+        for (_elem, scalar) in non_empty_scalars {
+            let handle = self.empty(scalar.data().len());
+            self.copy_to_handle(handle.clone(), scalar.data());
+            all_resources.push(self.get_resource(handle.binding()));
+        }
+
+        let dynamic_resource = if let CubeCount::Dynamic(binding) = dispatch {
+            Some(self.get_resource(binding.clone()))
+        } else {
+            None
+        };
+
+        // --- Phase 2: Encode and dispatch ---
+        if self.current_encoder.is_none() {
+            let buffer = self
+                .command_queue
+                .commandBuffer()
+                .expect("Failed to create command buffer");
+            self.current_encoder = Some(
+                buffer
+                    .computeCommandEncoder()
+                    .expect("Command encoder should exist"),
+            );
+            self.current_buffer = Some(buffer);
+        }
+
+        let compute_encoder = self.current_encoder.as_ref().unwrap();
+        compute_encoder.setComputePipelineState(&pipeline);
+
+        let threads_per_threadgroup = MTLSize {
+            width: cube_dim.x as usize,
+            height: cube_dim.y as usize,
+            depth: cube_dim.z as usize,
+        };
+
+        // Bind resources efficiently
+        for (index, resource) in all_resources.iter().enumerate() {
+            unsafe {
+                compute_encoder.setBuffer_offset_atIndex(
+                    Some(resource.buffer()),
+                    resource.offset(),
+                    index,
+                );
+            }
+        }
+
+        match dispatch {
+            CubeCount::Static(x, y, z) => {
+                compute_encoder.dispatchThreadgroups_threadsPerThreadgroup(
+                    MTLSize {
+                        width: *x as usize,
+                        height: *y as usize,
+                        depth: *z as usize,
+                    },
+                    threads_per_threadgroup,
+                );
+            }
+            CubeCount::Dynamic(_) => unsafe {
+                let metal_resource = dynamic_resource
+                    .as_ref()
+                    .expect("Dynamic resource should be allocated");
+
+                compute_encoder
+                        .dispatchThreadgroupsWithIndirectBuffer_indirectBufferOffset_threadsPerThreadgroup(
+                            metal_resource.buffer(),
+                            metal_resource.offset(),
+                            threads_per_threadgroup,
+                        );
+            },
+        }
+        self.tasks_count += 1;
+
+        if self.tasks_count >= METAL_DISPATCH_LIMIT {
+            self.flush();
+        }
+    }
+
+    pub fn flush(&mut self) {
+        if let (Some(buffer), Some(encoder)) =
+            (self.current_buffer.take(), self.current_encoder.take())
+        {
+            encoder.endEncoding();
+
+            let fence = self.event_counter.fetch_add(1, Ordering::SeqCst) + 1;
+
+            buffer.encodeSignalEvent_value(self.event.as_ref(), fence);
+            buffer.commit();
+
+            self.pending_operations.push_back((fence, buffer));
+            self.tasks_count = 0;
+        }
+    }
+}

--- a/crates/cubecl-metal/src/device.rs
+++ b/crates/cubecl-metal/src/device.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
+pub struct MetalDevice {
+    index: usize,
+}
+
+impl MetalDevice {
+    pub fn index(&self) -> usize {
+        self.index
+    }
+}

--- a/crates/cubecl-metal/src/lib.rs
+++ b/crates/cubecl-metal/src/lib.rs
@@ -1,0 +1,29 @@
+mod compute;
+mod device;
+mod runtime;
+
+pub use device::*;
+pub use runtime::{MetalRuntime, RuntimeOptions};
+
+pub(crate) const METAL_MEMORY_ALIGNMENT: usize = 256;
+pub(crate) const METAL_DISPATCH_LIMIT: usize = 32;
+
+#[cfg(test)]
+#[allow(unexpected_cfgs)]
+mod tests {
+    use crate::runtime::MetalRuntime;
+    use half::f16;
+
+    pub type TestRuntime = MetalRuntime;
+
+    cubecl_core::testgen_all!(f32: [f16, f32], i32: [i16, i32], u32: [u16, u32]);
+    cubecl_std::testgen!();
+    cubecl_std::testgen_tensor_identity!([f16, flex32, f32, u32]);
+    cubecl_convolution::testgen_conv2d_accelerated!([f16: f16]);
+    cubecl_matmul::testgen_matmul_simple!([f16, f32]);
+    cubecl_matmul::testgen_matmul_plane_accelerated!();
+    cubecl_matmul::testgen_matmul_unit!();
+    cubecl_reduce::testgen_reduce!();
+    cubecl_random::testgen_random!();
+    cubecl_reduce::testgen_shared_sum!([f32]);
+}

--- a/crates/cubecl-metal/src/runtime.rs
+++ b/crates/cubecl-metal/src/runtime.rs
@@ -1,0 +1,172 @@
+use crate::METAL_MEMORY_ALIGNMENT;
+use crate::compute::{MetalServer, contiguous_strides};
+use crate::device::MetalDevice;
+use cubecl_common::benchmark::TimingMethod;
+use cubecl_core::{CubeDim, Feature, Runtime};
+use cubecl_cpp::metal::MslDialect;
+use cubecl_cpp::metal::arch::MetalArchitecture;
+use cubecl_cpp::shared::{CompilationOptions, register_wmma_features};
+use cubecl_cpp::{DialectWmmaCompiler, MslCompiler};
+use cubecl_runtime::channel::MutexComputeChannel;
+use cubecl_runtime::client::ComputeClient;
+use cubecl_runtime::id::DeviceId;
+use cubecl_runtime::memory_management::{
+    HardwareProperties, MemoryConfiguration, MemoryDeviceProperties,
+};
+use cubecl_runtime::server::CubeCount;
+use cubecl_runtime::{ComputeRuntime, DeviceProperties};
+use objc2_metal::{MTLCreateSystemDefaultDevice, MTLDevice};
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+/// Options configuring the Metal runtime.
+#[derive(Default)]
+pub struct RuntimeOptions {
+    /// Configures the memory management.
+    pub memory_config: MemoryConfiguration,
+}
+
+impl RuntimeOptions {
+    fn default() -> Self {
+        Self {
+            memory_config: MemoryConfiguration::default(),
+        }
+    }
+
+    /// Create runtime options with custom memory configuration
+    pub fn with_memory_config(memory_config: MemoryConfiguration) -> Self {
+        Self { memory_config }
+    }
+}
+
+#[derive(Debug)]
+pub struct MetalRuntime;
+
+type Server = MetalServer;
+type Channel = MutexComputeChannel<Server>;
+
+static RUNTIME: ComputeRuntime<MetalDevice, Server, Channel> = ComputeRuntime::new();
+
+impl Runtime for MetalRuntime {
+    type Compiler = MslCompiler;
+    type Server = MetalServer;
+    type Channel = MutexComputeChannel<MetalServer>;
+    type Device = MetalDevice;
+
+    fn device_id(device: &Self::Device) -> DeviceId {
+        let device_hash = {
+            let mut hasher = DefaultHasher::new();
+
+            device.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        DeviceId::new(0, device_hash as u32)
+    }
+
+    fn client(device: &Self::Device) -> ComputeClient<Self::Server, Self::Channel> {
+        RUNTIME.client(device, || create_client(device, RuntimeOptions::default()))
+    }
+
+    fn name(_client: &ComputeClient<Self::Server, Self::Channel>) -> &'static str {
+        "metal"
+    }
+
+    fn supported_line_sizes() -> &'static [u8] {
+        &[8, 4, 2, 1]
+    }
+
+    fn max_cube_count() -> (u32, u32, u32) {
+        (u16::MAX as u32, u16::MAX as u32, u16::MAX as u32)
+    }
+
+    fn can_read_tensor(shape: &[usize], strides: &[usize]) -> bool {
+        if shape.is_empty() {
+            return true;
+        }
+
+        let expected_strides = contiguous_strides(shape);
+        expected_strides == strides
+    }
+}
+
+fn create_client(_device: &MetalDevice, options: RuntimeOptions) -> ComputeClient<Server, Channel> {
+    let metal_device = MTLCreateSystemDefaultDevice().expect("Failed to create Metal device");
+
+    let hardware_props = {
+        let max_threads_per_threadgroup = metal_device.maxThreadsPerThreadgroup().width.min(1024);
+        let max_shared_memory = metal_device.maxThreadgroupMemoryLength();
+
+        HardwareProperties {
+            plane_size_min: 32,
+            plane_size_max: 32,
+            max_bindings: 31,
+            max_shared_memory_size: max_shared_memory,
+            max_cube_count: CubeCount::new_3d(u16::MAX as u32, u16::MAX as u32, u16::MAX as u32),
+            max_units_per_cube: max_threads_per_threadgroup as u32,
+            max_cube_dim: CubeDim::new_3d(1024, 1024, 64),
+            num_streaming_multiprocessors: None,
+            num_tensor_cores: None,
+            min_tensor_cores_dim: Some(8),
+        }
+    };
+
+    let mem_properties = MemoryDeviceProperties {
+        max_page_size: metal_device.recommendedMaxWorkingSetSize() / 4,
+        alignment: METAL_MEMORY_ALIGNMENT as u64,
+    };
+
+    let compilation_options = CompilationOptions::default();
+
+    let mut device_props = DeviceProperties::new(
+        &[Feature::Plane],
+        mem_properties.clone(),
+        hardware_props,
+        TimingMethod::System,
+    );
+
+    register_types(&mut device_props);
+
+    let combinations = MslDialect::supported_wmma_combinations(&MetalArchitecture::Metal3);
+    register_wmma_features(combinations, &mut device_props);
+
+    device_props.register_feature(Feature::SyncPlane);
+
+    let server = MetalServer::new(
+        metal_device,
+        compilation_options,
+        mem_properties,
+        options.memory_config,
+    );
+
+    ComputeClient::new(MutexComputeChannel::new(server), device_props, ())
+}
+
+fn register_types(props: &mut DeviceProperties<Feature>) {
+    use cubecl_core::ir::{Elem, FloatKind, IntKind, UIntKind};
+
+    let mut register = |elem| {
+        props.register_feature(Feature::Type(elem));
+    };
+
+    let types = [
+        Elem::UInt(UIntKind::U8),
+        Elem::UInt(UIntKind::U16),
+        Elem::UInt(UIntKind::U32),
+        Elem::UInt(UIntKind::U64),
+        Elem::Int(IntKind::I8),
+        Elem::Int(IntKind::I16),
+        Elem::Int(IntKind::I32),
+        Elem::Int(IntKind::I64),
+        Elem::Float(FloatKind::F16),
+        Elem::Float(FloatKind::F32),
+        Elem::AtomicInt(IntKind::I32),
+        Elem::AtomicUInt(UIntKind::U32),
+        Elem::AtomicUInt(UIntKind::U64),
+        Elem::AtomicFloat(FloatKind::F32),
+        Elem::Bool,
+    ];
+
+    for ty in types {
+        register(ty);
+    }
+}

--- a/crates/cubecl/Cargo.toml
+++ b/crates/cubecl/Cargo.toml
@@ -42,6 +42,7 @@ hip-rocwmma = ["cubecl-hip?/rocwmma"]
 wgpu = ["cubecl-wgpu"]
 wgpu-spirv = ["wgpu", "cubecl-wgpu/spirv"]
 wgpu-msl = ["wgpu", "cubecl-wgpu/msl"]
+metal = ["cubecl-metal"]
 
 compilation-cache = [
     "cubecl-cuda?/compilation-cache",
@@ -59,6 +60,7 @@ cubecl-reduce = { path = "../cubecl-reduce", version = "0.6.0", default-features
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.6.0", default-features = false }
 cubecl-std = { path = "../cubecl-std", version = "0.6.0", optional = true }
 cubecl-wgpu = { path = "../cubecl-wgpu", version = "0.6.0", default-features = false, optional = true }
+cubecl-metal = { path = "../cubecl-metal", version = "0.6.0", default-features = false, optional = true }
 half = { workspace = true }
 
 [[bench]]

--- a/crates/cubecl/benches/matmul.rs
+++ b/crates/cubecl/benches/matmul.rs
@@ -268,4 +268,8 @@ fn main() {
     {
         run_benches::<cubecl::wgpu::WgpuRuntime, half::f16>();
     }
+    #[cfg(feature = "metal")]
+    {
+        run_benches::<cubecl::metal::MetalRuntime, half::f16>();
+    }
 }

--- a/crates/cubecl/benches/unary.rs
+++ b/crates/cubecl/benches/unary.rs
@@ -24,6 +24,7 @@ fn execute<F: Float>(lhs: &Tensor<F>, rhs: &Tensor<F>, out: &mut Tensor<F>) {
 
 impl<R: Runtime, E: Float> Benchmark for UnaryBench<R, E> {
     type Input = (TensorHandle<R, E>, TensorHandle<R, E>, TensorHandle<R, E>);
+    type Output = ();
 
     fn prepare(&self) -> Self::Input {
         let client = R::client(&self.device);
@@ -72,7 +73,9 @@ impl<R: Runtime, E: Float> Benchmark for UnaryBench<R, E> {
     }
 
     fn profile(&self, args: Self::Input) -> cubecl::benchmark::ProfileDuration {
-        self.client.profile(|| self.execute(args))
+        self.client
+            .profile(|| self.execute(args), "unary-bench")
+            .unwrap()
     }
 }
 
@@ -108,4 +111,8 @@ fn main() {
     run::<cubecl::wgpu::WgpuRuntime, f32>(Default::default(), 1);
     #[cfg(feature = "wgpu")]
     run::<cubecl::wgpu::WgpuRuntime, f32>(Default::default(), 4);
+    #[cfg(feature = "metal")]
+    run::<cubecl::metal::MetalRuntime, f32>(Default::default(), 1);
+    #[cfg(feature = "metal")]
+    run::<cubecl::metal::MetalRuntime, f32>(Default::default(), 4);
 }

--- a/crates/cubecl/src/lib.rs
+++ b/crates/cubecl/src/lib.rs
@@ -11,6 +11,9 @@ pub use cubecl_cuda as cuda;
 #[cfg(feature = "hip")]
 pub use cubecl_hip as hip;
 
+#[cfg(feature = "metal")]
+pub use cubecl_metal as metal;
+
 #[cfg(feature = "matmul")]
 pub use cubecl_matmul as matmul;
 

--- a/examples/gelu/Cargo.toml
+++ b/examples/gelu/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 default = []
 wgpu = ["cubecl/wgpu"]
 cuda = ["cubecl/cuda"]
+metal = ["cubecl/metal"]
 
 [dependencies]
 cubecl = { path = "../../crates/cubecl", version = "0.6.0" }

--- a/examples/gelu/examples/gelu.rs
+++ b/examples/gelu/examples/gelu.rs
@@ -3,4 +3,6 @@ fn main() {
     gelu::launch::<cubecl::cuda::CudaRuntime>(&Default::default());
     #[cfg(feature = "wgpu")]
     gelu::launch::<cubecl::wgpu::WgpuRuntime>(&Default::default());
+    #[cfg(feature = "metal")]
+    gelu::launch::<cubecl::metal::MetalRuntime>(&Default::default());
 }


### PR DESCRIPTION
This pull request introduces a new `cubecl-metal` crate, adding a native Metal backend to CubeCL for Apple platforms. This closes issue #27.

### Motivation

While `wgpu` provides a great cross-platform abstraction, a native Metal backend creates opportunities for significant advantages for users on Apple devices:

1. **Potential for Enhanced Performance:** A direct implementation allows for finer-grained control and unlocks the potential for future performance optimizations that are not possible through a generic abstraction layer.
2. **Deeper Optimization:** Bypassing the abstraction layer enables us to leverage Metal-specific features and performance tuning capabilities.
3. **Future-Readiness:** With Metal 4 scheduled for release in September, a native backend will allow us to integrate new features much more rapidly than waiting for `wgpu` to provide support.


---
### Benchmark: Native Metal vs. WGPU (MSL)

We conducted a series of benchmarks to establish a performance baseline for the native `metal` backend against the `wgpu-msl` backend.

While the current results do not show a dramatic performance increase, this native implementation provides the foundation needed for future, targeted optimizations. The percentage in the `Performance vs WGPU` column indicates how much faster (positive) or slower (negative) the native Metal backend is compared to WGPU MSL.

**Note on Benchmarking:**

* For a more accurate and fair comparison, the Unary benchmark, previously measured by `System` time, has been modified to be measured by `Device` time for both backends.

#### Detailed Results

**1. Unary Operations**
<details>
<summary>Benchmark Commands</summary>

```shell
# Metal
RUSTFLAGS=-Awarnings cargo bench --bench unary --features metal,random --no-default-features --quiet
# WGPU
RUSTFLAGS=-Awarnings cargo bench --bench unary --features wgpu-msl,random --no-default-features --quiet
```

</details>

| Benchmark | Metal Native (Mean) | WGPU MSL (Mean) | Performance vs WGPU |
| :--- | :--- | :--- | :--- |
| `unary-f32-1` | 1.488ms | 3.044ms | **+51.1%** |
| `unary-f32-4` | 62.899ms | 65.614ms | **+4.1%** |

**2. Convolution Operations**
<details>
<summary>Benchmark Commands</summary>

```shell
# Metal
RUSTFLAGS=-Awarnings cargo bench --bench conv2d --features metal,random --no-default-features --quiet
# WGPU
RUSTFLAGS=-Awarnings cargo bench --bench conv2d --features wgpu-msl,random --no-default-features --quiet
```

</details>

| Precision | Input / Weight | Metal Native (Mean) | WGPU MSL (Mean) | Performance vs WGPU |
| :--- | :--- | :--- | :--- | :--- |
| `f32` | `[16,3,227,227]`, `[96,3,11,11]` | 69.410ms | 72.661ms | **+4.5%** |
| `f32` | `[16,4,256,256]`, `[64,4,8,8]` | 58.109ms | 65.258ms | **+10.9%** |
| `f16` | `[16,3,227,227]`, `[96,3,11,11]` | 64.299ms | 66.889ms | **+3.9%** |
| `f16` | `[16,4,256,256]`, `[64,4,8,8]` | 44.649ms | 46.743ms | **+4.5%** |

**3. Matrix Multiplication Operations (`f16`)**
<details>
<summary>Benchmark Commands</summary>

```shell
# Metal
RUSTFLAGS=-Awarnings cargo bench --bench matmul --features metal,random --no-default-features --quiet
# WGPU
RUSTFLAGS=-Awarnings cargo bench --bench matmul --features wgpu-msl,random --no-default-features --quiet
```

</details>

| Dimensions (b, m, n, k) | Metal Native (Mean) | WGPU MSL (Mean) | Performance vs WGPU |
| :--- | :--- | :--- | :--- |
| `1, 6144, 6144, 6144` | 136.274ms | 140.816ms | **+3.2%** |
| `1, 5000, 5000, 5000` | 83.646ms | 87.231ms | **+4.1%** |
| `2, 4096, 4096, 4096` | 85.726ms | 84.682ms | **-1.2%** |
| `5, 512, 512, 512` | 1.770ms | 2.978ms | **+40.6%** |
| `10, 256, 256, 256` | 1.032ms | 2.484ms | **+58.5%** |

---

### Note on burn integration

Currently, `cubecl-metal` is not yet integrated with the burn repository. This means that automated validation or testing of `cubecl-metal` within burn is not possible until further integration work is done (e.g., adding `cubecl-metal` as a dependency, updating backend selection logic, and providing metal-specific tests/examples in burn). As such, this PR only validates the basic functionality and benchmarks of `cubecl-metal` itself. Integration with burn will be addressed in a future PR.

---

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
