### PR TITLE
Fix wgpu vec to scalar cast

### DIFF
--- a/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
@@ -197,7 +197,7 @@ impl Variable {
                 }
                 Scalar(_) => {
                     // Scalar to scalar or scalar to vec works fine
-                    format!("{item}({self}[0u])")
+                    format!("{item}({self})")
                 }
             }
         } else {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/base.rs
@@ -1,3 +1,4 @@
+use crate::compiler::wgsl::Item::{Scalar, Vec2, Vec3, Vec4};
 use cubecl_core::ir::{self as cube, ConstantScalarValue, FloatKind, Id, UIntKind};
 use std::fmt::Display;
 
@@ -182,7 +183,23 @@ impl Variable {
 
     pub fn fmt_cast_to(&self, item: Item) -> String {
         if self.item() != item {
-            format!("{item}({self})")
+            match self.item() {
+                Vec2(_) | Vec3(_) | Vec4(_) => {
+                    match item {
+                        Vec2(_) | Vec3(_) | Vec4(_) => {
+                            format!("{item}({self})")
+                        }
+                        Scalar(_) => {
+                            // Casting a vec to a scalar: just pick first component
+                            format!("{item}({self}.x)")
+                        }
+                    }
+                }
+                Scalar(_) => {
+                    // Scalar to scalar or scalar to vec works fine
+                    format!("{item}({self}[0u])")
+                }
+            }
         } else {
             format!("{self}")
         }


### PR DESCRIPTION
### Instructions

When casting a vec to a scalar, in wgpu we now do scalar_type(vec_type.x) instead of scalar_type(vec_type), which causes issues.

This shouldn't ever happen, but in some cases with fusion it happens. The metal compiler does the solution described above (chosing the first element). This PR replicates the same behavior for wgpu.

Burn cubecl update:
https://github.com/tracel-ai/burn/pull/3496

