### PR TITLE
Fix comparison vectorization

### DIFF
--- a/crates/cubecl-core/src/frontend/operation/base.rs
+++ b/crates/cubecl-core/src/frontend/operation/base.rs
@@ -142,11 +142,15 @@ pub(crate) fn cmp_expand<F>(
 where
     F: Fn(BinaryOperator) -> Comparison,
 {
-    let lhs: Variable = *lhs;
-    let rhs: Variable = *rhs;
-    let item = lhs.ty;
+    let lhs = lhs.consume();
+    let rhs = rhs.consume();
 
-    let out_item = Type::scalar(ElemType::Bool).line(item.line_size());
+    let item_lhs = lhs.ty;
+    let item_rhs = rhs.ty;
+
+    let line_size = find_vectorization(item_lhs, item_rhs);
+
+    let out_item = Type::scalar(ElemType::Bool).line(line_size);
 
     let out = scope.create_local(out_item);
     let out_var = *out;


### PR DESCRIPTION
Fixes fusion compilation errors with newly added tests
```
[Compilation Error]
    default_program(102): error: no operator "==" matches these operands
                operand types are: const float == const float_4
      const bool l_51 = l_49 == l_50;
```      
```
  failures:
      tests::cube_fusion::tensor::f32_ty::map_comparison::tests::test_equal_broadcast
      tests::cube_fusion::tensor::f32_ty::map_comparison::tests::test_greater_equal_broadcast
      tests::cube_fusion::tensor::f32_ty::map_comparison::tests::test_lower_equal_broadcast
      tests::cube_fusion::tensor::u32_bool_ty::map_comparison::tests::test_equal_broadcast
      tests::cube_fusion::tensor::u32_bool_ty::map_comparison::tests::test_greater_equal_broadcast
      tests::cube_fusion::tensor::u32_bool_ty::map_comparison::tests::test_lower_equal_broadcast
```

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
