### PR TITLE
Fix wasm/WebGPU

### DIFF
--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -63,7 +63,11 @@ impl WgpuStream {
 
         // Allocate a small buffer to use for synchronization.
         #[cfg(target_family = "wasm")]
-        let sync_buffer = Some(mem_manage.reserve(32));
+        let sync_buffer = Some(
+            mem_manage
+                .reserve(32)
+                .expect("Failed to reserve sync buffer memory"),
+        );
 
         #[cfg(not(target_family = "wasm"))]
         let sync_buffer = None;


### PR DESCRIPTION
Fix some compilation errors on Wasm/WebGPU.

Notably enumerate_adapters isn't supported as there's always only one adapter.