### PR TITLE
fix: Fix powf_scalar for wgsl

### DIFF
--- a/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
@@ -575,7 +575,7 @@ impl Display for Instruction {
             Instruction::Powf { lhs, rhs, out } => {
                 if rhs.is_always_scalar() || rhs.item().vectorization_factor() == 1 {
                     let out = out.fmt_left();
-                    let rhs = rhs.fmt_cast_to(lhs.item());
+                    let rhs = rhs.fmt_cast_to(Item::Scalar(lhs.elem()));
                     writeln!(f, "{out} = powf_scalar({lhs}, {rhs});")
                 } else {
                     let out = out.fmt_left();


### PR DESCRIPTION
Ensures rhs is cast to the scalar version of lhs, rather than the vector version
