### PR TITLE
Fix wasm autotune key

### DIFF
--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -227,8 +227,14 @@ impl<K: AutotuneKey> Tuner<K> {
             #[cfg(std_io)]
             let checksum = tunables.compute_checksum();
 
+            #[cfg(target_family = "wasm")]
+            let key_cloned = key.clone();
+
             let fut_result = async move {
                 Self::generate_tune_message(
+                    #[cfg(target_family = "wasm")]
+                    key_cloned,
+                    #[cfg(not(target_family = "wasm"))]
                     key,
                     &client,
                     plan,

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -227,15 +227,11 @@ impl<K: AutotuneKey> Tuner<K> {
             #[cfg(std_io)]
             let checksum = tunables.compute_checksum();
 
-            #[cfg(target_family = "wasm")]
             let key_cloned = key.clone();
 
             let fut_result = async move {
                 Self::generate_tune_message(
-                    #[cfg(target_family = "wasm")]
                     key_cloned,
-                    #[cfg(not(target_family = "wasm"))]
-                    key,
                     &client,
                     plan,
                     autotunables,


### PR DESCRIPTION
Small fix related to changes in #768.

The key is moved but with wasm it is also used to mark the tuning as pending just after.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
