### PR TITLE
Fix typo in example code of cubecl-book

### DIFF
--- a/cubecl-book/src/getting-started/src/bin/v2-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v2-gpu.rs
@@ -24,7 +24,7 @@ pub fn launch<R: Runtime, F: Float + CubeElement>(device: &R::Device) {
             CubeCount::Static(1, 1, 1),
             CubeDim::new(1, 1, 1),
             input.into_tensor_arg(1),
-            input.into_tensor_arg(1),
+            output.into_tensor_arg(1),
         )
     };
 


### PR DESCRIPTION
Hello,

I believe this line should be using the `output` variable instead of `input`. 

This is my first pull request and I have little to no experience with git in a collaborative environment, so if I should have contacted a developer instead, I apologise. I'm also a bit unsure about this step (since it is a typo fix):

- [] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.

A bit of guidance would be greatly appreciated :slightly_smiling_face: 

