### PR TITLE
Matmul: Refactor ident and stage memory config

### DIFF
--- a/crates/cubecl-convolution/src/algorithm/mod.rs
+++ b/crates/cubecl-convolution/src/algorithm/mod.rs
@@ -1,5 +1,5 @@
 use cubecl_matmul::components::{
-    AvailableLineSizes, MatmulIdent, LoadingPrecomputeStrategy, MatmulLineSizes, MatmulPrecision,
+    AvailableLineSizes, LoadingPrecomputeStrategy, MatmulIdent, MatmulLineSizes, MatmulPrecision,
     MatmulSelection, MatmulSetupError, MultiRowStrategy,
     global::{LoadSpecializationConfig, args::MatmulArgs, load::LoaderMode},
     stage::{NumStages, PartitionBuffering, StageMatmulFamily},

--- a/crates/cubecl-convolution/src/algorithm/mod.rs
+++ b/crates/cubecl-convolution/src/algorithm/mod.rs
@@ -1,5 +1,5 @@
 use cubecl_matmul::components::{
-    AvailableLineSizes, InputIdent, LoadingPrecomputeStrategy, MatmulLineSizes, MatmulPrecision,
+    AvailableLineSizes, MatmulIdent, LoadingPrecomputeStrategy, MatmulLineSizes, MatmulPrecision,
     MatmulSelection, MatmulSetupError, MultiRowStrategy,
     global::{LoadSpecializationConfig, args::MatmulArgs, load::LoaderMode},
     stage::{NumStages, PartitionBuffering, StageMatmulFamily},
@@ -75,7 +75,7 @@ pub trait Algorithm {
     fn into_tensor_handle<R: Runtime, E: Numeric>(
         client: &ComputeClient<R::Server, R::Channel>,
         handle: &TensorHandleRef<'_, R>,
-        ident: InputIdent,
+        ident: MatmulIdent,
     ) -> TensorHandle<R, E>;
 
     fn selection<R: Runtime>(

--- a/crates/cubecl-convolution/src/algorithm/multi_stage_tma.rs
+++ b/crates/cubecl-convolution/src/algorithm/multi_stage_tma.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use cubecl_matmul::components::{
-    InputIdent, MatmulSelection,
+    MatmulIdent, MatmulSelection,
     global::args::TensorMapArgs,
     stage::{FullReaderFamily, NumStages, PlaneMatmulFamily},
     tile::TileMatmulFamily,
@@ -40,7 +40,7 @@ impl<TMM: TileMatmulFamily> Algorithm for MultiStageTmaConvAlgorithm<TMM> {
     fn into_tensor_handle<R: Runtime, E: Numeric>(
         client: &ComputeClient<R::Server, R::Channel>,
         handle: &TensorHandleRef<'_, R>,
-        ident: InputIdent,
+        ident: MatmulIdent,
     ) -> TensorHandle<R, E> {
         into_tensor_handle_tma(client, handle, ident)
     }

--- a/crates/cubecl-convolution/src/homogeneous/base.rs
+++ b/crates/cubecl-convolution/src/homogeneous/base.rs
@@ -98,6 +98,7 @@ pub mod config {
             GlobalConfig, PlaneRoleConfig, SpecializedLoadingSides, load::LoaderMode,
             multi_stage::EventLoadingMode,
         },
+        stage::StageConfig,
     };
 
     use super::*;
@@ -123,6 +124,11 @@ pub mod config {
 
     impl<M: GlobalConfig> GlobalConfig for ConvolutionConfig<M> {
         type StageConfig = M::StageConfig;
+        type StageMemoryConfig = <M::StageConfig as StageConfig>::StageMemoryConfig;
+
+        fn stage_memory_config(&self) -> Self::StageMemoryConfig {
+            todo!()
+        }
 
         fn stage_config(&self) -> Self::StageConfig {
             self.matmul.stage_config()

--- a/crates/cubecl-convolution/src/homogeneous/base.rs
+++ b/crates/cubecl-convolution/src/homogeneous/base.rs
@@ -8,7 +8,7 @@ use cubecl_std::{
 use crate::base::{Convolution, ConvolutionFamily, RuntimeArgs};
 
 use cubecl_matmul::components::{
-    Ident,
+    MatmulIdent,
     global::{
         GlobalConfig,
         args::{MatmulArgs, TensorInput, TensorInputIdent, TensorOutput},
@@ -93,7 +93,7 @@ pub mod config {
 
     use crate::{ConvGemmConfig, base::Dimensionality};
     use cubecl_matmul::components::{
-        InputIdent, MatmulLineSizes, MatmulSetupError, MatrixLayout, TilingScheme,
+        MatmulLineSizes, MatmulSetupError, MatrixLayout, TilingScheme,
         global::{
             GlobalConfig, PlaneRoleConfig, SpecializedLoadingSides, load::LoaderMode,
             multi_stage::EventLoadingMode,
@@ -128,15 +128,15 @@ pub mod config {
             self.matmul.stage_config()
         }
 
-        fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
+        fn global_line_size(&self, ident: MatmulIdent) -> u32 {
             self.matmul.global_line_size(ident)
         }
 
-        fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
+        fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
             self.matmul.matrix_layout(ident)
         }
 
-        fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32 {
+        fn num_loading_planes(&self, ident: MatmulIdent) -> u32 {
             self.matmul.num_loading_planes(ident)
         }
 
@@ -144,11 +144,11 @@ pub mod config {
             self.matmul.plane_dim()
         }
 
-        fn check_row_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+        fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
             self.matmul.check_row_bounds(ident)
         }
 
-        fn check_col_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+        fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
             self.matmul.check_col_bounds(ident)
         }
 
@@ -160,7 +160,7 @@ pub mod config {
             self.matmul.precompute_job()
         }
 
-        fn num_stages(&self, _ident: InputIdent) -> u32 {
+        fn num_stages(&self, _ident: MatmulIdent) -> u32 {
             self.num_stages
         }
 
@@ -172,7 +172,7 @@ pub mod config {
             self.matmul.tiling_scheme()
         }
 
-        fn event_loading_mode(&self, ident: InputIdent) -> EventLoadingMode {
+        fn event_loading_mode(&self, ident: MatmulIdent) -> EventLoadingMode {
             self.matmul.event_loading_mode(ident)
         }
 
@@ -212,9 +212,9 @@ pub mod config {
 
         fn line_sizes(&self) -> cubecl_matmul::components::MatmulLineSizes {
             MatmulLineSizes {
-                lhs: self.global_line_size(Ident::Lhs) as u8,
-                rhs: self.global_line_size(Ident::Rhs) as u8,
-                out: self.global_line_size(Ident::Out) as u8,
+                lhs: self.global_line_size(MatmulIdent::Lhs) as u8,
+                rhs: self.global_line_size(MatmulIdent::Rhs) as u8,
+                out: self.global_line_size(MatmulIdent::Out) as u8,
             }
         }
     }

--- a/crates/cubecl-convolution/src/homogeneous/multi_stage_tma.rs
+++ b/crates/cubecl-convolution/src/homogeneous/multi_stage_tma.rs
@@ -18,7 +18,7 @@ use cubecl_core::{
     prelude::barrier::{Barrier, BarrierLevel},
 };
 use cubecl_matmul::components::{
-    AvailableLineSizes, EA, EI, EO, ES, InputIdent, InputRuntimeArg, MatmulLineSizes,
+    AvailableLineSizes, EA, EI, EO, ES, InputRuntimeArg, MatmulIdent, MatmulLineSizes,
     MatmulPrecision, MatmulSelection, MatmulSetupError, MatmulSpec, OutputRuntimeArg, TilingScheme,
     global::{
         AccumulatorLoader, GlobalConfig,
@@ -85,7 +85,7 @@ where
         #[comptime] config: Self::Config,
     ) {
         // Arbitrarily using Lhs, they should be the same
-        let num_stages = config.num_stages(InputIdent::Lhs);
+        let num_stages = config.num_stages(MatmulIdent::Lhs);
         let stage_config = config.stage_config();
         let k_step = config.k_step;
         let range = k_range.1 - k_range.0;
@@ -196,7 +196,7 @@ where
             x_offset,
             y_offset,
             runtime_args,
-            config.num_stages(InputIdent::Lhs),
+            config.num_stages(MatmulIdent::Lhs),
             config,
         )
     }
@@ -214,7 +214,7 @@ where
             y_offset,
             CubeOption::new_None(),
             runtime_args,
-            config.num_stages(InputIdent::Rhs),
+            config.num_stages(MatmulIdent::Rhs),
             config,
         )
     }

--- a/crates/cubecl-convolution/src/homogeneous/simple.rs
+++ b/crates/cubecl-convolution/src/homogeneous/simple.rs
@@ -10,7 +10,7 @@ use crate::{
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_matmul::components::{
-    AvailableLineSizes, EA, EI, EO, ES, MatmulIdent, InputRuntimeArg, MatmulLineSizes,
+    AvailableLineSizes, EA, EI, EO, ES, InputRuntimeArg, MatmulIdent, MatmulLineSizes,
     MatmulPrecision, MatmulSelection, MatmulSetupError, MatmulSpec, OutputRuntimeArg,
     global::{
         AccumulatorLoader, GlobalConfig,

--- a/crates/cubecl-convolution/src/homogeneous/simple.rs
+++ b/crates/cubecl-convolution/src/homogeneous/simple.rs
@@ -10,7 +10,7 @@ use crate::{
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_matmul::components::{
-    AvailableLineSizes, EA, EI, EO, ES, InputIdent, InputRuntimeArg, MatmulLineSizes,
+    AvailableLineSizes, EA, EI, EO, ES, MatmulIdent, InputRuntimeArg, MatmulLineSizes,
     MatmulPrecision, MatmulSelection, MatmulSetupError, MatmulSpec, OutputRuntimeArg,
     global::{
         AccumulatorLoader, GlobalConfig,
@@ -139,7 +139,7 @@ where
             y_offset,
             0,
             CubeOption::new_None(),
-            InputIdent::Rhs,
+            MatmulIdent::Rhs,
             config,
         )
     }

--- a/crates/cubecl-convolution/src/launch.rs
+++ b/crates/cubecl-convolution/src/launch.rs
@@ -8,7 +8,7 @@ use crate::ConvGemmConfig;
 use crate::base::ConvolutionLaunch;
 use cubecl_matmul::components::global::args::{ConcreteOutputFactory, MatmulArgs};
 use cubecl_matmul::components::{
-    self, AvailableLineSizes, InputIdent, MatmulPrecision, MatmulSelection,
+    self, AvailableLineSizes, MatmulIdent, MatmulPrecision, MatmulSelection,
 };
 
 use super::{
@@ -99,8 +99,8 @@ where
     let kernel_shape = &weight.shape[1..dim_c];
     let out_shape = &out.shape[1..dim_c];
 
-    let input = Alg::into_tensor_handle::<R, MP::EI>(client, input, InputIdent::Lhs);
-    let weight = Alg::into_tensor_handle::<R, MP::EI>(client, weight, InputIdent::Rhs);
+    let input = Alg::into_tensor_handle::<R, MP::EI>(client, input, MatmulIdent::Lhs);
+    let weight = Alg::into_tensor_handle::<R, MP::EI>(client, weight, MatmulIdent::Rhs);
 
     let plane_dim = client.properties().hardware.plane_size_max;
 

--- a/crates/cubecl-convolution/src/loader/im2col.rs
+++ b/crates/cubecl-convolution/src/loader/im2col.rs
@@ -32,8 +32,11 @@ impl<MP: MatmulPrecision, G: ConvGemmConfig> SimpleIm2colLoader<MP, G> {
         runtime_args: &RuntimeArgs,
         #[comptime] config: G,
     ) -> Self {
-        let stage =
-            StageMemory::new::<G::StageConfig>(1u32, StageIdent::Lhs, config.stage_config());
+        let stage = StageMemory::new::<G::StageMemoryConfig>(
+            1u32,
+            StageIdent::Lhs,
+            config.stage_memory_config(),
+        );
 
         let shape_m = runtime_args.size_m;
         let shape_k = runtime_args.size_k;
@@ -142,11 +145,9 @@ fn load_at_position<MP: MatmulPrecision, G: ConvGemmConfig>(
     let nth_tile = unit_position / tile_num_elements;
     let pos_within_tile = unit_position % tile_num_elements;
 
-    let (tile_x, tile_y) = ContiguousTilingLayout::<RowMajorTilingOrder>::to_x_y::<G::StageConfig>(
-        nth_tile,
-        ident.into_stage(),
-        config.stage_config(),
-    );
+    let (tile_x, tile_y) = ContiguousTilingLayout::<RowMajorTilingOrder>::to_x_y::<
+        G::StageMemoryConfig,
+    >(nth_tile, ident.into_stage(), config.stage_memory_config());
 
     let line_read = tensor_reader.load_simple::<G>(tile_x, tile_y, pos_within_tile, ident, config);
 

--- a/crates/cubecl-convolution/src/loader/im2col_tma.rs
+++ b/crates/cubecl-convolution/src/loader/im2col_tma.rs
@@ -42,10 +42,10 @@ impl<MP: MatmulPrecision, G: ConvGemmConfig> TmaIm2colLoader<MP, G> {
 
         #[unroll]
         for _ in 0..num_stages {
-            stages.push(StageMemory::new_aligned::<G::StageConfig>(
+            stages.push(StageMemory::new_aligned::<G::StageMemoryConfig>(
                 StageIdent::Lhs,
                 128u32,
-                config.stage_config(),
+                config.stage_memory_config(),
             ))
         }
 

--- a/crates/cubecl-convolution/src/loader/im2col_tma.rs
+++ b/crates/cubecl-convolution/src/loader/im2col_tma.rs
@@ -1,6 +1,7 @@
 use cubecl_core::{self as cubecl, prelude::barrier::Barrier};
 use cubecl_core::{intrinsic, prelude::*};
 
+use cubecl_matmul::components::StageIdent;
 use cubecl_std::{FastDivmod, tensor::r#virtual::VirtualTensor};
 use std::marker::PhantomData;
 
@@ -10,7 +11,7 @@ use crate::{
     reader::tma::Im2colTmaReader,
 };
 use cubecl_matmul::components::{
-    Ident, InputIdent, MatmulPrecision,
+    MatmulPrecision,
     stage::{ColMajorTilingOrder, ContiguousTilingLayout, FullStageToTileReader, StageMemory},
 };
 
@@ -42,7 +43,7 @@ impl<MP: MatmulPrecision, G: ConvGemmConfig> TmaIm2colLoader<MP, G> {
         #[unroll]
         for _ in 0..num_stages {
             stages.push(StageMemory::new_aligned::<G::StageConfig>(
-                Ident::Lhs,
+                StageIdent::Lhs,
                 128u32,
                 config.stage_config(),
             ))
@@ -156,7 +157,7 @@ impl<MP: MatmulPrecision, G: ConvGemmConfig> TmaIm2colLoader<MP, G> {
     }
 
     pub fn reader(this: &Self, #[comptime] stage_idx: u32) -> TmaIm2colReader<MP> {
-        TmaIm2colReader::<MP>::new(*this.stages.index(stage_idx), InputIdent::Lhs)
+        TmaIm2colReader::<MP>::new(*this.stages.index(stage_idx), StageIdent::Lhs)
     }
 }
 

--- a/crates/cubecl-convolution/src/loader/weight_tma.rs
+++ b/crates/cubecl-convolution/src/loader/weight_tma.rs
@@ -48,10 +48,10 @@ impl<MP: MatmulPrecision, S: StageConfig> TmaWeightLoader<MP, S> {
 
         #[unroll]
         for _ in 0..num_stages {
-            stages.push(StageMemory::new_aligned::<G::StageConfig>(
+            stages.push(StageMemory::new_aligned::<G::StageMemoryConfig>(
                 StageIdent::Rhs,
                 128u32,
-                config.stage_config(),
+                config.stage_memory_config(),
             ));
         }
 

--- a/crates/cubecl-convolution/src/loader/weight_tma.rs
+++ b/crates/cubecl-convolution/src/loader/weight_tma.rs
@@ -2,12 +2,13 @@ use core::marker::PhantomData;
 
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl, prelude::barrier::Barrier};
+use cubecl_matmul::components::{MatmulIdent, StageIdent};
 use cubecl_std::{CubeOption, FastDivmod};
 
 use crate::base::RuntimeArgs;
 use cubecl_matmul::components::stage::RowMajorTilingOrder;
 use cubecl_matmul::components::{
-    Ident, InputIdent, MatmulPrecision, global::Quantization, stage::FullStageToTileReader,
+    MatmulPrecision, global::Quantization, stage::FullStageToTileReader,
 };
 use cubecl_matmul::components::{
     global::{self, global_memory::MappedTensorReader},
@@ -48,7 +49,7 @@ impl<MP: MatmulPrecision, S: StageConfig> TmaWeightLoader<MP, S> {
         #[unroll]
         for _ in 0..num_stages {
             stages.push(StageMemory::new_aligned::<G::StageConfig>(
-                Ident::Rhs,
+                StageIdent::Rhs,
                 128u32,
                 config.stage_config(),
             ));
@@ -95,10 +96,10 @@ impl<MP: MatmulPrecision, S: StageConfig> TmaWeightLoader<MP, S> {
     }
 
     pub fn reader(this: &Self, #[comptime] stage_idx: u32) -> TmaWeightReader<MP> {
-        TmaWeightReader::<MP>::new(*this.stages.index(stage_idx), InputIdent::Rhs)
+        TmaWeightReader::<MP>::new(*this.stages.index(stage_idx), StageIdent::Rhs)
     }
 
     pub fn advance_view(this: &mut Self, k_offset: u32) {
-        this.tensor_view.update_view(k_offset, Ident::Rhs);
+        this.tensor_view.update_view(k_offset, MatmulIdent::Rhs);
     }
 }

--- a/crates/cubecl-convolution/src/reader/im2col.rs
+++ b/crates/cubecl-convolution/src/reader/im2col.rs
@@ -1,9 +1,9 @@
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl, intrinsic};
+use cubecl_matmul::components::MatmulIdent;
 use cubecl_std::{FastDivmod, tensor::r#virtual::VirtualTensor};
 
 use crate::{ConvGemmConfig, loader::im2col_tma::div_mod_seq};
-use cubecl_matmul::components::Ident;
 
 #[derive(CubeType)]
 /// A view of a feature map tensor that starts reading data from a specified offset.
@@ -94,7 +94,7 @@ impl<E: Numeric> Im2colReader<E> {
         tile_x: u32,
         tile_y: u32,
         unit_id: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Line<E> {
         let line_size = config.global_line_size(ident);
@@ -145,8 +145,10 @@ impl<E: Numeric> Im2colReader<E> {
             has_padding
         };
 
-        let m_in_bounds = comptime!(!config.check_row_bounds(Ident::Lhs)) || view_m < self.shape_m;
-        let k_in_bounds = comptime!(!config.check_col_bounds(Ident::Lhs)) || view_k < self.shape_k;
+        let m_in_bounds =
+            comptime!(!config.check_row_bounds(MatmulIdent::Lhs)) || view_m < self.shape_m;
+        let k_in_bounds =
+            comptime!(!config.check_col_bounds(MatmulIdent::Lhs)) || view_k < self.shape_k;
         let mut spatial_in_bounds = true;
 
         if has_padding {

--- a/crates/cubecl-matmul/src/components/batch/partitioned_matmul/config.rs
+++ b/crates/cubecl-matmul/src/components/batch/partitioned_matmul/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::CubeDim;
 
 use crate::components::{
-    Ident, MatmulLineSizes, MatmulProblem, MatmulSetupError,
+    MatmulIdent, MatmulLineSizes, MatmulProblem, MatmulSetupError,
     batch::{BatchConfig, HypercubeConfig},
     global::GlobalConfig,
 };
@@ -30,9 +30,9 @@ impl<G: GlobalConfig> BatchConfig for PartitionedBatchConfig<G> {
 
     fn line_sizes(&self) -> MatmulLineSizes {
         MatmulLineSizes {
-            lhs: self.global_config.global_line_size(Ident::Lhs) as u8,
-            rhs: self.global_config.global_line_size(Ident::Rhs) as u8,
-            out: self.global_config.global_line_size(Ident::Out) as u8,
+            lhs: self.global_config.global_line_size(MatmulIdent::Lhs) as u8,
+            rhs: self.global_config.global_line_size(MatmulIdent::Rhs) as u8,
+            out: self.global_config.global_line_size(MatmulIdent::Out) as u8,
         }
     }
 

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -4,12 +4,11 @@ use cubecl_core::{self as cubecl};
 use crate::components::error::MatmulSetupError;
 use crate::components::global::RoleRuleConfig;
 use crate::components::{
-    AvailableLineSizes, Ident, InputIdent, MatmulPrecision, MatmulProblem, MatrixLayout,
-    TilingScheme,
+    AvailableLineSizes, MatmulPrecision, MatmulProblem, MatrixLayout, TilingScheme,
     global::{PlaneRoleConfig, SpecializedLoadingSides, multi_stage::EventLoadingMode},
     stage::{self, StageConfig},
 };
-use crate::components::{MatmulLineSizes, MatmulSelection};
+use crate::components::{MatmulIdent, MatmulLineSizes, MatmulSelection};
 use cubecl_std::{
     CubeOption,
     tensor::r#virtual::{ReadWrite, VirtualTensor},
@@ -132,7 +131,7 @@ pub trait GlobalConfig:
     fn stage_config(&self) -> Self::StageConfig;
 
     /// Returns the line size for the global memory corresponding to the given ident
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32;
+    fn global_line_size(&self, ident: MatmulIdent) -> u32;
 
     /// Returns the [TilingScheme]
     fn tiling_scheme(&self) -> TilingScheme {
@@ -140,10 +139,10 @@ pub trait GlobalConfig:
     }
 
     /// Returns the [MatrixLayout] for the given ident
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout;
+    fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout;
 
     /// Returns the number of planes participating in loading `ident`
-    fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32;
+    fn num_loading_planes(&self, ident: MatmulIdent) -> u32;
 
     /// Indicates the specialization roles for the planes
     fn plane_role_config(&self) -> PlaneRoleConfig;
@@ -160,10 +159,10 @@ pub trait GlobalConfig:
     fn plane_dim(&self) -> u32;
 
     /// Whether to check if accessing a row would exceed bounds.
-    fn check_row_bounds<I: Into<Ident>>(&self, ident: I) -> bool;
+    fn check_row_bounds(&self, ident: MatmulIdent) -> bool;
 
     /// Whether to check if accessing a col would exceed bounds.
-    fn check_col_bounds<I: Into<Ident>>(&self, ident: I) -> bool;
+    fn check_col_bounds(&self, ident: MatmulIdent) -> bool;
 
     /// Whether to check if accessing a col for lhs or row for rhs would exceed bounds.
     fn check_k_bounds(&self) -> bool;
@@ -172,7 +171,7 @@ pub trait GlobalConfig:
     fn precompute_job(&self) -> bool;
 
     /// The number of stages in stage memory
-    fn num_stages(&self, ident: InputIdent) -> u32;
+    fn num_stages(&self, ident: MatmulIdent) -> u32;
 
     /// Whether to check loader is balanced in comptime or runtime.
     ///
@@ -180,7 +179,7 @@ pub trait GlobalConfig:
     fn loader_mode(&self) -> LoaderMode;
 
     /// Whether event loading is constrained to be ordered
-    fn event_loading_mode(&self, ident: InputIdent) -> EventLoadingMode;
+    fn event_loading_mode(&self, ident: MatmulIdent) -> EventLoadingMode;
 
     /// Whether the matmul is quantized
     fn quantized(&self) -> bool {

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -3,10 +3,11 @@ use cubecl_core::{self as cubecl};
 
 use crate::components::error::MatmulSetupError;
 use crate::components::global::RoleRuleConfig;
+use crate::components::stage::StageMemoryConfig;
 use crate::components::{
     AvailableLineSizes, MatmulPrecision, MatmulProblem, MatrixLayout, TilingScheme,
     global::{PlaneRoleConfig, SpecializedLoadingSides, multi_stage::EventLoadingMode},
-    stage::{self, StageConfig},
+    stage::StageConfig,
 };
 use crate::components::{MatmulIdent, MatmulLineSizes, MatmulSelection};
 use cubecl_std::{
@@ -125,10 +126,13 @@ pub trait GlobalConfig:
     Copy + Clone + Eq + PartialEq + Hash + Debug + Send + Sync + 'static
 {
     /// Underlying Stage matmul config
-    type StageConfig: stage::StageConfig;
+    type StageConfig: StageConfig;
+    type StageMemoryConfig: StageMemoryConfig;
 
     /// Convert itself to the underlying stage matmul config
     fn stage_config(&self) -> Self::StageConfig;
+
+    fn stage_memory_config(&self) -> Self::StageMemoryConfig;
 
     /// Returns the line size for the global memory corresponding to the given ident
     fn global_line_size(&self, ident: MatmulIdent) -> u32;

--- a/crates/cubecl-matmul/src/components/global/global_memory/tma.rs
+++ b/crates/cubecl-matmul/src/components/global/global_memory/tma.rs
@@ -1,7 +1,7 @@
-use crate::components::Ident;
-use crate::components::InputIdent;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
+
+use crate::components::MatmulIdent;
 
 #[derive(CubeType)]
 /// A view of a tensor that starts reading data from a specified offset.
@@ -29,14 +29,15 @@ impl<EG: Numeric> MappedTensorReader<EG> {
     }
 
     /// Advance the view along the k dimension by a specified offset, `k_offset`.
-    pub fn update_view(&mut self, k_offset: u32, #[comptime] ident: Ident) {
-        match ident.as_input_ident() {
-            InputIdent::Lhs => {
+    pub fn update_view(&mut self, k_offset: u32, #[comptime] ident: MatmulIdent) {
+        match ident {
+            MatmulIdent::Lhs => {
                 self.tile_y += k_offset;
             }
-            InputIdent::Rhs => {
+            MatmulIdent::Rhs => {
                 self.tile_x += k_offset;
             }
+            MatmulIdent::Out => comptime!(unreachable!()),
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/global/global_memory/writer.rs
+++ b/crates/cubecl-matmul/src/components/global/global_memory/writer.rs
@@ -1,4 +1,4 @@
-use crate::components::{global, MatmulIdent};
+use crate::components::{MatmulIdent, global};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};

--- a/crates/cubecl-matmul/src/components/global/global_memory/writer.rs
+++ b/crates/cubecl-matmul/src/components/global/global_memory/writer.rs
@@ -1,5 +1,4 @@
-use crate::components::Ident;
-use crate::components::global;
+use crate::components::{global, MatmulIdent};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
@@ -67,11 +66,11 @@ impl<EG: Numeric> TensorWriter<EG> {
         let view_y = tile_y * tile_size_n + unit_id % tile_size_n + self.y_offset;
 
         let write_position = (view_x * self.stride_x + view_y * self.stride_y + self.batch_offset)
-            / config.global_line_size(Ident::Out);
+            / config.global_line_size(MatmulIdent::Out);
 
         match comptime!((
-            config.check_row_bounds(Ident::Out),
-            config.check_col_bounds(Ident::Out)
+            config.check_row_bounds(MatmulIdent::Out),
+            config.check_col_bounds(MatmulIdent::Out)
         )) {
             (true, true) => {
                 if view_x < self.shape_x && view_y < self.shape_y {

--- a/crates/cubecl-matmul/src/components/global/load/loader/async_full_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/async_full_loader.rs
@@ -79,10 +79,10 @@ impl<
             }
         }
 
-        let mut stage_memory = StageMemory::new::<G::StageConfig>(
+        let mut stage_memory = StageMemory::new::<G::StageMemoryConfig>(
             1u32,
             comptime!(ident.into_stage()),
-            config.stage_config(),
+            config.stage_memory_config(),
         );
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 

--- a/crates/cubecl-matmul/src/components/global/load/loader/async_partial_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/async_partial_loader.rs
@@ -1,4 +1,4 @@
-use super::StageIdent;
+use super::StageBuffer;
 use crate::components::global::base::GlobalConfig;
 use crate::components::global::global_memory::TensorReader;
 use crate::components::global::load::{AsyncLoadingJob, LoadingValidation};
@@ -7,7 +7,7 @@ use crate::components::global::{CopyMechanism, Quantization};
 use crate::components::stage::PartialStageToTileReader;
 use crate::components::stage::TilingLayout;
 use crate::components::stage::{self, StageMemory};
-use crate::components::{InputIdent, MatmulPrecision};
+use crate::components::{MatmulIdent, MatmulPrecision, StageIdent};
 use core::marker::PhantomData;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::barrier::BarrierLevel;
@@ -27,7 +27,7 @@ pub trait AsyncPartialLoadingStrategy: 'static + Send + Sync + Clone + LoadingVa
     /// Returns the job with preliminary calculations done.
     fn new_job<MP: MatmulPrecision, G: GlobalConfig>(
         #[comptime] buffer_index: u32,
-        #[comptime] ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Self::Job<MP>;
 
@@ -50,7 +50,7 @@ pub struct AsyncBufferLoader<
     stage_memory: StageMemory<MP::ES, L::TilingLayout>,
     loading_job: CubeOption<(L::Job<MP>, L::Job<MP>)>,
     #[cube(comptime)]
-    input_ident: InputIdent,
+    ident: MatmulIdent,
     #[cube(comptime)]
     _phantom: PhantomData<(S, CM)>,
 }
@@ -70,11 +70,14 @@ impl<
         y_offset: u32,
         batch_offset: u32,
         quantization: CubeOption<Quantization<MP>>,
-        #[comptime] input_ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: DoubleBufferingGlobalConfig<S>,
     ) -> Self {
-        let stage_memory =
-            StageMemory::new::<S>(2u32, input_ident.as_ident(), config.stage_config());
+        let stage_memory = StageMemory::new::<S>(
+            2u32,
+            comptime!(StageIdent::from_matmul(ident)),
+            config.stage_config(),
+        );
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
         comptime! {
@@ -85,8 +88,8 @@ impl<
 
         let loading_job = match config.precompute_job() {
             true => CubeOption::new_Some((
-                L::new_job::<MP, DoubleBufferingGlobalConfig<S>>(0u32, input_ident, config),
-                L::new_job::<MP, DoubleBufferingGlobalConfig<S>>(1u32, input_ident, config),
+                L::new_job::<MP, DoubleBufferingGlobalConfig<S>>(0u32, ident, config),
+                L::new_job::<MP, DoubleBufferingGlobalConfig<S>>(1u32, ident, config),
             )),
             false => CubeOption::new_None(),
         };
@@ -95,7 +98,7 @@ impl<
             tensor_reader,
             stage_memory,
             loading_job,
-            input_ident,
+            ident,
             _phantom: PhantomData::<(S, CM)>,
         }
     }
@@ -103,34 +106,38 @@ impl<
     /// Give a reader to the loaded stage memory.
     pub fn reader(
         this: &Self,
-        #[comptime] stage_ident: StageIdent,
+        #[comptime] stage_buffer: StageBuffer,
     ) -> PartialStageToTileReader<MP::ES, L::TilingLayout> {
-        PartialStageToTileReader::new(this.stage_memory, stage_ident, this.input_ident)
+        PartialStageToTileReader::new(
+            this.stage_memory,
+            stage_buffer,
+            comptime!(StageIdent::from_matmul(this.ident)),
+        )
     }
 
     /// Advance the view over global memory along the k dimension by a specified offset, `k_offset`.
     pub fn advance_view(this: &mut Self, k_offset: u32) {
-        this.tensor_reader.update_view(k_offset, this.input_ident);
+        this.tensor_reader.update_view(k_offset, this.ident);
     }
 
     /// Accomplish the entire job of filling the stage memory
     pub fn fill_stage(
         this: &mut Self,
         mechanism: &CM,
-        #[comptime] stage_ident: StageIdent,
+        #[comptime] stage_buffer: StageBuffer,
         #[comptime] config: DoubleBufferingGlobalConfig<S>,
     ) {
         let mut loading_job = match this.loading_job {
-            CubeOption::Some(job) => match stage_ident {
-                StageIdent::A => job.0,
-                StageIdent::B => job.1,
+            CubeOption::Some(job) => match stage_buffer {
+                StageBuffer::A => job.0,
+                StageBuffer::B => job.1,
             },
-            CubeOption::None => match stage_ident {
-                StageIdent::A => {
-                    L::new_job::<MP, DoubleBufferingGlobalConfig<S>>(0u32, this.input_ident, config)
+            CubeOption::None => match stage_buffer {
+                StageBuffer::A => {
+                    L::new_job::<MP, DoubleBufferingGlobalConfig<S>>(0u32, this.ident, config)
                 }
-                StageIdent::B => {
-                    L::new_job::<MP, DoubleBufferingGlobalConfig<S>>(1u32, this.input_ident, config)
+                StageBuffer::B => {
+                    L::new_job::<MP, DoubleBufferingGlobalConfig<S>>(1u32, this.ident, config)
                 }
             },
         };
@@ -151,10 +158,14 @@ impl<
     /// Zero out the stage memory
     pub fn clear_stage(
         this: &mut Self,
-        #[comptime] stage_ident: StageIdent,
+        #[comptime] stage_buffer: StageBuffer,
         #[comptime] config: DoubleBufferingGlobalConfig<S>,
     ) {
         this.stage_memory
-            .clear_stage::<DoubleBufferingGlobalConfig<S>>(stage_ident, this.input_ident, config)
+            .clear_stage::<DoubleBufferingGlobalConfig<S>>(
+                stage_buffer,
+                comptime!(StageIdent::from_matmul(this.ident)),
+                config,
+            )
     }
 }

--- a/crates/cubecl-matmul/src/components/global/load/loader/async_partial_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/async_partial_loader.rs
@@ -73,8 +73,11 @@ impl<
         #[comptime] ident: MatmulIdent,
         #[comptime] config: DoubleBufferingGlobalConfig<S>,
     ) -> Self {
-        let stage_memory =
-            StageMemory::new::<S>(2u32, comptime!(ident.into_stage()), config.stage_config());
+        let stage_memory = StageMemory::new::<S::StageMemoryConfig>(
+            2u32,
+            comptime!(ident.into_stage()),
+            config.stage_memory_config(),
+        );
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
         comptime! {

--- a/crates/cubecl-matmul/src/components/global/load/loader/async_partial_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/async_partial_loader.rs
@@ -73,11 +73,8 @@ impl<
         #[comptime] ident: MatmulIdent,
         #[comptime] config: DoubleBufferingGlobalConfig<S>,
     ) -> Self {
-        let stage_memory = StageMemory::new::<S>(
-            2u32,
-            comptime!(StageIdent::from_matmul(ident)),
-            config.stage_config(),
-        );
+        let stage_memory =
+            StageMemory::new::<S>(2u32, comptime!(ident.into_stage()), config.stage_config());
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
         comptime! {
@@ -111,7 +108,10 @@ impl<
         PartialStageToTileReader::new(
             this.stage_memory,
             stage_buffer,
-            comptime!(StageIdent::from_matmul(this.ident)),
+            comptime! {
+                let stage_ident: StageIdent = this.ident.into();
+                stage_ident
+            },
         )
     }
 
@@ -162,10 +162,6 @@ impl<
         #[comptime] config: DoubleBufferingGlobalConfig<S>,
     ) {
         this.stage_memory
-            .clear_stage::<DoubleBufferingGlobalConfig<S>>(
-                stage_buffer,
-                comptime!(StageIdent::from_matmul(this.ident)),
-                config,
-            )
+            .clear_stage::<DoubleBufferingGlobalConfig<S>>(stage_buffer, this.ident, config)
     }
 }

--- a/crates/cubecl-matmul/src/components/global/load/loader/shared.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/shared.rs
@@ -3,18 +3,18 @@ use cubecl_core::prelude::CubeType;
 
 #[derive(Copy, Clone, CubeType)]
 /// Identifier for the stage in global double buffering
-pub enum StageIdent {
+pub enum StageBuffer {
     /// First buffer
     A,
     /// Second buffer
     B,
 }
 
-impl StageIdent {
+impl StageBuffer {
     pub fn to_index(&self) -> u32 {
         match self {
-            StageIdent::A => 0,
-            StageIdent::B => 1,
+            StageBuffer::A => 0,
+            StageBuffer::B => 1,
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/global/load/loader/sync_full_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/sync_full_loader.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use crate::components::StageIdent;
 use crate::components::global::GlobalConfig;
 use crate::components::global::Quantization;
 use crate::components::global::global_memory::TensorReader;
@@ -68,7 +67,7 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncFullLoadingStrategy> SyncFullL
     ) -> Self {
         let stage_memory = StageMemory::new::<G::StageConfig>(
             1u32,
-            comptime!(StageIdent::from_matmul(ident)),
+            comptime!(ident.into_stage()),
             config.stage_config(),
         );
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
@@ -90,10 +89,7 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncFullLoadingStrategy> SyncFullL
 
     /// Give a reader to the loaded stage memory.
     pub fn reader(this: &Self) -> FullStageToTileReader<MP::ES, L::TilingLayout> {
-        FullStageToTileReader::new(
-            this.stage_memory,
-            comptime!(StageIdent::from_matmul(this.ident)),
-        )
+        FullStageToTileReader::new(this.stage_memory, comptime!(this.ident.into_stage()))
     }
 
     /// Advance the view over global memory along the k dimension by a specified offset, `k_offset`.

--- a/crates/cubecl-matmul/src/components/global/load/loader/sync_full_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/sync_full_loader.rs
@@ -65,10 +65,10 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncFullLoadingStrategy> SyncFullL
         #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Self {
-        let stage_memory = StageMemory::new::<G::StageConfig>(
+        let stage_memory = StageMemory::new::<G::StageMemoryConfig>(
             1u32,
             comptime!(ident.into_stage()),
-            config.stage_config(),
+            config.stage_memory_config(),
         );
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 

--- a/crates/cubecl-matmul/src/components/global/load/loader/sync_partial_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/sync_partial_loader.rs
@@ -4,7 +4,6 @@ use super::StageBuffer;
 use super::TaskCounter;
 use crate::components::MatmulIdent;
 use crate::components::MatmulPrecision;
-use crate::components::StageIdent;
 use crate::components::global::GlobalConfig;
 use crate::components::global::Quantization;
 use crate::components::global::global_memory::TensorReader;
@@ -72,7 +71,7 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy>
     ) -> Self {
         let stage_memory = StageMemory::new::<G::StageConfig>(
             2u32,
-            comptime!(StageIdent::from_matmul(ident)),
+            comptime!(ident.into_stage()),
             config.stage_config(),
         );
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
@@ -103,7 +102,7 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy>
         PartialStageToTileReader::new(
             this.stage_memory,
             stage_buffer,
-            comptime!(StageIdent::from_matmul(this.ident)),
+            comptime!(this.ident.into_stage()),
         )
     }
 

--- a/crates/cubecl-matmul/src/components/global/load/loader/sync_partial_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/sync_partial_loader.rs
@@ -69,10 +69,10 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy>
         #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Self {
-        let stage_memory = StageMemory::new::<G::StageConfig>(
+        let stage_memory = StageMemory::new::<G::StageMemoryConfig>(
             2u32,
             comptime!(ident.into_stage()),
-            config.stage_config(),
+            config.stage_memory_config(),
         );
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 

--- a/crates/cubecl-matmul/src/components/global/load/loader/sync_partial_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/sync_partial_loader.rs
@@ -1,9 +1,10 @@
 use std::marker::PhantomData;
 
-use super::StageIdent;
+use super::StageBuffer;
 use super::TaskCounter;
-use crate::components::InputIdent;
+use crate::components::MatmulIdent;
 use crate::components::MatmulPrecision;
+use crate::components::StageIdent;
 use crate::components::global::GlobalConfig;
 use crate::components::global::Quantization;
 use crate::components::global::global_memory::TensorReader;
@@ -34,7 +35,7 @@ pub trait SyncPartialLoadingStrategy:
     /// Returns the job with preliminary calculations done.
     fn new_job<MP: MatmulPrecision, G: GlobalConfig>(
         #[comptime] stage_index: u32,
-        #[comptime] ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Self::Job<MP>;
 }
@@ -50,7 +51,7 @@ pub struct SyncPartialLoader<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartia
     loading_job: CubeOption<(L::Job<MP>, L::Job<MP>)>,
     quantization: CubeOption<Quantization<MP>>,
     #[cube(comptime)]
-    input_ident: InputIdent,
+    ident: MatmulIdent,
     #[cube(comptime)]
     _config: PhantomData<G>,
 }
@@ -66,17 +67,20 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy>
         y_offset: u32,
         batch_offset: u32,
         quantization: CubeOption<Quantization<MP>>,
-        #[comptime] input_ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Self {
-        let stage_memory =
-            StageMemory::new::<G::StageConfig>(2u32, input_ident.as_ident(), config.stage_config());
+        let stage_memory = StageMemory::new::<G::StageConfig>(
+            2u32,
+            comptime!(StageIdent::from_matmul(ident)),
+            config.stage_config(),
+        );
         let tensor_reader = TensorReader::new(tensor, x_offset, y_offset, batch_offset);
 
         let loading_job = match config.precompute_job() {
             true => CubeOption::new_Some((
-                L::new_job::<MP, G>(0u32, input_ident, config),
-                L::new_job::<MP, G>(1u32, input_ident, config),
+                L::new_job::<MP, G>(0u32, ident, config),
+                L::new_job::<MP, G>(1u32, ident, config),
             )),
             false => CubeOption::new_None(),
         };
@@ -86,7 +90,7 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy>
             stage_memory,
             loading_job,
             quantization,
-            input_ident,
+            ident,
             _config: PhantomData::<G>,
         }
     }
@@ -94,26 +98,34 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy>
     /// Give a reader to the loaded stage memory.
     pub fn reader(
         this: &Self,
-        #[comptime] stage_ident: StageIdent,
+        #[comptime] stage_buffer: StageBuffer,
     ) -> PartialStageToTileReader<MP::ES, L::TilingLayout> {
-        PartialStageToTileReader::new(this.stage_memory, stage_ident, this.input_ident)
+        PartialStageToTileReader::new(
+            this.stage_memory,
+            stage_buffer,
+            comptime!(StageIdent::from_matmul(this.ident)),
+        )
     }
 
     /// Advance the view over global memory along the k dimension by a specified offset, `k_offset`.
     pub fn advance_view(this: &mut Self, k_offset: u32) {
-        this.tensor_reader.update_view(k_offset, this.input_ident);
+        this.tensor_reader.update_view(k_offset, this.ident);
     }
 
     /// Accomplish the entire job of filling the stage memory
-    pub fn fill_stage(this: &mut Self, #[comptime] stage_ident: StageIdent, #[comptime] config: G) {
+    pub fn fill_stage(
+        this: &mut Self,
+        #[comptime] stage_buffer: StageBuffer,
+        #[comptime] config: G,
+    ) {
         let mut loading_job = match this.loading_job {
-            CubeOption::Some(job) => match stage_ident {
-                StageIdent::A => job.0,
-                StageIdent::B => job.1,
+            CubeOption::Some(job) => match stage_buffer {
+                StageBuffer::A => job.0,
+                StageBuffer::B => job.1,
             },
-            CubeOption::None => match stage_ident {
-                StageIdent::A => L::new_job::<MP, G>(0u32, this.input_ident, config),
-                StageIdent::B => L::new_job::<MP, G>(1u32, this.input_ident, config),
+            CubeOption::None => match stage_buffer {
+                StageBuffer::A => L::new_job::<MP, G>(0u32, this.ident, config),
+                StageBuffer::B => L::new_job::<MP, G>(1u32, this.ident, config),
             },
         };
 
@@ -145,17 +157,17 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy> JobExe
 
     fn create_job_iterator(
         this: &Self,
-        #[comptime] stage_ident: StageIdent,
+        #[comptime] stage_buffer: StageBuffer,
         #[comptime] config: G,
     ) -> Self::JobIterator {
         let job = match this.loading_job {
-            CubeOption::Some(job) => match stage_ident {
-                StageIdent::A => job.0,
-                StageIdent::B => job.1,
+            CubeOption::Some(job) => match stage_buffer {
+                StageBuffer::A => job.0,
+                StageBuffer::B => job.1,
             },
-            CubeOption::None => match stage_ident {
-                StageIdent::A => L::new_job::<MP, G>(0u32, this.input_ident, config),
-                StageIdent::B => L::new_job::<MP, G>(1u32, this.input_ident, config),
+            CubeOption::None => match stage_buffer {
+                StageBuffer::A => L::new_job::<MP, G>(0u32, this.ident, config),
+                StageBuffer::B => L::new_job::<MP, G>(1u32, this.ident, config),
             },
         };
 
@@ -219,12 +231,12 @@ impl<MP: MatmulPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy> JobExe
 
     fn execute_whole_job(
         this: &mut Self,
-        #[comptime] stage_ident: StageIdent,
+        #[comptime] stage_buffer: StageBuffer,
         #[comptime] config: G,
     ) {
         Self::execute_all_remaining_tasks(
             this,
-            &mut Self::create_job_iterator(this, stage_ident, config),
+            &mut Self::create_job_iterator(this, stage_buffer, config),
             config,
         );
     }

--- a/crates/cubecl-matmul/src/components/global/load/loader/tma_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/tma_loader.rs
@@ -5,7 +5,8 @@ use cubecl_core::{self as cubecl, prelude::barrier::Barrier};
 use cubecl_std::CubeOption;
 
 use crate::components::stage::{FullStageToTileReader, RowMajorTilingOrder, TilingOrderEnum};
-use crate::components::{Ident, InputIdent, MatmulPrecision, MatrixLayout, global::Quantization};
+use crate::components::{MatmulIdent, StageIdent};
+use crate::components::{MatmulPrecision, MatrixLayout, global::Quantization};
 use crate::components::{
     global::{GlobalConfig, global_memory::MappedTensorReader},
     stage::{ColMajorTilingOrder, ContiguousTilingLayout, StageConfig, StageMemory, TilingOrder},
@@ -28,7 +29,7 @@ impl TilingOrder for TmaTilingOrder {
         nth: u32,
         #[comptime] tile_count_rows: u32,
         #[comptime] tile_count_cols: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: C,
     ) -> (u32, u32) {
         match config.matrix_layout(ident) {
@@ -54,7 +55,7 @@ impl TilingOrder for TmaTilingOrder {
         col: u32,
         #[comptime] tile_count_rows: u32,
         #[comptime] tile_count_cols: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: C,
     ) -> u32 {
         match config.matrix_layout(ident) {
@@ -88,7 +89,7 @@ pub struct TmaLoader<MP: MatmulPrecision, G: GlobalConfig> {
     pub tensor_view: MappedTensorReader<MP::EI>,
     pub stage: StageMemory<MP::ES, TmaTiling>,
     #[cube(comptime)]
-    ident: InputIdent,
+    ident: MatmulIdent,
     #[cube(comptime)]
     _config: PhantomData<G>,
 }
@@ -102,7 +103,7 @@ impl<MP: MatmulPrecision, G: GlobalConfig> TmaLoader<MP, G> {
         y: u32,
         batch: u32,
         quantization: CubeOption<Quantization<MP>>,
-        #[comptime] ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Self {
         comptime! {
@@ -112,7 +113,7 @@ impl<MP: MatmulPrecision, G: GlobalConfig> TmaLoader<MP, G> {
         }
 
         let stage = StageMemory::new_aligned::<G::StageConfig>(
-            comptime!(ident.as_ident()),
+            comptime!(StageIdent::from_matmul(ident)),
             128u32,
             config.stage_config(),
         );
@@ -130,7 +131,7 @@ impl<MP: MatmulPrecision, G: GlobalConfig> TmaLoader<MP, G> {
     /// Fill the full stage memory
     pub fn fill_stage(this: &mut Self, barrier: &Barrier<MP::ES>, #[comptime] config: G) {
         if UNIT_POS == 0 {
-            let ident = comptime!(this.ident.as_ident());
+            let ident = comptime!(this.ident);
             // The tensor map is encoded as the transposed shape, so we need to swap coordinates
             let (row, col) = match config.matrix_layout(ident) {
                 MatrixLayout::RowMajor => (this.tensor_view.tile_x, this.tensor_view.tile_y),
@@ -168,13 +169,12 @@ impl<MP: MatmulPrecision, G: GlobalConfig> TmaLoader<MP, G> {
 
     /// Give a reader to the loaded stage memory.
     pub fn reader(this: &Self) -> TmaReader<MP> {
-        TmaReader::<MP>::new(this.stage, this.ident)
+        TmaReader::<MP>::new(this.stage, comptime!(StageIdent::from_matmul(this.ident)))
     }
 
     /// Advance the view over global memory along the k dimension by a specified offset, `k_offset`.
     pub fn advance_view(this: &mut Self, k_offset: u32) {
-        this.tensor_view
-            .update_view(k_offset, comptime!(this.ident.as_ident()));
+        this.tensor_view.update_view(k_offset, this.ident);
     }
 }
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cooperative.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cooperative.rs
@@ -1,7 +1,11 @@
 use crate::components::{
+    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout,
     global::{
-        global_memory::{TensorReader, Window}, load::AsyncFullLoadingStrategy, CopyMechanism, GlobalConfig
-    }, stage::{StageMemory, StridedTilingLayout}, InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent
+        CopyMechanism, GlobalConfig,
+        global_memory::{TensorReader, Window},
+        load::AsyncFullLoadingStrategy,
+    },
+    stage::{StageMemory, StridedTilingLayout},
 };
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl, prelude::barrier::BarrierLevel};
@@ -37,10 +41,7 @@ impl AsyncFullLoadingStrategy for AsyncFullCooperativeLoading {
             MatrixLayout::ColMajor => config.tiling_scheme().elements_in_stage_col(ident),
         };
 
-        AsyncFullCooperativeJob {
-            num_slices,
-            ident,
-        }
+        AsyncFullCooperativeJob { num_slices, ident }
     }
 
     fn barrier_level() -> BarrierLevel {
@@ -72,7 +73,7 @@ impl<MP: MatmulPrecision> AsyncLoadingJob<MP, StridedTilingLayout> for AsyncFull
             StridedTilingLayout::nth_slice::<MP::ES, G::StageConfig>(
                 stage,
                 task_id,
-                comptime!(StageIdent::from_matmul(this.ident)),
+                comptime!(this.ident.into_stage()),
                 config.stage_config(),
             );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cooperative.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cooperative.rs
@@ -70,11 +70,11 @@ impl<MP: MatmulPrecision> AsyncLoadingJob<MP, StridedTilingLayout> for AsyncFull
         let window: Window<MP::EI> =
             tensor_reader.load_window_in_stage::<G>(task_id, this.ident, config);
         let mut destination: SliceMut<Line<MP::ES>> =
-            StridedTilingLayout::nth_slice::<MP::ES, G::StageConfig>(
+            StridedTilingLayout::nth_slice::<MP::ES, G::StageMemoryConfig>(
                 stage,
                 task_id,
                 comptime!(this.ident.into_stage()),
-                config.stage_config(),
+                config.stage_memory_config(),
             );
 
         CM::memcpy_async(

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::components::{
-    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
+    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, 
     global::{
         CopyMechanism, GlobalConfig, RoleRule, global_memory::TensorReader,
         load::AsyncFullLoadingStrategy,
@@ -123,7 +123,7 @@ impl<MP: MatmulPrecision, TO: TilingOrder> AsyncLoadingJob<MP, ContiguousTilingL
         let nth_tile = slice_index / this.num_slices_per_tile;
         let (tile_x, tile_y) = ContiguousTilingLayout::<TO>::to_x_y::<G::StageConfig>(
             nth_tile,
-            comptime!(StageIdent::from_matmul(this.ident)),
+            comptime!(this.ident.into_stage()),
             config.stage_config(),
         );
         let nth_slice = slice_index % this.num_slices_per_tile;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::components::{
-    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, 
+    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout,
     global::{
         CopyMechanism, GlobalConfig, RoleRule, global_memory::TensorReader,
         load::AsyncFullLoadingStrategy,

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::components::{
-    Ident, InputIdent, InvalidConfigError, MatmulPrecision, MatrixLayout,
+    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
     global::{
         CopyMechanism, GlobalConfig, RoleRule, global_memory::TensorReader,
         load::AsyncFullLoadingStrategy,
@@ -22,7 +22,7 @@ pub struct AsyncFullCyclicLoading<T: TilingOrder> {
 }
 
 impl<T: TilingOrder> LoadingValidation for AsyncFullCyclicLoading<T> {
-    fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
+    fn check<C: GlobalConfig>(config: &C, ident: MatmulIdent) -> Result<(), InvalidConfigError> {
         let total_units = config.num_loading_planes(ident) * config.plane_dim();
         let num_slices = config.tiling_scheme().elements_in_tile_row(ident)
             * config.tiling_scheme().tiles_in_stage(ident);
@@ -43,29 +43,29 @@ impl<TO: TilingOrder> AsyncFullLoadingStrategy for AsyncFullCyclicLoading<TO> {
     type Job<MP: MatmulPrecision> = AsyncFullCyclicJob;
 
     fn new_job<MP: MatmulPrecision, G: GlobalConfig>(
-        #[comptime] input_ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> AsyncFullCyclicJob {
-        let total_units = config.plane_dim() * config.num_loading_planes(input_ident);
-        let line_size = config.global_line_size(input_ident);
+        let total_units = config.plane_dim() * config.num_loading_planes(ident);
+        let line_size = config.global_line_size(ident);
 
-        let (num_slices_per_tile, slice_length_in_lines) = match config.matrix_layout(input_ident) {
+        let (num_slices_per_tile, slice_length_in_lines) = match config.matrix_layout(ident) {
             MatrixLayout::RowMajor => (
-                config.tiling_scheme().elements_in_tile_row(input_ident),
-                config.tiling_scheme().elements_in_tile_col(input_ident) / line_size,
+                config.tiling_scheme().elements_in_tile_row(ident),
+                config.tiling_scheme().elements_in_tile_col(ident) / line_size,
             ),
             MatrixLayout::ColMajor => (
-                config.tiling_scheme().elements_in_tile_col(input_ident),
-                config.tiling_scheme().elements_in_tile_row(input_ident) / line_size,
+                config.tiling_scheme().elements_in_tile_col(ident),
+                config.tiling_scheme().elements_in_tile_row(ident) / line_size,
             ),
         };
 
         let num_slices =
-            comptime!(num_slices_per_tile * config.tiling_scheme().tiles_in_stage(input_ident));
+            comptime!(num_slices_per_tile * config.tiling_scheme().tiles_in_stage(ident));
         let num_tasks_per_unit = num_slices.div_ceil(total_units);
 
         let unit_id = RoleRule::new(config.role_rule_config())
-            .load_index(input_ident, config.specialized_loading_sides())
+            .load_index(ident, config.specialized_loading_sides())
             * config.plane_dim()
             + UNIT_POS_X;
 
@@ -74,7 +74,7 @@ impl<TO: TilingOrder> AsyncFullLoadingStrategy for AsyncFullCyclicLoading<TO> {
             num_tasks_per_unit,
             total_units,
             num_slices,
-            input_ident,
+            ident,
             num_slices_per_tile,
             slice_length_in_lines,
             line_size,
@@ -97,7 +97,7 @@ pub struct AsyncFullCyclicJob {
     #[cube(comptime)]
     num_slices: u32,
     #[cube(comptime)]
-    input_ident: InputIdent,
+    ident: MatmulIdent,
     #[cube(comptime)]
     num_slices_per_tile: u32,
     #[cube(comptime)]
@@ -123,7 +123,7 @@ impl<MP: MatmulPrecision, TO: TilingOrder> AsyncLoadingJob<MP, ContiguousTilingL
         let nth_tile = slice_index / this.num_slices_per_tile;
         let (tile_x, tile_y) = ContiguousTilingLayout::<TO>::to_x_y::<G::StageConfig>(
             nth_tile,
-            comptime!(this.input_ident.as_ident()),
+            comptime!(StageIdent::from_matmul(this.ident)),
             config.stage_config(),
         );
         let nth_slice = slice_index % this.num_slices_per_tile;
@@ -133,7 +133,7 @@ impl<MP: MatmulPrecision, TO: TilingOrder> AsyncLoadingJob<MP, ContiguousTilingL
             let window = tensor_reader.load_window_in_tile::<G>(
                 (tile_x, tile_y),
                 nth_slice,
-                this.input_ident,
+                this.ident,
                 config,
             );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
@@ -121,10 +121,10 @@ impl<MP: MatmulPrecision, TO: TilingOrder> AsyncLoadingJob<MP, ContiguousTilingL
         let slice_index = this.unit_id + this.total_units * task_id;
 
         let nth_tile = slice_index / this.num_slices_per_tile;
-        let (tile_x, tile_y) = ContiguousTilingLayout::<TO>::to_x_y::<G::StageConfig>(
+        let (tile_x, tile_y) = ContiguousTilingLayout::<TO>::to_x_y::<G::StageMemoryConfig>(
             nth_tile,
             comptime!(this.ident.into_stage()),
-            config.stage_config(),
+            config.stage_memory_config(),
         );
         let nth_slice = slice_index % this.num_slices_per_tile;
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_slice_length.rs
@@ -1,4 +1,3 @@
-use crate::components::StageIdent;
 use crate::components::{
     InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout,
     global::{
@@ -125,7 +124,7 @@ fn load_nth_slice<EG: Numeric, ES: Numeric, CM: CopyMechanism<ES>, G: GlobalConf
     let mut destination: SliceMut<Line<ES>> = StridedTilingLayout::nth_slice::<ES, G::StageConfig>(
         stage,
         nth_slice,
-        comptime!(StageIdent::from_matmul(ident)),
+        comptime!(ident.into_stage()),
         config.stage_config(),
     );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_slice_length.rs
@@ -121,12 +121,13 @@ fn load_nth_slice<EG: Numeric, ES: Numeric, CM: CopyMechanism<ES>, G: GlobalConf
     #[comptime] config: G,
 ) {
     let window: Window<EG> = tensor_reader.load_window_in_stage::<G>(nth_slice, ident, config);
-    let mut destination: SliceMut<Line<ES>> = StridedTilingLayout::nth_slice::<ES, G::StageConfig>(
-        stage,
-        nth_slice,
-        comptime!(ident.into_stage()),
-        config.stage_config(),
-    );
+    let mut destination: SliceMut<Line<ES>> =
+        StridedTilingLayout::nth_slice::<ES, G::StageMemoryConfig>(
+            stage,
+            nth_slice,
+            comptime!(ident.into_stage()),
+            config.stage_memory_config(),
+        );
 
     CM::memcpy_async(
         mechanism,

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
@@ -1,5 +1,5 @@
 use crate::components::{
-    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
+    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout,
     global::{
         CopyMechanism, GlobalConfig,
         global_memory::{TensorReader, Window},
@@ -61,7 +61,7 @@ impl AsyncFullLoadingStrategy for AsyncFullMaximizeUnitCountLoading {
         let matrix_layout = config.matrix_layout(ident);
         let line_size = config
             .stage_config()
-            .stage_line_size(comptime!(StageIdent::from_matmul(ident)));
+            .stage_line_size(comptime!(ident.into_stage()));
 
         let (num_slices, slice_length) = match matrix_layout {
             MatrixLayout::RowMajor => (
@@ -121,7 +121,7 @@ impl<MP: MatmulPrecision> AsyncLoadingJob<MP, StridedTilingLayout>
             StridedTilingLayout::nth_slice::<MP::ES, G::StageConfig>(
                 stage,
                 this.nth_slice,
-                comptime!(StageIdent::from_matmul(this.ident)),
+                comptime!(this.ident.into_stage()),
                 config.stage_config(),
             );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
@@ -1,5 +1,5 @@
 use crate::components::{
-    Ident, InputIdent, InvalidConfigError, MatmulPrecision, MatrixLayout,
+    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
     global::{
         CopyMechanism, GlobalConfig,
         global_memory::{TensorReader, Window},
@@ -18,7 +18,7 @@ use super::{AsyncLoadingJob, LoadingValidation};
 pub struct AsyncFullMaximizeUnitCountLoading {}
 
 impl LoadingValidation for AsyncFullMaximizeUnitCountLoading {
-    fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
+    fn check<C: GlobalConfig>(config: &C, ident: MatmulIdent) -> Result<(), InvalidConfigError> {
         let matrix_layout = config.matrix_layout(ident);
         let line_size = config.global_line_size(ident);
 
@@ -55,24 +55,26 @@ impl AsyncFullLoadingStrategy for AsyncFullMaximizeUnitCountLoading {
     type Job<MP: MatmulPrecision> = AsyncFullMaximizeUnitCountJob;
 
     fn new_job<MP: MatmulPrecision, G: GlobalConfig>(
-        #[comptime] input_ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> AsyncFullMaximizeUnitCountJob {
-        let matrix_layout = config.matrix_layout(input_ident);
-        let line_size = config.stage_config().stage_line_size(input_ident);
+        let matrix_layout = config.matrix_layout(ident);
+        let line_size = config
+            .stage_config()
+            .stage_line_size(comptime!(StageIdent::from_matmul(ident)));
 
         let (num_slices, slice_length) = match matrix_layout {
             MatrixLayout::RowMajor => (
-                config.tiling_scheme().elements_in_stage_row(input_ident),
-                config.tiling_scheme().elements_in_stage_col(input_ident) / line_size,
+                config.tiling_scheme().elements_in_stage_row(ident),
+                config.tiling_scheme().elements_in_stage_col(ident) / line_size,
             ),
             MatrixLayout::ColMajor => (
-                config.tiling_scheme().elements_in_stage_col(input_ident),
-                config.tiling_scheme().elements_in_stage_row(input_ident) / line_size,
+                config.tiling_scheme().elements_in_stage_col(ident),
+                config.tiling_scheme().elements_in_stage_row(ident) / line_size,
             ),
         };
 
-        let unit_count = config.plane_dim() * config.num_loading_planes(input_ident);
+        let unit_count = config.plane_dim() * config.num_loading_planes(ident);
 
         let units_per_slice = comptime!(unit_count / num_slices);
         let nth_slice = UNIT_POS / units_per_slice;
@@ -84,7 +86,7 @@ impl AsyncFullLoadingStrategy for AsyncFullMaximizeUnitCountLoading {
             nth_slice,
             nth_segment,
             segment_length,
-            input_ident,
+            ident,
         }
     }
 
@@ -100,7 +102,7 @@ pub struct AsyncFullMaximizeUnitCountJob {
     #[cube(comptime)]
     segment_length: u32,
     #[cube(comptime)]
-    input_ident: InputIdent,
+    ident: MatmulIdent,
 }
 
 #[cube]
@@ -119,12 +121,12 @@ impl<MP: MatmulPrecision> AsyncLoadingJob<MP, StridedTilingLayout>
             StridedTilingLayout::nth_slice::<MP::ES, G::StageConfig>(
                 stage,
                 this.nth_slice,
-                comptime!(this.input_ident.as_ident()),
+                comptime!(StageIdent::from_matmul(this.ident)),
                 config.stage_config(),
             );
 
         let window: Window<MP::EI> =
-            tensor_reader.load_window_in_stage::<G>(this.nth_slice, this.input_ident, config);
+            tensor_reader.load_window_in_stage::<G>(this.nth_slice, this.ident, config);
         let seg_start = Min::min(this.nth_segment * this.segment_length, window.size);
         let seg_end = Min::min((this.nth_segment + 1) * this.segment_length, window.size);
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
@@ -118,11 +118,11 @@ impl<MP: MatmulPrecision> AsyncLoadingJob<MP, StridedTilingLayout>
         #[comptime] config: G,
     ) {
         let mut destination: SliceMut<Line<MP::ES>> =
-            StridedTilingLayout::nth_slice::<MP::ES, G::StageConfig>(
+            StridedTilingLayout::nth_slice::<MP::ES, G::StageMemoryConfig>(
                 stage,
                 this.nth_slice,
                 comptime!(this.ident.into_stage()),
-                config.stage_config(),
+                config.stage_memory_config(),
             );
 
         let window: Window<MP::EI> =

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_partial_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_partial_maximize_slice_length.rs
@@ -1,5 +1,5 @@
 use crate::components::{
-    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
+    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout,
     global::{
         CopyMechanism, GlobalConfig,
         global_memory::{TensorReader, Window},
@@ -36,7 +36,7 @@ impl AsyncPartialLoadingStrategy for AsyncPartialMaximizeSliceLengthLoading {
         let matrix_layout = config.matrix_layout(ident);
         let line_size = config
             .stage_config()
-            .stage_line_size(comptime!(StageIdent::from_matmul(ident)));
+            .stage_line_size(comptime!(ident.into_stage()));
         let num_stages = 2;
 
         let total_row = config.tiling_scheme().elements_in_stage_row(ident);
@@ -129,7 +129,7 @@ impl<MP: MatmulPrecision> AsyncLoadingJob<MP, StridedTilingLayout>
             StridedTilingLayout::nth_slice::<MP::ES, G::StageConfig>(
                 stage,
                 nth_slice,
-                comptime!(StageIdent::from_matmul(this.ident)),
+                comptime!(this.ident.into_stage()),
                 config.stage_config(),
             );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_partial_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_partial_maximize_slice_length.rs
@@ -126,11 +126,11 @@ impl<MP: MatmulPrecision> AsyncLoadingJob<MP, StridedTilingLayout>
         let window: Window<MP::EI> =
             tensor_reader.load_window_in_stage::<G>(nth_slice, this.ident, config);
         let mut destination: SliceMut<Line<MP::ES>> =
-            StridedTilingLayout::nth_slice::<MP::ES, G::StageConfig>(
+            StridedTilingLayout::nth_slice::<MP::ES, G::StageMemoryConfig>(
                 stage,
                 nth_slice,
                 comptime!(this.ident.into_stage()),
-                config.stage_config(),
+                config.stage_memory_config(),
             );
 
         let start = this.slice_stage_offset;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_partial_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_partial_maximize_slice_length.rs
@@ -1,5 +1,5 @@
 use crate::components::{
-    Ident, InputIdent, InvalidConfigError, MatmulPrecision, MatrixLayout,
+    InvalidConfigError, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
     global::{
         CopyMechanism, GlobalConfig,
         global_memory::{TensorReader, Window},
@@ -18,7 +18,7 @@ use super::{AsyncLoadingJob, LoadingValidation};
 pub struct AsyncPartialMaximizeSliceLengthLoading {}
 
 impl LoadingValidation for AsyncPartialMaximizeSliceLengthLoading {
-    fn check<C: GlobalConfig>(_config: &C, _ident: Ident) -> Result<(), InvalidConfigError> {
+    fn check<C: GlobalConfig>(_config: &C, _ident: MatmulIdent) -> Result<(), InvalidConfigError> {
         Ok(())
     }
 }
@@ -30,51 +30,54 @@ impl AsyncPartialLoadingStrategy for AsyncPartialMaximizeSliceLengthLoading {
 
     fn new_job<MP: MatmulPrecision, G: GlobalConfig>(
         #[comptime] stage_index: u32,
-        #[comptime] input_ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> AsyncPartialMaximizeSliceLengthJob {
-        let matrix_layout = config.matrix_layout(input_ident);
-        let line_size = config.stage_config().stage_line_size(input_ident);
+        let matrix_layout = config.matrix_layout(ident);
+        let line_size = config
+            .stage_config()
+            .stage_line_size(comptime!(StageIdent::from_matmul(ident)));
         let num_stages = 2;
 
-        let total_row = config.tiling_scheme().elements_in_stage_row(input_ident);
-        let total_col = config.tiling_scheme().elements_in_stage_col(input_ident);
+        let total_row = config.tiling_scheme().elements_in_stage_row(ident);
+        let total_col = config.tiling_scheme().elements_in_stage_col(ident);
 
         // If stage is parallel to slices, slices are as long as in full stage memory, but there are less.
         // Otherwise, slices are shorter but there are as many as in full stage memory
         let (num_slices, num_slices_stage_offset, slice_length, slice_stage_offset) = comptime! {
-            match (input_ident, matrix_layout) {
-                (InputIdent::Lhs, MatrixLayout::RowMajor) => {
+            match (ident, matrix_layout) {
+                (MatmulIdent::Lhs, MatrixLayout::RowMajor) => {
                     let slice_length = total_col / (num_stages * line_size);
 
                     (total_row, 0, slice_length, stage_index * slice_length)
                 },
-                (InputIdent::Lhs, MatrixLayout::ColMajor) => {
+                (MatmulIdent::Lhs, MatrixLayout::ColMajor) => {
                     let num_slices = total_col / num_stages;
 
                     (num_slices, stage_index * num_slices, total_row / line_size, 0)
                 },
-                (InputIdent::Rhs, MatrixLayout::RowMajor) => {
+                (MatmulIdent::Rhs, MatrixLayout::RowMajor) => {
                     let num_slices = total_row / num_stages;
 
                     (num_slices, stage_index * num_slices, total_col / line_size, 0)
                 },
-                (InputIdent::Rhs, MatrixLayout::ColMajor) => {
+                (MatmulIdent::Rhs, MatrixLayout::ColMajor) => {
                     let slice_length = total_row / (num_stages * line_size);
 
                     (total_col, 0, slice_length, stage_index * slice_length)
                 },
+                (MatmulIdent::Out, _) => unreachable!()
             }
         };
 
-        let unit_count = config.plane_dim() * config.num_loading_planes(input_ident);
+        let unit_count = config.plane_dim() * config.num_loading_planes(ident);
         let num_tasks_per_unit = comptime!(num_slices.div_ceil(unit_count));
 
         AsyncPartialMaximizeSliceLengthJob {
             num_tasks_per_unit,
             unit_count,
             num_slices_stage_offset,
-            input_ident,
+            ident,
             slice_stage_offset,
             slice_length,
             num_slices,
@@ -95,7 +98,7 @@ pub struct AsyncPartialMaximizeSliceLengthJob {
     #[cube(comptime)]
     num_slices_stage_offset: u32,
     #[cube(comptime)]
-    input_ident: InputIdent,
+    ident: MatmulIdent,
     #[cube(comptime)]
     slice_stage_offset: u32,
     #[cube(comptime)]
@@ -121,12 +124,12 @@ impl<MP: MatmulPrecision> AsyncLoadingJob<MP, StridedTilingLayout>
         let nth_slice = nth_slice_in_stage + this.num_slices_stage_offset;
 
         let window: Window<MP::EI> =
-            tensor_reader.load_window_in_stage::<G>(nth_slice, this.input_ident, config);
+            tensor_reader.load_window_in_stage::<G>(nth_slice, this.ident, config);
         let mut destination: SliceMut<Line<MP::ES>> =
             StridedTilingLayout::nth_slice::<MP::ES, G::StageConfig>(
                 stage,
                 nth_slice,
-                comptime!(this.input_ident.as_ident()),
+                comptime!(StageIdent::from_matmul(this.ident)),
                 config.stage_config(),
             );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/base.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/base.rs
@@ -1,7 +1,7 @@
 use crate::components::global::global_memory::TensorReader;
 use crate::components::global::{CopyMechanism, GlobalConfig, Quantization};
 use crate::components::stage::{StageMemory, TilingLayout};
-use crate::components::{Ident, InvalidConfigError, MatmulPrecision};
+use crate::components::{InvalidConfigError, MatmulIdent, MatmulPrecision};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::CubeOption;
@@ -51,13 +51,13 @@ pub trait AsyncLoadingJob<MP: MatmulPrecision, TL: TilingLayout>: CubeType + Cop
 /// Allows to verify configs are valid for a loader
 pub trait LoadingValidation {
     /// Verify that configs are valid for a loader, otherwise return an error stating why
-    fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError>;
+    fn check<C: GlobalConfig>(config: &C, ident: MatmulIdent) -> Result<(), InvalidConfigError>;
 }
 
 /// Dummy trait implementation
 pub struct NoLoadingValidation {}
 impl LoadingValidation for NoLoadingValidation {
-    fn check<C: GlobalConfig>(_config: &C, _ident: Ident) -> Result<(), InvalidConfigError> {
+    fn check<C: GlobalConfig>(_config: &C, _ident: MatmulIdent) -> Result<(), InvalidConfigError> {
         Ok(())
     }
 }

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_cyclic.rs
@@ -5,7 +5,7 @@ use crate::components::global::load::SyncFullLoadingStrategy;
 use crate::components::global::multi_stage::LoadMaxRoundPlaneCount;
 use crate::components::global::{GlobalConfig, Quantization, RoleRule};
 use crate::components::stage::{ContiguousTilingLayout, StageMemory, TilingOrder};
-use crate::components::{Ident, InputIdent, InvalidConfigError};
+use crate::components::{InvalidConfigError, MatmulIdent, StageIdent};
 use crate::components::{MatmulPrecision, TilingScheme};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -22,7 +22,7 @@ pub struct SyncFullCyclicLoading<T: TilingOrder> {
 }
 
 impl<TO: TilingOrder> LoadingValidation for SyncFullCyclicLoading<TO> {
-    fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
+    fn check<C: GlobalConfig>(config: &C, ident: MatmulIdent) -> Result<(), InvalidConfigError> {
         if let LoaderMode::Strict = config.loader_mode() {
             let line_size = config.global_line_size(ident);
 
@@ -44,7 +44,7 @@ impl<TO: TilingOrder> LoadingValidation for SyncFullCyclicLoading<TO> {
 impl<TO: TilingOrder> LoadMaxRoundPlaneCount for SyncFullCyclicLoading<TO> {
     fn max_round_plane_count(
         tiling_scheme: &TilingScheme,
-        ident: InputIdent,
+        ident: MatmulIdent,
         line_size: u8,
         plane_dim: u32,
     ) -> u32 {
@@ -59,21 +59,21 @@ impl<TO: TilingOrder> SyncFullLoadingStrategy for SyncFullCyclicLoading<TO> {
     type Job<MP: MatmulPrecision> = SyncFullCyclicJob;
 
     fn new_job<MP: MatmulPrecision, G: GlobalConfig>(
-        #[comptime] input_ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Self::Job<MP> {
-        let tile_num_elements = config.tiling_scheme().elements_in_tile(input_ident);
-        let line_size = config.global_line_size(input_ident);
-        let num_stage_elements = config.tiling_scheme().elements_in_stage(input_ident);
+        let tile_num_elements = config.tiling_scheme().elements_in_tile(ident);
+        let line_size = config.global_line_size(ident);
+        let num_stage_elements = config.tiling_scheme().elements_in_stage(ident);
 
         let num_stage_lines = num_stage_elements.div_ceil(line_size);
-        let total_units = comptime!(config.num_loading_planes(input_ident) * config.plane_dim());
+        let total_units = comptime!(config.num_loading_planes(ident) * config.plane_dim());
         let num_tasks_per_unit = comptime!(num_stage_lines.div_ceil(total_units));
         let balanced_workload = comptime!(num_stage_lines % total_units == 0);
         let jump_length = comptime!(total_units * line_size);
 
         let unit_id = RoleRule::new(config.role_rule_config())
-            .load_index(input_ident, config.specialized_loading_sides())
+            .load_index(ident, config.specialized_loading_sides())
             * config.plane_dim()
             + UNIT_POS_X;
         let unit_position_base = unit_id * line_size;
@@ -84,7 +84,7 @@ impl<TO: TilingOrder> SyncFullLoadingStrategy for SyncFullCyclicLoading<TO> {
             tile_num_elements,
             jump_length,
             line_size,
-            input_ident,
+            ident,
             balanced_workload,
             num_stage_elements,
             loader_mode: comptime!(config.loader_mode()),
@@ -105,7 +105,7 @@ pub struct SyncFullCyclicJob {
     #[cube(comptime)]
     line_size: u32,
     #[cube(comptime)]
-    input_ident: InputIdent,
+    ident: MatmulIdent,
     #[cube(comptime)]
     balanced_workload: bool,
     #[cube(comptime)]
@@ -171,7 +171,7 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
 
     let (tile_x, tile_y) = ContiguousTilingLayout::<TO>::to_x_y::<G::StageConfig>(
         nth_tile,
-        comptime!(job.input_ident.as_ident()),
+        comptime!(StageIdent::from_matmul(job.ident)),
         comptime!(config.stage_config()),
     );
 
@@ -179,12 +179,12 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
         tile_x,
         tile_y,
         pos_within_tile,
-        job.input_ident,
+        job.ident,
         config,
     );
 
     stage.as_slice_mut(job.line_size)[unit_position / job.line_size] = match quantization {
-        CubeOption::Some(quantization) => quantization.dequantize(line_read, job.input_ident),
+        CubeOption::Some(quantization) => quantization.dequantize(line_read, job.ident),
         CubeOption::None => Line::cast_from(line_read),
     };
 }

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_cyclic.rs
@@ -5,7 +5,7 @@ use crate::components::global::load::SyncFullLoadingStrategy;
 use crate::components::global::multi_stage::LoadMaxRoundPlaneCount;
 use crate::components::global::{GlobalConfig, Quantization, RoleRule};
 use crate::components::stage::{ContiguousTilingLayout, StageMemory, TilingOrder};
-use crate::components::{InvalidConfigError, MatmulIdent, StageIdent};
+use crate::components::{InvalidConfigError, MatmulIdent};
 use crate::components::{MatmulPrecision, TilingScheme};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -171,7 +171,7 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
 
     let (tile_x, tile_y) = ContiguousTilingLayout::<TO>::to_x_y::<G::StageConfig>(
         nth_tile,
-        comptime!(StageIdent::from_matmul(job.ident)),
+        comptime!(job.ident.into_stage()),
         comptime!(config.stage_config()),
     );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_cyclic.rs
@@ -169,10 +169,10 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
     let nth_tile = unit_position / job.tile_num_elements;
     let pos_within_tile = unit_position % job.tile_num_elements;
 
-    let (tile_x, tile_y) = ContiguousTilingLayout::<TO>::to_x_y::<G::StageConfig>(
+    let (tile_x, tile_y) = ContiguousTilingLayout::<TO>::to_x_y::<G::StageMemoryConfig>(
         nth_tile,
         comptime!(job.ident.into_stage()),
-        comptime!(config.stage_config()),
+        comptime!(config.stage_memory_config()),
     );
 
     let line_read = tensor_reader.load_coalesced_in_tile::<G>(

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_ordered.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_ordered.rs
@@ -3,7 +3,7 @@ use crate::components::global::load::SyncFullLoadingStrategy;
 use crate::components::global::multi_stage::LoadMaxRoundPlaneCount;
 use crate::components::stage::OrderedTilingOrder;
 use crate::components::{
-    FormattedConfigError, Ident, InputIdent, InvalidConfigError, MatmulPrecision, TilingScheme,
+    FormattedConfigError, InvalidConfigError, MatmulIdent, MatmulPrecision, TilingScheme,
 };
 use crate::components::{global::GlobalConfig, stage::ContiguousTilingLayout};
 use cubecl_core as cubecl;
@@ -23,8 +23,8 @@ use super::{LoadingValidation, sync_full_tilewise};
 pub struct SyncFullOrderedLoading {}
 
 impl LoadingValidation for SyncFullOrderedLoading {
-    fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
-        if ident != Ident::Lhs {
+    fn check<C: GlobalConfig>(config: &C, ident: MatmulIdent) -> Result<(), InvalidConfigError> {
+        if ident != MatmulIdent::Lhs {
             return Err(FormattedConfigError::new(move || {
                 "Ordered loading only available on Lhs".to_string()
             }));
@@ -74,7 +74,7 @@ impl LoadingValidation for SyncFullOrderedLoading {
 impl LoadMaxRoundPlaneCount for SyncFullOrderedLoading {
     fn max_round_plane_count(
         tiling_scheme: &TilingScheme,
-        ident: InputIdent,
+        ident: MatmulIdent,
         _line_size: u8,
         _plane_dim: u32,
     ) -> u32 {
@@ -88,22 +88,22 @@ impl SyncFullLoadingStrategy for SyncFullOrderedLoading {
     type Job<MP: MatmulPrecision> = sync_full_tilewise::SyncFullTilewiseJob;
 
     fn new_job<MP: MatmulPrecision, G: GlobalConfig>(
-        #[comptime] input_ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> Self::Job<MP> {
-        let line_size = config.global_line_size(input_ident);
-        let num_planes = config.num_loading_planes(input_ident);
-        let num_tiles = config.tiling_scheme().tiles_in_stage(input_ident);
+        let line_size = config.global_line_size(ident);
+        let num_planes = config.num_loading_planes(ident);
+        let num_tiles = config.tiling_scheme().tiles_in_stage(ident);
         let plane_dim = config.plane_dim();
 
         let num_tiles_per_plane = comptime!(num_tiles / num_planes);
         let num_lines_per_tile =
-            comptime!(config.tiling_scheme().elements_in_tile(input_ident) / line_size);
+            comptime!(config.tiling_scheme().elements_in_tile(ident) / line_size);
         let num_lines_per_plane = num_lines_per_tile * num_tiles_per_plane;
         let num_lines_per_unit = num_lines_per_plane / plane_dim;
 
         let num_tiles_to_skip = RoleRule::new(config.role_rule_config())
-            .load_index(input_ident, config.specialized_loading_sides())
+            .load_index(ident, config.specialized_loading_sides())
             * num_tiles_per_plane;
         let num_lines_to_skip = num_tiles_to_skip * num_lines_per_tile;
 
@@ -115,7 +115,7 @@ impl SyncFullLoadingStrategy for SyncFullOrderedLoading {
             num_lines_per_unit,
             plane_dim,
             line_size,
-            input_ident,
+            ident,
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_tilewise.rs
@@ -4,7 +4,7 @@ use crate::components::global::load::SyncFullLoadingStrategy;
 use crate::components::global::multi_stage::LoadMaxRoundPlaneCount;
 use crate::components::global::{Quantization, RoleRule};
 use crate::components::{
-    FormattedConfigError, InvalidConfigError, MatmulIdent, MatmulPrecision, StageIdent, TilingScheme
+    FormattedConfigError, InvalidConfigError, MatmulIdent, MatmulPrecision, TilingScheme,
 };
 use crate::components::{
     global::{GlobalConfig, global_memory::TensorReader},
@@ -146,7 +146,7 @@ impl<MP: MatmulPrecision, TO: TilingOrder> LoadingJob<MP, ContiguousTilingLayout
         let nth_tile_global = nth_tile_for_this_plane + this.num_tiles_to_skip;
         let tile = ContiguousTilingLayout::<TO>::to_x_y::<G::StageConfig>(
             nth_tile_global,
-            comptime!(StageIdent::from_matmul(this.ident)),
+            comptime!(this.ident.into_stage()),
             config.stage_config(),
         );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_full_tilewise.rs
@@ -144,10 +144,10 @@ impl<MP: MatmulPrecision, TO: TilingOrder> LoadingJob<MP, ContiguousTilingLayout
         let line_index_within_tile = pos_across_tiles % this.num_lines_per_tile;
 
         let nth_tile_global = nth_tile_for_this_plane + this.num_tiles_to_skip;
-        let tile = ContiguousTilingLayout::<TO>::to_x_y::<G::StageConfig>(
+        let tile = ContiguousTilingLayout::<TO>::to_x_y::<G::StageMemoryConfig>(
             nth_tile_global,
             comptime!(this.ident.into_stage()),
-            config.stage_config(),
+            config.stage_memory_config(),
         );
 
         SyncFullTilewiseJob::load_and_store_line::<MP, TO, G>(

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_cyclic.rs
@@ -5,9 +5,7 @@ use crate::components::global::load::SyncPartialLoadingStrategy;
 use crate::components::global::multi_stage::LoadMaxRoundPlaneCount;
 use crate::components::global::{GlobalConfig, Quantization, RoleRule};
 use crate::components::stage::{ContiguousTilingLayout, StageMemory, TilingOrder};
-use crate::components::{
-    InvalidConfigError, MatmulIdent, MatmulPrecision, StageIdent, TilingScheme,
-};
+use crate::components::{InvalidConfigError, MatmulIdent, MatmulPrecision, TilingScheme};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::{CubeOption, CubeOptionExpand};
@@ -184,7 +182,7 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
     quantization: &CubeOption<Quantization<MP>>,
     #[comptime] config: G,
 ) {
-    let stage_ident = comptime!(StageIdent::from_matmul(job.ident));
+    let stage_ident = comptime!(job.ident.into_stage());
 
     let (line_size, tile_size, tile_count_row, tile_count_col) = comptime! {
         (

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_cyclic.rs
@@ -208,12 +208,12 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
         MatmulIdent::Out => comptime!(unreachable!()),
     };
 
-    let (tile_x_within_stage, tile_y_within_stage) = TO::to_row_col::<G::StageConfig>(
+    let (tile_x_within_stage, tile_y_within_stage) = TO::to_row_col::<G::StageMemoryConfig>(
         tile_index,
         tile_count_row,
         tile_count_col,
         stage_ident,
-        comptime!(config.stage_config()),
+        comptime!(config.stage_memory_config()),
     );
 
     let (tile_x, tile_y) = match comptime!(job.ident) {
@@ -236,13 +236,13 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
         config,
     );
 
-    let nth_tile_in_stage = TO::to_nth_tile::<G::StageConfig>(
+    let nth_tile_in_stage = TO::to_nth_tile::<G::StageMemoryConfig>(
         tile_x,
         tile_y,
         total_tile_count_row,
         total_tile_count_col,
         stage_ident,
-        config.stage_config(),
+        config.stage_memory_config(),
     );
 
     let tile_start = nth_tile_in_stage * job.num_lines_per_tile;

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_cyclic.rs
@@ -5,7 +5,9 @@ use crate::components::global::load::SyncPartialLoadingStrategy;
 use crate::components::global::multi_stage::LoadMaxRoundPlaneCount;
 use crate::components::global::{GlobalConfig, Quantization, RoleRule};
 use crate::components::stage::{ContiguousTilingLayout, StageMemory, TilingOrder};
-use crate::components::{Ident, InputIdent, InvalidConfigError, MatmulPrecision, TilingScheme};
+use crate::components::{
+    InvalidConfigError, MatmulIdent, MatmulPrecision, StageIdent, TilingScheme,
+};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::{CubeOption, CubeOptionExpand};
@@ -21,7 +23,7 @@ pub struct SyncPartialCyclicLoading<T: TilingOrder> {
 }
 
 impl<TO: TilingOrder> LoadingValidation for SyncPartialCyclicLoading<TO> {
-    fn check<C: GlobalConfig>(config: &C, ident: Ident) -> Result<(), InvalidConfigError> {
+    fn check<C: GlobalConfig>(config: &C, ident: MatmulIdent) -> Result<(), InvalidConfigError> {
         if let LoaderMode::Strict = config.loader_mode() {
             let line_size = config.global_line_size(ident);
             let num_lines_per_tile = config.tiling_scheme().elements_in_tile(ident) / line_size;
@@ -52,7 +54,7 @@ impl<TO: TilingOrder> LoadingValidation for SyncPartialCyclicLoading<TO> {
 impl<TO: TilingOrder> LoadMaxRoundPlaneCount for SyncPartialCyclicLoading<TO> {
     fn max_round_plane_count(
         tiling_scheme: &TilingScheme,
-        ident: InputIdent,
+        ident: MatmulIdent,
         line_size: u8,
         plane_dim: u32,
     ) -> u32 {
@@ -70,18 +72,18 @@ impl<TO: TilingOrder> SyncPartialLoadingStrategy for SyncPartialCyclicLoading<TO
 
     fn new_job<MP: MatmulPrecision, G: GlobalConfig>(
         #[comptime] stage_index: u32,
-        #[comptime] input_ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] config: G,
     ) -> SyncPartialCyclicJob {
-        let line_size = config.global_line_size(input_ident);
-        let num_stage_elements = config.tiling_scheme().elements_in_stage(input_ident);
+        let line_size = config.global_line_size(ident);
+        let num_stage_elements = config.tiling_scheme().elements_in_stage(ident);
 
-        let tile_size = config.tiling_scheme().elements_in_tile(input_ident);
-        let tile_count_row = config.tiling_scheme().tiles_in_stage_row(input_ident);
-        let tile_count_col = config.tiling_scheme().tiles_in_stage_col(input_ident);
+        let tile_size = config.tiling_scheme().elements_in_tile(ident);
+        let tile_count_row = config.tiling_scheme().tiles_in_stage_row(ident);
+        let tile_count_col = config.tiling_scheme().tiles_in_stage_col(ident);
 
         let num_lines_per_tile = tile_size / line_size;
-        let total_units = config.plane_dim() * config.num_loading_planes(input_ident);
+        let total_units = config.plane_dim() * config.num_loading_planes(ident);
 
         let num_tiles_in_stage = tile_count_row * tile_count_col;
         let total_num_lines = num_tiles_in_stage * num_lines_per_tile;
@@ -90,7 +92,7 @@ impl<TO: TilingOrder> SyncPartialLoadingStrategy for SyncPartialCyclicLoading<TO
         let jump_length = total_units * line_size;
 
         let plane_id = RoleRule::new(config.role_rule_config())
-            .load_index(input_ident, config.specialized_loading_sides());
+            .load_index(ident, config.specialized_loading_sides());
         let unit_id = plane_id * config.plane_dim() + UNIT_POS_X;
         let unit_position_base = unit_id * line_size;
 
@@ -100,7 +102,7 @@ impl<TO: TilingOrder> SyncPartialLoadingStrategy for SyncPartialCyclicLoading<TO
             stage_index,
             jump_length,
             num_lines_per_tile,
-            input_ident,
+            ident,
             balanced_workload,
             num_stage_elements,
             loader_mode: comptime!(config.loader_mode()),
@@ -121,7 +123,7 @@ pub struct SyncPartialCyclicJob {
     #[cube(comptime)]
     num_lines_per_tile: u32,
     #[cube(comptime)]
-    input_ident: InputIdent,
+    ident: MatmulIdent,
     #[cube(comptime)]
     balanced_workload: bool,
     #[cube(comptime)]
@@ -182,53 +184,57 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
     quantization: &CubeOption<Quantization<MP>>,
     #[comptime] config: G,
 ) {
+    let stage_ident = comptime!(StageIdent::from_matmul(job.ident));
+
     let (line_size, tile_size, tile_count_row, tile_count_col) = comptime! {
         (
-            config.global_line_size(job.input_ident),
-            config.tiling_scheme().elements_in_tile(job.input_ident),
-            config.tiling_scheme().tiles_in_stage_row(job.input_ident),
-            config.tiling_scheme().tiles_in_stage_col(job.input_ident),
+            config.global_line_size(job.ident),
+            config.tiling_scheme().elements_in_tile(job.ident),
+            config.tiling_scheme().tiles_in_stage_row(job.ident),
+            config.tiling_scheme().tiles_in_stage_col(job.ident),
         )
     };
 
     let tile_index = unit_position / tile_size;
     let pos_within_tile = unit_position % tile_size;
 
-    let (total_tile_count_row, total_tile_count_col) = match comptime!(job.input_ident) {
-        InputIdent::Lhs => (
+    let (total_tile_count_row, total_tile_count_col) = match comptime!(job.ident) {
+        MatmulIdent::Lhs => (
             comptime!(tile_count_row),
-            comptime!(tile_count_col * config.num_stages(InputIdent::Lhs)),
+            comptime!(tile_count_col * config.num_stages(MatmulIdent::Lhs)),
         ),
-        InputIdent::Rhs => (
-            comptime!(tile_count_row * config.num_stages(InputIdent::Rhs)),
+        MatmulIdent::Rhs => (
+            comptime!(tile_count_row * config.num_stages(MatmulIdent::Rhs)),
             comptime!(tile_count_col),
         ),
+        MatmulIdent::Out => comptime!(unreachable!()),
     };
 
     let (tile_x_within_stage, tile_y_within_stage) = TO::to_row_col::<G::StageConfig>(
         tile_index,
         tile_count_row,
         tile_count_col,
-        comptime!(job.input_ident.as_ident()),
+        stage_ident,
         comptime!(config.stage_config()),
     );
 
-    let (tile_x, tile_y) = match comptime!(job.input_ident) {
-        InputIdent::Lhs => (
+    let (tile_x, tile_y) = match comptime!(job.ident) {
+        MatmulIdent::Lhs => (
             tile_x_within_stage,
             job.stage_index * tile_count_col + tile_y_within_stage,
         ),
-        InputIdent::Rhs => (
+        MatmulIdent::Rhs => (
             job.stage_index * tile_count_row + tile_x_within_stage,
             tile_y_within_stage,
         ),
+        MatmulIdent::Out => comptime!(unreachable!()),
     };
 
     let line_read = tensor_reader.load_coalesced_in_tile::<G>(
         tile_x,
         tile_y,
         pos_within_tile,
-        job.input_ident,
+        job.ident,
         config,
     );
 
@@ -237,7 +243,7 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
         tile_y,
         total_tile_count_row,
         total_tile_count_col,
-        comptime!(job.input_ident.as_ident()),
+        stage_ident,
         config.stage_config(),
     );
 
@@ -248,7 +254,7 @@ pub(crate) fn load_and_store_line<MP: MatmulPrecision, TO: TilingOrder, G: Globa
         .slice_mut(tile_start, tile_end);
 
     tile_slice[pos_within_tile / line_size] = match quantization {
-        CubeOption::Some(quantization) => quantization.dequantize(line_read, job.input_ident),
+        CubeOption::Some(quantization) => quantization.dequantize(line_read, job.ident),
         CubeOption::None => Line::cast_from(line_read),
     }
 }

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_tilewise.rs
@@ -5,8 +5,7 @@ use crate::components::global::multi_stage::LoadMaxRoundPlaneCount;
 use crate::components::global::{Quantization, RoleRule};
 use crate::components::stage::TilingOrderEnum;
 use crate::components::{
-    FormattedConfigError, InvalidConfigError, MatmulIdent, MatmulPrecision, StageIdent,
-    TilingScheme,
+    FormattedConfigError, InvalidConfigError, MatmulIdent, MatmulPrecision, TilingScheme,
 };
 use crate::components::{
     global::{GlobalConfig, global_memory::TensorReader},
@@ -201,7 +200,7 @@ impl<MP: MatmulPrecision, TO: TilingOrder> LoadingJob<MP, ContiguousTilingLayout
             nth_tile_global,
             total_tile_count_row,
             total_tile_count_col,
-            comptime!(StageIdent::from_matmul(this.ident)),
+            comptime!(this.ident.into_stage()),
             config.stage_config(),
         );
 

--- a/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_tilewise.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/sync_partial_tilewise.rs
@@ -196,12 +196,12 @@ impl<MP: MatmulPrecision, TO: TilingOrder> LoadingJob<MP, ContiguousTilingLayout
             MatmulIdent::Out => comptime!(unreachable!()),
         };
 
-        let tile = TO::to_row_col::<G::StageConfig>(
+        let tile = TO::to_row_col::<G::StageMemoryConfig>(
             nth_tile_global,
             total_tile_count_row,
             total_tile_count_col,
             comptime!(this.ident.into_stage()),
-            config.stage_config(),
+            config.stage_memory_config(),
         );
 
         let num_lines_to_skip_global = nth_tile_global * this.num_lines_per_tile;

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffer_execution.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffer_execution.rs
@@ -3,7 +3,7 @@ use crate::components::global::LoadingSides;
 use crate::components::global::RoleRule;
 use crate::components::global::Specializer;
 use crate::components::global::SpecializerKind;
-use crate::components::global::load::StageIdent;
+use crate::components::global::load::StageBuffer;
 use crate::components::global::multi_stage::DoubleBufferingEventListener;
 use crate::components::global::multi_stage::JobExecutor;
 use crate::components::{MatmulPrecision, stage};
@@ -24,7 +24,7 @@ pub fn load_first<
     lhs_loader: &mut LJ,
     rhs_loader: &mut RJ,
     specializer: &Specializer,
-    #[comptime] stage_to_load: StageIdent,
+    #[comptime] stage_to_load: StageBuffer,
     #[comptime] config: G,
 ) {
     match comptime!(specializer.kind) {
@@ -76,7 +76,7 @@ pub fn execute_current_and_load_next<
     lhs_loader: &mut LJ,
     rhs_loader: &mut RJ,
     specializer: &Specializer,
-    #[comptime] stage_to_load: StageIdent,
+    #[comptime] stage_to_load: StageBuffer,
     #[comptime] config: G,
 ) {
     match comptime!(specializer.kind) {

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Runtime, client::ComputeClient};
 
 use crate::components::{
-    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
+    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout,
     error::MatmulSetupError,
     global::{
         GlobalConfig, PlaneRoleConfig, SpecializedLoadingSides,
@@ -33,13 +33,11 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
     }
 
     fn global_line_size(&self, ident: MatmulIdent) -> u32 {
-        self.stage_config
-            .global_line_size(StageIdent::from_matmul(ident))
+        self.stage_config.global_line_size(ident.into_stage())
     }
 
     fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
-        self.stage_config
-            .matrix_layout(StageIdent::from_matmul(ident))
+        self.stage_config.matrix_layout(ident.into_stage())
     }
 
     fn plane_dim(&self) -> u32 {

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -45,7 +45,7 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
     }
 
     fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_m_bounds,
             MatmulIdent::Rhs => self.check_k_bounds,
             MatmulIdent::Out => self.check_m_bounds,
@@ -53,7 +53,7 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
     }
 
     fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_k_bounds,
             MatmulIdent::Rhs => self.check_n_bounds,
             MatmulIdent::Out => self.check_n_bounds,

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Runtime, client::ComputeClient};
 
 use crate::components::{
-    Ident, InputIdent, LoadingPrecomputeStrategy, MatmulPrecision, MatrixLayout,
+    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
     error::MatmulSetupError,
     global::{
         GlobalConfig, PlaneRoleConfig, SpecializedLoadingSides,
@@ -32,31 +32,33 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
         self.stage_config
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
-        self.stage_config.global_line_size(ident)
+    fn global_line_size(&self, ident: MatmulIdent) -> u32 {
+        self.stage_config
+            .global_line_size(StageIdent::from_matmul(ident))
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
-        self.stage_config.matrix_layout(ident)
+    fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
+        self.stage_config
+            .matrix_layout(StageIdent::from_matmul(ident))
     }
 
     fn plane_dim(&self) -> u32 {
         self.stage_config.plane_dim()
     }
 
-    fn check_row_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_m_bounds,
-            Ident::Rhs => self.check_k_bounds,
-            Ident::Out => self.check_m_bounds,
+            MatmulIdent::Lhs => self.check_m_bounds,
+            MatmulIdent::Rhs => self.check_k_bounds,
+            MatmulIdent::Out => self.check_m_bounds,
         }
     }
 
-    fn check_col_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_k_bounds,
-            Ident::Rhs => self.check_n_bounds,
-            Ident::Out => self.check_n_bounds,
+            MatmulIdent::Lhs => self.check_k_bounds,
+            MatmulIdent::Rhs => self.check_n_bounds,
+            MatmulIdent::Out => self.check_n_bounds,
         }
     }
 
@@ -68,7 +70,7 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
         self.precompute_job.into()
     }
 
-    fn num_stages(&self, _ident: InputIdent) -> u32 {
+    fn num_stages(&self, _ident: MatmulIdent) -> u32 {
         2
     }
 
@@ -76,7 +78,7 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
         self.loader_mode
     }
 
-    fn event_loading_mode(&self, _ident: InputIdent) -> EventLoadingMode {
+    fn event_loading_mode(&self, _ident: MatmulIdent) -> EventLoadingMode {
         EventLoadingMode::Relaxed
     }
 
@@ -84,10 +86,10 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
         self.stage_config.plane_role_config()
     }
 
-    fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32 {
+    fn num_loading_planes(&self, ident: MatmulIdent) -> u32 {
         self.specialized_loading_sides.num_loading_planes(
             self.plane_role_config().has_specialization(),
-            ident.into().as_input_ident(),
+            ident,
             self.plane_role_config().plane_roles,
         )
     }
@@ -135,8 +137,8 @@ impl<S: stage::StageConfig> DoubleBufferingGlobalConfig<S> {
     fn validate<LL: LoadingValidation, RL: LoadingValidation>(
         self,
     ) -> Result<Self, MatmulSetupError> {
-        LL::check::<Self>(&self, Ident::Lhs)?;
-        RL::check::<Self>(&self, Ident::Rhs)?;
+        LL::check::<Self>(&self, MatmulIdent::Lhs)?;
+        RL::check::<Self>(&self, MatmulIdent::Rhs)?;
         shared_global_config_validation(self)?;
 
         Ok(self)

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/config.rs
@@ -9,12 +9,12 @@ use crate::components::{
         multi_stage::EventLoadingMode,
         shared::shared_global_config_validation,
     },
-    stage::{self},
+    stage::StageConfig,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Configuration for the double buffering global matmul
-pub struct DoubleBufferingGlobalConfig<S: stage::StageConfig> {
+pub struct DoubleBufferingGlobalConfig<S: StageConfig> {
     pub stage_config: S,
     num_planes: u32,
     pub check_m_bounds: bool,
@@ -25,8 +25,13 @@ pub struct DoubleBufferingGlobalConfig<S: stage::StageConfig> {
     specialized_loading_sides: SpecializedLoadingSides,
 }
 
-impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
+impl<S: StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
     type StageConfig = S;
+    type StageMemoryConfig = S::StageMemoryConfig;
+
+    fn stage_memory_config(&self) -> Self::StageMemoryConfig {
+        self.stage_config.stage_memory_config()
+    }
 
     fn stage_config(&self) -> Self::StageConfig {
         self.stage_config
@@ -101,7 +106,7 @@ impl<S: stage::StageConfig> GlobalConfig for DoubleBufferingGlobalConfig<S> {
     }
 }
 
-impl<S: stage::StageConfig> DoubleBufferingGlobalConfig<S> {
+impl<S: StageConfig> DoubleBufferingGlobalConfig<S> {
     #[allow(clippy::too_many_arguments)]
     /// Create a new config for double buffering global matmul
     ///

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -1,5 +1,4 @@
-use crate::components::global;
-use crate::components::global::load::{StageIdent, SyncPartialLoader, SyncPartialLoadingStrategy};
+use crate::components::global::load::{StageBuffer, SyncPartialLoader, SyncPartialLoadingStrategy};
 use crate::components::global::multi_stage::double_buffer_execution::{
     execute_current_and_load_next, execute_last_and_write_results, load_first,
 };
@@ -7,7 +6,8 @@ use crate::components::global::multi_stage::double_buffering::DoubleBufferingGlo
 use crate::components::global::{GlobalConfig, ZeroAccumulatorLoader};
 use crate::components::global::{Quantization, Specializer};
 use crate::components::stage::PartialStageToTileReader;
-use crate::components::{InputIdent, MatmulPrecision, stage};
+use crate::components::{MatmulIdent, global};
+use crate::components::{MatmulPrecision, stage};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
@@ -68,10 +68,10 @@ where
         SMM::zero_accumulator(acc, config.stage_config());
         let (mut lhs_tile, mut rhs_tile) = SMM::init_tile_inputs(config.stage_config());
 
-        let lhs_reader_a = Self::LhsLoader::reader(&lhs_loader, StageIdent::A);
-        let lhs_reader_b = Self::LhsLoader::reader(&lhs_loader, StageIdent::B);
-        let rhs_reader_a = Self::RhsLoader::reader(&rhs_loader, StageIdent::A);
-        let rhs_reader_b = Self::RhsLoader::reader(&rhs_loader, StageIdent::B);
+        let lhs_reader_a = Self::LhsLoader::reader(&lhs_loader, StageBuffer::A);
+        let lhs_reader_b = Self::LhsLoader::reader(&lhs_loader, StageBuffer::B);
+        let rhs_reader_a = Self::RhsLoader::reader(&rhs_loader, StageBuffer::A);
+        let rhs_reader_b = Self::RhsLoader::reader(&rhs_loader, StageBuffer::B);
 
         let specializer = Specializer::new::<Self::Config>(config);
 
@@ -79,7 +79,7 @@ where
             &mut lhs_loader,
             &mut rhs_loader,
             &specializer,
-            StageIdent::A,
+            StageBuffer::A,
             config,
         );
 
@@ -95,7 +95,7 @@ where
                 &mut lhs_loader,
                 &mut rhs_loader,
                 &specializer,
-                StageIdent::B,
+                StageBuffer::B,
                 config,
             );
 
@@ -115,7 +115,7 @@ where
                 &mut lhs_loader,
                 &mut rhs_loader,
                 &specializer,
-                StageIdent::A,
+                StageBuffer::A,
                 config,
             );
 
@@ -131,7 +131,7 @@ where
             &mut lhs_loader,
             &mut rhs_loader,
             &specializer,
-            StageIdent::B,
+            StageBuffer::B,
             config,
         );
 
@@ -164,7 +164,7 @@ where
             y_offset,
             batch_offset,
             quantization,
-            InputIdent::Lhs,
+            MatmulIdent::Lhs,
             config,
         )
     }
@@ -184,7 +184,7 @@ where
             y_offset,
             batch_offset,
             quantization,
-            InputIdent::Rhs,
+            MatmulIdent::Rhs,
             config,
         )
     }

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Runtime, client::ComputeClient};
 
 use crate::components::{
-    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
+    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout,
     error::MatmulSetupError,
     global::{
         GlobalConfig, PlaneRoleConfig, SpecializedLoadingSides,
@@ -37,8 +37,7 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
     }
 
     fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
-        self.stage_config
-            .matrix_layout(ident.into_stage())
+        self.stage_config.matrix_layout(ident.into_stage())
     }
 
     fn plane_dim(&self) -> u32 {

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Runtime, client::ComputeClient};
 
 use crate::components::{
-    Ident, InputIdent, LoadingPrecomputeStrategy, MatmulPrecision, MatrixLayout,
+    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
     error::MatmulSetupError,
     global::{
         GlobalConfig, PlaneRoleConfig, SpecializedLoadingSides,
@@ -32,31 +32,33 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
         self.stage_config
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
-        self.stage_config.global_line_size(ident)
+    fn global_line_size(&self, ident: MatmulIdent) -> u32 {
+        self.stage_config
+            .global_line_size(StageIdent::from_matmul(ident))
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
-        self.stage_config.matrix_layout(ident)
+    fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
+        self.stage_config
+            .matrix_layout(StageIdent::from_matmul(ident))
     }
 
     fn plane_dim(&self) -> u32 {
         self.stage_config.plane_dim()
     }
 
-    fn check_row_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_m_bounds,
-            Ident::Rhs => self.check_k_bounds,
-            Ident::Out => self.check_m_bounds,
+            MatmulIdent::Lhs => self.check_m_bounds,
+            MatmulIdent::Rhs => self.check_k_bounds,
+            MatmulIdent::Out => self.check_m_bounds,
         }
     }
 
-    fn check_col_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_k_bounds,
-            Ident::Rhs => self.check_n_bounds,
-            Ident::Out => self.check_n_bounds,
+            MatmulIdent::Lhs => self.check_k_bounds,
+            MatmulIdent::Rhs => self.check_n_bounds,
+            MatmulIdent::Out => self.check_n_bounds,
         }
     }
 
@@ -68,10 +70,11 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
         self.precompute_job.into()
     }
 
-    fn num_stages(&self, ident: InputIdent) -> u32 {
+    fn num_stages(&self, ident: MatmulIdent) -> u32 {
         match ident {
-            InputIdent::Lhs => 1,
-            InputIdent::Rhs => 2,
+            MatmulIdent::Lhs => 1,
+            MatmulIdent::Rhs => 2,
+            MatmulIdent::Out => unreachable!(),
         }
     }
 
@@ -79,10 +82,11 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
         self.loader_mode
     }
 
-    fn event_loading_mode(&self, ident: InputIdent) -> EventLoadingMode {
+    fn event_loading_mode(&self, ident: MatmulIdent) -> EventLoadingMode {
         match ident {
-            InputIdent::Lhs => EventLoadingMode::Ordered,
-            InputIdent::Rhs => EventLoadingMode::Relaxed,
+            MatmulIdent::Lhs => EventLoadingMode::Ordered,
+            MatmulIdent::Rhs => EventLoadingMode::Relaxed,
+            MatmulIdent::Out => unreachable!(),
         }
     }
 
@@ -90,10 +94,10 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
         self.stage_config.plane_role_config()
     }
 
-    fn num_loading_planes<I: Into<Ident>>(&self, ident: I) -> u32 {
+    fn num_loading_planes(&self, ident: MatmulIdent) -> u32 {
         self.specialized_loading_sides.num_loading_planes(
             self.plane_role_config().has_specialization(),
-            ident.into().as_input_ident(),
+            ident,
             self.plane_role_config().plane_roles,
         )
     }
@@ -143,8 +147,8 @@ impl<S: stage::StageConfig> OrderedDoubleBufferingGlobalConfig<S> {
     fn validate<LL: LoadingValidation, RL: LoadingValidation>(
         self,
     ) -> Result<Self, MatmulSetupError> {
-        LL::check::<Self>(&self, Ident::Lhs)?;
-        RL::check::<Self>(&self, Ident::Rhs)?;
+        LL::check::<Self>(&self, MatmulIdent::Lhs)?;
+        RL::check::<Self>(&self, MatmulIdent::Rhs)?;
         shared_global_config_validation(self)?;
         if self.tiling_scheme().stage_partitions_in_stage_n() > 1 {
             return Err(MatmulSetupError::InvalidConfig(Box::new(

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
@@ -27,6 +27,11 @@ pub struct OrderedDoubleBufferingGlobalConfig<S: stage::StageConfig> {
 
 impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<S> {
     type StageConfig = S;
+    type StageMemoryConfig = S::StageMemoryConfig;
+
+    fn stage_memory_config(&self) -> Self::StageMemoryConfig {
+        self.stage_config.stage_memory_config()
+    }
 
     fn stage_config(&self) -> Self::StageConfig {
         self.stage_config

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
@@ -33,13 +33,12 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
     }
 
     fn global_line_size(&self, ident: MatmulIdent) -> u32 {
-        self.stage_config
-            .global_line_size(StageIdent::from_matmul(ident))
+        self.stage_config.global_line_size(ident.into_stage())
     }
 
     fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
         self.stage_config
-            .matrix_layout(StageIdent::from_matmul(ident))
+            .matrix_layout(ident.into_stage())
     }
 
     fn plane_dim(&self) -> u32 {

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/config.rs
@@ -45,7 +45,7 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
     }
 
     fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_m_bounds,
             MatmulIdent::Rhs => self.check_k_bounds,
             MatmulIdent::Out => self.check_m_bounds,
@@ -53,7 +53,7 @@ impl<S: stage::StageConfig> GlobalConfig for OrderedDoubleBufferingGlobalConfig<
     }
 
     fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_k_bounds,
             MatmulIdent::Rhs => self.check_n_bounds,
             MatmulIdent::Out => self.check_n_bounds,

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
@@ -1,5 +1,5 @@
 use crate::components::global::load::{
-    StageIdent, SyncFullLoader, SyncFullLoadingStrategy, SyncPartialLoader,
+    StageBuffer, SyncFullLoader, SyncFullLoadingStrategy, SyncPartialLoader,
     SyncPartialLoadingStrategy,
 };
 use crate::components::global::multi_stage::double_buffer_execution::{
@@ -10,7 +10,7 @@ use crate::components::global::{self, GlobalConfig, ZeroAccumulatorLoader};
 use crate::components::global::{Quantization, Specializer};
 use crate::components::stage::FullStageToTileReader;
 use crate::components::stage::PartialStageToTileReader;
-use crate::components::{InputIdent, MatmulPrecision, stage};
+use crate::components::{MatmulIdent, MatmulPrecision, stage};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
@@ -78,8 +78,8 @@ where
         let (mut lhs_tile, mut rhs_tile) = SMM::init_tile_inputs(config.stage_config());
 
         let lhs_reader = Self::LhsLoader::reader(&lhs_loader);
-        let rhs_reader_a = Self::RhsLoader::reader(&rhs_loader, StageIdent::A);
-        let rhs_reader_b = Self::RhsLoader::reader(&rhs_loader, StageIdent::B);
+        let rhs_reader_a = Self::RhsLoader::reader(&rhs_loader, StageBuffer::A);
+        let rhs_reader_b = Self::RhsLoader::reader(&rhs_loader, StageBuffer::B);
 
         let specializer = Specializer::new::<Self::Config>(config);
 
@@ -87,7 +87,7 @@ where
             &mut lhs_loader,
             &mut rhs_loader,
             &specializer,
-            StageIdent::A,
+            StageBuffer::A,
             config,
         );
 
@@ -105,7 +105,7 @@ where
                 &mut lhs_loader,
                 &mut rhs_loader,
                 &specializer,
-                StageIdent::B,
+                StageBuffer::B,
                 config,
             );
 
@@ -123,7 +123,7 @@ where
                 &mut lhs_loader,
                 &mut rhs_loader,
                 &specializer,
-                StageIdent::A,
+                StageBuffer::A,
                 config,
             );
 
@@ -141,7 +141,7 @@ where
             &mut lhs_loader,
             &mut rhs_loader,
             &specializer,
-            StageIdent::B,
+            StageBuffer::B,
             config,
         );
 
@@ -174,7 +174,7 @@ where
             y_offset,
             batch_offset,
             quantization,
-            InputIdent::Lhs,
+            MatmulIdent::Lhs,
             config,
         )
     }
@@ -194,7 +194,7 @@ where
             y_offset,
             batch_offset,
             quantization,
-            InputIdent::Rhs,
+            MatmulIdent::Rhs,
             config,
         )
     }

--- a/crates/cubecl-matmul/src/components/global/quantization.rs
+++ b/crates/cubecl-matmul/src/components/global/quantization.rs
@@ -1,7 +1,7 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
 
-use crate::components::{InputIdent, MatmulPrecision};
+use crate::components::{MatmulIdent, MatmulPrecision};
 
 /// Store the quantization meta-parameters.
 /// For now, we only support symmetric quantization,
@@ -14,10 +14,11 @@ pub struct Quantization<MP: MatmulPrecision> {
 
 #[cube]
 impl<MP: MatmulPrecision> Quantization<MP> {
-    pub fn dequantize(&self, line: Line<MP::EI>, #[comptime] ident: InputIdent) -> Line<MP::ES> {
+    pub fn dequantize(&self, line: Line<MP::EI>, #[comptime] ident: MatmulIdent) -> Line<MP::ES> {
         match ident {
-            InputIdent::Lhs => Line::<MP::ES>::new(self.scaling_lhs) * Line::cast_from(line),
-            InputIdent::Rhs => Line::<MP::ES>::new(self.scaling_rhs) * Line::cast_from(line),
+            MatmulIdent::Lhs => Line::<MP::ES>::new(self.scaling_lhs) * Line::cast_from(line),
+            MatmulIdent::Rhs => Line::<MP::ES>::new(self.scaling_rhs) * Line::cast_from(line),
+            MatmulIdent::Out => comptime!(unreachable!()),
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/global/shared.rs
+++ b/crates/cubecl-matmul/src/components/global/shared.rs
@@ -1,5 +1,5 @@
 use crate::components::{
-    InputIdent, MatmulLineSizes, TilingScheme,
+    MatmulIdent, MatmulLineSizes, TilingScheme,
     error::MatmulSetupError,
     global::{GlobalConfig, multi_stage::LoadMaxRoundPlaneCount},
 };
@@ -38,13 +38,13 @@ impl MaxLoaderPlanes {
         MaxLoaderPlanes {
             lhs: LL::max_round_plane_count(
                 tiling_scheme,
-                InputIdent::Lhs,
+                MatmulIdent::Lhs,
                 line_sizes.lhs,
                 plane_dim,
             ),
             rhs: RL::max_round_plane_count(
                 tiling_scheme,
-                InputIdent::Rhs,
+                MatmulIdent::Rhs,
                 line_sizes.rhs,
                 plane_dim,
             ),

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Feature, Runtime, client::ComputeClient};
 
 use crate::components::{
-    Ident, InputIdent, LoadingPrecomputeStrategy, MatrixLayout,
+    LoadingPrecomputeStrategy, MatmulIdent, MatrixLayout, StageIdent,
     error::{MatmulAvailabilityError, MatmulSetupError},
     global::{
         self, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides,
@@ -32,31 +32,33 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleBarrierConfig<S> {
         self.stage_config
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
-        self.stage_config.global_line_size(ident)
+    fn global_line_size(&self, ident: MatmulIdent) -> u32 {
+        self.stage_config
+            .global_line_size(StageIdent::from_matmul(ident))
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
-        self.stage_config.matrix_layout(ident)
+    fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
+        self.stage_config
+            .matrix_layout(StageIdent::from_matmul(ident))
     }
 
     fn plane_dim(&self) -> u32 {
         self.stage_config.plane_dim()
     }
 
-    fn check_row_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_m_bounds,
-            Ident::Rhs => self.check_k_bounds,
-            Ident::Out => self.check_m_bounds,
+            MatmulIdent::Lhs => self.check_m_bounds,
+            MatmulIdent::Rhs => self.check_k_bounds,
+            MatmulIdent::Out => self.check_m_bounds,
         }
     }
 
-    fn check_col_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_k_bounds,
-            Ident::Rhs => self.check_n_bounds,
-            Ident::Out => self.check_n_bounds,
+            MatmulIdent::Lhs => self.check_k_bounds,
+            MatmulIdent::Rhs => self.check_n_bounds,
+            MatmulIdent::Out => self.check_n_bounds,
         }
     }
 
@@ -64,7 +66,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleBarrierConfig<S> {
         self.check_k_bounds
     }
 
-    fn num_stages(&self, _ident: InputIdent) -> u32 {
+    fn num_stages(&self, _ident: MatmulIdent) -> u32 {
         1
     }
 
@@ -76,7 +78,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleBarrierConfig<S> {
         self.loader_mode
     }
 
-    fn event_loading_mode(&self, _ident: InputIdent) -> EventLoadingMode {
+    fn event_loading_mode(&self, _ident: MatmulIdent) -> EventLoadingMode {
         EventLoadingMode::Relaxed
     }
 
@@ -84,7 +86,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleBarrierConfig<S> {
         self.stage_config.plane_role_config()
     }
 
-    fn num_loading_planes<I: Into<Ident>>(&self, _ident: I) -> u32 {
+    fn num_loading_planes(&self, _ident: MatmulIdent) -> u32 {
         // Specialized is not available
         self.stage_config().num_main_flow_planes()
     }
@@ -138,8 +140,8 @@ impl<S: stage::StageConfig> SimpleBarrierConfig<S> {
     fn validate<LL: LoadingValidation, RL: LoadingValidation>(
         self,
     ) -> Result<Self, MatmulSetupError> {
-        LL::check(&self, Ident::Lhs)?;
-        RL::check(&self, Ident::Rhs)?;
+        LL::check(&self, MatmulIdent::Lhs)?;
+        RL::check(&self, MatmulIdent::Rhs)?;
         shared_global_config_validation(self)?;
 
         Ok(self)

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Feature, Runtime, client::ComputeClient};
 
 use crate::components::{
-    LoadingPrecomputeStrategy, MatmulIdent, MatrixLayout, 
+    LoadingPrecomputeStrategy, MatmulIdent, MatrixLayout,
     error::{MatmulAvailabilityError, MatmulSetupError},
     global::{
         self, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides,

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
@@ -45,7 +45,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleBarrierConfig<S> {
     }
 
     fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_m_bounds,
             MatmulIdent::Rhs => self.check_k_bounds,
             MatmulIdent::Out => self.check_m_bounds,
@@ -53,7 +53,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleBarrierConfig<S> {
     }
 
     fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_k_bounds,
             MatmulIdent::Rhs => self.check_n_bounds,
             MatmulIdent::Out => self.check_n_bounds,

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
@@ -27,6 +27,11 @@ pub struct SimpleBarrierConfig<S: stage::StageConfig> {
 
 impl<S: stage::StageConfig> global::GlobalConfig for SimpleBarrierConfig<S> {
     type StageConfig = S;
+    type StageMemoryConfig = S::StageMemoryConfig;
+
+    fn stage_memory_config(&self) -> Self::StageMemoryConfig {
+        self.stage_config.stage_memory_config()
+    }
 
     fn stage_config(&self) -> Self::StageConfig {
         self.stage_config

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Feature, Runtime, client::ComputeClient};
 
 use crate::components::{
-    LoadingPrecomputeStrategy, MatmulIdent, MatrixLayout, StageIdent,
+    LoadingPrecomputeStrategy, MatmulIdent, MatrixLayout, 
     error::{MatmulAvailabilityError, MatmulSetupError},
     global::{
         self, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides,

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
@@ -33,13 +33,11 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleBarrierConfig<S> {
     }
 
     fn global_line_size(&self, ident: MatmulIdent) -> u32 {
-        self.stage_config
-            .global_line_size(StageIdent::from_matmul(ident))
+        self.stage_config.global_line_size(ident.into_stage())
     }
 
     fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
-        self.stage_config
-            .matrix_layout(StageIdent::from_matmul(ident))
+        self.stage_config.matrix_layout(ident.into_stage())
     }
 
     fn plane_dim(&self) -> u32 {

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/matmul.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::components::InputIdent;
+use crate::components::MatmulIdent;
 use crate::components::MatmulPrecision;
 use crate::components::global::GlobalConfig;
 use crate::components::global::GlobalMatmul;
@@ -120,7 +120,7 @@ where
             y_offset,
             batch_offset,
             quantization,
-            InputIdent::Lhs,
+            MatmulIdent::Lhs,
             config,
         )
     }
@@ -140,7 +140,7 @@ where
             y_offset,
             batch_offset,
             quantization,
-            InputIdent::Rhs,
+            MatmulIdent::Rhs,
             config,
         )
     }

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
@@ -45,7 +45,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleConfig<S> {
     }
 
     fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_m_bounds,
             MatmulIdent::Rhs => self.check_k_bounds,
             MatmulIdent::Out => self.check_m_bounds,
@@ -53,7 +53,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleConfig<S> {
     }
 
     fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_k_bounds,
             MatmulIdent::Rhs => self.check_n_bounds,
             MatmulIdent::Out => self.check_n_bounds,

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
@@ -33,13 +33,11 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleConfig<S> {
     }
 
     fn global_line_size(&self, ident: MatmulIdent) -> u32 {
-        self.stage_config
-            .global_line_size(StageIdent::from_matmul(ident))
+        self.stage_config.global_line_size(ident.into_stage())
     }
 
     fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
-        self.stage_config
-            .matrix_layout(StageIdent::from_matmul(ident))
+        self.stage_config.matrix_layout(ident.into_stage())
     }
 
     fn plane_dim(&self) -> u32 {

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Runtime, client::ComputeClient};
 
 use crate::components::{
-    Ident, InputIdent, LoadingPrecomputeStrategy, MatmulPrecision, MatrixLayout,
+    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
     error::MatmulSetupError,
     global::{
         self, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides,
@@ -32,31 +32,33 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleConfig<S> {
         self.stage_config
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
-        self.stage_config.global_line_size(ident)
+    fn global_line_size(&self, ident: MatmulIdent) -> u32 {
+        self.stage_config
+            .global_line_size(StageIdent::from_matmul(ident))
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
-        self.stage_config.matrix_layout(ident)
+    fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
+        self.stage_config
+            .matrix_layout(StageIdent::from_matmul(ident))
     }
 
     fn plane_dim(&self) -> u32 {
         self.stage_config.plane_dim()
     }
 
-    fn check_row_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_m_bounds,
-            Ident::Rhs => self.check_k_bounds,
-            Ident::Out => self.check_m_bounds,
+            MatmulIdent::Lhs => self.check_m_bounds,
+            MatmulIdent::Rhs => self.check_k_bounds,
+            MatmulIdent::Out => self.check_m_bounds,
         }
     }
 
-    fn check_col_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_k_bounds,
-            Ident::Rhs => self.check_n_bounds,
-            Ident::Out => self.check_n_bounds,
+            MatmulIdent::Lhs => self.check_k_bounds,
+            MatmulIdent::Rhs => self.check_n_bounds,
+            MatmulIdent::Out => self.check_n_bounds,
         }
     }
 
@@ -64,7 +66,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleConfig<S> {
         self.check_k_bounds
     }
 
-    fn num_stages(&self, _ident: InputIdent) -> u32 {
+    fn num_stages(&self, _ident: MatmulIdent) -> u32 {
         1
     }
 
@@ -76,7 +78,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleConfig<S> {
         self.loader_mode
     }
 
-    fn event_loading_mode(&self, _ident: InputIdent) -> EventLoadingMode {
+    fn event_loading_mode(&self, _ident: MatmulIdent) -> EventLoadingMode {
         EventLoadingMode::Relaxed
     }
 
@@ -84,7 +86,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleConfig<S> {
         self.stage_config.plane_role_config()
     }
 
-    fn num_loading_planes<I: Into<Ident>>(&self, _ident: I) -> u32 {
+    fn num_loading_planes(&self, _ident: MatmulIdent) -> u32 {
         // Specialized is not available
         self.stage_config().num_main_flow_planes()
     }
@@ -137,8 +139,8 @@ impl<S: stage::StageConfig> SimpleConfig<S> {
     fn validate<LL: LoadingValidation, RL: LoadingValidation>(
         self,
     ) -> Result<Self, MatmulSetupError> {
-        LL::check(&self, Ident::Lhs)?;
-        RL::check(&self, Ident::Rhs)?;
+        LL::check(&self, MatmulIdent::Lhs)?;
+        RL::check(&self, MatmulIdent::Rhs)?;
         shared_global_config_validation(self)?;
 
         Ok(self)

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
@@ -27,6 +27,11 @@ pub struct SimpleConfig<S: stage::StageConfig> {
 
 impl<S: stage::StageConfig> global::GlobalConfig for SimpleConfig<S> {
     type StageConfig = S;
+    type StageMemoryConfig = S::StageMemoryConfig;
+
+    fn stage_memory_config(&self) -> Self::StageMemoryConfig {
+        self.stage_config.stage_memory_config()
+    }
 
     fn stage_config(&self) -> Self::StageConfig {
         self.stage_config

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/config.rs
@@ -1,7 +1,7 @@
 use cubecl_core::{CubeDim, Runtime, client::ComputeClient};
 
 use crate::components::{
-    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
+    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout,
     error::MatmulSetupError,
     global::{
         self, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides,

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
@@ -1,5 +1,5 @@
 use crate::components::{
-    InputIdent, MatmulPrecision,
+    MatmulIdent, MatmulPrecision,
     global::{
         GlobalMatmul, Quantization, ZeroAccumulatorLoader,
         load::{SyncFullLoader, SyncFullLoadingStrategy},
@@ -106,7 +106,7 @@ where
             y_offset,
             batch_offset,
             quantization,
-            InputIdent::Lhs,
+            MatmulIdent::Lhs,
             config,
         )
     }
@@ -126,7 +126,7 @@ where
             y_offset,
             batch_offset,
             quantization,
-            InputIdent::Rhs,
+            MatmulIdent::Rhs,
             config,
         )
     }

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
@@ -3,7 +3,7 @@ use std::any::TypeId;
 use cubecl_core::{CubeDim, Feature, Runtime, TmaFeature, client::ComputeClient, tf32};
 
 use crate::components::{
-    Ident, InputIdent, LoadingPrecomputeStrategy, MatmulPrecision, MatrixLayout,
+    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
     error::{MatmulAvailabilityError, MatmulSetupError},
     global::{
         self, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides,
@@ -34,31 +34,33 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleTmaConfig<S> {
         self.stage_config
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
-        self.stage_config.global_line_size(ident)
+    fn global_line_size(&self, ident: MatmulIdent) -> u32 {
+        self.stage_config
+            .global_line_size(StageIdent::from_matmul(ident))
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
-        self.stage_config.matrix_layout(ident)
+    fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
+        self.stage_config
+            .matrix_layout(StageIdent::from_matmul(ident))
     }
 
     fn plane_dim(&self) -> u32 {
         self.stage_config.plane_dim()
     }
 
-    fn check_row_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_m_bounds,
-            Ident::Rhs => self.check_k_bounds,
-            Ident::Out => self.check_m_bounds,
+            MatmulIdent::Lhs => self.check_m_bounds,
+            MatmulIdent::Rhs => self.check_k_bounds,
+            MatmulIdent::Out => self.check_m_bounds,
         }
     }
 
-    fn check_col_bounds<I: Into<Ident>>(&self, ident: I) -> bool {
+    fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
         match ident.into() {
-            Ident::Lhs => self.check_k_bounds,
-            Ident::Rhs => self.check_n_bounds,
-            Ident::Out => self.check_n_bounds,
+            MatmulIdent::Lhs => self.check_k_bounds,
+            MatmulIdent::Rhs => self.check_n_bounds,
+            MatmulIdent::Out => self.check_n_bounds,
         }
     }
 
@@ -66,7 +68,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleTmaConfig<S> {
         self.check_k_bounds
     }
 
-    fn num_stages(&self, _ident: InputIdent) -> u32 {
+    fn num_stages(&self, _ident: MatmulIdent) -> u32 {
         1
     }
 
@@ -78,7 +80,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleTmaConfig<S> {
         self.loader_mode
     }
 
-    fn event_loading_mode(&self, _ident: InputIdent) -> EventLoadingMode {
+    fn event_loading_mode(&self, _ident: MatmulIdent) -> EventLoadingMode {
         EventLoadingMode::Relaxed
     }
 
@@ -86,7 +88,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleTmaConfig<S> {
         self.stage_config.plane_role_config()
     }
 
-    fn num_loading_planes<I: Into<Ident>>(&self, _ident: I) -> u32 {
+    fn num_loading_planes(&self, _ident: MatmulIdent) -> u32 {
         // Specialized is not available
         self.stage_config().num_main_flow_planes()
     }
@@ -140,8 +142,8 @@ impl<S: stage::StageConfig> SimpleTmaConfig<S> {
     fn validate<LL: LoadingValidation, RL: LoadingValidation>(
         self,
     ) -> Result<Self, MatmulSetupError> {
-        LL::check(&self, Ident::Lhs)?;
-        RL::check(&self, Ident::Rhs)?;
+        LL::check(&self, MatmulIdent::Lhs)?;
+        RL::check(&self, MatmulIdent::Rhs)?;
         shared_global_config_validation(self)?;
 
         Ok(self)

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
@@ -47,7 +47,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleTmaConfig<S> {
     }
 
     fn check_row_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_m_bounds,
             MatmulIdent::Rhs => self.check_k_bounds,
             MatmulIdent::Out => self.check_m_bounds,
@@ -55,7 +55,7 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleTmaConfig<S> {
     }
 
     fn check_col_bounds(&self, ident: MatmulIdent) -> bool {
-        match ident.into() {
+        match ident {
             MatmulIdent::Lhs => self.check_k_bounds,
             MatmulIdent::Rhs => self.check_n_bounds,
             MatmulIdent::Out => self.check_n_bounds,

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
@@ -3,7 +3,7 @@ use std::any::TypeId;
 use cubecl_core::{CubeDim, Feature, Runtime, TmaFeature, client::ComputeClient, tf32};
 
 use crate::components::{
-    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, StageIdent,
+    LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout,
     error::{MatmulAvailabilityError, MatmulSetupError},
     global::{
         self, LoadingSides, PlaneRoleConfig, SpecializedLoadingSides,

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
@@ -29,6 +29,11 @@ pub struct SimpleTmaConfig<S: stage::StageConfig> {
 
 impl<S: stage::StageConfig> global::GlobalConfig for SimpleTmaConfig<S> {
     type StageConfig = S;
+    type StageMemoryConfig = S::StageMemoryConfig;
+
+    fn stage_memory_config(&self) -> Self::StageMemoryConfig {
+        self.stage_config.stage_memory_config()
+    }
 
     fn stage_config(&self) -> Self::StageConfig {
         self.stage_config

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
@@ -35,13 +35,11 @@ impl<S: stage::StageConfig> global::GlobalConfig for SimpleTmaConfig<S> {
     }
 
     fn global_line_size(&self, ident: MatmulIdent) -> u32 {
-        self.stage_config
-            .global_line_size(StageIdent::from_matmul(ident))
+        self.stage_config.global_line_size(ident.into_stage())
     }
 
     fn matrix_layout(&self, ident: MatmulIdent) -> MatrixLayout {
-        self.stage_config
-            .matrix_layout(StageIdent::from_matmul(ident))
+        self.stage_config.matrix_layout(ident.into_stage())
     }
 
     fn plane_dim(&self) -> u32 {

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/matmul.rs
@@ -1,4 +1,4 @@
-use crate::components::InputIdent;
+use crate::components::MatmulIdent;
 use crate::components::MatmulPrecision;
 use crate::components::global::GlobalMatmul;
 use crate::components::global::ZeroAccumulatorLoader;
@@ -99,7 +99,7 @@ where
             y_offset,
             nth_batch,
             quantization,
-            InputIdent::Lhs,
+            MatmulIdent::Lhs,
             config,
         )
     }
@@ -119,7 +119,7 @@ where
             y_offset,
             nth_batch,
             quantization,
-            InputIdent::Rhs,
+            MatmulIdent::Rhs,
             config,
         )
     }

--- a/crates/cubecl-matmul/src/components/global/specialization/config.rs
+++ b/crates/cubecl-matmul/src/components/global/specialization/config.rs
@@ -1,5 +1,5 @@
 use crate::components::{
-    InputIdent,
+    MatmulIdent,
     global::{MaxLoaderPlanes, specialization::roles::PlaneRoles},
 };
 
@@ -106,21 +106,21 @@ pub enum LoadingSides {
 impl LoadingSides {
     /// Returns `true` if Lhs is included.
     pub fn includes_lhs(&self) -> bool {
-        self.includes(InputIdent::Lhs)
+        self.includes(MatmulIdent::Lhs)
     }
 
     /// Returns `true` if Rhs is included.
     pub fn includes_rhs(&self) -> bool {
-        self.includes(InputIdent::Rhs)
+        self.includes(MatmulIdent::Rhs)
     }
 
     /// Returns `true` if the given input is included.
-    pub fn includes(&self, ident: InputIdent) -> bool {
+    pub fn includes(&self, ident: MatmulIdent) -> bool {
         matches!(
             (self, ident),
             (LoadingSides::Both, _)
-                | (LoadingSides::Lhs, InputIdent::Lhs)
-                | (LoadingSides::Rhs, InputIdent::Rhs)
+                | (LoadingSides::Lhs, MatmulIdent::Lhs)
+                | (LoadingSides::Rhs, MatmulIdent::Rhs)
         )
     }
 }
@@ -137,7 +137,7 @@ impl SpecializedLoadingSides {
     pub fn num_loading_planes(
         &self,
         specialized: bool,
-        ident: InputIdent,
+        ident: MatmulIdent,
         plane_roles: PlaneRoles,
     ) -> u32 {
         if specialized {

--- a/crates/cubecl-matmul/src/components/global/specialization/roles.rs
+++ b/crates/cubecl-matmul/src/components/global/specialization/roles.rs
@@ -1,7 +1,7 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use crate::components::InputIdent;
+use crate::components::MatmulIdent;
 use crate::components::error::MatmulSetupError;
 use crate::components::global::MaxLoaderPlanes;
 use crate::components::global::specialization::config::{
@@ -149,7 +149,7 @@ impl RoleRule {
     /// ignoring any plane that does not participate for this `ident`.
     pub fn load_index(
         self,
-        #[comptime] ident: InputIdent,
+        #[comptime] ident: MatmulIdent,
         #[comptime] specialized_loading_sides: SpecializedLoadingSides,
     ) -> u32 {
         match self {

--- a/crates/cubecl-matmul/src/components/global/write/plane.rs
+++ b/crates/cubecl-matmul/src/components/global/write/plane.rs
@@ -1,4 +1,4 @@
-use crate::components::Ident;
+use crate::components::MatmulIdent;
 use crate::components::global::GlobalConfig;
 use crate::components::global::global_memory::TensorWriter;
 use cubecl_core as cubecl;
@@ -39,7 +39,7 @@ impl<EG: Numeric> GlobalWriter<EG> for PlaneWriter<EG> {
         #[comptime] config: G,
     ) {
         let tile_size = config.tiling_scheme().elements_in_tile_mn();
-        let output_line_size = config.global_line_size(Ident::Out);
+        let output_line_size = config.global_line_size(MatmulIdent::Out);
         let out_smem_slice = out_smem_slice.with_line_size(output_line_size);
 
         let unit_step = config.plane_dim() * output_line_size;

--- a/crates/cubecl-matmul/src/components/global/write/unit.rs
+++ b/crates/cubecl-matmul/src/components/global/write/unit.rs
@@ -1,5 +1,4 @@
-use crate::components::Ident;
-use crate::components::global::GlobalConfig;
+use crate::components::{global::GlobalConfig, MatmulIdent};
 use crate::components::global::global_memory::TensorWriter;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
@@ -38,7 +37,7 @@ impl<EG: Numeric> GlobalWriter<EG> for UnitWriter<EG> {
         #[comptime] config: G,
     ) {
         let tile_size = config.tiling_scheme().elements_in_tile_mn();
-        let output_line_size = config.global_line_size(Ident::Out);
+        let output_line_size = config.global_line_size(MatmulIdent::Out);
         let out_smem_slice = out_smem_slice.with_line_size(output_line_size);
 
         let num_lines = tile_size / output_line_size;

--- a/crates/cubecl-matmul/src/components/global/write/unit.rs
+++ b/crates/cubecl-matmul/src/components/global/write/unit.rs
@@ -1,5 +1,5 @@
-use crate::components::{global::GlobalConfig, MatmulIdent};
 use crate::components::global::global_memory::TensorWriter;
+use crate::components::{MatmulIdent, global::GlobalConfig};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};

--- a/crates/cubecl-matmul/src/components/ident.rs
+++ b/crates/cubecl-matmul/src/components/ident.rs
@@ -8,6 +8,13 @@ pub enum MatmulIdent {
     Out,
 }
 
+impl MatmulIdent {
+    /// Equivalent to into, but type inference works better within Cube functions
+    pub fn into_stage(self) -> StageIdent {
+        self.into()
+    }
+}
+
 // #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 // /// Identifier for all three tensors in a matmul
 // ///
@@ -20,21 +27,14 @@ pub enum MatmulIdent {
 // }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum TileIdent {
-    Lhs,
-    Rhs,
-    Acc,
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum StageIdent {
     Lhs,
     Rhs,
     Acc,
 }
 
-impl StageIdent {
-    pub fn from_matmul(matmul_ident: MatmulIdent) -> Self {
+impl From<MatmulIdent> for StageIdent {
+    fn from(matmul_ident: MatmulIdent) -> Self {
         match matmul_ident {
             MatmulIdent::Lhs => StageIdent::Lhs,
             MatmulIdent::Rhs => StageIdent::Rhs,

--- a/crates/cubecl-matmul/src/components/ident.rs
+++ b/crates/cubecl-matmul/src/components/ident.rs
@@ -2,42 +2,87 @@
 /// Identifier for all three tensors in a matmul
 ///
 /// Useful to specialize some functions depending on the tensor
-pub enum Ident {
+pub enum MatmulIdent {
     Lhs,
     Rhs,
     Out,
 }
 
-impl Ident {
-    pub fn as_input_ident(&self) -> InputIdent {
-        match self {
-            Ident::Lhs => InputIdent::Lhs,
-            Ident::Rhs => InputIdent::Rhs,
-            Ident::Out => panic!("Out is not an input."),
-        }
-    }
+// #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+// /// Identifier for all three tensors in a matmul
+// ///
+// /// Useful to specialize some functions depending on the tensor
+// pub enum FlashIdent {
+//     Query,
+//     Key,
+//     Value,
+//     Out,
+// }
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum TileIdent {
+    Lhs,
+    Rhs,
+    Acc,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-/// Identifier for the two input tensors in a matmul.
-///
-/// Useful to specialize some functions depending on the tensor
-pub enum InputIdent {
+pub enum StageIdent {
     Lhs,
     Rhs,
+    Acc,
 }
 
-impl InputIdent {
-    pub fn as_ident(&self) -> Ident {
-        match self {
-            InputIdent::Lhs => Ident::Lhs,
-            InputIdent::Rhs => Ident::Rhs,
+impl StageIdent {
+    pub fn from_matmul(matmul_ident: MatmulIdent) -> Self {
+        match matmul_ident {
+            MatmulIdent::Lhs => StageIdent::Lhs,
+            MatmulIdent::Rhs => StageIdent::Rhs,
+            MatmulIdent::Out => StageIdent::Acc,
         }
     }
 }
 
-impl From<InputIdent> for Ident {
-    fn from(value: InputIdent) -> Self {
-        value.as_ident()
-    }
-}
+// #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+// /// Identifier for all three tensors in a matmul
+// ///
+// /// Useful to specialize some functions depending on the tensor
+// pub enum Ident {
+//     Lhs,
+//     Rhs,
+//     Out,
+// }
+
+// impl Ident {
+//     pub fn as_input_ident(&self) -> InputIdent {
+//         match self {
+//             Ident::Lhs => InputIdent::Lhs,
+//             Ident::Rhs => InputIdent::Rhs,
+//             Ident::Out => panic!("Out is not an input."),
+//         }
+//     }
+// }
+
+// #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+// /// Identifier for the two input tensors in a matmul.
+// ///
+// /// Useful to specialize some functions depending on the tensor
+// pub enum InputIdent {
+//     Lhs,
+//     Rhs,
+// }
+
+// impl InputIdent {
+//     pub fn as_ident(&self) -> Ident {
+//         match self {
+//             InputIdent::Lhs => Ident::Lhs,
+//             InputIdent::Rhs => Ident::Rhs,
+//         }
+//     }
+// }
+
+// impl From<InputIdent> for Ident {
+//     fn from(value: InputIdent) -> Self {
+//         value.as_ident()
+//     }
+// }

--- a/crates/cubecl-matmul/src/components/problem.rs
+++ b/crates/cubecl-matmul/src/components/problem.rs
@@ -2,7 +2,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use super::{Ident, MatmulProblemSize};
+use super::{MatmulIdent, MatmulProblemSize};
 
 #[derive(Clone, Debug)]
 /// Description of a matmul problem to solve, regardless of actual data
@@ -41,21 +41,21 @@ impl MatmulProblem {
 
     /// Returns the shape of the identified tensor, inferred by the problem definition
     #[allow(unused)]
-    pub(crate) fn shape(&self, ident: Ident) -> Vec<usize> {
+    pub(crate) fn shape(&self, ident: MatmulIdent) -> Vec<usize> {
         match ident {
-            Ident::Lhs => self
+            MatmulIdent::Lhs => self
                 .lhs_batches
                 .iter()
                 .cloned()
                 .chain(vec![self.m, self.k])
                 .collect(),
-            Ident::Rhs => self
+            MatmulIdent::Rhs => self
                 .rhs_batches
                 .iter()
                 .cloned()
                 .chain(vec![self.k, self.n])
                 .collect(),
-            Ident::Out => self
+            MatmulIdent::Out => self
                 .output_batch_dims()
                 .iter()
                 .cloned()

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -6,9 +6,11 @@ use crate::components::error::MatmulSetupError;
 use crate::components::global::MaxLoaderPlanes;
 use crate::components::stage::NumStages;
 use crate::components::tile::Tile;
-use crate::components::{AvailableLineSizes, MatmulLineSizes, MatmulSelection};
 use crate::components::{
-    Ident, InputIdent, MatmulPrecision, MatmulProblem, MatrixLayout, TilingScheme,
+    AvailableLineSizes, MatmulIdent, MatmulLineSizes, MatmulSelection, StageIdent,
+};
+use crate::components::{
+    MatmulPrecision, MatmulProblem, MatrixLayout, TilingScheme,
     global::{self, AccumulatorLoader, GlobalWriter, PlaneRoleConfig, RoleRuleConfig},
     tile::TileConfig,
 };
@@ -166,13 +168,13 @@ pub trait StageConfig:
     fn tile_config(self) -> Self::TileConfig;
 
     /// Returns the line size for the given ident
-    fn stage_line_size<I: Into<Ident>>(&self, ident: I) -> u32;
+    fn stage_line_size(&self, ident: StageIdent) -> u32;
 
     /// Returns the line size for the given ident
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32;
+    fn global_line_size(&self, ident: StageIdent) -> u32;
 
     /// Returns the [MatrixLayout] for the given ident
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout;
+    fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout;
 
     /// Returns how many units are in a plane
     fn plane_dim(&self) -> u32;
@@ -181,7 +183,7 @@ pub trait StageConfig:
     fn partition_buffering(&self) -> PartitionBuffering;
 
     /// Returns the number of stages for the given input
-    fn num_stages(&self, ident: InputIdent) -> u32;
+    fn num_stages(&self, ident: StageIdent) -> u32;
 
     /// Returns the [TilingScheme]
     fn tiling_scheme(&self) -> TilingScheme;

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -6,9 +6,7 @@ use crate::components::error::MatmulSetupError;
 use crate::components::global::MaxLoaderPlanes;
 use crate::components::stage::NumStages;
 use crate::components::tile::Tile;
-use crate::components::{
-    AvailableLineSizes, MatmulIdent, MatmulLineSizes, MatmulSelection, StageIdent,
-};
+use crate::components::{AvailableLineSizes, MatmulLineSizes, MatmulSelection, StageIdent};
 use crate::components::{
     MatmulPrecision, MatmulProblem, MatrixLayout, TilingScheme,
     global::{self, AccumulatorLoader, GlobalWriter, PlaneRoleConfig, RoleRuleConfig},

--- a/crates/cubecl-matmul/src/components/stage/layout.rs
+++ b/crates/cubecl-matmul/src/components/stage/layout.rs
@@ -17,7 +17,7 @@ pub trait TilingOrder: 'static + Send + Sync + Clone + Copy {
         nth: u32,
         #[comptime] tile_count_rows: u32,
         #[comptime] tile_count_cols: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: C,
     ) -> (u32, u32);
 
@@ -28,7 +28,7 @@ pub trait TilingOrder: 'static + Send + Sync + Clone + Copy {
         col: u32,
         #[comptime] tile_count_rows: u32,
         #[comptime] tile_count_cols: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: C,
     ) -> u32;
 
@@ -281,7 +281,7 @@ impl<TO: TilingOrder> TilingLayout for ContiguousTilingLayout<TO> {
         let matrix_layout = config.matrix_layout(ident);
 
         let (row_buffer_offset, col_buffer_offset, total_tile_count_row, total_tile_count_col) =
-            match ident.as_input_ident() {
+            match ident {
                 StageIdent::Lhs => {
                     let x_tile_offset = 0;
                     let y_tile_offset = tiling_scheme.tiles_in_stage_col(ident) * buffer_index;
@@ -308,6 +308,7 @@ impl<TO: TilingOrder> TilingLayout for ContiguousTilingLayout<TO> {
                         total_tile_count_y,
                     )
                 }
+                StageIdent::Acc => comptime!(unreachable!()),
             };
 
         let (tile_size_x, tile_size_y, tile_slice_length) = match matrix_layout {
@@ -384,7 +385,7 @@ impl TilingLayout for StridedTilingLayout {
         #[comptime] ident: StageIdent,
         #[comptime] config: S,
     ) -> Tile<ES> {
-        if comptime!(config.num_stages(ident.as_input_ident()) > 1) {
+        if comptime!(config.num_stages(ident) > 1) {
             unimplemented!()
         }
 

--- a/crates/cubecl-matmul/src/components/stage/layout.rs
+++ b/crates/cubecl-matmul/src/components/stage/layout.rs
@@ -4,7 +4,7 @@ use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
 
 use crate::components::tile::Tile;
-use crate::components::{Ident, InputIdent, MatrixLayout};
+use crate::components::{MatrixLayout, StageIdent};
 
 use super::{StageConfig, StageMemory};
 
@@ -124,7 +124,7 @@ impl TilingOrder for RowMajorTilingOrder {
         nth: u32,
         #[comptime] _tile_count_rows: u32,
         #[comptime] tile_count_cols: u32,
-        #[comptime] _ident: Ident,
+        #[comptime] _ident: StageIdent,
         #[comptime] _config: C,
     ) -> (u32, u32) {
         (nth / tile_count_cols, nth % tile_count_cols)
@@ -134,7 +134,7 @@ impl TilingOrder for RowMajorTilingOrder {
         col: u32,
         #[comptime] _tile_count_rows: u32,
         #[comptime] tile_count_cols: u32,
-        #[comptime] _ident: Ident,
+        #[comptime] _ident: StageIdent,
         #[comptime] _config: C,
     ) -> u32 {
         row * tile_count_cols + col
@@ -151,7 +151,7 @@ impl TilingOrder for ColMajorTilingOrder {
         nth: u32,
         #[comptime] num_rows: u32,
         #[comptime] _num_cols: u32,
-        #[comptime] _ident: Ident,
+        #[comptime] _ident: StageIdent,
         #[comptime] _config: C,
     ) -> (u32, u32) {
         (nth % num_rows, nth / num_rows)
@@ -161,7 +161,7 @@ impl TilingOrder for ColMajorTilingOrder {
         col: u32,
         #[comptime] tile_count_rows: u32,
         #[comptime] _tile_count_cols: u32,
-        #[comptime] _ident: Ident,
+        #[comptime] _ident: StageIdent,
         #[comptime] _config: C,
     ) -> u32 {
         col * tile_count_rows + row
@@ -178,10 +178,10 @@ impl TilingOrder for OrderedTilingOrder {
         nth: u32,
         #[comptime] tile_count_rows: u32,
         #[comptime] tile_count_cols: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: C,
     ) -> (u32, u32) {
-        if Ident::Lhs != ident {
+        if StageIdent::Lhs != ident {
             panic!("Ordered tiling order should be used only on Lhs")
         }
 
@@ -203,10 +203,10 @@ impl TilingOrder for OrderedTilingOrder {
         col: u32,
         #[comptime] tile_count_rows: u32,
         #[comptime] tile_count_cols: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: C,
     ) -> u32 {
-        if Ident::Lhs != ident {
+        if StageIdent::Lhs != ident {
             panic!("Ordered tiling order should be used only on Lhs")
         }
 
@@ -234,7 +234,7 @@ pub trait TilingLayout: 'static + Send + Sync + Clone + Copy {
         row: u32,
         col: u32,
         #[comptime] buffer_index: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: S,
     ) -> Tile<ES>;
 }
@@ -256,7 +256,7 @@ impl<T: TilingOrder> ContiguousTilingLayout<T> {
     /// Converts a tile index in the stage to its (x,y) position
     pub fn to_x_y<S: StageConfig>(
         nth: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: S,
     ) -> (u32, u32) {
         let num_x = config.tiling_scheme().tiles_in_stage_row(ident);
@@ -273,7 +273,7 @@ impl<TO: TilingOrder> TilingLayout for ContiguousTilingLayout<TO> {
         row: u32,
         col: u32,
         #[comptime] buffer_index: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: S,
     ) -> Tile<ES> {
         let stage_line_size = config.stage_line_size(ident);
@@ -282,12 +282,12 @@ impl<TO: TilingOrder> TilingLayout for ContiguousTilingLayout<TO> {
 
         let (row_buffer_offset, col_buffer_offset, total_tile_count_row, total_tile_count_col) =
             match ident.as_input_ident() {
-                InputIdent::Lhs => {
+                StageIdent::Lhs => {
                     let x_tile_offset = 0;
                     let y_tile_offset = tiling_scheme.tiles_in_stage_col(ident) * buffer_index;
                     let total_tile_count_x = tiling_scheme.tiles_in_stage_row(ident);
                     let total_tile_count_y = tiling_scheme.tiles_in_stage_col(ident)
-                        * config.num_stages(InputIdent::Lhs);
+                        * config.num_stages(StageIdent::Lhs);
                     (
                         x_tile_offset,
                         y_tile_offset,
@@ -295,11 +295,11 @@ impl<TO: TilingOrder> TilingLayout for ContiguousTilingLayout<TO> {
                         total_tile_count_y,
                     )
                 }
-                InputIdent::Rhs => {
+                StageIdent::Rhs => {
                     let x_tile_offset = tiling_scheme.tiles_in_stage_row(ident) * buffer_index;
                     let y_tile_offset = 0;
                     let total_tile_count_x = tiling_scheme.tiles_in_stage_row(ident)
-                        * config.num_stages(InputIdent::Rhs);
+                        * config.num_stages(StageIdent::Rhs);
                     let total_tile_count_y = tiling_scheme.tiles_in_stage_col(ident);
                     (
                         x_tile_offset,
@@ -356,7 +356,7 @@ impl StridedTilingLayout {
     pub fn nth_slice<ES: Numeric, S: StageConfig>(
         stage: &mut StageMemory<ES, Self>,
         nth: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: S,
     ) -> SliceMut<Line<ES>> {
         let matrix_layout = config.matrix_layout(ident);
@@ -381,7 +381,7 @@ impl TilingLayout for StridedTilingLayout {
         x: u32,
         y: u32,
         #[comptime] _buffer_index: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: S,
     ) -> Tile<ES> {
         if comptime!(config.num_stages(ident.as_input_ident()) > 1) {

--- a/crates/cubecl-matmul/src/components/stage/matmul/mod.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/mod.rs
@@ -9,8 +9,8 @@ pub use unit_partitioned::UnitMatmulFamily;
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Number of stages in one shared memory, i.e. buffers for double buffering
 pub struct NumStages {
-    lhs: u32,
-    rhs: u32,
+    pub lhs: u32,
+    pub rhs: u32,
 }
 
 impl From<(u32, u32)> for NumStages {

--- a/crates/cubecl-matmul/src/components/stage/matmul/partition/matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/partition/matmul.rs
@@ -159,7 +159,12 @@ where
             #[allow(clippy::explicit_counter_loop)]
             #[unroll]
             for _ in 0..m_iterations {
-                let tile_lhs = RL::read_tile::<S>(lhs_reader, start_m + m_iter, k_iter, config);
+                let tile_lhs = RL::read_tile::<S::StageMemoryConfig>(
+                    lhs_reader,
+                    start_m + m_iter,
+                    k_iter,
+                    config.stage_memory_config(),
+                );
                 TMM::fill_lhs(
                     &tile_lhs,
                     lhs_fragment.index_mut(m_iter),
@@ -183,8 +188,12 @@ where
             #[unroll]
             #[allow(clippy::explicit_counter_loop)]
             for _ in 0..n_iterations {
-                let rhs_tile_next =
-                    RR::read_tile::<S>(rhs_reader, k_iter, start_n + n_iter, config);
+                let rhs_tile_next = RR::read_tile::<S::StageMemoryConfig>(
+                    rhs_reader,
+                    k_iter,
+                    start_n + n_iter,
+                    config.stage_memory_config(),
+                );
                 TMM::fill_rhs(&rhs_tile_next, rhs_fragment, config.tile_config());
                 SEL::on_event(
                     &mut listener,
@@ -272,7 +281,12 @@ where
             #[allow(clippy::explicit_counter_loop)]
             #[unroll]
             for _ in 0..m_iterations {
-                let tile_lhs = RL::read_tile::<S>(lhs_reader, start_m + m_iter, k_iter, config);
+                let tile_lhs = RL::read_tile::<S::StageMemoryConfig>(
+                    lhs_reader,
+                    start_m + m_iter,
+                    k_iter,
+                    config.stage_memory_config(),
+                );
                 TMM::fill_lhs(
                     &tile_lhs,
                     lhs_fragment.index_mut(m_iter),
@@ -293,7 +307,12 @@ where
 
             let mut n_iter = comptime![0u32];
 
-            let rhs_tile_first = RR::read_tile::<S>(rhs_reader, k_iter, start_n + n_iter, config);
+            let rhs_tile_first = RR::read_tile::<S::StageMemoryConfig>(
+                rhs_reader,
+                k_iter,
+                start_n + n_iter,
+                config.stage_memory_config(),
+            );
             TMM::fill_rhs(&rhs_tile_first, &mut rhs_fragments.0, config.tile_config());
             SEL::on_event(
                 &mut listener,
@@ -314,8 +333,12 @@ where
                     (&mut rhs_fragments.1, &mut rhs_fragments.0)
                 };
 
-                let rhs_tile_next =
-                    RR::read_tile::<S>(rhs_reader, k_iter, start_n + comptime![n_iter + 1], config);
+                let rhs_tile_next = RR::read_tile::<S::StageMemoryConfig>(
+                    rhs_reader,
+                    k_iter,
+                    start_n + comptime![n_iter + 1],
+                    config.stage_memory_config(),
+                );
                 TMM::fill_rhs(&rhs_tile_next, next, config.tile_config());
                 SEL::on_event(
                     &mut listener,

--- a/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
@@ -1,4 +1,5 @@
 use crate::components::MatmulPrecision;
+use crate::components::StageIdent;
 use crate::components::global::AccumulatorLoader;
 use crate::components::global::GlobalWriter;
 use crate::components::stage::StageConfig;
@@ -6,7 +7,6 @@ use crate::components::stage::StageMatmul;
 use crate::components::stage::StageToTileReader;
 use crate::components::stage::matmul::partition::{Accumulators, PartitionMatmul, RhsTile};
 use crate::components::stage::{NoEvent, StageEventListener};
-use crate::components::StageIdent;
 use crate::components::{global, tile};
 use core::marker::PhantomData;
 use cubecl::prelude::*;

--- a/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
@@ -1,4 +1,3 @@
-use crate::components::Ident;
 use crate::components::MatmulPrecision;
 use crate::components::global::AccumulatorLoader;
 use crate::components::global::GlobalWriter;
@@ -7,6 +6,7 @@ use crate::components::stage::StageMatmul;
 use crate::components::stage::StageToTileReader;
 use crate::components::stage::matmul::partition::{Accumulators, PartitionMatmul, RhsTile};
 use crate::components::stage::{NoEvent, StageEventListener};
+use crate::components::StageIdent;
 use crate::components::{global, tile};
 use core::marker::PhantomData;
 use cubecl::prelude::*;
@@ -142,7 +142,7 @@ where
         #[comptime] stage_config: S,
         #[comptime] global_config: G,
     ) {
-        let out_smem_line_size = stage_config.stage_line_size(Ident::Out);
+        let out_smem_line_size = stage_config.stage_line_size(StageIdent::Acc);
         let num_tile_lines =
             stage_config.tiling_scheme().elements_in_tile_mn() / out_smem_line_size;
         let out_smem_num_lines = num_tile_lines * comptime!(SP::num_primitives(stage_config));

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/config.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/config.rs
@@ -93,19 +93,19 @@ impl<T: TileConfig> StageMemoryConfig for PlanePartitionedStageConfig<T> {
     }
 
     fn num_main_flow_planes(&self) -> u32 {
-        <Self as StageConfig>::num_main_flow_planes(&self)
+        <Self as StageConfig>::num_main_flow_planes(self)
     }
 
     fn tiling_scheme(&self) -> TilingScheme {
-        <Self as StageConfig>::tiling_scheme(&self)
+        <Self as StageConfig>::tiling_scheme(self)
     }
 
     fn stage_line_size(&self, ident: StageIdent) -> u32 {
-        <Self as StageConfig>::stage_line_size(&self, ident)
+        <Self as StageConfig>::stage_line_size(self, ident)
     }
 
     fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout {
-        <Self as StageConfig>::matrix_layout(&self, ident)
+        <Self as StageConfig>::matrix_layout(self, ident)
     }
 
     fn num_stages(&self, ident: StageIdent) -> u32 {

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/config.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/config.rs
@@ -1,5 +1,5 @@
 use crate::components::{
-    Ident, InputIdent, MatrixLayout, TilingScheme,
+    MatrixLayout, StageIdent, TilingScheme,
     error::MatmulSetupError,
     global::{PlaneRoleConfig, RoleRuleConfig},
     stage::{NumStages, PartitionBuffering, StageConfig},
@@ -25,15 +25,15 @@ impl<T: TileConfig> StageConfig for PlanePartitionedStageConfig<T> {
         self.tile_config
     }
 
-    fn stage_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
+    fn stage_line_size(&self, ident: StageIdent) -> u32 {
         self.tile_config.stage_line_size(ident)
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
+    fn global_line_size(&self, ident: StageIdent) -> u32 {
         self.tile_config.global_line_size(ident)
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
+    fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout {
         self.tile_config.matrix_layout(ident)
     }
 
@@ -45,10 +45,11 @@ impl<T: TileConfig> StageConfig for PlanePartitionedStageConfig<T> {
         self.partition_buffering
     }
 
-    fn num_stages(&self, ident: InputIdent) -> u32 {
+    fn num_stages(&self, ident: StageIdent) -> u32 {
         match ident {
-            InputIdent::Lhs => self.num_stages.lhs,
-            InputIdent::Rhs => self.num_stages.rhs,
+            StageIdent::Lhs => self.num_stages.lhs,
+            StageIdent::Rhs => self.num_stages.rhs,
+            StageIdent::Acc => unreachable!(),
         }
     }
 

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/config.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/config.rs
@@ -2,7 +2,7 @@ use crate::components::{
     MatrixLayout, StageIdent, TilingScheme,
     error::MatmulSetupError,
     global::{PlaneRoleConfig, RoleRuleConfig},
-    stage::{NumStages, PartitionBuffering, StageConfig},
+    stage::{NumStages, PartitionBuffering, StageConfig, StageMemoryConfig},
     tile::TileConfig,
 };
 
@@ -20,9 +20,14 @@ pub struct PlanePartitionedStageConfig<T: TileConfig> {
 
 impl<T: TileConfig> StageConfig for PlanePartitionedStageConfig<T> {
     type TileConfig = T;
+    type StageMemoryConfig = Self;
 
     fn tile_config(self) -> Self::TileConfig {
         self.tile_config
+    }
+
+    fn stage_memory_config(self) -> Self::StageMemoryConfig {
+        self
     }
 
     fn stage_line_size(&self, ident: StageIdent) -> u32 {
@@ -43,14 +48,6 @@ impl<T: TileConfig> StageConfig for PlanePartitionedStageConfig<T> {
 
     fn partition_buffering(&self) -> PartitionBuffering {
         self.partition_buffering
-    }
-
-    fn num_stages(&self, ident: StageIdent) -> u32 {
-        match ident {
-            StageIdent::Lhs => self.num_stages.lhs,
-            StageIdent::Rhs => self.num_stages.rhs,
-            StageIdent::Acc => unreachable!(),
-        }
     }
 
     fn tiling_scheme(&self) -> TilingScheme {
@@ -85,6 +82,38 @@ impl<T: TileConfig> StageConfig for PlanePartitionedStageConfig<T> {
             }
         };
         !execution_is_sync && self.ordered
+    }
+}
+
+impl<T: TileConfig> StageMemoryConfig for PlanePartitionedStageConfig<T> {
+    type TileConfig = T;
+
+    fn tile_config(self) -> Self::TileConfig {
+        <Self as StageConfig>::tile_config(self)
+    }
+
+    fn num_main_flow_planes(&self) -> u32 {
+        <Self as StageConfig>::num_main_flow_planes(&self)
+    }
+
+    fn tiling_scheme(&self) -> TilingScheme {
+        <Self as StageConfig>::tiling_scheme(&self)
+    }
+
+    fn stage_line_size(&self, ident: StageIdent) -> u32 {
+        <Self as StageConfig>::stage_line_size(&self, ident)
+    }
+
+    fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout {
+        <Self as StageConfig>::matrix_layout(&self, ident)
+    }
+
+    fn num_stages(&self, ident: StageIdent) -> u32 {
+        match ident {
+            StageIdent::Lhs => self.num_stages.lhs,
+            StageIdent::Rhs => self.num_stages.rhs,
+            StageIdent::Acc => unreachable!(),
+        }
     }
 }
 
@@ -126,8 +155,9 @@ impl<T: TileConfig> PlanePartitionedStageConfig<T> {
         eo_size: u32,
         smem_limit: u32,
     ) -> Result<Self, MatmulSetupError> {
-        let num_planes_needed = self.tiling_scheme().stage_partitions_in_stage_mn();
-        let num_compute_planes = self.num_main_flow_planes();
+        let tiling_scheme = <Self as StageConfig>::tiling_scheme(&self);
+        let num_compute_planes = <Self as StageConfig>::num_main_flow_planes(&self);
+        let num_planes_needed = tiling_scheme.stage_partitions_in_stage_mn();
 
         if num_compute_planes != num_planes_needed {
             return Err(MatmulSetupError::InvalidConfig(Box::new(format!(
@@ -137,7 +167,7 @@ impl<T: TileConfig> PlanePartitionedStageConfig<T> {
 
         // TODO we should allow buffering on m dimension
         if self.partition_buffering() == PartitionBuffering::Double
-            && self.tiling_scheme().tiles_in_stage_partition_n() < 2
+            && tiling_scheme.tiles_in_stage_partition_n() < 2
         {
             return Err(MatmulSetupError::InvalidConfig(Box::new(
                 "Error: Tried doing double buffering with only one tile to compute.".to_string(),
@@ -146,8 +176,7 @@ impl<T: TileConfig> PlanePartitionedStageConfig<T> {
 
         let lhs_smem_size = self.tiling_scheme.elements_in_stage_mk() * self.num_stages.lhs;
         let rhs_smem_size = self.tiling_scheme.elements_in_stage_nk() * self.num_stages.rhs;
-        let num_primitives = self.num_main_flow_planes();
-        let out_smem_size = self.tiling_scheme.elements_in_tile_mn() * num_primitives;
+        let out_smem_size = self.tiling_scheme.elements_in_tile_mn() * num_compute_planes;
         let smem_total_size = es_size * (lhs_smem_size + rhs_smem_size) + eo_size * out_smem_size;
 
         if smem_total_size > smem_limit {

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/config.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/config.rs
@@ -1,9 +1,5 @@
 use crate::components::{
-    Ident, InputIdent, MatrixLayout, TilingScheme,
-    error::MatmulSetupError,
-    global::{PlaneRoleConfig, RoleRuleConfig},
-    stage::{NumStages, PartitionBuffering, StageConfig},
-    tile::TileConfig,
+    error::MatmulSetupError, global::{PlaneRoleConfig, RoleRuleConfig}, stage::{NumStages, PartitionBuffering, StageConfig}, tile::TileConfig, MatrixLayout, StageIdent, TilingScheme
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -25,15 +21,15 @@ impl<T: TileConfig> StageConfig for UnitPartitionedStageConfig<T> {
         self.tile_config
     }
 
-    fn stage_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
+    fn stage_line_size(&self, ident: StageIdent) -> u32 {
         self.tile_config.stage_line_size(ident)
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
+    fn global_line_size(&self, ident: StageIdent) -> u32 {
         self.tile_config.global_line_size(ident)
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
+    fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout {
         self.tile_config.matrix_layout(ident)
     }
 
@@ -45,10 +41,11 @@ impl<T: TileConfig> StageConfig for UnitPartitionedStageConfig<T> {
         self.partition_buffering
     }
 
-    fn num_stages(&self, ident: InputIdent) -> u32 {
+    fn num_stages(&self, ident: StageIdent) -> u32 {
         match ident {
-            InputIdent::Lhs => self.num_stages.lhs,
-            InputIdent::Rhs => self.num_stages.rhs,
+            StageIdent::Lhs => self.num_stages.lhs,
+            StageIdent::Rhs => self.num_stages.rhs,
+            StageIdent::Acc => unreachable!(),
         }
     }
 

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/config.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/config.rs
@@ -1,5 +1,9 @@
 use crate::components::{
-    error::MatmulSetupError, global::{PlaneRoleConfig, RoleRuleConfig}, stage::{NumStages, PartitionBuffering, StageConfig}, tile::TileConfig, MatrixLayout, StageIdent, TilingScheme
+    MatrixLayout, StageIdent, TilingScheme,
+    error::MatmulSetupError,
+    global::{PlaneRoleConfig, RoleRuleConfig},
+    stage::{NumStages, PartitionBuffering, StageConfig},
+    tile::TileConfig,
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/config.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/config.rs
@@ -93,19 +93,19 @@ impl<T: TileConfig> StageMemoryConfig for UnitPartitionedStageConfig<T> {
     }
 
     fn num_main_flow_planes(&self) -> u32 {
-        <Self as StageConfig>::num_main_flow_planes(&self)
+        <Self as StageConfig>::num_main_flow_planes(self)
     }
 
     fn tiling_scheme(&self) -> TilingScheme {
-        <Self as StageConfig>::tiling_scheme(&self)
+        <Self as StageConfig>::tiling_scheme(self)
     }
 
     fn stage_line_size(&self, ident: StageIdent) -> u32 {
-        <Self as StageConfig>::stage_line_size(&self, ident)
+        <Self as StageConfig>::stage_line_size(self, ident)
     }
 
     fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout {
-        <Self as StageConfig>::matrix_layout(&self, ident)
+        <Self as StageConfig>::matrix_layout(self, ident)
     }
 
     fn num_stages(&self, ident: StageIdent) -> u32 {

--- a/crates/cubecl-matmul/src/components/stage/memory/config.rs
+++ b/crates/cubecl-matmul/src/components/stage/memory/config.rs
@@ -1,0 +1,26 @@
+use std::{fmt::Debug, hash::Hash};
+
+use crate::components::{MatrixLayout, StageIdent, TilingScheme, tile::TileConfig};
+
+pub trait StageMemoryConfig:
+    Copy + Clone + Eq + PartialEq + Hash + Debug + Send + Sync + 'static
+{
+    type TileConfig: TileConfig;
+
+    fn tile_config(self) -> Self::TileConfig;
+
+    /// Number of planes participating in the main computation flow
+    fn num_main_flow_planes(&self) -> u32;
+
+    /// Returns the [TilingScheme]
+    fn tiling_scheme(&self) -> TilingScheme;
+
+    /// Returns the line size for the given ident
+    fn stage_line_size(&self, ident: StageIdent) -> u32;
+
+    /// Returns the [MatrixLayout] for the given ident
+    fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout;
+
+    /// Returns the number of stages for the given input
+    fn num_stages(&self, ident: StageIdent) -> u32;
+}

--- a/crates/cubecl-matmul/src/components/stage/memory/mod.rs
+++ b/crates/cubecl-matmul/src/components/stage/memory/mod.rs
@@ -1,0 +1,9 @@
+mod config;
+mod layout;
+mod reader;
+mod stage_memory;
+
+pub use config::*;
+pub use layout::*;
+pub use reader::*;
+pub use stage_memory::StageMemory;

--- a/crates/cubecl-matmul/src/components/stage/memory/reader.rs
+++ b/crates/cubecl-matmul/src/components/stage/memory/reader.rs
@@ -1,8 +1,8 @@
 use crate::components::StageIdent;
 use crate::components::global::load::StageBuffer;
 use crate::components::stage::ReaderFamily;
-use crate::components::stage::StageConfig;
 use crate::components::stage::StageMemory;
+use crate::components::stage::StageMemoryConfig;
 use crate::components::stage::StageToTileReader;
 use crate::components::stage::TilingLayout;
 use crate::components::tile::Tile;
@@ -40,7 +40,7 @@ impl<ES: Numeric, T: TilingLayout> FullStageToTileReader<ES, T> {
 
 #[cube]
 impl<ES: Numeric, T: TilingLayout> StageToTileReader<ES> for FullStageToTileReader<ES, T> {
-    fn read_tile<S: StageConfig>(
+    fn read_tile<S: StageMemoryConfig>(
         this: &Self,
         row: u32,
         col: u32,
@@ -86,7 +86,7 @@ impl<ES: Numeric, T: TilingLayout> PartialStageToTileReader<ES, T> {
 
 #[cube]
 impl<ES: Numeric, T: TilingLayout> StageToTileReader<ES> for PartialStageToTileReader<ES, T> {
-    fn read_tile<S: StageConfig>(
+    fn read_tile<S: StageMemoryConfig>(
         this: &Self,
         row: u32,
         col: u32,

--- a/crates/cubecl-matmul/src/components/stage/memory/stage_memory.rs
+++ b/crates/cubecl-matmul/src/components/stage/memory/stage_memory.rs
@@ -2,7 +2,8 @@ use std::marker::PhantomData;
 
 use crate::components::global::load::StageBuffer;
 use crate::components::global::{GlobalConfig, RoleRule};
-use crate::components::stage::{StageConfig, TilingLayout};
+use crate::components::stage::base::StageConfig;
+use crate::components::stage::{StageMemoryConfig, TilingLayout};
 use crate::components::tile::Tile;
 use crate::components::{MatmulIdent, MatrixLayout, StageIdent};
 use cubecl_core as cubecl;
@@ -26,7 +27,7 @@ pub struct StageMemory<ES: Numeric, T: TilingLayout> {
 #[cube]
 impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
     /// Instantiate a new stage memory for the given identifier
-    pub fn new<S: StageConfig>(
+    pub fn new<S: StageMemoryConfig>(
         #[comptime] num_stages: u32,
         #[comptime] ident: StageIdent,
         #[comptime] config: S,
@@ -42,7 +43,7 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
     }
 
     /// Instantiate a new stage memory for the given identifier, with shared memory alignment
-    pub fn new_aligned<S: StageConfig>(
+    pub fn new_aligned<S: StageMemoryConfig>(
         #[comptime] ident: StageIdent,
         #[comptime] alignment: u32,
         #[comptime] config: S,
@@ -71,7 +72,7 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
     }
 
     /// Get the tile at position (row, col)
-    pub fn get_tile<S: StageConfig>(
+    pub fn get_tile<S: StageMemoryConfig>(
         &self,
         row: u32,
         col: u32,

--- a/crates/cubecl-matmul/src/components/stage/mod.rs
+++ b/crates/cubecl-matmul/src/components/stage/mod.rs
@@ -5,13 +5,9 @@ mod matmul;
 
 mod base;
 mod event_listener;
-mod layout;
-mod reader;
-mod stage_memory;
+mod memory;
 
 pub use base::*;
 pub use event_listener::*;
-pub use layout::*;
 pub use matmul::*;
-pub use reader::*;
-pub use stage_memory::StageMemory;
+pub use memory::*;

--- a/crates/cubecl-matmul/src/components/stage/reader.rs
+++ b/crates/cubecl-matmul/src/components/stage/reader.rs
@@ -1,5 +1,5 @@
-use crate::components::InputIdent;
-use crate::components::global::load::StageIdent;
+use crate::components::StageIdent;
+use crate::components::global::load::StageBuffer;
 use crate::components::stage::ReaderFamily;
 use crate::components::stage::StageConfig;
 use crate::components::stage::StageMemory;
@@ -20,7 +20,7 @@ pub struct FullStageToTileReader<ES: Numeric, T: TilingLayout> {
 
     #[cube(comptime)]
     /// Ident of the stage memory
-    pub input_ident: InputIdent,
+    pub stage_ident: StageIdent,
 }
 
 impl ReaderFamily for FullReaderFamily {
@@ -30,10 +30,10 @@ impl ReaderFamily for FullReaderFamily {
 #[cube]
 impl<ES: Numeric, T: TilingLayout> FullStageToTileReader<ES, T> {
     /// Create a new FullStageToTileReader
-    pub fn new(stage_memory: StageMemory<ES, T>, #[comptime] input_ident: InputIdent) -> Self {
+    pub fn new(stage_memory: StageMemory<ES, T>, #[comptime] stage_ident: StageIdent) -> Self {
         FullStageToTileReader::<ES, T> {
             stage_memory,
-            input_ident,
+            stage_ident,
         }
     }
 }
@@ -50,7 +50,7 @@ impl<ES: Numeric, T: TilingLayout> StageToTileReader<ES> for FullStageToTileRead
             row,
             col,
             0u32,
-            comptime!(this.input_ident.as_ident()),
+            comptime!(this.stage_ident.as_ident()),
             config,
         )
     }
@@ -64,9 +64,9 @@ pub struct PartialReaderFamily;
 pub struct PartialStageToTileReader<ES: Numeric, T: TilingLayout> {
     pub stage_memory: StageMemory<ES, T>,
     #[cube(comptime)]
-    pub stage_ident: StageIdent,
+    pub stage_buffer: StageBuffer,
     #[cube(comptime)]
-    input_ident: InputIdent,
+    stage_ident: StageIdent,
 }
 
 impl ReaderFamily for PartialReaderFamily {
@@ -78,13 +78,13 @@ impl<ES: Numeric, T: TilingLayout> PartialStageToTileReader<ES, T> {
     /// Create a new PartialStageToTileReader
     pub fn new(
         stage_memory: StageMemory<ES, T>,
+        #[comptime] stage_buffer: StageBuffer,
         #[comptime] stage_ident: StageIdent,
-        #[comptime] input_ident: InputIdent,
     ) -> PartialStageToTileReader<ES, T> {
         PartialStageToTileReader::<ES, T> {
             stage_memory,
+            stage_buffer,
             stage_ident,
-            input_ident,
         }
     }
 }
@@ -100,8 +100,8 @@ impl<ES: Numeric, T: TilingLayout> StageToTileReader<ES> for PartialStageToTileR
         this.stage_memory.get_tile::<S>(
             row,
             col,
-            comptime!(this.stage_ident.to_index()),
-            comptime!(this.input_ident.as_ident()),
+            comptime!(this.stage_buffer.to_index()),
+            comptime!(this.stage_ident.as_ident()),
             config,
         )
     }

--- a/crates/cubecl-matmul/src/components/stage/reader.rs
+++ b/crates/cubecl-matmul/src/components/stage/reader.rs
@@ -50,7 +50,7 @@ impl<ES: Numeric, T: TilingLayout> StageToTileReader<ES> for FullStageToTileRead
             row,
             col,
             0u32,
-            comptime!(this.stage_ident.as_ident()),
+            this.stage_ident,
             config,
         )
     }
@@ -101,7 +101,7 @@ impl<ES: Numeric, T: TilingLayout> StageToTileReader<ES> for PartialStageToTileR
             row,
             col,
             comptime!(this.stage_buffer.to_index()),
-            comptime!(this.stage_ident.as_ident()),
+            this.stage_ident,
             config,
         )
     }

--- a/crates/cubecl-matmul/src/components/stage/reader.rs
+++ b/crates/cubecl-matmul/src/components/stage/reader.rs
@@ -46,13 +46,8 @@ impl<ES: Numeric, T: TilingLayout> StageToTileReader<ES> for FullStageToTileRead
         col: u32,
         #[comptime] config: S,
     ) -> Tile<ES> {
-        this.stage_memory.get_tile::<S>(
-            row,
-            col,
-            0u32,
-            this.stage_ident,
-            config,
-        )
+        this.stage_memory
+            .get_tile::<S>(row, col, 0u32, this.stage_ident, config)
     }
 }
 

--- a/crates/cubecl-matmul/src/components/stage/stage_memory.rs
+++ b/crates/cubecl-matmul/src/components/stage/stage_memory.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
-use crate::components::global::load::StageIdent;
+use crate::components::global::load::StageBuffer;
 use crate::components::global::{GlobalConfig, RoleRule};
 use crate::components::stage::{StageConfig, TilingLayout};
 use crate::components::tile::Tile;
-use crate::components::{Ident, InputIdent, MatrixLayout};
+use crate::components::{MatrixLayout, StageIdent};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
@@ -28,7 +28,7 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
     /// Instantiate a new stage memory for the given identifier
     pub fn new<S: StageConfig>(
         #[comptime] num_stages: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: S,
     ) -> StageMemory<ES, T> {
         let line_size = config.stage_line_size(ident);
@@ -43,14 +43,19 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
 
     /// Instantiate a new stage memory for the given identifier, with shared memory alignment
     pub fn new_aligned<S: StageConfig>(
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] alignment: u32,
         #[comptime] config: S,
     ) -> StageMemory<ES, T> {
         let line_size = config.stage_line_size(ident);
 
         let smem = SharedMemory::new_aligned(
-            comptime!(config.tiling_scheme().elements_in_stage(ident) / line_size),
+            comptime!(
+                config
+                    .tiling_scheme()
+                    .elements_in_stage(config.stage_to_matmul_ident(ident))
+                    / line_size
+            ),
             line_size,
             alignment,
         );
@@ -76,7 +81,7 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
         row: u32,
         col: u32,
         #[comptime] buffer_index: u32,
-        #[comptime] ident: Ident,
+        #[comptime] ident: StageIdent,
         #[comptime] config: S,
     ) -> Tile<ES> {
         T::get_tile::<ES, S>(self, row, col, buffer_index, ident, config)
@@ -95,16 +100,21 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
     /// Zero out the shared memory
     pub fn clear_all<G: GlobalConfig>(
         &mut self,
-        #[comptime] ident: InputIdent,
+        #[comptime] ident: StageIdent,
         #[comptime] config: G,
     ) {
         // TODO: this assumes the stage was created with new
+        let stage_config = config.stage_config();
+        let tensor_ident = stage_config.stage_to_matmul_ident(ident);
         let smem_length = comptime!(
-            self.num_stages * config.tiling_scheme().elements_in_stage(ident)
-                / config.stage_config().stage_line_size(ident)
+            self.num_stages
+                * config
+                    .tiling_scheme()
+                    .elements_in_stage(stage_config.stage_to_matmul_ident(ident))
+                / stage_config.stage_line_size(ident)
         );
 
-        let unit_count = config.num_loading_planes(ident) * config.plane_dim();
+        let unit_count = config.num_loading_planes(tensor_ident) * config.plane_dim();
         let num_writes_per_unit = smem_length.div_ceil(unit_count);
 
         let unit_base_position = RoleRule::new(config.role_rule_config())
@@ -129,16 +139,20 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
     /// Zero out the shared memory for only one stage
     pub fn clear_stage<G: GlobalConfig>(
         &mut self,
-        #[comptime] stage_ident: StageIdent,
-        #[comptime] ident: InputIdent,
+        #[comptime] stage_buffer: StageBuffer,
+        #[comptime] ident: StageIdent,
         #[comptime] config: G,
     ) {
         // TODO: this assumes the stage was created with new
         // Also assumes two buffers
         let tiling_scheme = config.tiling_scheme();
-        let line_size = config.stage_config().stage_line_size(ident.as_ident());
+        let line_size = config.stage_config().stage_line_size(ident);
         let smem_length = comptime!(
-            self.num_stages * config.tiling_scheme().elements_in_stage(ident) / line_size
+            self.num_stages
+                * config
+                    .tiling_scheme()
+                    .elements_in_stage(config.tensor_ident(ident))
+                / line_size
         );
         let buffer_length = smem_length / 2;
 
@@ -156,19 +170,19 @@ impl<ES: Numeric, T: TilingLayout> StageMemory<ES, T> {
             let unit_position = unit_base_position + i * unit_count;
 
             let smem_position = match (ident, matrix_layout) {
-                (InputIdent::Lhs, MatrixLayout::ColMajor)
-                | (InputIdent::Rhs, MatrixLayout::RowMajor) => {
-                    stage_ident.to_index() * buffer_length + unit_position
+                (StageIdent::Lhs, MatrixLayout::ColMajor)
+                | (StageIdent::Rhs, MatrixLayout::RowMajor) => {
+                    stage_buffer.to_index() * buffer_length + unit_position
                 }
-                (InputIdent::Lhs, MatrixLayout::RowMajor) => {
+                (StageIdent::Lhs, MatrixLayout::RowMajor) => {
                     let buffer_width = tiling_scheme.elements_in_tile_col(ident) / line_size;
-                    stage_ident.to_index() * buffer_width
+                    stage_buffer.to_index() * buffer_width
                         + unit_position
                         + (unit_position / buffer_width) * buffer_width
                 }
-                (InputIdent::Rhs, MatrixLayout::ColMajor) => {
+                (StageIdent::Rhs, MatrixLayout::ColMajor) => {
                     let buffer_height = tiling_scheme.elements_in_tile_row(ident) / line_size;
-                    stage_ident.to_index() * buffer_height
+                    stage_buffer.to_index() * buffer_height
                         + unit_position
                         + (unit_position / buffer_height) * buffer_height
                 }

--- a/crates/cubecl-matmul/src/components/tile/accelerated/config.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated/config.rs
@@ -4,7 +4,7 @@ use cubecl_core::{Feature, Runtime};
 
 use crate::components::error::{MatmulAvailabilityError, MatmulSetupError};
 use crate::components::tile::TileConfig;
-use crate::components::{Ident, MatmulPrecision, MatrixLayout, TileSize, TilingScheme};
+use crate::components::{MatmulPrecision, MatrixLayout, TileIdent, TileSize, TilingScheme};
 use cubecl_core::frontend::CubePrimitive;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -26,27 +26,27 @@ impl TileConfig for AcceleratedConfig {
         self.plane_dim
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
+    fn matrix_layout(&self, ident: TileIdent) -> MatrixLayout {
         match ident.into() {
-            Ident::Lhs => self.lhs_layout,
-            Ident::Rhs => self.rhs_layout,
-            Ident::Out => MatrixLayout::RowMajor,
+            TileIdent::Lhs => self.lhs_layout,
+            TileIdent::Rhs => self.rhs_layout,
+            TileIdent::Acc => MatrixLayout::RowMajor,
         }
     }
 
-    fn stage_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
+    fn stage_line_size(&self, ident: TileIdent) -> u32 {
         match ident.into() {
-            Ident::Lhs => self.lhs_stage_line_size,
-            Ident::Rhs => self.rhs_stage_line_size,
-            Ident::Out => self.out_global_line_size,
+            TileIdent::Lhs => self.lhs_stage_line_size,
+            TileIdent::Rhs => self.rhs_stage_line_size,
+            TileIdent::Acc => self.out_global_line_size,
         }
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
+    fn global_line_size(&self, ident: TileIdent) -> u32 {
         match ident.into() {
-            Ident::Lhs => self.lhs_global_line_size,
-            Ident::Rhs => self.rhs_global_line_size,
-            Ident::Out => self.out_global_line_size,
+            TileIdent::Lhs => self.lhs_global_line_size,
+            TileIdent::Rhs => self.rhs_global_line_size,
+            TileIdent::Acc => self.out_global_line_size,
         }
     }
 

--- a/crates/cubecl-matmul/src/components/tile/accelerated/config.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated/config.rs
@@ -4,7 +4,7 @@ use cubecl_core::{Feature, Runtime};
 
 use crate::components::error::{MatmulAvailabilityError, MatmulSetupError};
 use crate::components::tile::TileConfig;
-use crate::components::{MatmulPrecision, MatrixLayout, TileIdent, TileSize, TilingScheme};
+use crate::components::{MatmulPrecision, MatrixLayout, StageIdent, TileSize, TilingScheme};
 use cubecl_core::frontend::CubePrimitive;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -26,27 +26,27 @@ impl TileConfig for AcceleratedConfig {
         self.plane_dim
     }
 
-    fn matrix_layout(&self, ident: TileIdent) -> MatrixLayout {
+    fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout {
         match ident.into() {
-            TileIdent::Lhs => self.lhs_layout,
-            TileIdent::Rhs => self.rhs_layout,
-            TileIdent::Acc => MatrixLayout::RowMajor,
+            StageIdent::Lhs => self.lhs_layout,
+            StageIdent::Rhs => self.rhs_layout,
+            StageIdent::Acc => MatrixLayout::RowMajor,
         }
     }
 
-    fn stage_line_size(&self, ident: TileIdent) -> u32 {
+    fn stage_line_size(&self, ident: StageIdent) -> u32 {
         match ident.into() {
-            TileIdent::Lhs => self.lhs_stage_line_size,
-            TileIdent::Rhs => self.rhs_stage_line_size,
-            TileIdent::Acc => self.out_global_line_size,
+            StageIdent::Lhs => self.lhs_stage_line_size,
+            StageIdent::Rhs => self.rhs_stage_line_size,
+            StageIdent::Acc => self.out_global_line_size,
         }
     }
 
-    fn global_line_size(&self, ident: TileIdent) -> u32 {
+    fn global_line_size(&self, ident: StageIdent) -> u32 {
         match ident.into() {
-            TileIdent::Lhs => self.lhs_global_line_size,
-            TileIdent::Rhs => self.rhs_global_line_size,
-            TileIdent::Acc => self.out_global_line_size,
+            StageIdent::Lhs => self.lhs_global_line_size,
+            StageIdent::Rhs => self.rhs_global_line_size,
+            StageIdent::Acc => self.out_global_line_size,
         }
     }
 

--- a/crates/cubecl-matmul/src/components/tile/accelerated/config.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated/config.rs
@@ -27,7 +27,7 @@ impl TileConfig for AcceleratedConfig {
     }
 
     fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout {
-        match ident.into() {
+        match ident {
             StageIdent::Lhs => self.lhs_layout,
             StageIdent::Rhs => self.rhs_layout,
             StageIdent::Acc => MatrixLayout::RowMajor,
@@ -35,7 +35,7 @@ impl TileConfig for AcceleratedConfig {
     }
 
     fn stage_line_size(&self, ident: StageIdent) -> u32 {
-        match ident.into() {
+        match ident {
             StageIdent::Lhs => self.lhs_stage_line_size,
             StageIdent::Rhs => self.rhs_stage_line_size,
             StageIdent::Acc => self.out_global_line_size,
@@ -43,7 +43,7 @@ impl TileConfig for AcceleratedConfig {
     }
 
     fn global_line_size(&self, ident: StageIdent) -> u32 {
-        match ident.into() {
+        match ident {
             StageIdent::Lhs => self.lhs_global_line_size,
             StageIdent::Rhs => self.rhs_global_line_size,
             StageIdent::Acc => self.out_global_line_size,

--- a/crates/cubecl-matmul/src/components/tile/accelerated/matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated/matmul.rs
@@ -1,7 +1,7 @@
 use crate::components::tile::accelerated::config::AcceleratedConfig;
 use crate::components::tile::tile_data::Tile;
 use crate::components::tile::{TileConfig, TileMatmul};
-use crate::components::{Ident, MatmulPrecision, as_cmma_layout};
+use crate::components::{MatmulPrecision, TileIdent, as_cmma_layout};
 use cubecl_core as cubecl;
 use cubecl_core::{cmma, prelude::*};
 
@@ -26,7 +26,7 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for AcceleratedMatmul {
 
     fn allocate_lhs(#[comptime] config: Self::Config) -> Self::Lhs {
         let size = config.tile_size();
-        let layout = config.matrix_layout(Ident::Lhs);
+        let layout = config.matrix_layout(TileIdent::Lhs);
         unsafe {
             cmma::Matrix::<MP::ES>::uninitialized(
                 cmma::MatrixIdent::A,
@@ -40,7 +40,7 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for AcceleratedMatmul {
 
     fn allocate_rhs(#[comptime] config: Self::Config) -> Self::Rhs {
         let size = config.tile_size();
-        let layout = config.matrix_layout(Ident::Rhs);
+        let layout = config.matrix_layout(TileIdent::Rhs);
         unsafe {
             cmma::Matrix::<MP::ES>::uninitialized(
                 cmma::MatrixIdent::B,
@@ -53,12 +53,12 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for AcceleratedMatmul {
     }
 
     fn fill_lhs(tile: &Tile<MP::ES>, lhs: &mut Self::Lhs, #[comptime] config: Self::Config) {
-        let (slice, stride) = tile.as_unlined::<Self::Config>(Ident::Lhs, config);
+        let (slice, stride) = tile.as_unlined::<Self::Config>(TileIdent::Lhs, config);
         cmma::load(lhs, &slice, stride);
     }
 
     fn fill_rhs(tile: &Tile<MP::ES>, rhs: &mut Self::Rhs, #[comptime] config: Self::Config) {
-        let (slice, stride) = tile.as_unlined::<Self::Config>(Ident::Rhs, config);
+        let (slice, stride) = tile.as_unlined::<Self::Config>(TileIdent::Rhs, config);
         cmma::load(rhs, &slice, stride);
     }
 
@@ -67,8 +67,8 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for AcceleratedMatmul {
         acc: &mut Self::Accumulator,
         #[comptime] config: Self::Config,
     ) {
-        let layout = comptime!(as_cmma_layout(config.matrix_layout(Ident::Out)));
-        let (slice, stride) = tile.as_unlined::<Self::Config>(Ident::Out, config);
+        let layout = comptime!(as_cmma_layout(config.matrix_layout(TileIdent::Acc)));
+        let (slice, stride) = tile.as_unlined::<Self::Config>(TileIdent::Acc, config);
         cmma::load_with_layout(acc, &slice, stride, layout);
     }
 

--- a/crates/cubecl-matmul/src/components/tile/accelerated/matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/accelerated/matmul.rs
@@ -1,7 +1,7 @@
 use crate::components::tile::accelerated::config::AcceleratedConfig;
 use crate::components::tile::tile_data::Tile;
 use crate::components::tile::{TileConfig, TileMatmul};
-use crate::components::{MatmulPrecision, TileIdent, as_cmma_layout};
+use crate::components::{MatmulPrecision, StageIdent, as_cmma_layout};
 use cubecl_core as cubecl;
 use cubecl_core::{cmma, prelude::*};
 
@@ -26,7 +26,7 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for AcceleratedMatmul {
 
     fn allocate_lhs(#[comptime] config: Self::Config) -> Self::Lhs {
         let size = config.tile_size();
-        let layout = config.matrix_layout(TileIdent::Lhs);
+        let layout = config.matrix_layout(StageIdent::Lhs);
         unsafe {
             cmma::Matrix::<MP::ES>::uninitialized(
                 cmma::MatrixIdent::A,
@@ -40,7 +40,7 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for AcceleratedMatmul {
 
     fn allocate_rhs(#[comptime] config: Self::Config) -> Self::Rhs {
         let size = config.tile_size();
-        let layout = config.matrix_layout(TileIdent::Rhs);
+        let layout = config.matrix_layout(StageIdent::Rhs);
         unsafe {
             cmma::Matrix::<MP::ES>::uninitialized(
                 cmma::MatrixIdent::B,
@@ -53,12 +53,12 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for AcceleratedMatmul {
     }
 
     fn fill_lhs(tile: &Tile<MP::ES>, lhs: &mut Self::Lhs, #[comptime] config: Self::Config) {
-        let (slice, stride) = tile.as_unlined::<Self::Config>(TileIdent::Lhs, config);
+        let (slice, stride) = tile.as_unlined::<Self::Config>(StageIdent::Lhs, config);
         cmma::load(lhs, &slice, stride);
     }
 
     fn fill_rhs(tile: &Tile<MP::ES>, rhs: &mut Self::Rhs, #[comptime] config: Self::Config) {
-        let (slice, stride) = tile.as_unlined::<Self::Config>(TileIdent::Rhs, config);
+        let (slice, stride) = tile.as_unlined::<Self::Config>(StageIdent::Rhs, config);
         cmma::load(rhs, &slice, stride);
     }
 
@@ -67,8 +67,8 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for AcceleratedMatmul {
         acc: &mut Self::Accumulator,
         #[comptime] config: Self::Config,
     ) {
-        let layout = comptime!(as_cmma_layout(config.matrix_layout(TileIdent::Acc)));
-        let (slice, stride) = tile.as_unlined::<Self::Config>(TileIdent::Acc, config);
+        let layout = comptime!(as_cmma_layout(config.matrix_layout(StageIdent::Acc)));
+        let (slice, stride) = tile.as_unlined::<Self::Config>(StageIdent::Acc, config);
         cmma::load_with_layout(acc, &slice, stride, layout);
     }
 

--- a/crates/cubecl-matmul/src/components/tile/base.rs
+++ b/crates/cubecl-matmul/src/components/tile/base.rs
@@ -3,10 +3,10 @@ use cubecl_core::{self as cubecl};
 
 use crate::components::error::MatmulSetupError;
 use crate::components::{
-    AvailableLineSizes, Ident, InvalidConfigError, MatmulPrecision, MatmulProblem, MatrixLayout,
-    TileSize, resource::ComputeResources, tile::tile_data::Tile,
+    AvailableLineSizes, InvalidConfigError, MatmulPrecision, MatmulProblem, MatrixLayout, TileSize,
+    resource::ComputeResources, tile::tile_data::Tile,
 };
-use crate::components::{MatmulLineSizes, MatmulSelection};
+use crate::components::{MatmulLineSizes, MatmulSelection, TileIdent};
 use std::{fmt::Debug, hash::Hash};
 
 /// A family of [TileMatmul] implementations that operate with any [precision](MatmulPrecision).
@@ -126,13 +126,13 @@ pub trait TileConfig: Copy + Clone + Eq + PartialEq + Hash + Debug + Send + Sync
     fn plane_dim(&self) -> u32;
 
     /// Returns the [MatrixLayout] for the given ident
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout;
+    fn matrix_layout(&self, ident: TileIdent) -> MatrixLayout;
 
     /// Returns the line size for the given ident
-    fn stage_line_size<I: Into<Ident>>(&self, ident: I) -> u32;
+    fn stage_line_size(&self, ident: TileIdent) -> u32;
 
     /// Returns the line size for the given ident
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32;
+    fn global_line_size(&self, ident: TileIdent) -> u32;
 
     /// Returns the (m,n,k) shape of the tiles
     fn tile_size(&self) -> &TileSize;

--- a/crates/cubecl-matmul/src/components/tile/base.rs
+++ b/crates/cubecl-matmul/src/components/tile/base.rs
@@ -6,7 +6,7 @@ use crate::components::{
     AvailableLineSizes, InvalidConfigError, MatmulPrecision, MatmulProblem, MatrixLayout, TileSize,
     resource::ComputeResources, tile::tile_data::Tile,
 };
-use crate::components::{MatmulLineSizes, MatmulSelection, TileIdent};
+use crate::components::{MatmulLineSizes, MatmulSelection, StageIdent};
 use std::{fmt::Debug, hash::Hash};
 
 /// A family of [TileMatmul] implementations that operate with any [precision](MatmulPrecision).
@@ -126,13 +126,13 @@ pub trait TileConfig: Copy + Clone + Eq + PartialEq + Hash + Debug + Send + Sync
     fn plane_dim(&self) -> u32;
 
     /// Returns the [MatrixLayout] for the given ident
-    fn matrix_layout(&self, ident: TileIdent) -> MatrixLayout;
+    fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout;
 
     /// Returns the line size for the given ident
-    fn stage_line_size(&self, ident: TileIdent) -> u32;
+    fn stage_line_size(&self, ident: StageIdent) -> u32;
 
     /// Returns the line size for the given ident
-    fn global_line_size(&self, ident: TileIdent) -> u32;
+    fn global_line_size(&self, ident: StageIdent) -> u32;
 
     /// Returns the (m,n,k) shape of the tiles
     fn tile_size(&self) -> &TileSize;

--- a/crates/cubecl-matmul/src/components/tile/register/config.rs
+++ b/crates/cubecl-matmul/src/components/tile/register/config.rs
@@ -4,7 +4,7 @@ use cubecl_core::ir::{Elem, FloatKind};
 
 use crate::components::error::{MatmulAvailabilityError, MatmulSetupError};
 use crate::components::tile::TileConfig;
-use crate::components::{Ident, MatmulPrecision, MatrixLayout, TileSize, TilingScheme};
+use crate::components::{MatmulPrecision, MatrixLayout, TileIdent, TileSize, TilingScheme};
 use cubecl_core::frontend::CubePrimitive;
 
 /// Execution mode for the RegisterMatmul
@@ -40,27 +40,27 @@ impl TileConfig for RegisterConfig {
         self.plane_dim
     }
 
-    fn matrix_layout<I: Into<Ident>>(&self, ident: I) -> MatrixLayout {
-        match ident.into() {
-            Ident::Lhs => self.lhs_layout,
-            Ident::Rhs => self.rhs_layout,
-            Ident::Out => MatrixLayout::RowMajor,
+    fn matrix_layout(&self, ident: TileIdent) -> MatrixLayout {
+        match ident {
+            TileIdent::Lhs => self.lhs_layout,
+            TileIdent::Rhs => self.rhs_layout,
+            TileIdent::Acc => MatrixLayout::RowMajor,
         }
     }
 
-    fn stage_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
-        match ident.into() {
-            Ident::Lhs => self.lhs_stage_line_size,
-            Ident::Rhs => self.rhs_stage_line_size,
-            Ident::Out => self.out_global_line_size,
+    fn stage_line_size(&self, ident: TileIdent) -> u32 {
+        match ident {
+            TileIdent::Lhs => self.lhs_stage_line_size,
+            TileIdent::Rhs => self.rhs_stage_line_size,
+            TileIdent::Acc => self.out_global_line_size,
         }
     }
 
-    fn global_line_size<I: Into<Ident>>(&self, ident: I) -> u32 {
-        match ident.into() {
-            Ident::Lhs => self.lhs_global_line_size,
-            Ident::Rhs => self.rhs_global_line_size,
-            Ident::Out => self.out_global_line_size,
+    fn global_line_size(&self, ident: TileIdent) -> u32 {
+        match ident {
+            TileIdent::Lhs => self.lhs_global_line_size,
+            TileIdent::Rhs => self.rhs_global_line_size,
+            TileIdent::Acc => self.out_global_line_size,
         }
     }
 
@@ -113,11 +113,11 @@ impl RegisterConfig {
         let n = self.tile_size().n();
         let k = self.tile_size().k();
 
-        let lhs = self.stage_line_size(Ident::Lhs);
-        let rhs = self.stage_line_size(Ident::Rhs);
-        let out = self.global_line_size(Ident::Out);
+        let lhs = self.lhs_stage_line_size;
+        let rhs = self.rhs_stage_line_size;
+        let out = self.out_global_line_size;
 
-        match self.matrix_layout(Ident::Lhs) {
+        match self.matrix_layout(TileIdent::Lhs) {
             MatrixLayout::RowMajor => {
                 if k % lhs != 0 {
                     return Err(MatmulSetupError::InvalidConfig(Box::new(format!(
@@ -133,7 +133,7 @@ impl RegisterConfig {
                 }
             }
         }
-        match self.matrix_layout(Ident::Rhs) {
+        match self.matrix_layout(TileIdent::Rhs) {
             MatrixLayout::RowMajor => {
                 if n % rhs != 0 {
                     return Err(MatmulSetupError::InvalidConfig(Box::new(format!(

--- a/crates/cubecl-matmul/src/components/tile/register/config.rs
+++ b/crates/cubecl-matmul/src/components/tile/register/config.rs
@@ -4,7 +4,7 @@ use cubecl_core::ir::{Elem, FloatKind};
 
 use crate::components::error::{MatmulAvailabilityError, MatmulSetupError};
 use crate::components::tile::TileConfig;
-use crate::components::{MatmulPrecision, MatrixLayout, TileIdent, TileSize, TilingScheme};
+use crate::components::{MatmulPrecision, MatrixLayout, StageIdent, TileSize, TilingScheme};
 use cubecl_core::frontend::CubePrimitive;
 
 /// Execution mode for the RegisterMatmul
@@ -40,27 +40,27 @@ impl TileConfig for RegisterConfig {
         self.plane_dim
     }
 
-    fn matrix_layout(&self, ident: TileIdent) -> MatrixLayout {
+    fn matrix_layout(&self, ident: StageIdent) -> MatrixLayout {
         match ident {
-            TileIdent::Lhs => self.lhs_layout,
-            TileIdent::Rhs => self.rhs_layout,
-            TileIdent::Acc => MatrixLayout::RowMajor,
+            StageIdent::Lhs => self.lhs_layout,
+            StageIdent::Rhs => self.rhs_layout,
+            StageIdent::Acc => MatrixLayout::RowMajor,
         }
     }
 
-    fn stage_line_size(&self, ident: TileIdent) -> u32 {
+    fn stage_line_size(&self, ident: StageIdent) -> u32 {
         match ident {
-            TileIdent::Lhs => self.lhs_stage_line_size,
-            TileIdent::Rhs => self.rhs_stage_line_size,
-            TileIdent::Acc => self.out_global_line_size,
+            StageIdent::Lhs => self.lhs_stage_line_size,
+            StageIdent::Rhs => self.rhs_stage_line_size,
+            StageIdent::Acc => self.out_global_line_size,
         }
     }
 
-    fn global_line_size(&self, ident: TileIdent) -> u32 {
+    fn global_line_size(&self, ident: StageIdent) -> u32 {
         match ident {
-            TileIdent::Lhs => self.lhs_global_line_size,
-            TileIdent::Rhs => self.rhs_global_line_size,
-            TileIdent::Acc => self.out_global_line_size,
+            StageIdent::Lhs => self.lhs_global_line_size,
+            StageIdent::Rhs => self.rhs_global_line_size,
+            StageIdent::Acc => self.out_global_line_size,
         }
     }
 
@@ -117,7 +117,7 @@ impl RegisterConfig {
         let rhs = self.rhs_stage_line_size;
         let out = self.out_global_line_size;
 
-        match self.matrix_layout(TileIdent::Lhs) {
+        match self.matrix_layout(StageIdent::Lhs) {
             MatrixLayout::RowMajor => {
                 if k % lhs != 0 {
                     return Err(MatmulSetupError::InvalidConfig(Box::new(format!(
@@ -133,7 +133,7 @@ impl RegisterConfig {
                 }
             }
         }
-        match self.matrix_layout(TileIdent::Rhs) {
+        match self.matrix_layout(StageIdent::Rhs) {
             MatrixLayout::RowMajor => {
                 if n % rhs != 0 {
                     return Err(MatmulSetupError::InvalidConfig(Box::new(format!(

--- a/crates/cubecl-matmul/src/components/tile/register/matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/register/matmul.rs
@@ -1,7 +1,7 @@
 use crate::components::tile::register::config::{ProductType, RegisterConfig};
 use crate::components::tile::tile_data::Tile;
 use crate::components::tile::{TileConfig, TileMatmul};
-use crate::components::{MatmulPrecision, MatrixLayout, TileIdent};
+use crate::components::{MatmulPrecision, MatrixLayout, StageIdent};
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
 
@@ -52,8 +52,8 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for RegisterMatmul {
 
     fn fill_lhs(tile: &Tile<MP::ES>, lhs: &mut Self::Lhs, #[comptime] config: Self::Config) {
         let size = config.tile_size();
-        let lhs_line_size = config.stage_line_size(TileIdent::Lhs);
-        let lhs_layout = config.matrix_layout(TileIdent::Lhs);
+        let lhs_line_size = config.stage_line_size(StageIdent::Lhs);
+        let lhs_layout = config.matrix_layout(StageIdent::Lhs);
 
         match config.product_type() {
             ProductType::Inner => match lhs_layout {
@@ -77,8 +77,8 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for RegisterMatmul {
 
     fn fill_rhs(tile: &Tile<MP::ES>, rhs: &mut Self::Rhs, #[comptime] config: Self::Config) {
         let size = config.tile_size();
-        let rhs_line_size = config.stage_line_size(TileIdent::Rhs);
-        let rhs_layout = config.matrix_layout(TileIdent::Rhs);
+        let rhs_line_size = config.stage_line_size(StageIdent::Rhs);
+        let rhs_layout = config.matrix_layout(StageIdent::Rhs);
 
         match config.product_type() {
             ProductType::Inner => match rhs_layout {
@@ -120,7 +120,7 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for RegisterMatmul {
         slice: &mut SliceMut<Line<MP::EO>>,
         #[comptime] config: Self::Config,
     ) {
-        let out_line_size = config.stage_line_size(TileIdent::Acc);
+        let out_line_size = config.stage_line_size(StageIdent::Acc);
         #[unroll(UNROLL)]
         for i in 0..comptime!(acc.rows * acc.cols / out_line_size) {
             let mut line = Line::empty(out_line_size);

--- a/crates/cubecl-matmul/src/components/tile/register/matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/register/matmul.rs
@@ -1,7 +1,7 @@
 use crate::components::tile::register::config::{ProductType, RegisterConfig};
 use crate::components::tile::tile_data::Tile;
 use crate::components::tile::{TileConfig, TileMatmul};
-use crate::components::{Ident, MatmulPrecision, MatrixLayout};
+use crate::components::{MatmulPrecision, MatrixLayout, TileIdent};
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
 
@@ -52,8 +52,8 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for RegisterMatmul {
 
     fn fill_lhs(tile: &Tile<MP::ES>, lhs: &mut Self::Lhs, #[comptime] config: Self::Config) {
         let size = config.tile_size();
-        let lhs_line_size = config.stage_line_size(Ident::Lhs);
-        let lhs_layout = config.matrix_layout(Ident::Lhs);
+        let lhs_line_size = config.stage_line_size(TileIdent::Lhs);
+        let lhs_layout = config.matrix_layout(TileIdent::Lhs);
 
         match config.product_type() {
             ProductType::Inner => match lhs_layout {
@@ -77,8 +77,8 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for RegisterMatmul {
 
     fn fill_rhs(tile: &Tile<MP::ES>, rhs: &mut Self::Rhs, #[comptime] config: Self::Config) {
         let size = config.tile_size();
-        let rhs_line_size = config.stage_line_size(Ident::Rhs);
-        let rhs_layout = config.matrix_layout(Ident::Rhs);
+        let rhs_line_size = config.stage_line_size(TileIdent::Rhs);
+        let rhs_layout = config.matrix_layout(TileIdent::Rhs);
 
         match config.product_type() {
             ProductType::Inner => match rhs_layout {
@@ -120,7 +120,7 @@ impl<MP: MatmulPrecision> TileMatmul<MP> for RegisterMatmul {
         slice: &mut SliceMut<Line<MP::EO>>,
         #[comptime] config: Self::Config,
     ) {
-        let out_line_size = config.stage_line_size(Ident::Out);
+        let out_line_size = config.stage_line_size(TileIdent::Acc);
         #[unroll(UNROLL)]
         for i in 0..comptime!(acc.rows * acc.cols / out_line_size) {
             let mut line = Line::empty(out_line_size);

--- a/crates/cubecl-matmul/src/components/tile/tile_data.rs
+++ b/crates/cubecl-matmul/src/components/tile/tile_data.rs
@@ -1,7 +1,7 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use crate::components::{tile::TileConfig, MatrixLayout, StageIdent};
+use crate::components::{MatrixLayout, StageIdent, tile::TileConfig};
 
 #[derive(CubeType, Clone)]
 /// Data to be handed to the Tile Matmul

--- a/crates/cubecl-matmul/src/components/tile/tile_data.rs
+++ b/crates/cubecl-matmul/src/components/tile/tile_data.rs
@@ -1,7 +1,7 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
-use crate::components::{Ident, InputIdent, MatrixLayout, tile::TileConfig};
+use crate::components::{MatrixLayout, TileIdent, tile::TileConfig};
 
 #[derive(CubeType, Clone)]
 /// Data to be handed to the Tile Matmul
@@ -22,20 +22,21 @@ impl<ES: Numeric> Tile<ES> {
     /// The slice length must exactly match the tile size.
     pub fn new_contiguous<T: TileConfig>(
         slice: Slice<Line<ES>>,
-        #[comptime] ident: Ident,
+        #[comptime] ident: TileIdent,
         #[comptime] config: T,
     ) -> Tile<ES> {
         let layout = config.matrix_layout(ident);
         let stride = comptime! {
-            (match ident.as_input_ident() {
-            InputIdent::Lhs => match layout {
+            (match ident {
+            TileIdent::Lhs => match layout {
                 MatrixLayout::RowMajor => config.tile_size().k(),
                 MatrixLayout::ColMajor => config.tile_size().m(),
             },
-            InputIdent::Rhs => match layout {
+            TileIdent::Rhs => match layout {
                 MatrixLayout::RowMajor => config.tile_size().n(),
                 MatrixLayout::ColMajor => config.tile_size().k(),
             },
+            TileIdent::Acc => unreachable!()
         }) / config.stage_line_size(ident)};
 
         Tile::<ES> {
@@ -67,7 +68,7 @@ impl<ES: Numeric> Tile<ES> {
     /// - The updated stride to account for line width removal
     pub fn as_unlined<T: TileConfig>(
         &self,
-        #[comptime] ident: Ident,
+        #[comptime] ident: TileIdent,
         #[comptime] config: T,
     ) -> (Slice<ES>, u32) {
         (

--- a/crates/cubecl-matmul/src/components/tiling_scheme.rs
+++ b/crates/cubecl-matmul/src/components/tiling_scheme.rs
@@ -1,4 +1,4 @@
-use super::Ident;
+use super::MatmulIdent;
 use super::size::{GlobalPartitionSize, MatmulDim, PartitionSize, StageSize, TileSize};
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -160,29 +160,29 @@ impl TilingScheme {
             })
     }
 
-    fn count_1d_ident_row<I: Into<Ident>>(
+    fn count_1d_ident_row(
         &self,
         child_level: TilingLevel,
         parent_level: TilingLevel,
-        ident: I,
+        ident: MatmulIdent,
     ) -> u32 {
         match ident.into() {
-            Ident::Lhs => self.count_1d(child_level, parent_level, MatmulDim::M),
-            Ident::Rhs => self.count_1d(child_level, parent_level, MatmulDim::K),
-            Ident::Out => self.count_1d(child_level, parent_level, MatmulDim::M),
+            MatmulIdent::Lhs => self.count_1d(child_level, parent_level, MatmulDim::M),
+            MatmulIdent::Rhs => self.count_1d(child_level, parent_level, MatmulDim::K),
+            MatmulIdent::Out => self.count_1d(child_level, parent_level, MatmulDim::M),
         }
     }
 
-    fn count_1d_ident_col<I: Into<Ident>>(
+    fn count_1d_ident_col(
         &self,
         child_level: TilingLevel,
         parent_level: TilingLevel,
-        ident: I,
+        ident: MatmulIdent,
     ) -> u32 {
         match ident.into() {
-            Ident::Lhs => self.count_1d(child_level, parent_level, MatmulDim::K),
-            Ident::Rhs => self.count_1d(child_level, parent_level, MatmulDim::N),
-            Ident::Out => self.count_1d(child_level, parent_level, MatmulDim::N),
+            MatmulIdent::Lhs => self.count_1d(child_level, parent_level, MatmulDim::K),
+            MatmulIdent::Rhs => self.count_1d(child_level, parent_level, MatmulDim::N),
+            MatmulIdent::Out => self.count_1d(child_level, parent_level, MatmulDim::N),
         }
     }
 
@@ -199,16 +199,22 @@ impl TilingScheme {
             })
     }
 
-    fn count_2d_ident<I: Into<Ident>>(
+    fn count_2d_ident(
         &self,
         child_level: TilingLevel,
         parent_level: TilingLevel,
-        ident: I,
+        ident: MatmulIdent,
     ) -> u32 {
         match ident.into() {
-            Ident::Lhs => self.count_2d(child_level, parent_level, MatmulDim::M, MatmulDim::K),
-            Ident::Rhs => self.count_2d(child_level, parent_level, MatmulDim::K, MatmulDim::N),
-            Ident::Out => self.count_2d(child_level, parent_level, MatmulDim::M, MatmulDim::N),
+            MatmulIdent::Lhs => {
+                self.count_2d(child_level, parent_level, MatmulDim::M, MatmulDim::K)
+            }
+            MatmulIdent::Rhs => {
+                self.count_2d(child_level, parent_level, MatmulDim::K, MatmulDim::N)
+            }
+            MatmulIdent::Out => {
+                self.count_2d(child_level, parent_level, MatmulDim::M, MatmulDim::N)
+            }
         }
     }
 }
@@ -223,7 +229,7 @@ macro_rules! count_1d_method {
 
 macro_rules! count_1d_ident_row_method {
     ($name:ident, $child:ident, $parent:ident) => {
-        pub fn $name<I: Into<Ident>>(&self, ident: I) -> u32 {
+        pub fn $name(&self, ident: MatmulIdent) -> u32 {
             self.count_1d_ident_row(TilingLevel::$child, TilingLevel::$parent, ident)
         }
     };
@@ -231,7 +237,7 @@ macro_rules! count_1d_ident_row_method {
 
 macro_rules! count_1d_ident_col_method {
     ($name:ident, $child:ident, $parent:ident) => {
-        pub fn $name<I: Into<Ident>>(&self, ident: I) -> u32 {
+        pub fn $name(&self, ident: MatmulIdent) -> u32 {
             self.count_1d_ident_col(TilingLevel::$child, TilingLevel::$parent, ident)
         }
     };
@@ -252,7 +258,7 @@ macro_rules! count_2d_method {
 
 macro_rules! count_2d_ident_method {
     ($name:ident, $child:ident, $parent:ident) => {
-        pub fn $name<I: Into<Ident>>(&self, ident: I) -> u32 {
+        pub fn $name(&self, ident: MatmulIdent) -> u32 {
             self.count_2d_ident(TilingLevel::$child, TilingLevel::$parent, ident)
         }
     };

--- a/crates/cubecl-matmul/src/components/tiling_scheme.rs
+++ b/crates/cubecl-matmul/src/components/tiling_scheme.rs
@@ -1,4 +1,4 @@
-use super::MatmulIdent;
+use super::StageIdent;
 use super::size::{GlobalPartitionSize, MatmulDim, PartitionSize, StageSize, TileSize};
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -164,12 +164,12 @@ impl TilingScheme {
         &self,
         child_level: TilingLevel,
         parent_level: TilingLevel,
-        ident: MatmulIdent,
+        ident: StageIdent,
     ) -> u32 {
-        match ident.into() {
-            MatmulIdent::Lhs => self.count_1d(child_level, parent_level, MatmulDim::M),
-            MatmulIdent::Rhs => self.count_1d(child_level, parent_level, MatmulDim::K),
-            MatmulIdent::Out => self.count_1d(child_level, parent_level, MatmulDim::M),
+        match ident {
+            StageIdent::Lhs => self.count_1d(child_level, parent_level, MatmulDim::M),
+            StageIdent::Rhs => self.count_1d(child_level, parent_level, MatmulDim::K),
+            StageIdent::Acc => self.count_1d(child_level, parent_level, MatmulDim::M),
         }
     }
 
@@ -177,12 +177,12 @@ impl TilingScheme {
         &self,
         child_level: TilingLevel,
         parent_level: TilingLevel,
-        ident: MatmulIdent,
+        ident: StageIdent,
     ) -> u32 {
-        match ident.into() {
-            MatmulIdent::Lhs => self.count_1d(child_level, parent_level, MatmulDim::K),
-            MatmulIdent::Rhs => self.count_1d(child_level, parent_level, MatmulDim::N),
-            MatmulIdent::Out => self.count_1d(child_level, parent_level, MatmulDim::N),
+        match ident {
+            StageIdent::Lhs => self.count_1d(child_level, parent_level, MatmulDim::K),
+            StageIdent::Rhs => self.count_1d(child_level, parent_level, MatmulDim::N),
+            StageIdent::Acc => self.count_1d(child_level, parent_level, MatmulDim::N),
         }
     }
 
@@ -203,18 +203,12 @@ impl TilingScheme {
         &self,
         child_level: TilingLevel,
         parent_level: TilingLevel,
-        ident: MatmulIdent,
+        ident: StageIdent,
     ) -> u32 {
-        match ident.into() {
-            MatmulIdent::Lhs => {
-                self.count_2d(child_level, parent_level, MatmulDim::M, MatmulDim::K)
-            }
-            MatmulIdent::Rhs => {
-                self.count_2d(child_level, parent_level, MatmulDim::K, MatmulDim::N)
-            }
-            MatmulIdent::Out => {
-                self.count_2d(child_level, parent_level, MatmulDim::M, MatmulDim::N)
-            }
+        match ident {
+            StageIdent::Lhs => self.count_2d(child_level, parent_level, MatmulDim::M, MatmulDim::K),
+            StageIdent::Rhs => self.count_2d(child_level, parent_level, MatmulDim::K, MatmulDim::N),
+            StageIdent::Acc => self.count_2d(child_level, parent_level, MatmulDim::M, MatmulDim::N),
         }
     }
 }
@@ -229,16 +223,16 @@ macro_rules! count_1d_method {
 
 macro_rules! count_1d_ident_row_method {
     ($name:ident, $child:ident, $parent:ident) => {
-        pub fn $name(&self, ident: MatmulIdent) -> u32 {
-            self.count_1d_ident_row(TilingLevel::$child, TilingLevel::$parent, ident)
+        pub fn $name<I: Into<StageIdent>>(&self, ident: I) -> u32 {
+            self.count_1d_ident_row(TilingLevel::$child, TilingLevel::$parent, ident.into())
         }
     };
 }
 
 macro_rules! count_1d_ident_col_method {
     ($name:ident, $child:ident, $parent:ident) => {
-        pub fn $name(&self, ident: MatmulIdent) -> u32 {
-            self.count_1d_ident_col(TilingLevel::$child, TilingLevel::$parent, ident)
+        pub fn $name<I: Into<StageIdent>>(&self, ident: I) -> u32 {
+            self.count_1d_ident_col(TilingLevel::$child, TilingLevel::$parent, ident.into())
         }
     };
 }
@@ -258,8 +252,8 @@ macro_rules! count_2d_method {
 
 macro_rules! count_2d_ident_method {
     ($name:ident, $child:ident, $parent:ident) => {
-        pub fn $name(&self, ident: MatmulIdent) -> u32 {
-            self.count_2d_ident(TilingLevel::$child, TilingLevel::$parent, ident)
+        pub fn $name<I: Into<StageIdent>>(&self, ident: I) -> u32 {
+            self.count_2d_ident(TilingLevel::$child, TilingLevel::$parent, ident.into())
         }
     };
 }

--- a/crates/cubecl-matmul/src/tests/layered/matmul_test_launcher.rs
+++ b/crates/cubecl-matmul/src/tests/layered/matmul_test_launcher.rs
@@ -1,10 +1,10 @@
 use cubecl_core::prelude::*;
 use cubecl_core::{CubeElement, server};
 
-use crate::components::AvailableLineSizes;
 use crate::components::MatrixLayout;
 use crate::components::batch::{BatchConfig, BatchMatmulFamily};
 use crate::components::global::args::TensorInputsLaunch;
+use crate::components::{AvailableLineSizes, MatmulIdent};
 use crate::components::{MatmulProblem, MatmulSelection};
 use crate::kernels::layered::Algorithm;
 use crate::tests::test_utils::Sample;
@@ -41,9 +41,9 @@ pub fn test_matmul_algorithm<A, P, R>(
         },
         Err(_) => false,
     };
-    let lhs = tensor_raw_parts::<P, R>(&client, &problem, Ident::Lhs);
-    let rhs = tensor_raw_parts::<P, R>(&client, &problem, Ident::Rhs);
-    let out = tensor_raw_parts::<P, R>(&client, &problem, Ident::Out);
+    let lhs = tensor_raw_parts::<P, R>(&client, &problem, MatmulIdent::Lhs);
+    let rhs = tensor_raw_parts::<P, R>(&client, &problem, MatmulIdent::Rhs);
+    let out = tensor_raw_parts::<P, R>(&client, &problem, MatmulIdent::Out);
 
     let line_sizes = AvailableLineSizes::from_elem_types::<R>(
         &P::EG::as_elem_native_unchecked(),
@@ -135,11 +135,11 @@ pub fn test_matmul_algorithm<A, P, R>(
 fn tensor_raw_parts<P: TestPrecision, R: Runtime>(
     client: &ComputeClient<R::Server, R::Channel>,
     problem: &MatmulProblem,
-    ident: Ident,
+    ident: MatmulIdent,
 ) -> TensorRawParts<P::EG> {
     match ident {
-        Ident::Lhs => {
-            let mut tensor_shape = problem.shape(Ident::Lhs);
+        MatmulIdent::Lhs => {
+            let mut tensor_shape = problem.shape(MatmulIdent::Lhs);
 
             let handle = P::EG::sample::<R>(client, &tensor_shape, 1234);
 
@@ -151,7 +151,7 @@ fn tensor_raw_parts<P: TestPrecision, R: Runtime>(
 
             let rank = tensor_shape.len();
 
-            if let Some(params) = P::quantization_params(Ident::Lhs) {
+            if let Some(params) = P::quantization_params(MatmulIdent::Lhs) {
                 let scaling = P::EG::as_bytes(&params.scaling);
                 let scaling = f32::from_be_bytes([scaling[0], scaling[1], scaling[2], scaling[3]]);
                 let zero = P::EG::from_int(0);
@@ -200,8 +200,8 @@ fn tensor_raw_parts<P: TestPrecision, R: Runtime>(
                 quant_params,
             }
         }
-        Ident::Rhs => {
-            let mut tensor_shape = problem.shape(Ident::Rhs);
+        MatmulIdent::Rhs => {
+            let mut tensor_shape = problem.shape(MatmulIdent::Rhs);
 
             let handle = P::EG::sample::<R>(client, &tensor_shape, 5678);
 
@@ -213,7 +213,7 @@ fn tensor_raw_parts<P: TestPrecision, R: Runtime>(
 
             let rank = tensor_shape.len();
 
-            if let Some(params) = P::quantization_params(Ident::Rhs) {
+            if let Some(params) = P::quantization_params(MatmulIdent::Rhs) {
                 let scaling = P::EG::as_bytes(&params.scaling);
                 let scaling = f32::from_be_bytes([scaling[0], scaling[1], scaling[2], scaling[3]]);
                 let zero = P::EG::from_int(0);
@@ -262,15 +262,15 @@ fn tensor_raw_parts<P: TestPrecision, R: Runtime>(
                 quant_params,
             }
         }
-        Ident::Out => {
+        MatmulIdent::Out => {
             let zero = P::EG::from_int(0);
 
-            let data = vec![zero; tensor_size(problem, Ident::Out)];
+            let data = vec![zero; tensor_size(problem, MatmulIdent::Out)];
             let mut quant_params = None;
 
-            let tensor_shape = problem.shape(Ident::Out);
+            let tensor_shape = problem.shape(MatmulIdent::Out);
 
-            if let Some(params) = P::quantization_params(Ident::Out) {
+            if let Some(params) = P::quantization_params(MatmulIdent::Out) {
                 let scaling = P::EG::as_bytes(&params.scaling);
                 let scaling = f32::from_be_bytes([scaling[0], scaling[1], scaling[2], scaling[3]]);
                 let zero = P::EG::from_int(0);
@@ -322,30 +322,30 @@ pub(crate) fn transpose<E: Copy>(array: &[E], batches: usize, rows: usize, cols:
 }
 
 /// Returns the total number of elements for the identified tensor, inferred by the problem definition
-pub(crate) fn tensor_size(problem: &MatmulProblem, ident: Ident) -> usize {
+pub(crate) fn tensor_size(problem: &MatmulProblem, ident: MatmulIdent) -> usize {
     match ident {
-        Ident::Lhs => problem.num_batches() * problem.m * problem.k,
-        Ident::Rhs => problem.num_batches() * problem.k * problem.n,
-        Ident::Out => problem.num_batches() * problem.m * problem.n,
+        MatmulIdent::Lhs => problem.num_batches() * problem.m * problem.k,
+        MatmulIdent::Rhs => problem.num_batches() * problem.k * problem.n,
+        MatmulIdent::Out => problem.num_batches() * problem.m * problem.n,
     }
 }
 
 /// Returns the stride of the identified tensor, inferred by the problem definition
-pub(crate) fn strides(problem: &MatmulProblem, ident: Ident) -> Vec<usize> {
+pub(crate) fn strides(problem: &MatmulProblem, ident: MatmulIdent) -> Vec<usize> {
     let shape = problem.shape(ident);
     let rank = shape.len();
     let mut strides = Vec::with_capacity(rank);
 
     let (last_batch, x, y) = match ident {
-        Ident::Lhs => match problem.lhs_layout {
+        MatmulIdent::Lhs => match problem.lhs_layout {
             MatrixLayout::RowMajor => (problem.m * problem.k, problem.k, 1),
             MatrixLayout::ColMajor => (problem.m * problem.k, 1, problem.m),
         },
-        Ident::Rhs => match problem.rhs_layout {
+        MatmulIdent::Rhs => match problem.rhs_layout {
             MatrixLayout::RowMajor => (problem.k * problem.n, problem.n, 1),
             MatrixLayout::ColMajor => (problem.k * problem.n, 1, problem.k),
         },
-        Ident::Out => (problem.m * problem.n, problem.n, 1),
+        MatmulIdent::Out => (problem.m * problem.n, problem.n, 1),
     };
 
     strides.push(y);

--- a/crates/cubecl-matmul/src/tests/layered/matmul_test_launcher.rs
+++ b/crates/cubecl-matmul/src/tests/layered/matmul_test_launcher.rs
@@ -1,10 +1,10 @@
 use cubecl_core::prelude::*;
 use cubecl_core::{CubeElement, server};
 
+use crate::components::AvailableLineSizes;
 use crate::components::MatrixLayout;
 use crate::components::batch::{BatchConfig, BatchMatmulFamily};
 use crate::components::global::args::TensorInputsLaunch;
-use crate::components::{AvailableLineSizes, Ident};
 use crate::components::{MatmulProblem, MatmulSelection};
 use crate::kernels::layered::Algorithm;
 use crate::tests::test_utils::Sample;

--- a/crates/cubecl-matmul/src/tests/layered/tma_test_launcher.rs
+++ b/crates/cubecl-matmul/src/tests/layered/tma_test_launcher.rs
@@ -4,7 +4,7 @@ use cubecl_core::CubeElement;
 use cubecl_core::prelude::*;
 
 use crate::components::AvailableLineSizes;
-use crate::components::Ident;
+use crate::components::MatmulIdent;
 use crate::components::MatmulProblem;
 use crate::components::MatmulSelection;
 use crate::components::MatrixLayout;
@@ -39,9 +39,9 @@ pub fn test_tma_matmul_algorithm<A, P, R>(
         },
         Err(_) => false,
     };
-    let lhs = tensor_raw_parts::<P, R>(&client, &problem, Ident::Lhs);
-    let rhs = tensor_raw_parts::<P, R>(&client, &problem, Ident::Rhs);
-    let out = tensor_raw_parts::<P, R>(&client, &problem, Ident::Out);
+    let lhs = tensor_raw_parts::<P, R>(&client, &problem, MatmulIdent::Lhs);
+    let rhs = tensor_raw_parts::<P, R>(&client, &problem, MatmulIdent::Rhs);
+    let out = tensor_raw_parts::<P, R>(&client, &problem, MatmulIdent::Out);
 
     let elem_size = size_of::<P::EG>();
     let lhs_handle = TensorHandleRef {
@@ -141,10 +141,10 @@ pub fn test_tma_matmul_algorithm<A, P, R>(
 fn tensor_raw_parts<P: TestPrecision, R: Runtime>(
     client: &ComputeClient<R::Server, R::Channel>,
     problem: &MatmulProblem,
-    ident: Ident,
+    ident: MatmulIdent,
 ) -> TensorRawParts<P::EG> {
     match ident {
-        Ident::Lhs => {
+        MatmulIdent::Lhs => {
             let mut shape = problem.shape(ident);
 
             let handle = P::EG::sample::<R>(client, &shape, 1234);
@@ -180,7 +180,7 @@ fn tensor_raw_parts<P: TestPrecision, R: Runtime>(
                 quant_params: None,
             }
         }
-        Ident::Rhs => {
+        MatmulIdent::Rhs => {
             let mut shape = problem.shape(ident);
 
             let handle = P::EG::sample::<R>(client, &shape, 5678);
@@ -216,12 +216,12 @@ fn tensor_raw_parts<P: TestPrecision, R: Runtime>(
                 quant_params: None,
             }
         }
-        Ident::Out => {
+        MatmulIdent::Out => {
             let zero = P::EG::from_int(0);
 
-            let data = vec![zero; tensor_size(problem, Ident::Out)];
+            let data = vec![zero; tensor_size(problem, MatmulIdent::Out)];
 
-            let shape = problem.shape(Ident::Out);
+            let shape = problem.shape(MatmulIdent::Out);
             let (handle, strides) =
                 client.create_tensor(P::EG::as_bytes(&data), &shape, size_of::<P::EG>());
             TensorRawParts {

--- a/crates/cubecl-matmul/src/tests/test_utils.rs
+++ b/crates/cubecl-matmul/src/tests/test_utils.rs
@@ -12,7 +12,7 @@ use cubecl_core::{
 pub use cubecl_std::SymQ8;
 
 use crate::{
-    components::{Ident, MatmulPrecision, MatmulProblem},
+    components::{MatmulIdent, MatmulPrecision, MatmulProblem},
     tests::layered::matmul_test_launcher::strides,
 };
 use cubecl_std::tensor::TensorHandle;
@@ -29,7 +29,7 @@ pub trait TestPrecision {
     type MP: MatmulPrecision;
     const QUANTIZED: bool;
 
-    fn quantization_params(ident: Ident) -> Option<QuantizationParams<Self::EG>>;
+    fn quantization_params(ident: MatmulIdent) -> Option<QuantizationParams<Self::EG>>;
 
     #[allow(clippy::too_many_arguments)]
     fn assert_result<R: Runtime>(
@@ -58,7 +58,7 @@ where
     type MP = EG;
     const QUANTIZED: bool = false;
 
-    fn quantization_params(_: Ident) -> Option<QuantizationParams<Self::EG>> {
+    fn quantization_params(_: MatmulIdent) -> Option<QuantizationParams<Self::EG>> {
         None
     }
 
@@ -161,19 +161,19 @@ impl TestPrecision for SymQ8 {
 
     const QUANTIZED: bool = true;
 
-    fn quantization_params(ident: Ident) -> Option<QuantizationParams<Self::EG>> {
+    fn quantization_params(ident: MatmulIdent) -> Option<QuantizationParams<Self::EG>> {
         // These are somewhat arbitrary values. I try to use f32 that are exactly representable
         // to avoid some rounding issues.
         Some(match ident {
-            Ident::Lhs => QuantizationParams {
+            MatmulIdent::Lhs => QuantizationParams {
                 scaling: f32::to_be_bytes(0.6).to_vec(),
                 zero_offset: 15,
             },
-            Ident::Rhs => QuantizationParams {
+            MatmulIdent::Rhs => QuantizationParams {
                 scaling: f32::to_be_bytes(0.1).to_vec(),
                 zero_offset: 20,
             },
-            Ident::Out => QuantizationParams {
+            MatmulIdent::Out => QuantizationParams {
                 scaling: f32::to_be_bytes(0.4).to_vec(),
                 zero_offset: 50,
             },
@@ -444,9 +444,9 @@ where
         "Cpu reference only works with batches of equal length. Please pad the shortest one with ones at the beginning."
     );
 
-    let lhs_strides = strides(problem, Ident::Lhs);
-    let rhs_strides = strides(problem, Ident::Rhs);
-    let out_strides = strides(problem, Ident::Out);
+    let lhs_strides = strides(problem, MatmulIdent::Lhs);
+    let rhs_strides = strides(problem, MatmulIdent::Rhs);
+    let out_strides = strides(problem, MatmulIdent::Out);
 
     let mut out = vec![P::EA::from_int(0); m * n * num_batches];
 
@@ -504,9 +504,9 @@ where
         "Cpu reference only works with batches of equal length. Please pad the shortest one with ones at the beginning."
     );
 
-    let lhs_strides = strides(problem, Ident::Lhs);
-    let rhs_strides = strides(problem, Ident::Rhs);
-    let out_strides = strides(problem, Ident::Out);
+    let lhs_strides = strides(problem, MatmulIdent::Lhs);
+    let rhs_strides = strides(problem, MatmulIdent::Rhs);
+    let out_strides = strides(problem, MatmulIdent::Out);
 
     let mut out = vec![0; m * n * num_batches];
 


### PR DESCRIPTION
Instead of having Ident and InputIdent, we have MatmulIdent and StageIdent. 

- **Removed InputIdent:** this had the sole purpose of saving a few `Ident::Out => unreachable!()` in match statements, but the pain it saved was less than the pain it gave, because there were always conversions between Ident and InputIdent. 
- **Split Ident into MatmulIdent and StageIdent:** I'm working on flash attention, and realized I will need, at the stage or tile level, to refer to which side I'm working, but they do not map to a tensor of the same name. For instance there are two tile matmuls, one where its Rhs is Key and another whose Rhs is Value. So I had to decouple the ident at stage and tile level from ident at tensor (global) level. 

Edit: Also decoupled stage matmul from stage memory with StageMemoryConfig, so I can use stage memory in stage attention. 