### PR TITLE
[Needs 1.88 MSRV] Replace nightly-only `Span` function with stable version

### DIFF
--- a/crates/cubecl-macros/Cargo.toml
+++ b/crates/cubecl-macros/Cargo.toml
@@ -19,7 +19,6 @@ proc-macro = true
 [features]
 debug_symbols = []
 default = []
-nightly = []
 std = []
 
 [dependencies]

--- a/crates/cubecl-macros/build.rs
+++ b/crates/cubecl-macros/build.rs
@@ -4,23 +4,13 @@ use std::env;
 // everywhere
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(debug_symbols)");
-    println!("cargo::rustc-check-cfg=cfg(nightly)");
     println!("cargo:rerun-if-env-changed=CUBECL_DEBUG");
-    println!("cargo:rerun-if-env-changed=CUBECL_DEBUG_NIGHTLY");
 
     let debug_feature_enabled = env::var("CARGO_FEATURE_DEBUG_SYMBOLS").is_ok();
     let debug_override_enabled = env::var("CUBECL_DEBUG").is_ok();
     let debug_enabled = debug_feature_enabled || debug_override_enabled;
 
-    let nightly_feature_enabled = env::var("CARGO_FEATURE_NIGHTLY").is_ok();
-    let nightly_override_enabled = env::var("CUBECL_DEBUG_NIGHTLY").is_ok();
-    let nightly_enabled = nightly_feature_enabled || nightly_override_enabled;
-
-    if debug_enabled || nightly_enabled {
+    if debug_enabled {
         println!("cargo:rustc-cfg=debug_symbols");
-    }
-
-    if nightly_enabled {
-        println!("cargo:rustc-cfg=nightly");
     }
 }

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -26,15 +26,12 @@ impl KernelFn {
             let debug_source = frontend_type("debug_source_expand");
             let cube_debug = frontend_type("CubeDebug");
             let src_file = self.src_file.as_ref().map(|file| file.value());
-            #[cfg(nightly)]
-            let src_file = {
-                src_file.or_else(|| {
-                    let span: proc_macro::Span = self.span.unwrap();
-                    let source_path = span.source().local_file();
-                    let source_file = source_path.as_ref().and_then(|path| path.file_name());
-                    source_file.map(|file| file.to_string_lossy().into())
-                })
-            };
+            let src_file = src_file.or_else(|| {
+                let span: proc_macro::Span = self.span.unwrap();
+                let source_path = span.local_file();
+                let source_file = source_path.as_ref().and_then(|path| path.file_name());
+                source_file.map(|file| file.to_string_lossy().into())
+            });
             let source_text = match src_file {
                 Some(file) => quote![include_str!(#file)],
                 None => quote![""],

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(nightly, feature(proc_macro_span))]
 #![allow(clippy::large_enum_variant)]
 
 use core::panic;


### PR DESCRIPTION
Replaces the nightly-only `Span` function in the macro with the now-stabilized version, and removes the nightly feature. Wait to merge this until Rust 1.89 is released and 1.88 becomes the cubecl MSRV.