### PR TITLE
Cleanup code in SPIR-V backend

### DIFF
--- a/crates/cubecl-spirv/src/cmma.rs
+++ b/crates/cubecl-spirv/src/cmma.rs
@@ -86,9 +86,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         let item = self.item(&mat);
         let ty = item.id(self);
         let mat_id = match value {
-            Variable::ConstantScalar(id, value, _) => {
-                self.get_or_insert_const(value, item, |b| b.constant_composite(ty, vec![id]))
-            }
+            Variable::ConstantScalar(id, _, _) => self.constant_composite(ty, vec![id]),
             var => {
                 let var = self.read(&var);
                 self.composite_construct(ty, None, vec![var]).unwrap()

--- a/crates/cubecl-spirv/src/item.rs
+++ b/crates/cubecl-spirv/src/item.rs
@@ -112,27 +112,25 @@ impl Item {
 
     pub fn constant<T: SpirvTarget>(&self, b: &mut SpirvCompiler<T>, value: ConstVal) -> Word {
         let scalar = self.elem().constant(b, value);
-        b.get_or_insert_const(value, self.clone(), |b| {
-            let ty = self.id(b);
-            match self {
-                Item::Scalar(_) => scalar,
-                Item::Vector(_, vec) => b.constant_composite(ty, (0..*vec).map(|_| scalar)),
-                Item::Array(item, len) => {
-                    let elem = item.constant(b, value);
-                    b.constant_composite(ty, (0..*len).map(|_| elem))
-                }
-                Item::RuntimeArray(_) => unimplemented!("Can't create constant runtime array"),
-                Item::Struct(elems) => {
-                    let items = elems
-                        .iter()
-                        .map(|item| item.constant(b, value))
-                        .collect::<Vec<_>>();
-                    b.constant_composite(ty, items)
-                }
-                Item::Pointer(_, _) => unimplemented!("Can't create constant pointer"),
-                Item::CoopMatrix { .. } => unimplemented!("Can't create constant cmma matrix"),
+        let ty = self.id(b);
+        match self {
+            Item::Scalar(_) => scalar,
+            Item::Vector(_, vec) => b.constant_composite(ty, (0..*vec).map(|_| scalar)),
+            Item::Array(item, len) => {
+                let elem = item.constant(b, value);
+                b.constant_composite(ty, (0..*len).map(|_| elem))
             }
-        })
+            Item::RuntimeArray(_) => unimplemented!("Can't create constant runtime array"),
+            Item::Struct(elems) => {
+                let items = elems
+                    .iter()
+                    .map(|item| item.constant(b, value))
+                    .collect::<Vec<_>>();
+                b.constant_composite(ty, items)
+            }
+            Item::Pointer(_, _) => unimplemented!("Can't create constant pointer"),
+            Item::CoopMatrix { .. } => unimplemented!("Can't create constant cmma matrix"),
+        }
     }
 
     pub fn const_u32<T: SpirvTarget>(&self, b: &mut SpirvCompiler<T>, value: u32) -> Word {
@@ -295,18 +293,16 @@ impl Elem {
     }
 
     pub fn constant<T: SpirvTarget>(&self, b: &mut SpirvCompiler<T>, value: ConstVal) -> Word {
-        b.get_or_insert_const(value, Item::Scalar(*self), |b| {
-            let ty = self.id(b);
-            match self {
-                Elem::Void => unreachable!(),
-                Elem::Bool if value.as_u64() != 0 => b.constant_true(ty),
-                Elem::Bool => b.constant_false(ty),
-                _ => match value {
-                    ConstVal::Bit32(val) => b.constant_bit32(ty, val),
-                    ConstVal::Bit64(val) => b.constant_bit64(ty, val),
-                },
-            }
-        })
+        let ty = self.id(b);
+        match self {
+            Elem::Void => unreachable!(),
+            Elem::Bool if value.as_u64() != 0 => b.constant_true(ty),
+            Elem::Bool => b.constant_false(ty),
+            _ => match value {
+                ConstVal::Bit32(val) => b.constant_bit32(ty, val),
+                ConstVal::Bit64(val) => b.constant_bit64(ty, val),
+            },
+        }
     }
 }
 

--- a/crates/cubecl-spirv/src/metadata.rs
+++ b/crates/cubecl-spirv/src/metadata.rs
@@ -5,7 +5,7 @@ use rspirv::spirv::{StorageClass, Word};
 use crate::{
     SpirvCompiler, SpirvTarget,
     item::{Elem, Item},
-    variable::{Globals, Variable},
+    variable::Variable,
 };
 
 impl<T: SpirvTarget> SpirvCompiler<T> {
@@ -145,7 +145,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
     }
 
     pub fn load_const_metadata(&mut self, index: u32, out: Option<Word>) -> Word {
-        self.get_or_insert_global(Globals::Metadata(index), |b| {
+        self.insert_global(|b| {
             let int = Item::Scalar(Elem::Int(32, false));
             let int_ty = int.id(b);
             let int_ptr = Item::Pointer(StorageClass::StorageBuffer, Box::new(int)).id(b);

--- a/crates/cubecl-spirv/src/variable.rs
+++ b/crates/cubecl-spirv/src/variable.rs
@@ -317,39 +317,6 @@ pub enum IndexedVariable {
     Scalar(Variable),
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum Globals {
-    Id,
-    LocalInvocationId,
-    LocalInvocationIdX,
-    LocalInvocationIdY,
-    LocalInvocationIdZ,
-    LocalInvocationIndex,
-    WorkgroupId,
-    WorkgroupIdX,
-    WorkgroupIdY,
-    WorkgroupIdZ,
-    WorkgroupIndex,
-    GlobalInvocationId,
-    GlobalInvocationIdX,
-    GlobalInvocationIdY,
-    GlobalInvocationIdZ,
-    GlobalInvocationIndex,
-    WorkgroupSize,
-    WorkgroupSizeX,
-    WorkgroupSizeY,
-    WorkgroupSizeZ,
-    NumWorkgroups,
-    NumWorkgroupsTotal,
-    NumWorkgroupsX,
-    NumWorkgroupsY,
-    NumWorkgroupsZ,
-    SubgroupSize,
-    SubgroupInvocationId,
-
-    Metadata(u32),
-}
-
 impl<T: SpirvTarget> SpirvCompiler<T> {
     pub fn compile_variable(&mut self, variable: ir::Variable) -> Variable {
         let item = variable.item;


### PR DESCRIPTION
Refactor by inlining get_or_insert_const and rename get_or_insert_global to insert_global, because of previous simplification in PR #764 .

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [X] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [X] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [X] Fix any broken tests or compilation errors in burn.
- [X] Submit a PR in burn with your fixes and link it here.
