### PR TITLE
chore: Refactor barrier and pipeline to remove the type

### DIFF
--- a/crates/cubecl-convolution/src/components/global/load/loader/im2col_tma.rs
+++ b/crates/cubecl-convolution/src/components/global/load/loader/im2col_tma.rs
@@ -62,7 +62,7 @@ impl<IP: InputPrecision, G: ConvGemmConfig> TmaIm2colLoader<IP, G> {
 
     pub fn fill_stage(
         this: &mut Self,
-        bar: &Barrier<IP::Stage>,
+        bar: &Barrier,
         #[comptime] stage_idx: u32,
         #[comptime] config: G,
     ) {

--- a/crates/cubecl-convolution/src/components/global/load/loader/weight_tma.rs
+++ b/crates/cubecl-convolution/src/components/global/load/loader/weight_tma.rs
@@ -60,7 +60,7 @@ impl<IP: InputPrecision, S: StageConfig> TmaWeightLoader<IP, S> {
 
     pub fn fill_stage(
         this: &mut Self,
-        barrier: &Barrier<IP::Stage>,
+        barrier: &Barrier,
         #[comptime] stage_idx: u32,
         #[comptime] config: S,
     ) {

--- a/crates/cubecl-convolution/src/components/global/multi_stage/tma/convolution.rs
+++ b/crates/cubecl-convolution/src/components/global/multi_stage/tma/convolution.rs
@@ -96,8 +96,13 @@ where
         // so the stage index is comptime. This is needed to make `Sequence` work.
         let num_loops = (num_loops + num_stages - 1) / num_stages;
 
-        let stage_elems_lhs = config.tiling_scheme().elements_in_stage_mk();
-        let stage_elems_rhs = config.tiling_scheme().elements_in_stage_nk();
+        let lhs_elem_size = LhsS::<MP>::elem_size();
+        let rhs_elem_size = RhsS::<MP>::elem_size();
+        let stage_bytes_lhs =
+            comptime![config.tiling_scheme().elements_in_stage_mk() * lhs_elem_size];
+        let stage_bytes_rhs =
+            comptime![config.tiling_scheme().elements_in_stage_nk() * rhs_elem_size];
+        let stages_bytes = stage_bytes_lhs + stage_bytes_rhs;
 
         Self::AccumulatorLoader::fill_stage::<Self::Config>(&mut acc_loader, config);
 
@@ -105,8 +110,7 @@ where
 
         SMM::fill_accumulator::<Self::AccumulatorLoader>(&mut acc_loader, acc, stage_config);
 
-        let mut lhs_barriers = Sequence::<Barrier<LhsS<MP>>>::new();
-        let mut rhs_barriers = Sequence::<Barrier<RhsS<MP>>>::new();
+        let mut barriers = Sequence::<Barrier>::new();
         let (mut tile_lhs, mut tile_rhs) = SMM::init_tile_inputs(stage_config);
 
         let mut stage = comptime![0u32];
@@ -115,20 +119,17 @@ where
         #[unroll]
         #[allow(clippy::explicit_counter_loop)]
         for _ in 0..num_stages {
-            let lhs_barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
-            let rhs_barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
+            let barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
 
-            Self::LhsLoader::fill_stage(&mut lhs_loader, &lhs_barrier, stage, config);
-            Self::RhsLoader::fill_stage(&mut rhs_loader, &rhs_barrier, stage, stage_config);
+            Self::LhsLoader::fill_stage(&mut lhs_loader, &barrier, stage, config);
+            Self::RhsLoader::fill_stage(&mut rhs_loader, &barrier, stage, stage_config);
 
-            arrive_tma::<LhsS<MP>>(&lhs_barrier, stage_elems_lhs);
-            arrive_tma::<RhsS<MP>>(&rhs_barrier, stage_elems_rhs);
+            arrive_tma(&barrier, stages_bytes);
 
             Self::LhsLoader::advance_view(&mut lhs_loader, k_step);
             Self::RhsLoader::advance_view(&mut rhs_loader, k_step);
 
-            lhs_barriers.push(lhs_barrier);
-            rhs_barriers.push(rhs_barrier);
+            barriers.push(barrier);
 
             comptime![stage += 1];
         }
@@ -147,15 +148,13 @@ where
 
                 // Bounds check for k stage, for when `k_stages % num_stages != 0`
                 if k < k_range.1 {
-                    let lhs_barrier = lhs_barriers.index(stage);
-                    let rhs_barrier = rhs_barriers.index(stage);
+                    let barrier = barriers.index(stage);
 
                     let lhs_stage_reader = &Self::LhsLoader::reader(&lhs_loader, stage);
                     let rhs_stage_reader = &Self::RhsLoader::reader(&rhs_loader, stage);
 
                     // Wait for load and execute matmul on this stage
-                    lhs_barrier.wait();
-                    rhs_barrier.wait();
+                    barrier.wait();
                     SMM::execute(
                         lhs_stage_reader,
                         rhs_stage_reader,
@@ -164,25 +163,17 @@ where
                         acc,
                         config.stage_config(),
                     );
-                    lhs_barrier.arrive();
-                    rhs_barrier.arrive();
+                    barrier.arrive();
 
                     // Check if there's any stages left to load in the k dimension
                     if next_k < k_range.1 {
-                        lhs_barrier.wait();
-                        rhs_barrier.wait();
+                        barrier.wait();
 
                         // Refill stage and advance view
-                        Self::LhsLoader::fill_stage(&mut lhs_loader, lhs_barrier, stage, config);
-                        Self::RhsLoader::fill_stage(
-                            &mut rhs_loader,
-                            rhs_barrier,
-                            stage,
-                            stage_config,
-                        );
+                        Self::LhsLoader::fill_stage(&mut lhs_loader, barrier, stage, config);
+                        Self::RhsLoader::fill_stage(&mut rhs_loader, barrier, stage, stage_config);
 
-                        arrive_tma::<LhsS<MP>>(lhs_barrier, stage_elems_lhs);
-                        arrive_tma::<RhsS<MP>>(rhs_barrier, stage_elems_rhs);
+                        arrive_tma(barrier, stages_bytes);
 
                         Self::LhsLoader::advance_view(&mut lhs_loader, k_step);
                         Self::RhsLoader::advance_view(&mut rhs_loader, k_step);

--- a/crates/cubecl-convolution/src/components/global/single_stage/tma/convolution.rs
+++ b/crates/cubecl-convolution/src/components/global/single_stage/tma/convolution.rs
@@ -77,8 +77,13 @@ where
         #[allow(clippy::manual_div_ceil)]
         let num_loops = (range + k_step - 1) / k_step;
 
-        let stage_elems_lhs = config.tiling_scheme().elements_in_stage_mk();
-        let stage_elems_rhs = config.tiling_scheme().elements_in_stage_nk();
+        let lhs_elem_size = LhsS::<MP>::elem_size();
+        let rhs_elem_size = RhsS::<MP>::elem_size();
+        let stage_bytes_lhs =
+            comptime!(config.tiling_scheme().elements_in_stage_mk() * lhs_elem_size);
+        let stage_bytes_rhs =
+            comptime!(config.tiling_scheme().elements_in_stage_nk() * rhs_elem_size);
+        let stages_bytes = stage_bytes_lhs + stage_bytes_rhs;
 
         Self::AccumulatorLoader::fill_stage::<Self::Config>(&mut acc_loader, config);
         let (mut lhs_tile, mut rhs_tile) = SMM::init_tile_inputs(config.stage_config());
@@ -91,20 +96,17 @@ where
             config.stage_config(),
         );
 
-        let lhs_barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
-        let rhs_barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
+        let barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
 
         for _ in 0..num_loops {
             sync_cube();
 
-            Self::LhsLoader::fill_stage(&mut lhs_loader, &lhs_barrier, 0u32, config);
-            Self::RhsLoader::fill_stage(&mut rhs_loader, &rhs_barrier, 0u32, config.stage_config());
+            Self::LhsLoader::fill_stage(&mut lhs_loader, &barrier, 0u32, config);
+            Self::RhsLoader::fill_stage(&mut rhs_loader, &barrier, 0u32, config.stage_config());
 
-            arrive_tma::<LhsS<MP>>(&lhs_barrier, stage_elems_lhs);
-            arrive_tma::<RhsS<MP>>(&rhs_barrier, stage_elems_rhs);
+            arrive_tma(&barrier, stages_bytes);
 
-            lhs_barrier.wait();
-            rhs_barrier.wait();
+            barrier.wait();
 
             let lhs_stage_reader = &Self::LhsLoader::reader(&lhs_loader, 0u32);
             let rhs_stage_reader = &Self::RhsLoader::reader(&rhs_loader, 0u32);

--- a/crates/cubecl-core/src/runtime_tests/barrier.rs
+++ b/crates/cubecl-core/src/runtime_tests/barrier.rs
@@ -4,7 +4,7 @@ use cubecl::prelude::*;
 
 #[cube(launch)]
 pub fn async_copy_test<F: Float>(input: &Array<Line<F>>, output: &mut Array<Line<F>>) {
-    let barrier = Barrier::<F>::new(BarrierLevel::unit());
+    let barrier = Barrier::new(BarrierLevel::unit());
     let mut smem = SharedMemory::<F>::new_lined(1u32, 1u32);
 
     let source = input.slice(2, 3);
@@ -47,7 +47,7 @@ pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(
 fn one_load<F: Float>(lhs: &Tensor<Line<F>>, output: &mut Tensor<Line<F>>) {
     let mut lhs_smem = SharedMemory::<F>::new_lined(4u32, 1u32);
 
-    let barrier = Barrier::<F>::new(BarrierLevel::cube_manual(0u32));
+    let barrier = Barrier::new(BarrierLevel::cube_manual(0u32));
     sync_cube();
 
     // Can't use lhs.to_slice() because then generated input_length will not exist
@@ -72,7 +72,7 @@ fn two_loads<F: Float>(
     let mut lhs_smem = SharedMemory::<F>::new_lined(num_data, 1u32);
     let mut rhs_smem = SharedMemory::<F>::new_lined(num_data, 1u32);
 
-    let barrier = Barrier::<F>::new(BarrierLevel::cube_manual(0u32));
+    let barrier = Barrier::new(BarrierLevel::cube_manual(0u32));
     sync_cube();
 
     let start = UNIT_POS_X * num_data / 2;

--- a/crates/cubecl-core/src/runtime_tests/tensormap.rs
+++ b/crates/cubecl-core/src/runtime_tests/tensormap.rs
@@ -13,7 +13,7 @@ use cubecl_runtime::{
 
 #[cube(launch)]
 fn tensormap_load<F: Float>(input: &TensorMap<F>, output: &mut Array<Line<F>>) {
-    let barrier = Barrier::<F>::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
+    let barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
     let mut stage = SharedMemory::<F>::new_aligned(32u32 * 16, 1u32, 128u32);
 
     if UNIT_POS == 0 {
@@ -59,7 +59,7 @@ fn tensormap_im2col_load<F: Float>(
     let tile_k = comptime!(kernel_h as u32 * kernel_w as u32);
     let tile_width = tile_m * channels; // Preserve 128-byte alignment, works for all float kinds.
 
-    let barrier = Barrier::<F>::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
+    let barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
     let mut stage = SharedMemory::<F>::new_aligned(tile_k * tile_width, 1u32, 128u32);
 
     if UNIT_POS == 0 {

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -1410,16 +1410,9 @@ impl<D: Dialect> CppCompiler<D> {
                     frag: self.compile_matrix(mat),
                 }
             }
-            gpu::VariableKind::Pipeline {
-                id,
-                item,
-                num_stages,
-            } => {
+            gpu::VariableKind::Pipeline { id, num_stages } => {
                 self.flags.op_pipeline = true;
-                let pipeline = Variable::Pipeline {
-                    id,
-                    item: self.compile_item(item),
-                };
+                let pipeline = Variable::Pipeline { id };
                 if !self.pipelines.iter().any(|s| s.pipeline_id() == id) {
                     self.pipelines.push(PipelineOps::Init {
                         pipeline,
@@ -1428,7 +1421,7 @@ impl<D: Dialect> CppCompiler<D> {
                 }
                 pipeline
             }
-            gpu::VariableKind::Barrier { id, item, level } => {
+            gpu::VariableKind::Barrier { id, level } => {
                 self.flags.op_barrier = true;
                 match level {
                     gpu::BarrierLevel::CubeCoop(_) | gpu::BarrierLevel::CubeManual(_) => {
@@ -1437,11 +1430,7 @@ impl<D: Dialect> CppCompiler<D> {
                     }
                     _ => {}
                 }
-                Variable::Barrier {
-                    id,
-                    item: self.compile_item(item),
-                    level,
-                }
+                Variable::Barrier { id, level }
             }
         }
     }

--- a/crates/cubecl-cpp/src/shared/variable.rs
+++ b/crates/cubecl-cpp/src/shared/variable.rs
@@ -91,11 +91,9 @@ pub enum Variable<D: Dialect> {
     },
     Pipeline {
         id: Id,
-        item: Item<D>,
     },
     Barrier {
         id: Id,
-        item: Item<D>,
         level: BarrierLevel,
     },
     Tmp {
@@ -180,8 +178,7 @@ impl<D: Dialect> Component<D> for Variable<D> {
             Variable::GlobalScalar { elem, .. } => Item::scalar(*elem, false),
             Variable::WmmaFragment { frag, .. } => Item::scalar(frag.elem, false),
             Variable::Tmp { item, .. } => *item,
-            Variable::Pipeline { id: _, item } => *item,
-            Variable::Barrier { id: _, item, .. } => *item,
+            Variable::Pipeline { .. } | Variable::Barrier { .. } => Item::new(Elem::Bool, 1, false),
             Variable::TensorMap(_) => unreachable!(),
         }
     }

--- a/crates/cubecl-ir/src/allocator.rs
+++ b/crates/cubecl-ir/src/allocator.rs
@@ -4,7 +4,7 @@ use core::cell::RefCell;
 use hashbrown::HashMap;
 use portable_atomic::{AtomicU32, Ordering};
 
-use crate::BarrierLevel;
+use crate::{BarrierLevel, Elem};
 
 use super::{Item, Matrix, Variable, VariableKind};
 
@@ -92,22 +92,19 @@ impl Allocator {
         ExpandElement::Plain(variable)
     }
 
-    pub fn create_pipeline(&self, item: Item, num_stages: u8) -> ExpandElement {
+    pub fn create_pipeline(&self, num_stages: u8) -> ExpandElement {
         let id = self.new_local_index();
         let variable = Variable::new(
-            VariableKind::Pipeline {
-                id,
-                item,
-                num_stages,
-            },
-            item,
+            VariableKind::Pipeline { id, num_stages },
+            Item::new(Elem::Bool),
         );
         ExpandElement::Plain(variable)
     }
 
-    pub fn create_barrier(&self, item: Item, level: BarrierLevel) -> ExpandElement {
+    pub fn create_barrier(&self, level: BarrierLevel) -> ExpandElement {
         let id = self.new_local_index();
-        let variable = Variable::new(VariableKind::Barrier { id, item, level }, item);
+        // Dummy elem for now, awaiting a rework to item to include non-native conceptual types
+        let variable = Variable::new(VariableKind::Barrier { id, level }, Item::new(Elem::Bool));
         ExpandElement::Plain(variable)
     }
 

--- a/crates/cubecl-ir/src/scope.rs
+++ b/crates/cubecl-ir/src/scope.rs
@@ -125,15 +125,15 @@ impl Scope {
     }
 
     /// Create a new pipeline element.
-    pub fn create_pipeline(&mut self, item: Item, num_stages: u8) -> ExpandElement {
-        let pipeline = self.allocator.create_pipeline(item, num_stages);
+    pub fn create_pipeline(&mut self, num_stages: u8) -> ExpandElement {
+        let pipeline = self.allocator.create_pipeline(num_stages);
         self.add_pipeline(*pipeline);
         pipeline
     }
 
     /// Create a new barrier element.
-    pub fn create_barrier(&mut self, item: Item, level: BarrierLevel) -> ExpandElement {
-        let barrier = self.allocator.create_barrier(item, level);
+    pub fn create_barrier(&mut self, level: BarrierLevel) -> ExpandElement {
+        let barrier = self.allocator.create_barrier(level);
         self.add_barrier(*barrier);
         barrier
     }

--- a/crates/cubecl-ir/src/variable.rs
+++ b/crates/cubecl-ir/src/variable.rs
@@ -84,12 +84,10 @@ pub enum VariableKind {
     Builtin(Builtin),
     Pipeline {
         id: Id,
-        item: Item,
         num_stages: u8,
     },
     Barrier {
         id: Id,
-        item: Item,
         level: BarrierLevel,
     },
 }

--- a/crates/cubecl-matmul/src/components/global/copy_mechanism.rs
+++ b/crates/cubecl-matmul/src/components/global/copy_mechanism.rs
@@ -4,14 +4,22 @@ use cubecl_core::prelude::*;
 
 #[cube]
 /// Allows to copy a slice of data from global to shared memory asynchronously
-pub trait CopyMechanism<ES: Numeric>: CubeType + Sync + Send + 'static {
+pub trait CopyMechanism: CubeType + Sync + Send + 'static {
     /// Copy the `source` slice to `destination`, assuming `source`'s length <= `destination`'s
-    fn memcpy_async(this: &Self, source: &Slice<Line<ES>>, destination: &mut SliceMut<Line<ES>>);
+    fn memcpy_async<ES: Numeric>(
+        this: &Self,
+        source: &Slice<Line<ES>>,
+        destination: &mut SliceMut<Line<ES>>,
+    );
 }
 
 #[cube]
-impl<ES: Numeric> CopyMechanism<ES> for Barrier<ES> {
-    fn memcpy_async(this: &Self, source: &Slice<Line<ES>>, destination: &mut SliceMut<Line<ES>>) {
+impl CopyMechanism for Barrier {
+    fn memcpy_async<ES: Numeric>(
+        this: &Self,
+        source: &Slice<Line<ES>>,
+        destination: &mut SliceMut<Line<ES>>,
+    ) {
         this.memcpy_async(source, destination)
     }
 }

--- a/crates/cubecl-matmul/src/components/global/load/loader/async_full_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/async_full_loader.rs
@@ -41,7 +41,7 @@ pub trait AsyncFullLoadingStrategy: 'static + Send + Sync + Clone + LoadingValid
 /// each Task represents a single data transfer for a specific unit
 pub struct AsyncFullLoader<
     IP: InputPrecision,
-    CM: CopyMechanism<IP::Stage>,
+    CM: CopyMechanism,
     S: stage::StageConfig,
     L: AsyncFullLoadingStrategy,
     G: GlobalConfig,
@@ -58,7 +58,7 @@ pub struct AsyncFullLoader<
 #[cube]
 impl<
     IP: InputPrecision,
-    CM: CopyMechanism<IP::Stage>,
+    CM: CopyMechanism,
     S: stage::StageConfig,
     L: AsyncFullLoadingStrategy,
     G: GlobalConfig,

--- a/crates/cubecl-matmul/src/components/global/load/loader/async_partial_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/async_partial_loader.rs
@@ -45,7 +45,7 @@ pub trait AsyncPartialLoadingStrategy: 'static + Send + Sync + Clone + LoadingVa
 pub struct AsyncBufferLoader<
     IP: InputPrecision,
     S: stage::StageConfig,
-    CM: CopyMechanism<IP::Stage>,
+    CM: CopyMechanism,
     L: AsyncPartialLoadingStrategy,
 > {
     tensor_reader: TensorReader<IP::Global>,
@@ -58,12 +58,8 @@ pub struct AsyncBufferLoader<
 }
 
 #[cube]
-impl<
-    IP: InputPrecision,
-    S: stage::StageConfig,
-    CM: CopyMechanism<IP::Stage>,
-    L: AsyncPartialLoadingStrategy,
-> AsyncBufferLoader<IP, S, CM, L>
+impl<IP: InputPrecision, S: stage::StageConfig, CM: CopyMechanism, L: AsyncPartialLoadingStrategy>
+    AsyncBufferLoader<IP, S, CM, L>
 {
     /// Create a new AsyncPartialLoader
     pub fn new(

--- a/crates/cubecl-matmul/src/components/global/load/loader/tma_loader.rs
+++ b/crates/cubecl-matmul/src/components/global/load/loader/tma_loader.rs
@@ -123,7 +123,7 @@ impl<IP: InputPrecision, G: GlobalConfig> TmaLoader<IP, G> {
     }
 
     /// Fill the full stage memory
-    pub fn fill_stage(this: &mut Self, barrier: &Barrier<IP::Stage>, #[comptime] config: G) {
+    pub fn fill_stage(this: &mut Self, barrier: &Barrier, #[comptime] config: G) {
         if UNIT_POS == 0 {
             let ident = comptime!(this.ident);
             let stage_ident = comptime!(ident.into_stage());
@@ -175,9 +175,9 @@ impl<IP: InputPrecision, G: GlobalConfig> TmaLoader<IP, G> {
 
 #[cube]
 /// Barrier for TMA
-pub fn arrive_tma<E: CubePrimitive>(barrier: &Barrier<E>, #[comptime] num_elems: u32) {
+pub fn arrive_tma(barrier: &Barrier, #[comptime] num_bytes: u32) {
     if UNIT_POS == 0 {
-        barrier.arrive_tx(1, num_elems * E::elem_size());
+        barrier.arrive_tx(1, num_bytes);
     } else {
         barrier.arrive();
     }

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cooperative.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cooperative.rs
@@ -59,7 +59,7 @@ pub struct AsyncFullCooperativeJob {
 
 #[cube]
 impl<IP: InputPrecision> AsyncLoadingJob<IP, StridedTilingLayout> for AsyncFullCooperativeJob {
-    fn execute_task<CM: CopyMechanism<IP::Stage>, G: GlobalConfig>(
+    fn execute_task<CM: CopyMechanism, G: GlobalConfig>(
         this: &mut Self,
         task_id: u32,
         tensor_reader: &TensorReader<IP::Global>,

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_cyclic.rs
@@ -109,7 +109,7 @@ pub struct AsyncFullCyclicJob {
 impl<IP: InputPrecision, TO: TilingOrder> AsyncLoadingJob<IP, ContiguousTilingLayout<TO>>
     for AsyncFullCyclicJob
 {
-    fn execute_task<CM: CopyMechanism<IP::Stage>, G: GlobalConfig>(
+    fn execute_task<CM: CopyMechanism, G: GlobalConfig>(
         this: &mut Self,
         task_id: u32,
         tensor_reader: &TensorReader<IP::Global>,

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_slice_length.rs
@@ -72,7 +72,7 @@ pub struct AsynFullMaximizeSliceLengthJob {
 impl<IP: InputPrecision> AsyncLoadingJob<IP, StridedTilingLayout>
     for AsynFullMaximizeSliceLengthJob
 {
-    fn execute_task<CM: CopyMechanism<IP::Stage>, G: GlobalConfig>(
+    fn execute_task<CM: CopyMechanism, G: GlobalConfig>(
         this: &mut Self,
         task_id: u32,
         tensor_reader: &TensorReader<IP::Global>,
@@ -112,7 +112,7 @@ impl<IP: InputPrecision> AsyncLoadingJob<IP, StridedTilingLayout>
 }
 
 #[cube]
-fn load_nth_slice<EG: Numeric, ES: Numeric, CM: CopyMechanism<ES>, G: GlobalConfig>(
+fn load_nth_slice<EG: Numeric, ES: Numeric, CM: CopyMechanism, G: GlobalConfig>(
     nth_slice: u32,
     tensor_reader: &TensorReader<EG>,
     stage: &mut StageMemory<ES, StridedTilingLayout>,

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_full_maximize_unit_count.rs
@@ -109,7 +109,7 @@ pub struct AsyncFullMaximizeUnitCountJob {
 impl<IP: InputPrecision> AsyncLoadingJob<IP, StridedTilingLayout>
     for AsyncFullMaximizeUnitCountJob
 {
-    fn execute_task<CM: CopyMechanism<IP::Stage>, G: GlobalConfig>(
+    fn execute_task<CM: CopyMechanism, G: GlobalConfig>(
         this: &mut Self,
         _task_id: u32,
         tensor_reader: &TensorReader<IP::Global>,

--- a/crates/cubecl-matmul/src/components/global/load/strategy/async_partial_maximize_slice_length.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/async_partial_maximize_slice_length.rs
@@ -111,7 +111,7 @@ pub struct AsyncPartialMaximizeSliceLengthJob {
 impl<IP: InputPrecision> AsyncLoadingJob<IP, StridedTilingLayout>
     for AsyncPartialMaximizeSliceLengthJob
 {
-    fn execute_task<CM: CopyMechanism<IP::Stage>, G: GlobalConfig>(
+    fn execute_task<CM: CopyMechanism, G: GlobalConfig>(
         this: &mut Self,
         task_id: u32,
         tensor_reader: &TensorReader<IP::Global>,

--- a/crates/cubecl-matmul/src/components/global/load/strategy/base.rs
+++ b/crates/cubecl-matmul/src/components/global/load/strategy/base.rs
@@ -33,7 +33,7 @@ pub trait LoadingJob<IP: InputPrecision, TL: TilingLayout>: CubeType + Copy + Cl
 /// By calling execute_task at strategic moments, one can hope to speed up the matmul.
 pub trait AsyncLoadingJob<IP: InputPrecision, TL: TilingLayout>: CubeType + Copy + Clone {
     /// Execute the `task_id`th loading task
-    fn execute_task<CM: CopyMechanism<IP::Stage>, G: GlobalConfig>(
+    fn execute_task<CM: CopyMechanism, G: GlobalConfig>(
         this: &mut Self,
         task_id: u32,
         tensor_reader: &TensorReader<IP::Global>,

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/matmul.rs
@@ -54,27 +54,30 @@ where
         let k_step = config.k_step;
         let range = k_range.1 - k_range.0;
         let num_loops = (range + k_step - 1) / k_step;
-        let num_elems_lhs = config.tiling_scheme().elements_in_stage_mk();
-        let num_elems_rhs = config.tiling_scheme().elements_in_stage_nk();
+
+        let lhs_elem_size = LhsS::<MP>::elem_size();
+        let rhs_elem_size = RhsS::<MP>::elem_size();
+        let num_bytes_lhs =
+            comptime!(config.tiling_scheme().elements_in_stage_mk() * lhs_elem_size);
+        let num_bytes_rhs =
+            comptime!(config.tiling_scheme().elements_in_stage_nk() * rhs_elem_size);
+        let num_bytes_stages = num_bytes_lhs + num_bytes_rhs;
 
         let (mut lhs_tile, mut rhs_tile) = SMM::init_tile_inputs(config.stage_config());
         SMM::zero_accumulator(acc, config.stage_config());
 
-        let barrier_lhs = Barrier::<LhsS<MP>>::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
-        let barrier_rhs = Barrier::<RhsS<MP>>::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
+        let barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
 
         for _ in 0..num_loops {
             sync_cube();
 
             // Start loading
-            Self::LhsLoader::fill_stage(&mut lhs_loader, &barrier_lhs, config);
-            Self::RhsLoader::fill_stage(&mut rhs_loader, &barrier_rhs, config);
+            Self::LhsLoader::fill_stage(&mut lhs_loader, &barrier, config);
+            Self::RhsLoader::fill_stage(&mut rhs_loader, &barrier, config);
 
-            arrive_tma::<LhsS<MP>>(&barrier_lhs, num_elems_lhs);
-            arrive_tma::<RhsS<MP>>(&barrier_rhs, num_elems_rhs);
+            arrive_tma(&barrier, num_bytes_stages);
 
-            barrier_lhs.wait();
-            barrier_rhs.wait();
+            barrier.wait();
 
             let lhs_stage_reader = &Self::LhsLoader::reader(&lhs_loader);
             let rhs_stage_reader = &Self::RhsLoader::reader(&rhs_loader);


### PR DESCRIPTION
All tests pass, including the TMA loaders with now-combined barriers.

Fixes https://github.com/tracel-ai/cubecl/issues/825