### PR TITLE
[Feat] Bump default version of CUDA to 12.8 and implement missing features from CUDA 12.8

### DIFF
--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -17,7 +17,7 @@ default = [
     "cubecl-runtime/default",
     "cubecl-common/default",
     "cubecl-core/default",
-    "cudarc/cuda-12050",
+    "cudarc/cuda-12080",
     "cudarc/dynamic-loading",
 ]
 ptx-wmma = []

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -35,8 +35,9 @@ use cubecl_runtime::{
 };
 use cudarc::driver::sys::{
     CUDA_MEMCPY2D_st, CUctx_st, CUfunction_attribute, CUmemorytype, CUtensorMap,
-    CUtensorMapDataType, CUtensorMapFloatOOBfill, CUtensorMapL2promotion, CUtensorMapSwizzle,
-    cuMemcpy2DAsync_v2, cuTensorMapEncodeIm2col, cuTensorMapEncodeTiled,
+    CUtensorMapDataType, CUtensorMapFloatOOBfill, CUtensorMapIm2ColWideMode,
+    CUtensorMapL2promotion, CUtensorMapSwizzle, cuMemcpy2DAsync_v2, cuTensorMapEncodeIm2col,
+    cuTensorMapEncodeIm2colWide, cuTensorMapEncodeTiled,
 };
 use cudarc::driver::sys::{CUfunc_st, CUtensorMapInterleave};
 use std::collections::HashMap;
@@ -473,9 +474,33 @@ impl ComputeServer for CudaServer {
                         .result()
                         .unwrap()
                     },
-                    TensorMapFormat::Im2colWide { .. } => {
-                        unimplemented!("Not yet implemented in cudarc")
-                    }
+                    TensorMapFormat::Im2colWide {
+                        pixel_box_lower_corner_width,
+                        pixel_box_upper_corner_width,
+                        channels_per_pixel,
+                        pixels_per_column,
+                    } => unsafe {
+                        cuTensorMapEncodeIm2colWide(
+                            map_ptr.as_mut_ptr(),
+                            elem_to_tensor_map_type(map.elem),
+                            map.rank as u32,
+                            device_ptr,
+                            shape.as_ptr(),
+                            strides.as_ptr(),
+                            *pixel_box_lower_corner_width,
+                            *pixel_box_upper_corner_width,
+                            *channels_per_pixel,
+                            *pixels_per_column,
+                            elem_stride.as_ptr(),
+                            interleave_to_cuda(map.interleave),
+                            CUtensorMapIm2ColWideMode::CU_TENSOR_MAP_IM2COL_WIDE_MODE_W,
+                            swizzle_to_cuda(map.swizzle),
+                            prefetch_to_cuda(map.prefetch),
+                            oob_to_cuda(map.oob_fill),
+                        )
+                        .result()
+                        .unwrap()
+                    },
                 };
                 unsafe { map_ptr.assume_init() }
             })
@@ -836,11 +861,16 @@ fn elem_to_tensor_map_type(elem: Elem) -> CUtensorMapDataType {
     use cudarc::driver::sys::CUtensorMapDataType::*;
     match elem {
         Elem::Float(kind) => match kind {
-            FloatKind::E2M1 | FloatKind::E2M1x2 | FloatKind::E2M3 | FloatKind::E3M2 => {
-                todo!("Needs more complex handling and CUDA 12.8")
-            }
+            // packed fp4 should be treated as single 4-bit values to simplify indexing/shape handling
+            // So a tile of width 16 with fp4 elements is 8 x fp4x2 elements wide.
+            FloatKind::E2M1x2 => CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B,
             // There's no special handling for FP8, so load as u8. `0u8 == 0.0` when reinterpreting.
-            FloatKind::E4M3 | FloatKind::E5M2 | FloatKind::UE8M0 => CU_TENSOR_MAP_DATA_TYPE_UINT8,
+            FloatKind::E2M1 // single fp4s are padded to a full byte
+            | FloatKind::E4M3
+            | FloatKind::E5M2
+            | FloatKind::UE8M0
+            | FloatKind::E2M3
+            | FloatKind::E3M2 => CU_TENSOR_MAP_DATA_TYPE_UINT8,
             FloatKind::F16 => CU_TENSOR_MAP_DATA_TYPE_FLOAT16,
             FloatKind::BF16 => CU_TENSOR_MAP_DATA_TYPE_BFLOAT16,
             FloatKind::Flex32 | FloatKind::F32 => CU_TENSOR_MAP_DATA_TYPE_FLOAT32,


### PR DESCRIPTION
CUDA 12.8 is fairly old now, and the bump allows us to implement some of the missing TMA-related features.