### PR TITLE
fix: Fix CUDA version selection with a simple build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ env:
   MESA_VERSION: "23.3.1"
   # Corresponds to https://github.com/gfx-rs/ci-build/releases
   MESA_CI_BINARY_BUILD: "build18"
+  # Override cudarc version since it can't be detected on CI. Should correspond to highest feature
+  # set supported by CubeCL
+  CUDARC_CUDA_VERSION: "12080"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,15 @@ futures-lite = { version = "2.3.0", default-features = false }
 # CubeCL-CPU
 sysinfo = "0.36.1"
 
+# CubeCL-CUDA
+cudarc = { version = "0.17.2", features = [
+    "std",
+    "driver",
+    "cuda-version-from-build-system",
+    "dynamic-loading",
+], default-features = false }
+
+
 [profile.dev]
 debug = 0     # Speed up compilation time and not necessary.
 opt-level = 0

--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -17,13 +17,12 @@ default = [
     "cubecl-runtime/default",
     "cubecl-common/default",
     "cubecl-core/default",
-    "cudarc/cuda-12050",
     "cudarc/dynamic-loading",
 ]
 ptx-wmma = []
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 
-cuda-12080 = ["cudarc/cuda-12080"]
+cuda-12080 = []
 
 conv_tests = ["cubecl-convolution/conv_tests"]
 matmul_tests_all = [
@@ -70,13 +69,13 @@ matmul_tests_partition_buffering = [
     "cubecl-matmul/matmul_tests_partition_buffering",
 ]
 matmul_tests_plane = ["cubecl-matmul/matmul_tests_plane"]
-matmul_tests_vecmat = ["cubecl-matmul/matmul_tests_vecmat"]
 matmul_tests_simple = ["cubecl-matmul/matmul_tests_simple"]
 matmul_tests_specialized = ["cubecl-matmul/matmul_tests_specialized"]
 matmul_tests_strided = ["cubecl-matmul/matmul_tests_strided"]
 matmul_tests_tilewise = ["cubecl-matmul/matmul_tests_tilewise"]
 matmul_tests_tma = ["cubecl-matmul/matmul_tests_tma"]
 matmul_tests_unit = ["cubecl-matmul/matmul_tests_unit"]
+matmul_tests_vecmat = ["cubecl-matmul/matmul_tests_vecmat"]
 
 [dependencies]
 cubecl-common = { path = "../cubecl-common", version = "0.7.0", default-features = false }
@@ -89,17 +88,15 @@ cubecl-runtime = { path = "../cubecl-runtime", version = "0.7.0", default-featur
 ] }
 
 bytemuck = { workspace = true }
-cudarc = { version = "0.17.2", features = [
-    "std",
-    "driver",
-    "cuda-version-from-build-system",
-    "dynamic-loading",
-], default-features = false }
+cudarc = { workspace = true }
 
 derive-new = { workspace = true }
 half = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
+
+[build-dependencies]
+cudarc = { workspace = true }
 
 [dev-dependencies]
 cubecl-convolution = { path = "../cubecl-convolution", version = "0.7.0", features = [

--- a/crates/cubecl-cuda/build.rs
+++ b/crates/cubecl-cuda/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let version = cudarc::driver::sys::CUDA_VERSION;
+
+    if version >= 12080 {
+        println!("cargo:rustc-cfg=feature=\"cuda-12080\"");
+    }
+}

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -483,7 +483,7 @@ impl ComputeServer for CudaServer {
                     } => unsafe {
                         cuTensorMapEncodeIm2colWide(
                             map_ptr.as_mut_ptr(),
-                            elem_to_tensor_map_type(map.elem),
+                            elem_to_tensor_map_type(map.storage_ty),
                             map.rank as u32,
                             device_ptr,
                             shape.as_ptr(),


### PR DESCRIPTION
Instead of forcibly setting cudarc to 12.5, we should use the `CUDA_VERSION` constant in a build script to detect the feature set. This way, any version of CUDA can be used (12.0 or higher, if someone needs CUDA 11 we'll need to add more feature gates).
It also allows us to enable newer features automatically, without having to set a feature.