### PR TITLE
chore: Merge visibility marker types for `VirtualTensor` with the one…

### DIFF
--- a/crates/cubecl-attention/src/components/batch/base.rs
+++ b/crates/cubecl-attention/src/components/batch/base.rs
@@ -1,6 +1,6 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::{tensor::r#virtual::ReadWrite, tensor::r#virtual::VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 use crate::components::{
     AttentionLineSizes, AttentionPrecision, AttentionProblem, AttentionSelection,

--- a/crates/cubecl-attention/src/components/batch/dummy/attention.rs
+++ b/crates/cubecl-attention/src/components/batch/dummy/attention.rs
@@ -1,6 +1,6 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 use std::marker::PhantomData;
 
 use crate::components::{

--- a/crates/cubecl-attention/src/components/batch/entry_point.rs
+++ b/crates/cubecl-attention/src/components/batch/entry_point.rs
@@ -7,7 +7,7 @@ use crate::components::batch::CubeCountInput;
 use crate::components::batch::base::BatchAttention;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 type Input<Args, EI> = <Args as AttentionArgs>::Input<EI>;
 type Output<Args, EO> = <Args as AttentionArgs>::Output<EO>;

--- a/crates/cubecl-attention/src/components/global/base.rs
+++ b/crates/cubecl-attention/src/components/global/base.rs
@@ -1,7 +1,7 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_matmul::components::{global::memory::GlobalMemoryConfig, stage::StageMemoryConfig};
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 use crate::components::{
     AttentionLineSizes, AttentionPrecision, AttentionProblem, AttentionSelection,

--- a/crates/cubecl-attention/src/components/global/dummy/attention.rs
+++ b/crates/cubecl-attention/src/components/global/dummy/attention.rs
@@ -2,7 +2,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_matmul::components::global::memory::SimpleGlobalLayout;
 use cubecl_matmul::components::stage::FullStageToTileReader;
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 use std::marker::PhantomData;
 
 use crate::components::FlashIdent;

--- a/crates/cubecl-attention/src/components/stage/base.rs
+++ b/crates/cubecl-attention/src/components/stage/base.rs
@@ -1,7 +1,7 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_matmul::components::stage::{ReaderFamily, StageMemoryConfig};
-use cubecl_std::tensor::{View, layout::Coords3d, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, layout::Coords3d, };
 use std::{fmt::Debug, hash::Hash};
 
 use crate::components::{

--- a/crates/cubecl-attention/src/components/stage/base.rs
+++ b/crates/cubecl-attention/src/components/stage/base.rs
@@ -1,7 +1,7 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 use cubecl_matmul::components::stage::{ReaderFamily, StageMemoryConfig};
-use cubecl_std::tensor::{View, layout::Coords3d, };
+use cubecl_std::tensor::{View, layout::Coords3d};
 use std::{fmt::Debug, hash::Hash};
 
 use crate::components::{

--- a/crates/cubecl-attention/src/components/stage/dummy/attention.rs
+++ b/crates/cubecl-attention/src/components/stage/dummy/attention.rs
@@ -3,7 +3,6 @@ use cubecl_core::prelude::*;
 use cubecl_matmul::components::stage::StageToTileReader;
 use cubecl_std::tensor::View;
 use cubecl_std::tensor::layout::Coords3d;
-use cubecl_std::tensor::r#virtual::ReadWrite;
 use std::marker::PhantomData;
 
 use crate::components::global::dummy::QueryRegisterReader;

--- a/crates/cubecl-attention/src/components/tile/base.rs
+++ b/crates/cubecl-attention/src/components/tile/base.rs
@@ -4,7 +4,7 @@ use cubecl_matmul::components::{
     stage::{ContiguousTilingLayout, RowMajorTilingOrder},
     tile::Tile,
 };
-use cubecl_std::tensor::{View, layout::Coords3d, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, layout::Coords3d, };
 
 use crate::components::global::dummy::QueryRegisterReader;
 use crate::components::{

--- a/crates/cubecl-attention/src/components/tile/base.rs
+++ b/crates/cubecl-attention/src/components/tile/base.rs
@@ -4,7 +4,7 @@ use cubecl_matmul::components::{
     stage::{ContiguousTilingLayout, RowMajorTilingOrder},
     tile::Tile,
 };
-use cubecl_std::tensor::{View, layout::Coords3d, };
+use cubecl_std::tensor::{View, layout::Coords3d};
 
 use crate::components::global::dummy::QueryRegisterReader;
 use crate::components::{

--- a/crates/cubecl-attention/src/components/tile/dummy/attention.rs
+++ b/crates/cubecl-attention/src/components/tile/dummy/attention.rs
@@ -3,7 +3,6 @@ use cubecl_core::prelude::*;
 use cubecl_matmul::components::tile::Tile;
 use cubecl_std::tensor::View;
 use cubecl_std::tensor::layout::Coords3d;
-use cubecl_std::tensor::r#virtual::ReadWrite;
 use std::marker::PhantomData;
 
 use crate::components::global::dummy::QueryRegisterReader;

--- a/crates/cubecl-attention/src/components/tile/dummy/writer.rs
+++ b/crates/cubecl-attention/src/components/tile/dummy/writer.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 use cubecl_matmul::components::{global::memory::TensorWriter, stage::StageMemoryConfig as _};
 use cubecl_std::{
     div_ceil,
-    tensor::{View, layout::Coords3d, r#virtual::ReadWrite},
+    tensor::{View, layout::Coords3d, },
 };
 
 use crate::components::{FlashIdent, global::GlobalAttentionConfig};

--- a/crates/cubecl-attention/src/components/tile/dummy/writer.rs
+++ b/crates/cubecl-attention/src/components/tile/dummy/writer.rs
@@ -3,7 +3,7 @@ use cubecl_core::prelude::*;
 use cubecl_matmul::components::{global::memory::TensorWriter, stage::StageMemoryConfig as _};
 use cubecl_std::{
     div_ceil,
-    tensor::{View, layout::Coords3d, },
+    tensor::{View, layout::Coords3d},
 };
 
 use crate::components::{FlashIdent, global::GlobalAttentionConfig};

--- a/crates/cubecl-convolution/src/components/global/base.rs
+++ b/crates/cubecl-convolution/src/components/global/base.rs
@@ -6,10 +6,7 @@ use cubecl_matmul::components::{
     global::{AccumulatorLoader, GlobalWriter},
     stage::{ContiguousTilingLayout, RowMajorTilingOrder},
 };
-use cubecl_std::{
-    CubeOption,
-    tensor::r#virtual::{ReadWrite, VirtualTensor},
-};
+use cubecl_std::{CubeOption, tensor::r#virtual::VirtualTensor};
 
 use crate::{
     components::{ConvGemmConfig, ConvolutionProblem, global::entry_point::ConvolutionLaunch},

--- a/crates/cubecl-convolution/src/components/global/entry_point.rs
+++ b/crates/cubecl-convolution/src/components/global/entry_point.rs
@@ -9,8 +9,7 @@ use cubecl_matmul::components::{
     },
 };
 use cubecl_std::{
-    CubeOption, CubeOptionExpand, FastDivmod, FastDivmodArgs,
-    tensor::r#virtual::{ReadWrite, VirtualTensor},
+    CubeOption, CubeOptionExpand, FastDivmod, FastDivmodArgs, tensor::r#virtual::VirtualTensor,
 };
 
 use crate::{

--- a/crates/cubecl-convolution/src/components/global/layout/write.rs
+++ b/crates/cubecl-convolution/src/components/global/layout/write.rs
@@ -5,7 +5,7 @@ use cubecl_std::{
     FastDivmod,
     tensor::{
         layout::{Coords3d, Layout},
-        r#virtual::{ReadWrite, VirtualTensor},
+        r#virtual::VirtualTensor,
     },
 };
 

--- a/crates/cubecl-convolution/src/components/global/multi_stage/tma/convolution.rs
+++ b/crates/cubecl-convolution/src/components/global/multi_stage/tma/convolution.rs
@@ -14,10 +14,7 @@ use cubecl_matmul::components::{
 };
 use cubecl_std::{
     CubeOption,
-    tensor::{
-        layout::Coords3d,
-        r#virtual::{ReadWrite, VirtualTensor},
-    },
+    tensor::{layout::Coords3d, r#virtual::VirtualTensor},
 };
 
 use crate::{

--- a/crates/cubecl-convolution/src/components/global/single_stage/simple/convolution.rs
+++ b/crates/cubecl-convolution/src/components/global/single_stage/simple/convolution.rs
@@ -13,10 +13,7 @@ use cubecl_matmul::components::{
 };
 use cubecl_std::{
     CubeOption,
-    tensor::{
-        layout::Coords3d,
-        r#virtual::{ReadWrite, VirtualTensor},
-    },
+    tensor::{layout::Coords3d, r#virtual::VirtualTensor},
 };
 
 use crate::{

--- a/crates/cubecl-convolution/src/components/global/single_stage/tma/convolution.rs
+++ b/crates/cubecl-convolution/src/components/global/single_stage/tma/convolution.rs
@@ -14,10 +14,7 @@ use cubecl_matmul::components::{
 };
 use cubecl_std::{
     CubeOption,
-    tensor::{
-        layout::Coords3d,
-        r#virtual::{ReadWrite, VirtualTensor},
-    },
+    tensor::{layout::Coords3d, r#virtual::VirtualTensor},
 };
 
 use crate::{

--- a/crates/cubecl-matmul/src/components/batch/base.rs
+++ b/crates/cubecl-matmul/src/components/batch/base.rs
@@ -7,7 +7,7 @@ use crate::components::{
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 use std::{fmt::Debug, hash::Hash};
 
 /// A family of [matmuls](BatchMatmul) working with any [precision](MatmulPrecision).

--- a/crates/cubecl-matmul/src/components/batch/entry_point.rs
+++ b/crates/cubecl-matmul/src/components/batch/entry_point.rs
@@ -7,7 +7,7 @@ use crate::components::{
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 type Input<Args, Lhs, Rhs, EO> = <Args as MatmulArgs>::Input<Lhs, Rhs, EO>;
 type Output<Args, EO> = <Args as MatmulArgs>::Output<EO>;

--- a/crates/cubecl-matmul/src/components/batch/partitioned_matmul/matmul.rs
+++ b/crates/cubecl-matmul/src/components/batch/partitioned_matmul/matmul.rs
@@ -9,7 +9,7 @@ use crate::components::global::{self, GlobalMatmul};
 use crate::components::{LhsG, MatmulPrecision, RhsG};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 /// Executes matrix multiplication at the batch level,
 /// assigning each cube to handle multiple global matmuls.

--- a/crates/cubecl-matmul/src/components/batch/partitioned_matmul/partition/matmul.rs
+++ b/crates/cubecl-matmul/src/components/batch/partitioned_matmul/partition/matmul.rs
@@ -2,7 +2,7 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 use crate::components::{LhsG, MatmulPrecision, RhsG, global};
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 #[derive(CubeType)]
 /// Area of a tensor a cube is responsible of performing matmul

--- a/crates/cubecl-matmul/src/components/global/base.rs
+++ b/crates/cubecl-matmul/src/components/global/base.rs
@@ -11,7 +11,7 @@ use crate::components::{
     stage::StageConfig,
 };
 use crate::components::{LhsG, MatmulIdent, MatmulLineSizes, MatmulSelection, RhsG};
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 use std::{fmt::Debug, hash::Hash};
 
 use super::{GlobalWriter, load::LoaderMode};

--- a/crates/cubecl-matmul/src/components/global/memory/writer.rs
+++ b/crates/cubecl-matmul/src/components/global/memory/writer.rs
@@ -1,7 +1,7 @@
 use crate::components::global::memory::GlobalMemoryConfig;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{View, layout::Coords3d, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, layout::Coords3d, };
 
 #[derive(CubeType)]
 /// A view of a tensor that starts reading data from a specified offset.

--- a/crates/cubecl-matmul/src/components/global/memory/writer.rs
+++ b/crates/cubecl-matmul/src/components/global/memory/writer.rs
@@ -1,7 +1,7 @@
 use crate::components::global::memory::GlobalMemoryConfig;
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{View, layout::Coords3d, };
+use cubecl_std::tensor::{View, layout::Coords3d};
 
 #[derive(CubeType)]
 /// A view of a tensor that starts reading data from a specified offset.

--- a/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/double_buffering/matmul.rs
@@ -10,7 +10,7 @@ use crate::components::{LhsG, LhsS, MatmulIdent, RhsG, RhsS, global};
 use crate::components::{MatmulPrecision, stage};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 use cubecl_std::{div_ceil, tensor::layout::Coords3d};
 use std::marker::PhantomData;
 

--- a/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/multi_stage/ordered/matmul.rs
@@ -13,7 +13,7 @@ use crate::components::stage::PartialStageToTileReader;
 use crate::components::{LhsG, LhsS, MatmulIdent, MatmulPrecision, RhsG, RhsS, stage};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::{ReadWrite, VirtualTensor};
+use cubecl_std::tensor::r#virtual::VirtualTensor;
 use cubecl_std::{div_ceil, tensor::layout::Coords3d};
 use std::marker::PhantomData;
 

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/matmul.rs
@@ -19,7 +19,7 @@ use barrier::Barrier;
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
 use cubecl_std::tensor::r#virtual::VirtualTensor;
-use cubecl_std::tensor::{layout::Coords3d, r#virtual::ReadWrite};
+use cubecl_std::tensor::{layout::Coords3d, };
 
 /// Performs matrix multiplication at the global level
 /// Similar to simple matmul but using asynchronous loading

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/matmul.rs
@@ -18,8 +18,8 @@ use crate::components::stage::StageMatmul;
 use barrier::Barrier;
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
+use cubecl_std::tensor::layout::Coords3d;
 use cubecl_std::tensor::r#virtual::VirtualTensor;
-use cubecl_std::tensor::{layout::Coords3d, };
 
 /// Performs matrix multiplication at the global level
 /// Similar to simple matmul but using asynchronous loading

--- a/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/simple/matmul.rs
@@ -10,10 +10,7 @@ use crate::components::{
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{
-    layout::Coords3d,
-    r#virtual::{ReadWrite, VirtualTensor},
-};
+use cubecl_std::tensor::{layout::Coords3d, r#virtual::VirtualTensor};
 use std::marker::PhantomData;
 
 use crate::components::global::GlobalConfig;

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/matmul.rs
@@ -14,8 +14,8 @@ use crate::components::{LhsG, global::memory::SimpleGlobalLayout};
 use barrier::Barrier;
 use cubecl_core::prelude::{barrier::BarrierLevel, *};
 use cubecl_core::{self as cubecl};
+use cubecl_std::tensor::layout::Coords3d;
 use cubecl_std::tensor::r#virtual::VirtualTensor;
-use cubecl_std::tensor::{layout::Coords3d, };
 use std::marker::PhantomData;
 
 use crate::components::global::GlobalConfig;

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/matmul.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/matmul.rs
@@ -15,7 +15,7 @@ use barrier::Barrier;
 use cubecl_core::prelude::{barrier::BarrierLevel, *};
 use cubecl_core::{self as cubecl};
 use cubecl_std::tensor::r#virtual::VirtualTensor;
-use cubecl_std::tensor::{layout::Coords3d, r#virtual::ReadWrite};
+use cubecl_std::tensor::{layout::Coords3d, };
 use std::marker::PhantomData;
 
 use crate::components::global::GlobalConfig;

--- a/crates/cubecl-matmul/src/components/global/write/plane.rs
+++ b/crates/cubecl-matmul/src/components/global/write/plane.rs
@@ -5,7 +5,7 @@ use crate::components::{
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{View, };
+use cubecl_std::tensor::View;
 use cubecl_std::{div_ceil, tensor::layout::Coords3d};
 
 use super::GlobalWriter;

--- a/crates/cubecl-matmul/src/components/global/write/plane.rs
+++ b/crates/cubecl-matmul/src/components/global/write/plane.rs
@@ -5,7 +5,7 @@ use crate::components::{
 };
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{View, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, };
 use cubecl_std::{div_ceil, tensor::layout::Coords3d};
 
 use super::GlobalWriter;

--- a/crates/cubecl-matmul/src/components/global/write/unit.rs
+++ b/crates/cubecl-matmul/src/components/global/write/unit.rs
@@ -2,7 +2,7 @@ use crate::components::global::memory::TensorWriter;
 use crate::components::{MatmulIdent, global::GlobalConfig};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{View, layout::Coords3d, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, layout::Coords3d, };
 
 use super::GlobalWriter;
 

--- a/crates/cubecl-matmul/src/components/global/write/unit.rs
+++ b/crates/cubecl-matmul/src/components/global/write/unit.rs
@@ -2,7 +2,7 @@ use crate::components::global::memory::TensorWriter;
 use crate::components::{MatmulIdent, global::GlobalConfig};
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{View, layout::Coords3d, };
+use cubecl_std::tensor::{View, layout::Coords3d};
 
 use super::GlobalWriter;
 

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -1,6 +1,6 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{View, layout::Coordinates, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, layout::Coordinates, };
 
 use crate::components::error::MatmulSetupError;
 use crate::components::global::MaxLoaderPlanes;

--- a/crates/cubecl-matmul/src/components/stage/base.rs
+++ b/crates/cubecl-matmul/src/components/stage/base.rs
@@ -1,6 +1,6 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::{View, layout::Coordinates, };
+use cubecl_std::tensor::{View, layout::Coordinates};
 
 use crate::components::error::MatmulSetupError;
 use crate::components::global::MaxLoaderPlanes;

--- a/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
@@ -16,7 +16,7 @@ use crate::components::tile::TileMatmul;
 use core::marker::PhantomData;
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_std::tensor::{View, layout::Coordinates, };
+use cubecl_std::tensor::{View, layout::Coordinates};
 
 #[cube]
 /// Defines how the stage is partitioned among compute primitives (e.g., units or planes).

--- a/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
@@ -16,7 +16,7 @@ use crate::components::tile::TileMatmul;
 use core::marker::PhantomData;
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_std::tensor::{View, layout::Coordinates, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, layout::Coordinates, };
 
 #[cube]
 /// Defines how the stage is partitioned among compute primitives (e.g., units or planes).

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/matmul.rs
@@ -9,7 +9,7 @@ use crate::components::stage::matmul::plane_partitioned::PlanePartitionedStageCo
 use crate::components::tile::TileMatmul;
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_std::tensor::{View, layout::Coords3d, };
+use cubecl_std::tensor::{View, layout::Coords3d};
 
 #[allow(type_alias_bounds)]
 /// [PartitionedStageMatmul] partitioned across units

--- a/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/plane_partitioned/matmul.rs
@@ -9,7 +9,7 @@ use crate::components::stage::matmul::plane_partitioned::PlanePartitionedStageCo
 use crate::components::tile::TileMatmul;
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_std::tensor::{View, layout::Coords3d, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, layout::Coords3d, };
 
 #[allow(type_alias_bounds)]
 /// [PartitionedStageMatmul] partitioned across units

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/matmul.rs
@@ -9,7 +9,7 @@ use crate::components::stage::matmul::unit_partitioned::UnitPartitionedStageConf
 use crate::components::tile::TileMatmul;
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_std::tensor::{View, layout::Coords3d, r#virtual::ReadWrite};
+use cubecl_std::tensor::{View, layout::Coords3d, };
 
 #[allow(type_alias_bounds)]
 /// [PartitionedStageMatmul] partitioned across units

--- a/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/unit_partitioned/matmul.rs
@@ -9,7 +9,7 @@ use crate::components::stage::matmul::unit_partitioned::UnitPartitionedStageConf
 use crate::components::tile::TileMatmul;
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_std::tensor::{View, layout::Coords3d, };
+use cubecl_std::tensor::{View, layout::Coords3d};
 
 #[allow(type_alias_bounds)]
 /// [PartitionedStageMatmul] partitioned across units

--- a/crates/cubecl-quant/src/dequantize.rs
+++ b/crates/cubecl-quant/src/dequantize.rs
@@ -10,7 +10,6 @@ use crate::{
 use cubecl_std::tensor::{
     View,
     layout::linear::{LinearView, linear_view},
-    r#virtual::ReadWrite,
 };
 use half::{bf16, f16};
 

--- a/crates/cubecl-quant/src/quantize.rs
+++ b/crates/cubecl-quant/src/quantize.rs
@@ -2,8 +2,8 @@ use cubecl::calculate_cube_count_elemwise;
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
 use cubecl_core::tensor_line_size_parallel;
+use cubecl_std::tensor::layout::linear::LinearView;
 use cubecl_std::tensor::{View, into_contiguous, layout::linear::linear_view};
-use cubecl_std::tensor::{layout::linear::LinearView, r#virtual::ReadWrite};
 
 use crate::scheme::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue};
 use crate::utils::check_block_size_compat;

--- a/crates/cubecl-random/src/base.rs
+++ b/crates/cubecl-random/src/base.rs
@@ -8,7 +8,6 @@ use cubecl_std::tensor::{
         Coords1d,
         linear::{LinearView, linear_view},
     },
-    r#virtual::ReadWrite,
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
 

--- a/crates/cubecl-random/src/bernoulli.rs
+++ b/crates/cubecl-random/src/bernoulli.rs
@@ -4,7 +4,7 @@ use cubecl::prelude::*;
 use cubecl_core as cubecl;
 
 use cubecl::{CubeLaunch, CubeType, Runtime};
-use cubecl_std::tensor::{View, r#virtual::ReadWrite};
+use cubecl_std::tensor::View;
 
 use crate::RandomFamily;
 

--- a/crates/cubecl-random/src/normal.rs
+++ b/crates/cubecl-random/src/normal.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_std::tensor::{View, r#virtual::ReadWrite};
+use cubecl_std::tensor::View;
 use std::f32::consts::PI;
 
 use super::{PrngArgs, PrngRuntime, random};

--- a/crates/cubecl-random/src/uniform.rs
+++ b/crates/cubecl-random/src/uniform.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_std::tensor::{View, r#virtual::ReadWrite};
+use cubecl_std::tensor::View;
 
 use crate::{
     RandomFamily, lcg_step, taus_step_0, taus_step_1, taus_step_2, to_unit_interval_closed_open,

--- a/crates/cubecl-reduce/src/args.rs
+++ b/crates/cubecl-reduce/src/args.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, unexpanded};
 use cubecl_std::tensor::r#virtual::{
-    ReadWrite, VirtualTensor, VirtualTensorOperations, VirtualTensorOperationsExpand,
+    VirtualTensor, VirtualTensorOperations, VirtualTensorOperationsExpand,
 };
 
 pub trait ReduceDType {

--- a/crates/cubecl-reduce/src/launch.rs
+++ b/crates/cubecl-reduce/src/launch.rs
@@ -1,6 +1,5 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::ReadWrite;
 use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 use crate::BoundChecksInner;

--- a/crates/cubecl-reduce/src/primitives.rs
+++ b/crates/cubecl-reduce/src/primitives.rs
@@ -1,6 +1,5 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
-use cubecl_std::tensor::r#virtual::ReadWrite;
 use cubecl_std::tensor::r#virtual::VirtualTensor;
 
 use crate::BoundChecksInner;

--- a/crates/cubecl-std/src/tensor/layout/linear.rs
+++ b/crates/cubecl-std/src/tensor/layout/linear.rs
@@ -10,7 +10,6 @@ use crate::tensor::{
         strided::{StridedLayout, StridedLayoutLaunch},
         virtual_layout,
     },
-    r#virtual::Read,
 };
 
 /// Maps a linear index based on line count to a potentially strided tensor. Only applies the
@@ -99,7 +98,7 @@ virtual_layout!(LinearLayout, LinearLayoutExpand);
 
 /// [TensorView] with a linear layout inferred from the shape/strides at launch.
 /// Useful for elementwise kernels.
-pub type LinearView<E, IO = Read> = TypedView<E, LinearLayout, IO>;
+pub type LinearView<E, IO = ReadOnly> = TypedView<E, LinearLayout, IO>;
 /// Launch type for [LinearTensorView].
 pub type LinearViewLaunch<'a, R> = TypedViewLaunch<'a, LinearLayout, R>;
 

--- a/crates/cubecl-std/src/tensor/virtual.rs
+++ b/crates/cubecl-std/src/tensor/virtual.rs
@@ -8,17 +8,9 @@ use crate::tensor::{
     view::View,
 };
 
-/// The read tag for [virtual tensor](VirtualTensor).
-#[derive(Clone)]
-pub struct Read;
-
-/// The read write tag for [virtual tensor](VirtualTensor).
-#[derive(Clone)]
-pub struct ReadWrite;
-
 /// Tensor representation that is decoupled from how the tensor is stored.
 #[derive(Clone)]
-pub struct VirtualTensor<E: Numeric, IO = Read> {
+pub struct VirtualTensor<E: Numeric, IO = ReadOnly> {
     // state: Arc<dyn VirtualTensorOperations<E>>,
     _e: PhantomData<E>,
     _p: PhantomData<IO>,
@@ -244,7 +236,7 @@ impl<E: Numeric, IO: Clone> VirtualTensorExpand<E, IO> {
 impl<E: Numeric, IO: Clone + 'static> VirtualTensor<E, IO> {
     /// Create a conceptual view over this tensor, allowing for multi-dimensional indexing with custom
     /// layouts
-    pub fn view<C: Coordinates>(&self, layout: VirtualLayout<C>) -> View<E, C, Read> {
+    pub fn view<C: Coordinates>(&self, layout: VirtualLayout<C>) -> View<E, C, ReadOnly> {
         View::new::<VirtualTensor<E, IO>>(*self, layout)
     }
 }
@@ -311,14 +303,14 @@ impl<E: Numeric> SliceMutOperatorExpand<Line<E>> for VirtualTensorExpand<E, Read
     }
 }
 
-impl<E: Numeric> VirtualTensor<E, Read> {
+impl<E: Numeric> VirtualTensor<E, ReadOnly> {
     /// Create a new [read only](Read) [virtual tensor](VirtualTensor).
     pub fn new<V: VirtualTensorOperations<E> + 'static>(_v: &V) -> Self {
         unexpanded!()
     }
 
     /// Expand function of [Self::new].
-    pub fn __expand_new<V>(_scope: &mut Scope, v: V::ExpandType) -> VirtualTensorExpand<E, Read>
+    pub fn __expand_new<V>(_scope: &mut Scope, v: V::ExpandType) -> VirtualTensorExpand<E, ReadOnly>
     where
         V::ExpandType: VirtualTensorOperationsExpand<E>,
         V: VirtualTensorOperations<E> + CubeType + 'static,


### PR DESCRIPTION
Removes the pointless duplication between `VirtualTensor`'s `Read` and `ReadWrite`, and the slice `ReadOnly` and `ReadWrite` types in core.