### PR TITLE
Expose cache config to be able to configure all fields in `GlobalConfig`

### DIFF
--- a/crates/cubecl-runtime/src/config/mod.rs
+++ b/crates/cubecl-runtime/src/config/mod.rs
@@ -4,10 +4,11 @@ pub mod autotune;
 pub mod compilation;
 /// Profiling config module.
 pub mod profiling;
-
-mod base;
+/// Cache config module.
 #[cfg(std_io)]
 pub mod cache;
+
+mod base;
 mod logger;
 
 pub use base::*;

--- a/crates/cubecl-runtime/src/config/mod.rs
+++ b/crates/cubecl-runtime/src/config/mod.rs
@@ -7,7 +7,7 @@ pub mod profiling;
 
 mod base;
 #[cfg(std_io)]
-pub(crate) mod cache;
+pub mod cache;
 mod logger;
 
 pub use base::*;

--- a/crates/cubecl-runtime/src/config/mod.rs
+++ b/crates/cubecl-runtime/src/config/mod.rs
@@ -1,12 +1,12 @@
 /// Autotune config module.
 pub mod autotune;
+/// Cache config module.
+#[cfg(std_io)]
+pub mod cache;
 /// Compilation config module.
 pub mod compilation;
 /// Profiling config module.
 pub mod profiling;
-/// Cache config module.
-#[cfg(std_io)]
-pub mod cache;
 
 mod base;
 mod logger;


### PR DESCRIPTION
This PR changes the visibility of the `config::cache` module to `pub` to be able to use it from user's code with `cubecl::config::GlobalConfig::set`


I'm not sure what was the reason for `cache` module to be `pub(crate)`, but this makes it impossible to use `cubecl::config::GlobalConfig`, because `AutotuneConfig` and `CompilationConfig` have the `cache` field with private type