### PR TITLE
`calculate_bin_stats` include high in last bin 

### DIFF
--- a/crates/cubecl-random/src/tests_utils.rs
+++ b/crates/cubecl-random/src/tests_utils.rs
@@ -23,7 +23,8 @@ pub fn calculate_bin_stats<E: Numeric>(
         if num < low || num > high {
             continue;
         }
-        let index = f32::floor((num - low) / range) as usize;
+        // When num = high, index should be clamped to `number_of_bins` - 1
+        let index = (f32::floor((num - low) / range) as usize).min(number_of_bins - 1);
         output[index].count += 1;
         if initialized && index != current_runs {
             output[current_runs].n_runs += 1;


### PR DESCRIPTION
Encountered this bug in the latest Burn [tests run](https://github.com/tracel-ai/burn/actions/runs/16276707339/job/45957393487)

```
  failures:
  
  ---- tests::cube::kernel::normal::tests::normal_respects_68_95_99_rule stdout ----
  
  thread 'tests::cube::kernel::normal::tests::normal_respects_68_95_99_rule' panicked at /home/agent/.cargo/git/checkouts/cubecl-058c47895211d464/e5e86e8/crates/cubecl-random/src/tests_utils.rs:27:15:
  index out of bounds: the len is 6 but the index is 6
  
  
  failures:
      tests::cube::kernel::normal::tests::normal_respects_68_95_99_rule
```

When `num = low` it's included (0) but when `num = high` the index should probably be in the last bin (previously, index would be out of bounds).

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
