### PR TITLE
Adjust the `max_bindings` limit to take into account wgpu's internal buffer

### DIFF
--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -258,7 +258,10 @@ pub(crate) fn create_client_on_setup(
         plane_size_max: 32,
         #[cfg(not(apple_silicon))]
         plane_size_max: adapter_limits.max_subgroup_size,
-        max_bindings: limits.max_storage_buffers_per_shader_stage,
+        // wgpu uses an additional buffer for variable-length buffers,
+        // so we have to use one buffer less on our side to make room for that wgpu internal buffer.
+        // See: https://github.com/gfx-rs/wgpu/blob/a9638c8e3ac09ce4f27ac171f8175671e30365fd/wgpu-hal/src/metal/device.rs#L799
+        max_bindings: limits.max_storage_buffers_per_shader_stage.saturating_sub(1),
         max_shared_memory_size: limits.max_compute_workgroup_storage_size as usize,
         max_cube_count: CubeCount::new_3d(max_count, max_count, max_count),
         max_units_per_cube: adapter_limits.max_compute_invocations_per_workgroup,

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -261,7 +261,9 @@ pub(crate) fn create_client_on_setup(
         // wgpu uses an additional buffer for variable-length buffers,
         // so we have to use one buffer less on our side to make room for that wgpu internal buffer.
         // See: https://github.com/gfx-rs/wgpu/blob/a9638c8e3ac09ce4f27ac171f8175671e30365fd/wgpu-hal/src/metal/device.rs#L799
-        max_bindings: limits.max_storage_buffers_per_shader_stage.saturating_sub(1),
+        max_bindings: limits
+            .max_storage_buffers_per_shader_stage
+            .saturating_sub(1),
         max_shared_memory_size: limits.max_compute_workgroup_storage_size as usize,
         max_cube_count: CubeCount::new_3d(max_count, max_count, max_count),
         max_units_per_cube: adapter_limits.max_compute_invocations_per_workgroup,


### PR DESCRIPTION
This PR addresses an issue with wgpu throwing `OutOfMemory` error with `Resource limit exceeded`. 

Previously `max_bindings` value was set directly to `limits.max_storage_buffers_per_shader_stage` and that value was used to limit the amount of buffers created when doing fusion in burn.

However, in wgpu, there's one extra buffer created for variable-length buffers [here](https://github.com/gfx-rs/wgpu/blob/a9638c8e3ac09ce4f27ac171f8175671e30365fd/wgpu-hal/src/metal/device.rs#L799-L805). 
`needs_sizes_buffer` is set to true when the pipeline contains [any storage buffers.](https://github.com/gfx-rs/wgpu/blob/a9638c8e3ac09ce4f27ac171f8175671e30365fd/wgpu-hal/src/metal/device.rs#L720-L725)

If CubeCL decided to create `max_bindings` buffers, it was exhausing the device limit because there was no space for the wgpu's internal buffer.

## Validate your PR with burn.

I validated the PR with burn, and it fixes the panic observed [here](https://github.com/tracel-ai/burn/issues/3667) and [here](https://github.com/tracel-ai/burn/issues/3635)


