### PR TITLE
fix: Fix `TensorHandle::zeros` OOB

### DIFF
--- a/crates/cubecl-core/src/frontend/container/array/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/array/launch.rs
@@ -84,7 +84,7 @@ impl<'a, R: Runtime> ArrayArg<'a, R> {
     pub unsafe fn from_raw_parts<E: CubePrimitive>(
         handle: &'a cubecl_runtime::server::Handle,
         length: usize,
-        vectorization_factor: u8,
+        line_size: u8,
     ) -> Self {
         unsafe {
             ArrayArg::Handle {
@@ -93,7 +93,7 @@ impl<'a, R: Runtime> ArrayArg<'a, R> {
                     length,
                     E::size().expect("Element should have a size"),
                 ),
-                line_size: vectorization_factor,
+                line_size,
             }
         }
     }
@@ -106,13 +106,13 @@ impl<'a, R: Runtime> ArrayArg<'a, R> {
     pub unsafe fn from_raw_parts_and_size(
         handle: &'a cubecl_runtime::server::Handle,
         length: usize,
-        vectorization_factor: u8,
+        line_size: u8,
         elem_size: usize,
     ) -> Self {
         unsafe {
             ArrayArg::Handle {
                 handle: ArrayHandleRef::from_raw_parts(handle, length, elem_size),
-                line_size: vectorization_factor,
+                line_size,
             }
         }
     }

--- a/crates/cubecl-std/src/tensor/handle.rs
+++ b/crates/cubecl-std/src/tensor/handle.rs
@@ -168,18 +168,14 @@ where
         let cube_dim = CubeDim::default();
         let cube_count =
             calculate_cube_count_elemwise(num_elements / vectorization_factor as usize, cube_dim);
-        let array_len = output.handle.size();
+        let array_len = output.handle.size() as usize / size_of::<E>();
 
         unsafe {
             init::zeros_array::launch_unchecked::<E, R>(
                 client,
                 cube_count,
                 cube_dim,
-                ArrayArg::from_raw_parts::<E>(
-                    &output.handle,
-                    array_len as usize,
-                    vectorization_factor,
-                ),
+                ArrayArg::from_raw_parts::<E>(&output.handle, array_len, vectorization_factor),
             )
         };
 
@@ -192,9 +188,9 @@ pub(crate) mod init {
     use cubecl_core as cubecl;
 
     #[cube(launch_unchecked)]
-    pub fn zeros_array<C: Numeric>(output: &mut Array<C>) {
+    pub fn zeros_array<C: Numeric>(output: &mut Array<Line<C>>) {
         if ABSOLUTE_POS < output.len() {
-            output[ABSOLUTE_POS] = C::from_int(0);
+            output[ABSOLUTE_POS] = Line::cast_from(C::from_int(0));
         }
     }
 }

--- a/crates/cubecl-std/src/tensor/handle.rs
+++ b/crates/cubecl-std/src/tensor/handle.rs
@@ -158,7 +158,7 @@ where
         let rank = shape.len();
         let output = Self::empty(client, shape);
 
-        let vectorization_factor = tensor_line_size_parallel(
+        let line_size = tensor_line_size_parallel(
             R::supported_line_sizes().iter().cloned(),
             &output.shape,
             &output.strides,
@@ -166,8 +166,7 @@ where
         );
 
         let cube_dim = CubeDim::default();
-        let cube_count =
-            calculate_cube_count_elemwise(num_elements / vectorization_factor as usize, cube_dim);
+        let cube_count = calculate_cube_count_elemwise(num_elements / line_size as usize, cube_dim);
         let array_len = output.handle.size() as usize / size_of::<E>();
 
         unsafe {
@@ -175,7 +174,7 @@ where
                 client,
                 cube_count,
                 cube_dim,
-                ArrayArg::from_raw_parts::<E>(&output.handle, array_len, vectorization_factor),
+                ArrayArg::from_raw_parts::<E>(&output.handle, array_len, line_size),
             )
         };
 


### PR DESCRIPTION
Fixes OOB caused by an incorrect array length in the zeros kernel