### PR TITLE
refactor: Runtime features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ num-traits = { version = "0.2.19", default-features = false, features = [
 
 cfg-if = "1.0.0"
 darling = "0.21.0"
+enumset = "1.1.10"
 ident_case = "1"
 paste = "1"
 proc-macro2 = "1"

--- a/crates/cubecl-attention/src/tests/test_utils.rs
+++ b/crates/cubecl-attention/src/tests/test_utils.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use cubecl_core::{
-    CubeElement, Feature, Runtime,
+    CubeElement, Runtime,
     client::ComputeClient,
     flex32,
     prelude::{CubePrimitive, Exp, Float, Numeric},
@@ -9,6 +9,7 @@ use cubecl_core::{
     tf32,
 };
 
+use cubecl_runtime::MmaConfig;
 use cubecl_std::tensor::TensorHandle;
 
 use crate::{
@@ -60,18 +61,18 @@ where
         shape: &[usize],
         strides: &[usize],
     ) {
-        let maybe_f16 = client.properties().feature_enabled(Feature::Cmma {
-            a: ES::as_type_native().expect("To be a native type"),
-            b: ES::as_type_native().expect("To be a native type"),
-            c: EG::as_type_native().expect("To be a native type"),
+        let maybe_f16 = client.properties().features.cmma.contains(&MmaConfig {
+            a_type: ES::as_type_native().expect("To be a native type"),
+            b_type: ES::as_type_native().expect("To be a native type"),
+            cd_type: EG::as_type_native().expect("To be a native type"),
             m: 16,
             k: 16,
             n: 16,
         });
-        let maybe_tf32 = client.properties().feature_enabled(Feature::Cmma {
-            a: ES::as_type_native().expect("To be a native type"),
-            b: ES::as_type_native().expect("To be a native type"),
-            c: EG::as_type_native().expect("To be a native type"),
+        let maybe_tf32 = client.properties().features.cmma.contains(&MmaConfig {
+            a_type: ES::as_type_native().expect("To be a native type"),
+            b_type: ES::as_type_native().expect("To be a native type"),
+            cd_type: EG::as_type_native().expect("To be a native type"),
             m: 16,
             k: 8,
             n: 16,

--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -16,10 +16,10 @@ version.workspace = true
 [features]
 cache = ["std", "serde_json", "dirs", "sanitize-filename"]
 default = ["std"]
-serde = []
-std = ["rand/std", "futures-lite", "rand/thread_rng", "serde_json?/std"]
 fp4 = ["float4"]
 fp8 = ["float8", "float4"]
+serde = []
+std = ["rand/std", "futures-lite", "rand/thread_rng", "serde_json?/std"]
 
 [dependencies]
 # ** Please make sure all dependencies support no_std when std is disabled **

--- a/crates/cubecl-convolution/src/launch.rs
+++ b/crates/cubecl-convolution/src/launch.rs
@@ -2,6 +2,7 @@ use std::any::TypeId;
 
 use cubecl_core::{Runtime, client::ComputeClient, prelude::*};
 use cubecl_matmul::MatmulInputHandleRef;
+use cubecl_runtime::TypeUsage;
 use half::f16;
 
 use crate::{
@@ -140,7 +141,7 @@ where
     let rhs_is_f32 = TypeId::of::<RhsG<MP>>() == TypeId::of::<f32>();
 
     let launch = if lhs_is_f32 || rhs_is_f32 {
-        if tf32::is_supported(client) {
+        if tf32::supported_uses(client).contains(TypeUsage::Conversion) {
             if lhs_is_f32 && rhs_is_f32 {
                 launch_kernel::<R, (LhsG<MP>, RhsG<MP>, tf32, tf32, f32, MP::EO), Alg>
             } else if lhs_is_f32 {

--- a/crates/cubecl-convolution/src/tests/test_utils.rs
+++ b/crates/cubecl-convolution/src/tests/test_utils.rs
@@ -1,12 +1,13 @@
 use std::fmt::Display;
 
 use cubecl_core::{
-    CubeElement, Feature, Runtime,
+    CubeElement, Runtime,
     client::ComputeClient,
     prelude::{Float, Numeric},
     server::{self},
 };
 use cubecl_matmul::tests::test_utils::{CastInto, Sample};
+use cubecl_runtime::MmaConfig;
 
 use crate::components::ConvolutionProblem;
 
@@ -45,18 +46,18 @@ where
         shape: &[usize],
         strides: &[usize],
     ) {
-        let maybe_f16 = client.properties().feature_enabled(Feature::Cmma {
-            a: ES::as_type_native().expect("To be a native type"),
-            b: ES::as_type_native().expect("To be a native type"),
-            c: EG::as_type_native().expect("To be a native type"),
+        let maybe_f16 = client.properties().features.cmma.contains(&MmaConfig {
+            a_type: ES::as_type_native().expect("To be a native type"),
+            b_type: ES::as_type_native().expect("To be a native type"),
+            cd_type: EG::as_type_native().expect("To be a native type"),
             m: 16,
             k: 16,
             n: 16,
         });
-        let maybe_tf32 = client.properties().feature_enabled(Feature::Cmma {
-            a: ES::as_type_native().expect("To be a native type"),
-            b: ES::as_type_native().expect("To be a native type"),
-            c: EG::as_type_native().expect("To be a native type"),
+        let maybe_tf32 = client.properties().features.cmma.contains(&MmaConfig {
+            a_type: ES::as_type_native().expect("To be a native type"),
+            b_type: ES::as_type_native().expect("To be a native type"),
+            cd_type: EG::as_type_native().expect("To be a native type"),
             m: 16,
             k: 8,
             n: 16,

--- a/crates/cubecl-core/Cargo.toml
+++ b/crates/cubecl-core/Cargo.toml
@@ -38,6 +38,7 @@ derive_more = { workspace = true, features = [
     "mul_assign",
     "display",
 ] }
+enumset = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 hashbrown = { workspace = true }
 log = { workspace = true }

--- a/crates/cubecl-core/src/codegen/integrator.rs
+++ b/crates/cubecl-core/src/codegen/integrator.rs
@@ -1,5 +1,6 @@
 use cubecl_common::CubeDim;
 use cubecl_ir::{Id, Scope, StorageType, Type};
+use enumset::EnumSet;
 
 use crate::{
     compute::{Binding, KernelDefinition, Location, ScalarBinding, Visibility},
@@ -35,7 +36,7 @@ pub struct KernelSettings {
 pub struct KernelOptions {
     pub kernel_name: String,
     pub debug_symbols: bool,
-    pub fp_math_mode: FastMath,
+    pub fp_math_mode: EnumSet<FastMath>,
     pub cluster_dim: Option<CubeDim>,
 }
 
@@ -61,7 +62,7 @@ impl KernelSettings {
     }
 
     /// Set FP math mode
-    pub fn fp_math_mode(mut self, mode: FastMath) -> Self {
+    pub fn fp_math_mode(mut self, mode: EnumSet<FastMath>) -> Self {
         self.options.fp_math_mode = mode;
         self
     }

--- a/crates/cubecl-core/src/frontend/element/cube_elem.rs
+++ b/crates/cubecl-core/src/frontend/element/cube_elem.rs
@@ -1,8 +1,11 @@
 use cubecl_ir::{ExpandElement, StorageType};
-use cubecl_runtime::{channel::ComputeChannel, client::ComputeClient, server::ComputeServer};
+use cubecl_runtime::{
+    TypeUsage, channel::ComputeChannel, client::ComputeClient, server::ComputeServer,
+};
+use enumset::EnumSet;
 
+use crate::frontend::CubeType;
 use crate::ir::Scope;
-use crate::{Feature, frontend::CubeType};
 
 use super::{ExpandElementIntoMut, ExpandElementTyped};
 
@@ -48,11 +51,11 @@ pub trait CubePrimitive:
         ExpandElementTyped::new(elem)
     }
 
-    fn is_supported<S: ComputeServer<Feature = Feature>, C: ComputeChannel<S>>(
+    fn supported_uses<S: ComputeServer, C: ComputeChannel<S>>(
         client: &ComputeClient<S, C>,
-    ) -> bool {
+    ) -> EnumSet<TypeUsage> {
         let elem = Self::as_type_native_unchecked();
-        client.properties().feature_enabled(Feature::Type(elem))
+        client.properties().features.type_usage(elem)
     }
 
     fn elem_size() -> u32 {

--- a/crates/cubecl-core/src/frontend/options.rs
+++ b/crates/cubecl-core/src/frontend/options.rs
@@ -1,34 +1,40 @@
+use enumset::{EnumSet, EnumSetType};
 use serde::{Deserialize, Serialize};
 
-bitflags::bitflags! {
-    /// Unchecked optimizations for float operations. May cause precision differences, or undefined
-    /// behaviour if the relevant conditions are not followed.
-    #[derive(Default, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
-    pub struct FastMath: u32 {
-        /// Disable unsafe optimizations
-        const None = 0;
-        /// Assume values are never `NaN`. If they are, the result is considered undefined behaviour.
-        const NotNaN = 1;
-        /// Assume values are never `Inf`/`-Inf`. If they are, the result is considered undefined
-        /// behaviour.
-        const NotInf = 1 << 1;
-        /// Ignore sign on zero values.
-        const UnsignedZero = 1 << 2;
-        /// Allow swapping float division with a reciprocal, even if that swap would change precision.
-        const AllowReciprocal = 1 << 3;
-        /// Allow contracting float operations into fewer operations, even if the precision could
-        /// change.
-        const AllowContraction = 1 << 4;
-        /// Allow reassociation for float operations, even if the precision could change.
-        const AllowReassociation = 1 << 5;
-        /// Allow all mathematical transformations for float operations, including contraction and
-        /// reassociation, even if the precision could change.
-        const AllowTransform = 1 << 6;
-        /// Allow using lower precision intrinsics (CUDA `--use_fast_math`)
-        /// Also impacts `NaN`, `Inf` and signed zero handling, as well as subnormals and rounding.
-        ///
-        /// Notable edge case:
-        /// powf - Returns `NaN` for negative bases
-        const ReducedPrecision = 1 << 7;
+/// Unchecked optimizations for float operations. May cause precision differences, or undefined
+/// behaviour if the relevant conditions are not followed.
+#[derive(Default, Debug, Hash, Serialize, Deserialize, EnumSetType)]
+pub enum FastMath {
+    /// Disable unsafe optimizations
+    #[default]
+    None,
+    /// Assume values are never `NaN`. If they are, the result is considered undefined behaviour.
+    NotNaN,
+    /// Assume values are never `Inf`/`-Inf`. If they are, the result is considered undefined
+    /// behaviour.
+    NotInf,
+    /// Ignore sign on zero values.
+    UnsignedZero,
+    /// Allow swapping float division with a reciprocal, even if that swap would change precision.
+    AllowReciprocal,
+    /// Allow contracting float operations into fewer operations, even if the precision could
+    /// change.
+    AllowContraction,
+    /// Allow reassociation for float operations, even if the precision could change.
+    AllowReassociation,
+    /// Allow all mathematical transformations for float operations, including contraction and
+    /// reassociation, even if the precision could change.
+    AllowTransform,
+    /// Allow using lower precision intrinsics (CUDA `--use_fast_math`)
+    /// Also impacts `NaN`, `Inf` and signed zero handling, as well as subnormals and rounding.
+    ///
+    /// Notable edge case:
+    /// powf - Returns `NaN` for negative bases
+    ReducedPrecision,
+}
+
+impl FastMath {
+    pub fn all() -> EnumSet<FastMath> {
+        EnumSet::all()
     }
 }

--- a/crates/cubecl-core/src/runtime.rs
+++ b/crates/cubecl-core/src/runtime.rs
@@ -14,7 +14,7 @@ pub trait Runtime: Send + Sync + 'static + core::fmt::Debug {
     /// The compiler used to compile the inner representation into tokens.
     type Compiler: Compiler;
     /// The compute server used to run kernels and perform autotuning.
-    type Server: ComputeServer<Kernel = Box<dyn CubeTask<Self::Compiler>>, Feature = Feature>;
+    type Server: ComputeServer<Kernel = Box<dyn CubeTask<Self::Compiler>>>;
     /// The channel used to communicate with the compute server.
     type Channel: ComputeChannel<Self::Server>;
     /// The device used to retrieve the compute client.
@@ -49,92 +49,4 @@ pub trait Runtime: Send + Sync + 'static + core::fmt::Debug {
 
     /// Returns the properties of the target hardware architecture.
     fn target_properties() -> TargetProperties;
-}
-
-/// Every feature that can be supported by a [cube runtime](Runtime).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Feature {
-    /// The plane feature enables all basic warp/subgroup operations.
-    Plane,
-    /// The cmma feature enables cooperative matrix-multiply and accumulate operations.
-    Cmma {
-        a: StorageType,
-        b: StorageType,
-        c: StorageType,
-        m: u8,
-        k: u8,
-        n: u8,
-    },
-    /// The manual MMA feature enables cooperative matrix-multiply with manually managed data
-    /// movement
-    ManualMma {
-        /// Element of the A matrix
-        a_type: StorageType,
-        /// Element of the B matrix
-        b_type: StorageType,
-        /// Element of the C/D matrices
-        cd_type: StorageType,
-        m: u32,
-        n: u32,
-        k: u32,
-    },
-    /// Scaled MMA allows combining matrix multiplication with unscaling quantized values into a single
-    /// instruction. Scales must fit a specific layout and block size.
-    ScaledMma {
-        /// Element of the quantized A matrix
-        a_type: StorageType,
-        /// Element of the quantized B matrix
-        b_type: StorageType,
-        /// Element of the unquantized C/D matrices
-        cd_type: StorageType,
-        /// Element of the blocks scales
-        scales_type: StorageType,
-        m: u32,
-        n: u32,
-        k: u32,
-        /// Number of scales per tile row/col.
-        /// A scale factor of 2 means `m x 2` scales for A and `2 x n` for B (in CUDA)
-        /// Scales blocks must be organized along the natural `line_layout` of the operation
-        scales_factor: u32,
-    },
-    CmmaWarpSize(i32),
-    Type(StorageType),
-    /// Features supported for floating point atomics.
-    AtomicFloat(AtomicFeature),
-    /// Features supported for integer atomics.
-    AtomicInt(AtomicFeature),
-    /// Features supported for unsigned integer atomics.
-    AtomicUInt(AtomicFeature),
-    /// The pipeline feature enables pipelined (async) operations
-    Pipeline,
-    /// The barrier feature enables barrier (async) operations
-    Barrier,
-    /// Tensor Memory Accelerator features. Minimum H100/RTX 5000 series for base set
-    Tma(TmaFeature),
-    /// Clustered launches and intra-cluster operations like cluster shared memory
-    CubeCluster,
-    /// Enables to change the line size of containers during kernel execution.
-    DynamicLineSize,
-    /// Enables synchronization within a plane only
-    SyncPlane,
-    /// Enables using plane-wide operations like plane_sum, etc.
-    PlaneOps,
-}
-
-/// Atomic features that may be supported by a [cube runtime](Runtime).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum AtomicFeature {
-    LoadStore,
-    Add,
-    MinMax,
-}
-
-/// Atomic features that may be supported by a [cube runtime](Runtime).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TmaFeature {
-    /// Base feature set for tensor memory accelerator features. Includes tiling and im2col
-    Base,
-    /// im2colWide encoding for tensor map.
-    /// TODO: Not yet implemented due to missing `cudarc` support
-    Im2colWide,
 }

--- a/crates/cubecl-core/src/runtime_tests/barrier.rs
+++ b/crates/cubecl-core/src/runtime_tests/barrier.rs
@@ -1,6 +1,7 @@
-use crate::{self as cubecl, Feature, as_bytes, prelude::barrier::BarrierLevel};
+use crate::{self as cubecl, as_bytes, prelude::barrier::BarrierLevel};
 use barrier::Barrier;
 use cubecl::prelude::*;
+use cubecl_ir::SemanticType;
 
 #[cube(launch)]
 pub fn async_copy_test<F: Float>(input: &Array<Line<F>>, output: &mut Array<Line<F>>) {
@@ -19,7 +20,7 @@ pub fn async_copy_test<F: Float>(input: &Array<Line<F>>, output: &mut Array<Line
 pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    if !client.properties().feature_enabled(Feature::Barrier) {
+    if !client.properties().supports_type(SemanticType::Barrier) {
         // We can't execute the test, skip.
         return;
     }
@@ -132,7 +133,7 @@ fn two_independent_loads<F: Float>(
 pub fn test_memcpy_one_load<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    if !client.properties().feature_enabled(Feature::Barrier) {
+    if !client.properties().supports_type(SemanticType::Barrier) {
         // We can't execute the test, skip.
         return;
     }
@@ -161,7 +162,7 @@ pub fn test_memcpy_two_loads<R: Runtime, F: Float + CubeElement>(
     independent: bool,
     client: ComputeClient<R::Server, R::Channel>,
 ) {
-    if !client.properties().feature_enabled(Feature::Barrier) {
+    if !client.properties().supports_type(SemanticType::Barrier) {
         // We can't execute the test, skip.
         return;
     }

--- a/crates/cubecl-core/src/runtime_tests/cluster.rs
+++ b/crates/cubecl-core/src/runtime_tests/cluster.rs
@@ -1,5 +1,5 @@
+use crate::prelude::*;
 use crate::{self as cubecl};
-use crate::{Feature, prelude::*};
 
 #[cube(launch, cluster_dim = CubeDim::new_3d(1, 2, 3))]
 fn cluster_meta_kernel(out: &mut Array<u32>) {
@@ -21,7 +21,7 @@ fn cluster_meta_kernel(out: &mut Array<u32>) {
 }
 
 pub fn test_cluster_meta<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
-    if !client.properties().feature_enabled(Feature::CubeCluster) {
+    if !client.properties().features.cube_cluster {
         return;
     }
 

--- a/crates/cubecl-core/src/runtime_tests/cmma.rs
+++ b/crates/cubecl-core/src/runtime_tests/cmma.rs
@@ -1,6 +1,5 @@
 use crate::{self as cubecl, runtime_tests::binary::assert_equals_approx};
 
-use crate::Feature;
 use cubecl::{
     ir::{ElemType, FloatKind},
     prelude::*,
@@ -8,6 +7,7 @@ use cubecl::{
 
 use cubecl_common::{e2m1, e2m1x2, ue8m0};
 use cubecl_ir::MatrixIdent;
+use cubecl_runtime::{MmaConfig, ScaledMmaConfig};
 use half::{bf16, f16};
 
 #[cube(launch)]
@@ -305,10 +305,10 @@ pub fn test_simple_1_lined<R: Runtime>(
     client: ComputeClient<R::Server, R::Channel>,
     cube_dimensions: CubeDim,
 ) {
-    if !client.properties().feature_enabled(Feature::Cmma {
-        a: ElemType::Float(FloatKind::F16).into(),
-        b: ElemType::Float(FloatKind::F16).into(),
-        c: ElemType::Float(FloatKind::F32).into(),
+    if !client.properties().features.cmma.contains(&MmaConfig {
+        a_type: ElemType::Float(FloatKind::F16).into(),
+        b_type: ElemType::Float(FloatKind::F16).into(),
+        cd_type: ElemType::Float(FloatKind::F32).into(),
         m: 16,
         k: 16,
         n: 16,
@@ -345,10 +345,10 @@ pub fn test_simple_1_lined_offset<R: Runtime>(
     client: ComputeClient<R::Server, R::Channel>,
     cube_dimensions: CubeDim,
 ) {
-    if !client.properties().feature_enabled(Feature::Cmma {
-        a: ElemType::Float(FloatKind::F16).into(),
-        b: ElemType::Float(FloatKind::F16).into(),
-        c: ElemType::Float(FloatKind::F32).into(),
+    if !client.properties().features.cmma.contains(&MmaConfig {
+        a_type: ElemType::Float(FloatKind::F16).into(),
+        b_type: ElemType::Float(FloatKind::F16).into(),
+        cd_type: ElemType::Float(FloatKind::F32).into(),
         m: 16,
         k: 16,
         n: 16,
@@ -403,10 +403,10 @@ pub fn test_simple_1<R: Runtime>(
     client: ComputeClient<R::Server, R::Channel>,
     cube_dimensions: CubeDim,
 ) {
-    if !client.properties().feature_enabled(Feature::Cmma {
-        a: ElemType::Float(FloatKind::F16).into(),
-        b: ElemType::Float(FloatKind::F16).into(),
-        c: ElemType::Float(FloatKind::F32).into(),
+    if !client.properties().features.cmma.contains(&MmaConfig {
+        a_type: ElemType::Float(FloatKind::F16).into(),
+        b_type: ElemType::Float(FloatKind::F16).into(),
+        cd_type: ElemType::Float(FloatKind::F32).into(),
         m: 16,
         k: 16,
         n: 16,
@@ -469,7 +469,7 @@ pub fn test_simple_1_expected() -> Vec<f32> {
 //     client: ComputeClient<R::Server, R::Channel>,
 //     cube_dimensions: CubeDim,
 // ) {
-//     if !client.properties().feature_enabled(Feature::Cmma {
+//     if !client.properties().features.cmma.contains(&MmaConfig {
 //         a: Elem::Float(FloatKind::F16),
 //         b: Elem::Float(FloatKind::F16),
 //         c: Elem::Float(FloatKind::F16),
@@ -511,10 +511,10 @@ pub fn test_cmma_cast_f16<R: Runtime>(
     client: ComputeClient<R::Server, R::Channel>,
     cube_dimensions: CubeDim,
 ) {
-    if !client.properties().feature_enabled(Feature::Cmma {
-        a: ElemType::Float(FloatKind::F16).into(),
-        b: ElemType::Float(FloatKind::F16).into(),
-        c: ElemType::Float(FloatKind::F32).into(),
+    if !client.properties().features.cmma.contains(&MmaConfig {
+        a_type: ElemType::Float(FloatKind::F16).into(),
+        b_type: ElemType::Float(FloatKind::F16).into(),
+        cd_type: ElemType::Float(FloatKind::F32).into(),
         m: 16,
         k: 16,
         n: 16,
@@ -548,10 +548,10 @@ pub fn test_cmma_cast_bf16<R: Runtime>(
     client: ComputeClient<R::Server, R::Channel>,
     cube_dimensions: CubeDim,
 ) {
-    if !client.properties().feature_enabled(Feature::Cmma {
-        a: ElemType::Float(FloatKind::BF16).into(),
-        b: ElemType::Float(FloatKind::BF16).into(),
-        c: ElemType::Float(FloatKind::F32).into(),
+    if !client.properties().features.cmma.contains(&MmaConfig {
+        a_type: ElemType::Float(FloatKind::BF16).into(),
+        b_type: ElemType::Float(FloatKind::BF16).into(),
+        cd_type: ElemType::Float(FloatKind::F32).into(),
         m: 16,
         k: 16,
         n: 16,
@@ -585,10 +585,10 @@ pub fn test_simple_tf32<R: Runtime>(
     client: ComputeClient<R::Server, R::Channel>,
     cube_dimensions: CubeDim,
 ) {
-    if !client.properties().feature_enabled(Feature::Cmma {
-        a: ElemType::Float(FloatKind::TF32).into(),
-        b: ElemType::Float(FloatKind::TF32).into(),
-        c: ElemType::Float(FloatKind::F32).into(),
+    if !client.properties().features.cmma.contains(&MmaConfig {
+        a_type: ElemType::Float(FloatKind::TF32).into(),
+        b_type: ElemType::Float(FloatKind::TF32).into(),
+        cd_type: ElemType::Float(FloatKind::F32).into(),
         m: 16,
         k: 8,
         n: 16,
@@ -694,13 +694,13 @@ pub fn test_cmma_strided<R: Runtime>(
     // Lhs (row major) will have strided tiles
     let (m, n, k) = (16, 16, 32);
     let (t_m, t_n, t_k) = (16, 16, 16);
-    if !client.properties().feature_enabled(Feature::Cmma {
-        a: ElemType::Float(FloatKind::F16).into(),
-        b: ElemType::Float(FloatKind::F16).into(),
-        c: ElemType::Float(FloatKind::F32).into(),
-        m: t_m as u8,
-        k: t_k as u8,
-        n: t_n as u8,
+    if !client.properties().features.cmma.contains(&MmaConfig {
+        a_type: ElemType::Float(FloatKind::F16).into(),
+        b_type: ElemType::Float(FloatKind::F16).into(),
+        cd_type: ElemType::Float(FloatKind::F32).into(),
+        m: t_m as u32,
+        k: t_k as u32,
+        n: t_n as u32,
     }) {
         // We can't execute the test, skip.
         return;
@@ -864,7 +864,7 @@ pub fn test_cmma_manual<
     cube_dimensions: CubeDim,
     (m, n, k): (usize, usize, usize),
 ) {
-    if !client.properties().feature_enabled(Feature::ManualMma {
+    if !client.properties().features.mma.contains(&MmaConfig {
         a_type: A::cube_type(),
         b_type: B::cube_type(),
         cd_type: CD::cube_type(),
@@ -1069,16 +1069,21 @@ pub fn test_cmma_scaled<R: Runtime, A: CubeElement + Numeric, B: CubeElement + N
     let a_line_size = 32 / a_elem.size_bits();
     let b_line_size = 32 / b_elem.size_bits();
 
-    if !client.properties().feature_enabled(Feature::ScaledMma {
-        a_type: a_elem,
-        b_type: b_elem,
-        cd_type: f32::cube_type(),
-        scales_type: S::cube_type(),
-        m: m as u32,
-        n: n as u32,
-        k: k as u32,
-        scales_factor: scales_factor as u32,
-    }) {
+    if !client
+        .properties()
+        .features
+        .scaled_mma
+        .contains(&ScaledMmaConfig {
+            a_type: a_elem,
+            b_type: b_elem,
+            cd_type: f32::cube_type(),
+            scales_type: S::cube_type(),
+            m: m as u32,
+            n: n as u32,
+            k: k as u32,
+            scales_factor: scales_factor as u32,
+        })
+    {
         // We can't execute the test, skip.
         println!(
             "Skipping test for a: {:?}, b: {:?}, scales: {:?} m: {m}, n: {n}, k: {k}",
@@ -1175,16 +1180,21 @@ pub fn test_cmma_scaled_fp4<R: Runtime>(
     let ab_elem = AB::cube_type();
     let ab_line_size = 32 / ab_elem.size_bits();
 
-    if !client.properties().feature_enabled(Feature::ScaledMma {
-        a_type: ab_elem,
-        b_type: ab_elem,
-        cd_type: f32::cube_type(),
-        scales_type: S::cube_type(),
-        m: m as u32,
-        n: n as u32,
-        k: k as u32,
-        scales_factor: scales_factor as u32,
-    }) {
+    if !client
+        .properties()
+        .features
+        .scaled_mma
+        .contains(&ScaledMmaConfig {
+            a_type: ab_elem,
+            b_type: ab_elem,
+            cd_type: f32::cube_type(),
+            scales_type: S::cube_type(),
+            m: m as u32,
+            n: n as u32,
+            k: k as u32,
+            scales_factor: scales_factor as u32,
+        })
+    {
         // We can't execute the test, skip.
         println!(
             "Skipping test for ab: {:?}, scales: {:?} m: {m}, n: {n}, k: {k}",

--- a/crates/cubecl-core/src/runtime_tests/minifloat.rs
+++ b/crates/cubecl-core/src/runtime_tests/minifloat.rs
@@ -2,6 +2,7 @@ use crate::{self as cubecl, as_type};
 
 use cubecl::prelude::*;
 use cubecl_common::{e2m3, e3m2, e4m3, e5m2, ue8m0};
+use cubecl_runtime::TypeUsage;
 
 #[cube(launch_unchecked)]
 pub fn kernel_fp8<F: Float>(input: &mut Array<Line<F>>, out: &mut Array<Line<u8>>) {
@@ -40,7 +41,7 @@ pub fn test_fp8<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
     vectorization: u8,
 ) {
-    if !e4m3::is_supported(&client) {
+    if !e4m3::supported_uses(&client).contains(TypeUsage::Conversion) {
         println!("Unsupported, skipping");
         return;
     }
@@ -82,7 +83,7 @@ pub fn test_fp6<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R::Server, R::Channel>,
     vectorization: u8,
 ) {
-    if !e2m3::is_supported(&client) {
+    if !e2m3::supported_uses(&client).contains(TypeUsage::Conversion) {
         println!("Unsupported, skipping");
         return;
     }
@@ -120,7 +121,7 @@ pub fn test_fp6<R: Runtime, F: Float + CubeElement>(
 }
 
 pub fn test_scale<R: Runtime>(client: ComputeClient<R::Server, R::Channel>, vectorization: u8) {
-    if !ue8m0::is_supported(&client) {
+    if !ue8m0::supported_uses(&client).contains(TypeUsage::Conversion) {
         println!("Unsupported, skipping");
         return;
     }

--- a/crates/cubecl-core/src/runtime_tests/plane.rs
+++ b/crates/cubecl-core/src/runtime_tests/plane.rs
@@ -1,8 +1,9 @@
 use std::fmt::Display;
 
+use crate::runtime_tests::binary::assert_equals_approx;
 use crate::{self as cubecl};
-use crate::{Feature, runtime_tests::binary::assert_equals_approx};
 use cubecl::prelude::*;
+use cubecl_runtime::Plane;
 
 #[cube(launch)]
 pub fn kernel_sum<F: Float>(output: &mut Tensor<F>) {
@@ -535,7 +536,7 @@ pub fn test_plane_any<
 pub fn test_plane_ballot<TestRuntime: Runtime>(
     client: ComputeClient<TestRuntime::Server, TestRuntime::Channel>,
 ) {
-    if !client.properties().feature_enabled(Feature::Plane) {
+    if !client.properties().features.plane.contains(Plane::Ops) {
         // Can't execute the test.
         return;
     }
@@ -638,7 +639,7 @@ fn test_plane_operation<
 ) where
     Launch: Fn(CubeCount, TensorArg<'_, TestRuntime>),
 {
-    if !client.properties().feature_enabled(Feature::Plane) {
+    if !client.properties().features.plane.contains(Plane::Ops) {
         // Can't execute the test.
         return;
     }

--- a/crates/cubecl-core/src/runtime_tests/synchronization.rs
+++ b/crates/cubecl-core/src/runtime_tests/synchronization.rs
@@ -1,5 +1,7 @@
+use cubecl_runtime::Plane;
+
 use crate::prelude::*;
-use crate::{self as cubecl, Feature};
+use crate::{self as cubecl};
 
 #[cube(launch)]
 /// First 32 elements should be 1, while last 32 elements may or may not be 1
@@ -87,7 +89,7 @@ fn kernel_test_sync_plane<F: Float>(out: &mut Array<F>) {
 }
 
 pub fn test_sync_plane<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
-    if !client.properties().feature_enabled(Feature::SyncPlane) {
+    if !client.properties().features.plane.contains(Plane::Sync) {
         // We can't execute the test, skip.
         return;
     }

--- a/crates/cubecl-core/src/runtime_tests/tensormap.rs
+++ b/crates/cubecl-core/src/runtime_tests/tensormap.rs
@@ -1,12 +1,13 @@
 use std::fmt::Debug;
 
 use crate::{
-    self as cubecl, Feature, TmaFeature,
+    self as cubecl,
     prelude::barrier::{Barrier, BarrierLevel},
 };
 
 use cubecl::prelude::*;
 use cubecl_runtime::{
+    Tma,
     server::{Allocation, ComputeServer},
     storage::ComputeStorage,
 };
@@ -110,10 +111,7 @@ pub fn test_tensormap_load<R: Runtime, F: Float + CubeElement>(
 ) where
     <<R::Server as ComputeServer>::Storage as ComputeStorage>::Resource: Debug,
 {
-    if !client
-        .properties()
-        .feature_enabled(Feature::Tma(TmaFeature::Base))
-    {
+    if !client.properties().features.tma.contains(Tma::Base) {
         println!("Skipped test_tensormap_load due to unavailability");
         return;
     }
@@ -154,10 +152,7 @@ pub fn test_tensormap_store<R: Runtime, F: Float + CubeElement>(
 ) where
     <<R::Server as ComputeServer>::Storage as ComputeStorage>::Resource: Debug,
 {
-    if !client
-        .properties()
-        .feature_enabled(Feature::Tma(TmaFeature::Base))
-    {
+    if !client.properties().features.tma.contains(Tma::Base) {
         println!("Skipped test_tensormap_load due to unavailability");
         return;
     }
@@ -205,10 +200,7 @@ pub fn test_tensormap_load_im2col<R: Runtime, F: Float + CubeElement>(
 ) where
     <<R::Server as ComputeServer>::Storage as ComputeStorage>::Resource: Debug,
 {
-    if !client
-        .properties()
-        .feature_enabled(Feature::Tma(TmaFeature::Base))
-    {
+    if !client.properties().features.tma.contains(Tma::Base) {
         println!("Skipped test_tensormap_load due to unavailability");
         return;
     }
@@ -296,10 +288,7 @@ pub fn test_tensormap_metadata<R: Runtime, F: Float + CubeElement>(
 ) where
     <<R::Server as ComputeServer>::Storage as ComputeStorage>::Resource: Debug,
 {
-    if !client
-        .properties()
-        .feature_enabled(Feature::Tma(TmaFeature::Base))
-    {
+    if !client.properties().features.tma.contains(Tma::Base) {
         println!("Skipped test_tensormap_load due to unavailability");
         return;
     }

--- a/crates/cubecl-cpp/Cargo.toml
+++ b/crates/cubecl-cpp/Cargo.toml
@@ -11,16 +11,16 @@ repository = "https://github.com/tracel-ai/cubecl/tree/main/crates/cubecl-cpp"
 version.workspace = true
 
 [features]
+cuda = []
 default = [
     "cubecl-runtime/default",
     "cubecl-common/default",
     "cubecl-core/default",
     "metal",
 ]
-std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
-cuda = []
 hip = []
 metal = []
+std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 
 [dependencies]
 cubecl-common = { path = "../cubecl-common", version = "0.7.0", default-features = false }
@@ -28,6 +28,7 @@ cubecl-core = { path = "../cubecl-core", version = "0.7.0", default-features = f
 cubecl-runtime = { path = "../cubecl-runtime", version = "0.7.0", default-features = false, features = [
     "channel-mutex",
 ] }
+itertools = { version = "0.14.0", default-features = false }
 
 bytemuck = { workspace = true }
 derive-new = { workspace = true }

--- a/crates/cubecl-cpp/src/cuda/dialect.rs
+++ b/crates/cubecl-cpp/src/cuda/dialect.rs
@@ -588,7 +588,7 @@ impl<M: DialectWmmaCompiler<Self>> DialectWmmaCompiler<Self> for CudaDialect<M> 
 
     fn supported_wmma_combinations(
         arch: &CudaArchitecture,
-    ) -> crate::shared::SupportedWmmaCombinations {
+    ) -> crate::shared::SupportedMmaCombinations {
         M::supported_wmma_combinations(arch)
     }
 

--- a/crates/cubecl-cpp/src/hip/dialect.rs
+++ b/crates/cubecl-cpp/src/hip/dialect.rs
@@ -548,7 +548,7 @@ impl<M: DialectWmmaCompiler<Self>> DialectWmmaCompiler<Self> for HipDialect<M> {
 
     fn supported_wmma_combinations(
         arch: &AMDArchitecture,
-    ) -> crate::shared::SupportedWmmaCombinations {
+    ) -> crate::shared::SupportedMmaCombinations {
         M::supported_wmma_combinations(arch)
     }
 

--- a/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
+++ b/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
@@ -6,11 +6,11 @@ use crate::{
     },
     shared::{
         DialectWmmaCompiler, Flags, Fragment, FragmentIdent, FragmentLayout, ManualMma,
-        SupportedMmaCombinations, SupportedWmmaCombinations, Variable, WmmaInstruction,
-        wmma_api_base,
+        SupportedMmaCombinations, Variable, WmmaInstruction, wmma_api_base,
     },
 };
 use cubecl_core::ir::{self as gpu};
+use cubecl_runtime::MmaConfig;
 
 const ROCWMMA_NAMESPACE: &str = "rocwmma";
 
@@ -94,8 +94,8 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
         unimplemented!("Scaled MMA not supported in HIP")
     }
 
-    fn supported_wmma_combinations(arch: &AMDArchitecture) -> SupportedWmmaCombinations {
-        match arch {
+    fn supported_wmma_combinations(arch: &AMDArchitecture) -> SupportedMmaCombinations {
+        let combinations = match arch {
             AMDArchitecture::GFX10 | AMDArchitecture::GFX11 => {
                 // For gfx11 the supported tile dimensions are always the same
                 //                                   m   n   k
@@ -132,20 +132,16 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         gpu::ElemType::Float(gpu::FloatKind::BF16),
                     ),
                 ];
-                types
-                    .into_iter()
-                    .map(|(i, o, c)| {
-                        let dimensions = tdims.clone();
-                        (i.into(), o.into(), c.into(), dimensions)
-                    })
-                    .collect()
+                types.into_iter().map(|it| (it, tdims.clone())).collect()
             }
             AMDArchitecture::GFX908 => {
                 vec![
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(), // m / i
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(), // n / o
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(), // k / c
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::F32), // m / i
+                            gpu::ElemType::Float(gpu::FloatKind::F32), // n / o
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                        ), // k / c
                         vec![
                             //m  n   k
                             (16, 16, 4),
@@ -160,9 +156,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -172,9 +170,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -184,9 +184,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -196,23 +198,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                        vec![
-                            (16, 16, 8),
-                            (16, 16, 16),
-                            (16, 16, 32),
-                            (32, 32, 4),
-                            (32, 32, 8),
-                            (32, 32, 16),
-                            (32, 32, 32),
-                        ],
-                    ),
-                    (
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                        ),
                         vec![
                             (16, 16, 8),
                             (16, 16, 16),
@@ -224,9 +214,27 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                        ),
+                        vec![
+                            (16, 16, 8),
+                            (16, 16, 16),
+                            (16, 16, 32),
+                            (32, 32, 4),
+                            (32, 32, 8),
+                            (32, 32, 16),
+                            (32, 32, 32),
+                        ],
+                    ),
+                    (
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                        ),
                         vec![
                             (16, 16, 8),
                             (16, 16, 16),
@@ -242,9 +250,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
             AMDArchitecture::GFX90A | AMDArchitecture::GFX94 => {
                 vec![
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(), // m / i
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(), // n / o
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(), // k / c
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(), // m / i
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(), // n / o
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        ), // k / c
                         vec![
                             //m  n   k
                             (16, 16, 4),
@@ -259,9 +269,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -271,9 +283,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -283,9 +297,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -295,9 +311,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -307,9 +325,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -319,9 +339,11 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                         ],
                     ),
                     (
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                        gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                        (
+                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                        ),
                         vec![
                             (16, 16, 16),
                             (16, 16, 32),
@@ -333,7 +355,19 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                 ]
             }
             AMDArchitecture::Other => vec![],
-        }
+        };
+        combinations
+            .into_iter()
+            .flat_map(|(ty, sizes)| sizes.into_iter().map(move |size| (ty, size)))
+            .map(|((i, o, c), (m, n, k))| MmaConfig {
+                a_type: i.into(),
+                b_type: o.into(),
+                cd_type: c.into(),
+                m,
+                n,
+                k,
+            })
+            .collect()
     }
 
     fn supported_mma_combinations(arch: &AMDArchitecture) -> SupportedMmaCombinations {

--- a/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
+++ b/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
@@ -251,9 +251,9 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                 vec![
                     (
                         (
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(), // m / i
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(), // n / o
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F32), // m / i
+                            gpu::ElemType::Float(gpu::FloatKind::F32), // n / o
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
                         ), // k / c
                         vec![
                             //m  n   k
@@ -270,9 +270,9 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                     ),
                     (
                         (
-                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
                         ),
                         vec![
                             (16, 16, 16),
@@ -284,9 +284,9 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                     ),
                     (
                         (
-                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
                         ),
                         vec![
                             (16, 16, 16),
@@ -298,9 +298,9 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                     ),
                     (
                         (
-                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
+                            gpu::ElemType::Float(gpu::FloatKind::F16),
                         ),
                         vec![
                             (16, 16, 16),
@@ -312,9 +312,9 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                     ),
                     (
                         (
-                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
                         ),
                         vec![
                             (16, 16, 16),
@@ -326,9 +326,9 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                     ),
                     (
                         (
-                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::F32).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::F32),
                         ),
                         vec![
                             (16, 16, 16),
@@ -340,9 +340,9 @@ impl DialectWmmaCompiler<HipDialect<Self>> for RocWmmaCompiler {
                     ),
                     (
                         (
-                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                            gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
+                            gpu::ElemType::Float(gpu::FloatKind::BF16),
                         ),
                         vec![
                             (16, 16, 16),

--- a/crates/cubecl-cpp/src/metal/dialect.rs
+++ b/crates/cubecl-cpp/src/metal/dialect.rs
@@ -8,14 +8,14 @@ use crate::{
         DialectIncludes, DialectInstructions, DialectProcessors, DialectTypes,
         DialectWarpReduceCompiler, DialectWmmaCompiler, Elem, Flags, FmtLeft, Fragment,
         FragmentIdent, FragmentLayout, Instruction, Item, ManualMma, SharedMemory,
-        SupportedMmaCombinations, SupportedWmmaCombinations, Variable, WarpInstruction,
-        WmmaInstruction, wmma_api_base,
+        SupportedMmaCombinations, Variable, WarpInstruction, WmmaInstruction, wmma_api_base,
     },
 };
 use cubecl_core::{
     compute::{Location, Visibility},
     ir::{self as gpu, Id},
 };
+use cubecl_runtime::MmaConfig;
 
 use super::{
     AddressSpace, Extension,
@@ -1149,33 +1149,40 @@ impl DialectWmmaCompiler<Self> for MslDialect {
         unimplemented!("Not supported")
     }
 
-    fn supported_wmma_combinations(_arch: &MetalArchitecture) -> SupportedWmmaCombinations {
-        vec![
+    fn supported_wmma_combinations(_arch: &MetalArchitecture) -> SupportedMmaCombinations {
+        let types = vec![
             (
                 gpu::ElemType::Float(gpu::FloatKind::F16).into(),
                 gpu::ElemType::Float(gpu::FloatKind::F16).into(),
                 gpu::ElemType::Float(gpu::FloatKind::F16).into(),
-                vec![(8, 8, 8)],
             ),
             (
                 gpu::ElemType::Float(gpu::FloatKind::F16).into(),
                 gpu::ElemType::Float(gpu::FloatKind::F16).into(),
                 gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                vec![(8, 8, 8)],
             ),
             (
                 gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
                 gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
                 gpu::ElemType::Float(gpu::FloatKind::BF16).into(),
-                vec![(8, 8, 8)],
             ),
             (
                 gpu::ElemType::Float(gpu::FloatKind::F32).into(),
                 gpu::ElemType::Float(gpu::FloatKind::F32).into(),
                 gpu::ElemType::Float(gpu::FloatKind::F32).into(),
-                vec![(8, 8, 8)],
             ),
-        ]
+        ];
+        types
+            .into_iter()
+            .map(|(a_type, b_type, cd_type)| MmaConfig {
+                a_type,
+                b_type,
+                cd_type,
+                m: 8,
+                n: 8,
+                k: 8,
+            })
+            .collect()
     }
 
     fn supported_mma_combinations(_arch: &MetalArchitecture) -> SupportedMmaCombinations {

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -12,7 +12,7 @@ use cubecl_core::{
     ir::{Operation, SourceLoc},
     prelude::{FastMath, KernelDefinition},
 };
-use cubecl_runtime::{DeviceProperties, EnumSet, TypeUsage};
+use cubecl_runtime::{DeviceProperties, TypeUsage};
 
 use crate::shared::MmaShape;
 

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -5,14 +5,14 @@ use cubecl_core::CubeDim;
 use cubecl_core::ir::{FloatKind, Processor, UIntKind, VariableKind};
 use cubecl_core::post_processing::checked_io::CheckedIoProcessor;
 use cubecl_core::{
-    Compiler, Feature,
+    Compiler,
     ir::{self as gpu},
 };
 use cubecl_core::{
     ir::{Operation, SourceLoc},
     prelude::{FastMath, KernelDefinition},
 };
-use cubecl_runtime::DeviceProperties;
+use cubecl_runtime::{DeviceProperties, EnumSet, TypeUsage};
 
 use crate::shared::MmaShape;
 
@@ -1613,7 +1613,7 @@ fn const_u32<D: Dialect>(value: u32) -> Variable<D> {
     )
 }
 
-pub fn register_supported_types(props: &mut DeviceProperties<Feature>) {
+pub fn register_supported_types(props: &mut DeviceProperties) {
     let supported_types = [
         gpu::ElemType::UInt(gpu::UIntKind::U8),
         gpu::ElemType::UInt(gpu::UIntKind::U16),
@@ -1641,10 +1641,13 @@ pub fn register_supported_types(props: &mut DeviceProperties<Feature>) {
     ];
 
     for ty in supported_types {
-        props.register_feature(Feature::Type(gpu::StorageType::Scalar(ty)));
+        props.register_type_usage(ty, TypeUsage::all_scalar());
     }
 
     for ty in supported_atomic_types {
-        props.register_feature(Feature::Type(gpu::StorageType::Atomic(ty)));
+        props.register_type_usage(
+            gpu::StorageType::Atomic(ty),
+            TypeUsage::AtomicAdd | TypeUsage::AtomicLoadStore,
+        );
     }
 }

--- a/crates/cubecl-cpp/src/shared/dialect.rs
+++ b/crates/cubecl-cpp/src/shared/dialect.rs
@@ -10,8 +10,8 @@ use crate::shared::{
 
 use super::{
     Architecture, AtomicKind, Binding, Body, Component, CubeIndexFlags, Elem, Flags, Fragment,
-    FragmentIdent, FragmentLayout, Instruction, Item, SharedMemory, SupportedWmmaCombinations,
-    Variable, WarpInstruction, WmmaInstruction,
+    FragmentIdent, FragmentLayout, Instruction, Item, SharedMemory, Variable, WarpInstruction,
+    WmmaInstruction,
 };
 
 // Base dialect
@@ -794,7 +794,7 @@ pub trait DialectWmmaCompiler<D: Dialect>:
         scales_b: Variable<D>,
         scales_factor: u32,
     ) -> std::fmt::Result;
-    fn supported_wmma_combinations(arch: &D::Architecture) -> SupportedWmmaCombinations;
+    fn supported_wmma_combinations(arch: &D::Architecture) -> SupportedMmaCombinations;
     fn supported_mma_combinations(arch: &D::Architecture) -> SupportedMmaCombinations;
     fn supported_scaled_mma_combinations(
         _arch: &D::Architecture,

--- a/crates/cubecl-cpu/src/compiler/visitor/elem.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/elem.rs
@@ -1,8 +1,5 @@
-use cubecl_core::{
-    Feature,
-    ir::{ElemType, FloatKind, IntKind, StorageType, UIntKind},
-};
-use cubecl_runtime::DeviceProperties;
+use cubecl_core::ir::{ElemType, FloatKind, IntKind, StorageType, UIntKind};
+use cubecl_runtime::{DeviceProperties, TypeUsage};
 use tracel_llvm::melior::{
     dialect::index,
     ir::{ValueLike, r#type::IntegerType},
@@ -68,7 +65,7 @@ impl<'a> Visitor<'a> {
     }
 }
 
-pub fn register_supported_types(props: &mut DeviceProperties<Feature>) {
+pub fn register_supported_types(props: &mut DeviceProperties) {
     let supported_types = [
         ElemType::UInt(UIntKind::U8),
         ElemType::UInt(UIntKind::U16),
@@ -90,6 +87,6 @@ pub fn register_supported_types(props: &mut DeviceProperties<Feature>) {
     ];
 
     for ty in supported_types {
-        props.register_feature(Feature::Type(ty.into()));
+        props.register_type_usage(ty, TypeUsage::all_scalar());
     }
 }

--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use cubecl_common::profile::ProfileDuration;
 use cubecl_core::{
-    CubeCount, ExecutionMode, Feature, MemoryUsage,
+    CubeCount, ExecutionMode, MemoryUsage,
     compute::CubeTask,
     future::DynFut,
     server::{
@@ -88,7 +88,6 @@ impl CpuServer {
 impl ComputeServer for CpuServer {
     type Kernel = Box<dyn CubeTask<CpuCompiler>>;
     type Storage = BytesStorage;
-    type Feature = Feature;
     type Info = ();
 
     fn create(

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -67,8 +67,12 @@ fn create_client(options: RuntimeOptions) -> ComputeClient<Server, Channel> {
 
     let memory_management =
         MemoryManagement::from_configuration(storage, &mem_properties, options.memory_config);
-    let mut device_props =
-        DeviceProperties::new(&[], mem_properties, topology, TimingMethod::Device);
+    let mut device_props = DeviceProperties::new(
+        Default::default(),
+        mem_properties,
+        topology,
+        TimingMethod::Device,
+    );
     register_supported_types(&mut device_props);
 
     let ctx = CpuContext::new(memory_management);

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -28,7 +28,6 @@ use cubecl_common::profile::ProfileDuration;
 use cubecl_core::ir::{ElemType, IntKind, UIntKind};
 use cubecl_core::prelude::*;
 use cubecl_core::{
-    Feature,
     ir::FloatKind,
     server::{Bindings, CopyDescriptor, TensorMapBinding},
 };
@@ -190,7 +189,6 @@ impl CudaServer {
 impl ComputeServer for CudaServer {
     type Kernel = Box<dyn CubeTask<CudaCompiler>>;
     type Storage = CudaStorage;
-    type Feature = Feature;
     type Info = ();
 
     fn read(

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -195,6 +195,7 @@ fn create_client<M: DialectWmmaCompiler<CudaDialect<M>>>(
     }
     if arch_version >= 90 {
         device_props.features.tma.insert(Tma::Base);
+        device_props.register_semantic_type(SemanticType::TensorMap);
         device_props.features.cube_cluster = true;
         comp_opts.supports_clusters = true;
     }

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -190,8 +190,14 @@ fn create_client<M: DialectWmmaCompiler<CudaDialect<M>>>(
     // }
 
     if arch_version >= 89 {
-        device_props.register_type_usage(ElemType::Float(FloatKind::E4M3), TypeUsage::Conversion);
-        device_props.register_type_usage(ElemType::Float(FloatKind::E5M2), TypeUsage::Conversion);
+        device_props.register_type_usage(
+            ElemType::Float(FloatKind::E4M3),
+            TypeUsage::Conversion | TypeUsage::Buffer,
+        );
+        device_props.register_type_usage(
+            ElemType::Float(FloatKind::E5M2),
+            TypeUsage::Conversion | TypeUsage::Buffer,
+        );
     }
     if arch_version >= 90 {
         device_props.features.tma.insert(Tma::Base);
@@ -211,11 +217,20 @@ fn create_client<M: DialectWmmaCompiler<CudaDialect<M>>>(
         device_props.register_type_usage(ElemType::Float(FloatKind::E2M1), TypeUsage::Conversion);
         device_props.register_type_usage(
             StorageType::Packed(ElemType::Float(FloatKind::E2M1), 2),
-            TypeUsage::Conversion,
+            TypeUsage::Conversion | TypeUsage::Buffer,
         );
-        device_props.register_type_usage(ElemType::Float(FloatKind::E2M3), TypeUsage::Conversion);
-        device_props.register_type_usage(ElemType::Float(FloatKind::E3M2), TypeUsage::Conversion);
-        device_props.register_type_usage(ElemType::Float(FloatKind::UE8M0), TypeUsage::Conversion);
+        device_props.register_type_usage(
+            ElemType::Float(FloatKind::E2M3),
+            TypeUsage::Conversion | TypeUsage::Buffer,
+        );
+        device_props.register_type_usage(
+            ElemType::Float(FloatKind::E3M2),
+            TypeUsage::Conversion | TypeUsage::Buffer,
+        );
+        device_props.register_type_usage(
+            ElemType::Float(FloatKind::UE8M0),
+            TypeUsage::Conversion | TypeUsage::Buffer,
+        );
     }
 
     device_props.features.dynamic_line_size = true;

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -7,11 +7,11 @@ use cubecl_common::profile::ProfileDuration;
 use cubecl_core::compute::CubeTask;
 use cubecl_core::compute::DebugInformation;
 use cubecl_core::prelude::*;
+use cubecl_core::server::Bindings;
 use cubecl_core::server::{
     Allocation, AllocationKind, CopyDescriptor, DataTransferService, IoError, ProfileError,
     ProfilingToken,
 };
-use cubecl_core::{Feature, server::Bindings};
 use cubecl_cpp::formatter::format_cpp;
 use cubecl_cpp::shared::CompilationOptions;
 use cubecl_hip_sys::{
@@ -159,7 +159,6 @@ impl HipServer {
 impl ComputeServer for HipServer {
     type Kernel = Box<dyn CubeTask<HipCompiler>>;
     type Storage = HipStorage;
-    type Feature = Feature;
     type Info = ();
 
     fn create(

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -356,7 +356,7 @@ impl Launch {
                 settings.extend(quote![.debug_symbols()]);
             }
             if let Some(mode) = &self.args.fast_math {
-                settings.extend(quote![.fp_math_mode(#mode)]);
+                settings.extend(quote![.fp_math_mode((#mode).into())]);
             }
             if let Some(cluster_dim) = &self.args.cluster_dim {
                 settings.extend(quote![.cluster_dim(#cluster_dim)]);

--- a/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/barrier/config.rs
@@ -1,4 +1,4 @@
-use cubecl_core::{CubeDim, Feature, Runtime, client::ComputeClient};
+use cubecl_core::{CubeDim, Runtime, client::ComputeClient, ir::SemanticType};
 
 use crate::components::{
     LoadingPrecomputeStrategy, MatmulIdent, MatrixLayout,
@@ -154,7 +154,7 @@ impl<S: stage::StageConfig> SimpleBarrierConfig<S> {
         self,
         client: &ComputeClient<R::Server, R::Channel>,
     ) -> Result<Self, MatmulSetupError> {
-        if !client.properties().feature_enabled(Feature::Barrier) {
+        if !client.properties().supports_type(SemanticType::Barrier) {
             return Err(MatmulSetupError::Unavailable(
                 MatmulAvailabilityError::BarrierUnavailable,
             ));

--- a/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
+++ b/crates/cubecl-matmul/src/components/global/single_stage/tma/config.rs
@@ -1,6 +1,7 @@
 use std::any::TypeId;
 
-use cubecl_core::{CubeDim, Feature, Runtime, TmaFeature, client::ComputeClient, tf32};
+use cubecl_core::{CubeDim, Runtime, client::ComputeClient, tf32};
+use cubecl_runtime::Tma;
 
 use crate::components::{
     LhsG, LhsS, LoadingPrecomputeStrategy, MatmulIdent, MatmulPrecision, MatrixLayout, RhsG, RhsS,
@@ -170,10 +171,7 @@ impl<S: stage::StageConfig> SimpleTmaConfig<S> {
             ));
         }
 
-        if !client
-            .properties()
-            .feature_enabled(Feature::Tma(TmaFeature::Base))
-        {
+        if !client.properties().features.tma.contains(Tma::Base) {
             return Err(MatmulSetupError::Unavailable(
                 MatmulAvailabilityError::TmaUnavailable,
             ));

--- a/crates/cubecl-matmul/src/components/tile/register/config.rs
+++ b/crates/cubecl-matmul/src/components/tile/register/config.rs
@@ -2,6 +2,7 @@ use cubecl_core::client::ComputeClient;
 use cubecl_core::ir::{ElemType, FloatKind};
 use cubecl_core::prelude::Numeric;
 use cubecl_core::{Runtime, ir::StorageType};
+use cubecl_runtime::TypeUsage;
 
 use crate::components::error::{MatmulAvailabilityError, MatmulSetupError};
 use crate::components::tile::TileConfig;
@@ -187,7 +188,10 @@ impl RegisterConfig {
             _ => acc,
         };
 
-        if !(Lhs::is_supported(client) && Rhs::is_supported(client) && Acc::is_supported(client)) {
+        if !(Lhs::supported_uses(client).contains(TypeUsage::Arithmetic)
+            && Rhs::supported_uses(client).contains(TypeUsage::Arithmetic)
+            && Acc::supported_uses(client).contains(TypeUsage::Arithmetic))
+        {
             return Err(MatmulSetupError::Unavailable(
                 MatmulAvailabilityError::TypesUnavailable { lhs, rhs, output },
             ));

--- a/crates/cubecl-matmul/src/kernels/layered/algorithm/simple.rs
+++ b/crates/cubecl-matmul/src/kernels/layered/algorithm/simple.rs
@@ -1,4 +1,5 @@
-use cubecl_core::{Feature, Runtime, client::ComputeClient};
+use cubecl_core::{Runtime, client::ComputeClient};
+use cubecl_runtime::MmaConfig;
 use std::marker::PhantomData;
 
 use crate::{
@@ -87,11 +88,11 @@ fn selection_multi_rows<R: Runtime, TMM: TileMatmulFamily>(
     plane_dim: u32,
     elems: MatmulElems,
 ) -> Result<MatmulSelection, MatmulSetupError> {
-    let supported = |m: u8, n: u8, k: u8| {
-        client.properties().feature_enabled(Feature::Cmma {
-            a: elems.lhs_register,
-            b: elems.rhs_register,
-            c: elems.acc,
+    let supported = |m: u32, n: u32, k: u32| {
+        client.properties().features.cmma.contains(&MmaConfig {
+            a_type: elems.lhs_register,
+            b_type: elems.rhs_register,
+            cd_type: elems.acc,
             m,
             n,
             k,

--- a/crates/cubecl-matmul/src/tests/test_utils.rs
+++ b/crates/cubecl-matmul/src/tests/test_utils.rs
@@ -1,13 +1,14 @@
 use std::fmt::Display;
 
 use cubecl_core::{
-    CubeElement, Feature, Runtime,
+    CubeElement, Runtime,
     client::ComputeClient,
     flex32,
     prelude::{CubePrimitive, Float, Numeric},
     server::{self},
     tf32,
 };
+use cubecl_runtime::MmaConfig;
 
 use crate::{
     components::{MatmulIdent, MatmulPrecision, MatmulProblem},
@@ -53,18 +54,18 @@ where
         shape: &[usize],
         strides: &[usize],
     ) {
-        let maybe_f16 = client.properties().feature_enabled(Feature::Cmma {
-            a: ES::as_type_native().expect("To be a native type"),
-            b: ES::as_type_native().expect("To be a native type"),
-            c: EG::as_type_native().expect("To be a native type"),
+        let maybe_f16 = client.properties().features.cmma.contains(&MmaConfig {
+            a_type: ES::as_type_native().expect("To be a native type"),
+            b_type: ES::as_type_native().expect("To be a native type"),
+            cd_type: EG::as_type_native().expect("To be a native type"),
             m: 16,
             k: 16,
             n: 16,
         });
-        let maybe_tf32 = client.properties().feature_enabled(Feature::Cmma {
-            a: ES::as_type_native().expect("To be a native type"),
-            b: ES::as_type_native().expect("To be a native type"),
-            c: EG::as_type_native().expect("To be a native type"),
+        let maybe_tf32 = client.properties().features.cmma.contains(&MmaConfig {
+            a_type: ES::as_type_native().expect("To be a native type"),
+            b_type: ES::as_type_native().expect("To be a native type"),
+            cd_type: EG::as_type_native().expect("To be a native type"),
             m: 16,
             k: 8,
             n: 16,

--- a/crates/cubecl-quant/src/dequantize.rs
+++ b/crates/cubecl-quant/src/dequantize.rs
@@ -2,6 +2,7 @@
 
 use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, calculate_cube_count_elemwise, tensor_line_size_parallel};
+use cubecl_runtime::TypeUsage;
 
 use crate::{
     qparams::QParams,
@@ -198,7 +199,7 @@ pub fn launch_ref<R: Runtime, F: Float>(
             store: QuantStore::Native,
             ..
         } => {
-            if !i8::is_supported(client) {
+            if !i8::supported_uses(client).contains(TypeUsage::Conversion) {
                 panic!(
                     "{:?} is not supported for native quantization",
                     scheme.value

--- a/crates/cubecl-quant/src/quantize.rs
+++ b/crates/cubecl-quant/src/quantize.rs
@@ -2,6 +2,7 @@ use cubecl::calculate_cube_count_elemwise;
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
 use cubecl_core::tensor_line_size_parallel;
+use cubecl_runtime::TypeUsage;
 use cubecl_std::tensor::layout::linear::LinearView;
 use cubecl_std::tensor::{View, into_contiguous, layout::linear::linear_view};
 
@@ -222,7 +223,7 @@ pub fn launch_ref<R: Runtime, F: Float>(
             store: QuantStore::Native,
             ..
         } => {
-            if !i8::is_supported(client) {
+            if !i8::supported_uses(client).contains(TypeUsage::Conversion) {
                 panic!(
                     "{:?} is not supported for native quantization",
                     scheme.value

--- a/crates/cubecl-reduce/src/shared_sum.rs
+++ b/crates/cubecl-reduce/src/shared_sum.rs
@@ -1,5 +1,6 @@
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
+use cubecl_runtime::TypeUsage;
 
 use crate::ReduceError;
 
@@ -61,12 +62,8 @@ pub fn shared_sum<R: Runtime, N: Numeric + CubeElement>(
     let atomic_elem = Atomic::<N>::as_type_native_unchecked();
     if !client
         .properties()
-        .feature_enabled(cubecl_core::Feature::Type(atomic_elem))
-        || !client
-            .properties()
-            .feature_enabled(cubecl_core::Feature::AtomicFloat(
-                cubecl_core::AtomicFeature::Add,
-            ))
+        .type_usage(atomic_elem)
+        .contains(TypeUsage::AtomicAdd)
     {
         return Err(ReduceError::MissingAtomicAdd(N::as_type_native_unchecked()));
     }

--- a/crates/cubecl-reduce/src/strategy.rs
+++ b/crates/cubecl-reduce/src/strategy.rs
@@ -1,4 +1,5 @@
-use cubecl_core::{Feature, prelude::*};
+use cubecl_core::prelude::*;
+use cubecl_runtime::Plane;
 use serde::{Deserialize, Serialize};
 
 use crate::ReduceError;
@@ -41,7 +42,7 @@ impl ReduceStrategy {
 }
 
 fn support_plane<R: Runtime>(client: &ComputeClient<R::Server, R::Channel>) -> bool {
-    client.properties().feature_enabled(Feature::Plane)
+    client.properties().features.plane.contains(Plane::Ops)
 }
 
 fn precise_plane_dim<R: Runtime>(client: &ComputeClient<R::Server, R::Channel>) -> bool {

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -36,6 +36,7 @@ cubecl-common = { path = "../cubecl-common", version = "0.7.0", default-features
 cubecl-ir = { path = "../cubecl-ir", version = "0.7.0", default-features = false }
 derive-new = { workspace = true }
 dirs = { workspace = true, optional = true }
+enumset = { workspace = true }
 foldhash = { workspace = true }
 hashbrown = { workspace = true }
 log = { workspace = true }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -39,7 +39,7 @@ struct ComputeClientState<Server: ComputeServer> {
     #[cfg(feature = "profile-tracy")]
     gpu_client: tracy_client::GpuContext,
 
-    properties: DeviceProperties<Server::Feature>,
+    properties: DeviceProperties,
     info: Server::Info,
     logger: Arc<ServerLogger>,
 
@@ -71,11 +71,7 @@ where
     }
 
     /// Create a new client.
-    pub fn new(
-        channel: Channel,
-        properties: DeviceProperties<Server::Feature>,
-        info: Server::Info,
-    ) -> Self {
+    pub fn new(channel: Channel, properties: DeviceProperties, info: Server::Info) -> Self {
         let logger = ServerLogger::default();
 
         // Start a tracy client if needed.
@@ -431,14 +427,14 @@ where
     }
 
     /// Get the features supported by the compute server.
-    pub fn properties(&self) -> &DeviceProperties<Server::Feature> {
+    pub fn properties(&self) -> &DeviceProperties {
         &self.state.properties
     }
 
     /// # Warning
     ///
     /// For private use only.
-    pub fn properties_mut(&mut self) -> Option<&mut DeviceProperties<Server::Feature>> {
+    pub fn properties_mut(&mut self) -> Option<&mut DeviceProperties> {
         Arc::get_mut(&mut self.state).map(|state| &mut state.properties)
     }
 

--- a/crates/cubecl-runtime/src/features.rs
+++ b/crates/cubecl-runtime/src/features.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 use cubecl_ir::{SemanticType, StorageType, Type};
 use enumset::EnumSetType;

--- a/crates/cubecl-runtime/src/features.rs
+++ b/crates/cubecl-runtime/src/features.rs
@@ -20,8 +20,6 @@ pub struct Features {
     /// Semantic constructs supported by this runtime.
     pub semantic_types: BTreeSet<SemanticType>,
 
-    /// Statically known warp size for CMMA ops
-    pub cmma_warp_size: Option<u32>,
     /// Tensor Memory Accelerator supported features
     pub tma: EnumSet<Tma>,
     /// The cmma feature enables cooperative matrix-multiply and accumulate operations.

--- a/crates/cubecl-runtime/src/features.rs
+++ b/crates/cubecl-runtime/src/features.rs
@@ -41,6 +41,8 @@ pub enum TypeUsage {
     Arithmetic,
     /// Dot product, mainly for BF16 on Intel
     DotProduct,
+    /// Whether this type can be stored in a buffer
+    Buffer,
     /// Atomic loads and stores
     AtomicLoadStore,
     /// Atomic add/sub
@@ -130,7 +132,7 @@ impl Features {
 impl TypeUsage {
     /// All uses except atomics
     pub fn all_scalar() -> EnumSet<TypeUsage> {
-        TypeUsage::Conversion | TypeUsage::Arithmetic | TypeUsage::DotProduct
+        TypeUsage::Conversion | TypeUsage::Arithmetic | TypeUsage::DotProduct | TypeUsage::Buffer
     }
 
     /// All atomic uses

--- a/crates/cubecl-runtime/src/features.rs
+++ b/crates/cubecl-runtime/src/features.rs
@@ -1,0 +1,142 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use cubecl_ir::{SemanticType, StorageType, Type};
+use enumset::EnumSetType;
+
+pub use enumset::EnumSet;
+
+/// Features supported by a runtime
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Features {
+    /// Plane features supported by this runtime.
+    pub plane: EnumSet<Plane>,
+    /// Clustered launches and intra-cluster operations like cluster shared memory
+    pub cube_cluster: bool,
+    /// Enables to change the line size of containers during kernel execution.
+    pub dynamic_line_size: bool,
+
+    /// Types supported by this runtime, and which usages they support.
+    pub storage_types: BTreeMap<StorageType, EnumSet<TypeUsage>>,
+    /// Semantic constructs supported by this runtime.
+    pub semantic_types: BTreeSet<SemanticType>,
+
+    /// Statically known warp size for CMMA ops
+    pub cmma_warp_size: Option<u32>,
+    /// Tensor Memory Accelerator supported features
+    pub tma: EnumSet<Tma>,
+    /// The cmma feature enables cooperative matrix-multiply and accumulate operations.
+    pub cmma: BTreeSet<MmaConfig>,
+    /// The manual MMA feature enables cooperative matrix-multiply with manually managed data
+    /// movement
+    pub mma: BTreeSet<MmaConfig>,
+    /// Scaled MMA allows combining matrix multiplication with unscaling quantized values into a single
+    /// instruction. Scales must fit a specific layout and block size.
+    pub scaled_mma: BTreeSet<ScaledMmaConfig>,
+}
+
+/// Operations allowed for this type. CMMA is defined separately.
+#[derive(Debug, Hash, PartialOrd, Ord, EnumSetType)]
+pub enum TypeUsage {
+    /// Conversion to/from the type. All types should support this.
+    Conversion,
+    /// All math/logic instructions except dot product
+    Arithmetic,
+    /// Dot product, mainly for BF16 on Intel
+    DotProduct,
+    /// Atomic loads and stores
+    AtomicLoadStore,
+    /// Atomic add/sub
+    AtomicAdd,
+    /// Atomic min/max
+    AtomicMinMax,
+}
+
+/// Supported plane features
+#[derive(Debug, Hash, PartialOrd, Ord, EnumSetType)]
+pub enum Plane {
+    /// Basic plane-wide operations
+    Ops,
+    /// Plane-wide sync
+    Sync,
+}
+
+/// Shape and element types of a valid MMA configuration
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MmaConfig {
+    /// Element of the A matrix
+    pub a_type: StorageType,
+    /// Element of the B matrix
+    pub b_type: StorageType,
+    /// Element of the C/D matrices
+    pub cd_type: StorageType,
+    /// The size of the matrix on the `m` dimension
+    pub m: u32,
+    /// The size of the matrix on the `n` dimension
+    pub n: u32,
+    /// The size of the matrix on the `k` dimension
+    pub k: u32,
+}
+
+/// Shape and element types of a valid block-scaled MMA configuration
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ScaledMmaConfig {
+    /// Element of the A matrix
+    pub a_type: StorageType,
+    /// Element of the B matrix
+    pub b_type: StorageType,
+    /// Element of the C/D matrices
+    pub cd_type: StorageType,
+    /// Element of the blocks scales
+    pub scales_type: StorageType,
+    /// The size of the matrix on the `m` dimension
+    pub m: u32,
+    /// The size of the matrix on the `n` dimension
+    pub n: u32,
+    /// The size of the matrix on the `k` dimension
+    pub k: u32,
+    /// Number of scales per tile row/col.
+    /// A scale factor of 2 means `m x 2` scales for A and `2 x n` for B (in CUDA)
+    /// Scales blocks must be organized along the natural `line_layout` of the operation
+    pub scales_factor: u32,
+}
+
+/// Atomic features that may be supported by a [cube runtime](Runtime).
+#[derive(Debug, PartialOrd, Ord, EnumSetType)]
+pub enum Tma {
+    /// Base feature set for tensor memory accelerator features. Includes tiling and im2col
+    Base,
+    /// im2colWide encoding for tensor map.
+    Im2colWide,
+}
+
+impl Features {
+    /// Get the usages for a type
+    pub fn type_usage(&self, ty: StorageType) -> EnumSet<TypeUsage> {
+        self.storage_types
+            .get(&ty)
+            .cloned()
+            .unwrap_or_else(EnumSet::empty)
+    }
+
+    /// Whether the type is supported in any way
+    pub fn supports_type(&self, ty: impl Into<Type>) -> bool {
+        match ty.into() {
+            Type::Scalar(storage_type) | Type::Line(storage_type, _) => {
+                self.storage_types.contains_key(&storage_type)
+            }
+            Type::Semantic(semantic_type) => self.semantic_types.contains(&semantic_type),
+        }
+    }
+}
+
+impl TypeUsage {
+    /// All uses except atomics
+    pub fn all_scalar() -> EnumSet<TypeUsage> {
+        TypeUsage::Conversion | TypeUsage::Arithmetic | TypeUsage::DotProduct
+    }
+
+    /// All atomic uses
+    pub fn all_atomic() -> EnumSet<TypeUsage> {
+        TypeUsage::AtomicAdd | TypeUsage::AtomicLoadStore | TypeUsage::AtomicMinMax
+    }
+}

--- a/crates/cubecl-runtime/src/lib.rs
+++ b/crates/cubecl-runtime/src/lib.rs
@@ -33,12 +33,14 @@ pub mod storage;
 pub mod config;
 
 mod feature_set;
+pub mod features;
 
 mod base;
 pub use base::*;
 pub use cubecl_common::benchmark;
 
 pub use feature_set::*;
+pub use features::*;
 /// Logging utilities to be used by a compute server.
 pub mod logging;
 

--- a/crates/cubecl-runtime/src/lib.rs
+++ b/crates/cubecl-runtime/src/lib.rs
@@ -33,6 +33,7 @@ pub mod storage;
 pub mod config;
 
 mod feature_set;
+/// Runtime features and associated types
 pub mod features;
 
 mod base;

--- a/crates/cubecl-runtime/src/server.rs
+++ b/crates/cubecl-runtime/src/server.rs
@@ -42,8 +42,6 @@ where
     type Info: Debug + Send + Sync;
     /// The [storage](ComputeStorage) type defines how data is stored and accessed.
     type Storage: ComputeStorage;
-    /// The type of the features supported by the server.
-    type Feature: Ord + Copy + Debug + Send + Sync;
 
     /// Reserves `size` bytes in the storage, and returns a handle over them.
     fn create(

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -47,7 +47,12 @@ pub fn init_client() -> ComputeClient<DummyServer, MutexComputeChannel<DummyServ
     let channel = MutexComputeChannel::new(server);
     ComputeClient::new(
         channel,
-        DeviceProperties::new(&[], mem_properties, topology, TimingMethod::System),
+        DeviceProperties::new(
+            Default::default(),
+            mem_properties,
+            topology,
+            TimingMethod::System,
+        ),
         (),
     )
 }

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -64,7 +64,6 @@ impl ComputeServer for DummyServer {
     type Kernel = KernelTask;
     type Storage = BytesStorage;
     type Info = ();
-    type Feature = ();
 
     fn create(
         &mut self,

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -5,7 +5,10 @@ use cubecl_core::{
     prelude::FastMath,
 };
 use cubecl_opt::{BasicBlock, NodeIndex, Optimizer, OptimizerBuilder, Uniformity};
-use cubecl_runtime::config::{GlobalConfig, compilation::CompilationLogLevel};
+use cubecl_runtime::{
+    EnumSet,
+    config::{GlobalConfig, compilation::CompilationLogLevel},
+};
 use std::{
     collections::HashSet,
     fmt::Debug,
@@ -417,7 +420,7 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
     }
 }
 
-fn convert_math_mode(math_mode: FastMath) -> FPFastMathMode {
+fn convert_math_mode(math_mode: EnumSet<FastMath>) -> FPFastMathMode {
     let mut flags = FPFastMathMode::NONE;
 
     for mode in math_mode.iter() {

--- a/crates/cubecl-std/src/fast_math.rs
+++ b/crates/cubecl-std/src/fast_math.rs
@@ -1,5 +1,6 @@
 use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
+use cubecl_runtime::TypeUsage;
 
 /// Create a fast-divmod object if supported, or a regular fallback if not.
 /// This precalculates certain values on the host, in exchange for making division and modulo
@@ -42,7 +43,7 @@ impl<R: Runtime> FastDivmodArgs<'_, R> {
             };
         }
 
-        if !u64::is_supported(client) {
+        if !u64::supported_uses(client).contains(TypeUsage::Arithmetic) {
             return FastDivmodArgs::Fallback {
                 divisor: ScalarArg::new(divisor),
             };

--- a/crates/cubecl-std/src/tests/reinterpret_slice.rs
+++ b/crates/cubecl-std/src/tests/reinterpret_slice.rs
@@ -15,10 +15,7 @@ pub fn run_test_read_global<R: Runtime>(
     client: ComputeClient<R::Server, R::Channel>,
     line_size: usize,
 ) {
-    if !client
-        .properties()
-        .feature_enabled(cubecl_core::Feature::DynamicLineSize)
-    {
+    if !client.properties().features.dynamic_line_size {
         return; // can't run test
     }
 
@@ -54,10 +51,7 @@ pub fn run_test_write_global<R: Runtime>(
     client: ComputeClient<R::Server, R::Channel>,
     line_size: usize,
 ) {
-    if !client
-        .properties()
-        .feature_enabled(cubecl_core::Feature::DynamicLineSize)
-    {
+    if !client.properties().features.dynamic_line_size {
         return; // can't run test
     }
     let source = [f16::from_f32(1.0), f16::from_f32(-8.5)];
@@ -99,10 +93,7 @@ fn kernel_read_shared_memory(output: &mut Array<f16>) {
 }
 
 pub fn run_test_read_shared_memory<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
-    if !client
-        .properties()
-        .feature_enabled(cubecl_core::Feature::DynamicLineSize)
-    {
+    if !client.properties().features.dynamic_line_size {
         return; // can't run test
     }
 
@@ -135,10 +126,7 @@ fn kernel_write_shared_memory(output: &mut Array<Line<i8>>, input: &Array<f16>) 
 }
 
 pub fn run_test_write_shared_memory<R: Runtime>(client: ComputeClient<R::Server, R::Channel>) {
-    if !client
-        .properties()
-        .feature_enabled(cubecl_core::Feature::DynamicLineSize)
-    {
+    if !client.properties().features.dynamic_line_size {
         return; // can't run test
     }
 

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -21,41 +21,13 @@ std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
 # 'msl' and 'spirv' features are exclusive
 # TODO find a way to have wgpu runtime auto-compiler to support several compilers at the same time
 msl = ["cubecl-cpp/metal"]
-spirv = ["cubecl-spirv", "ash"]
 profile-tracy = ["tracy-client"]
+spirv = ["cubecl-spirv", "ash"]
 
 spirv-dump = ["sanitize-filename"]
 
-matmul_tests_unit = ["cubecl-matmul/matmul_tests_unit"]
-matmul_tests_plane = ["cubecl-matmul/matmul_tests_plane"]
-matmul_tests_vecmat = ["cubecl-matmul/matmul_tests_vecmat"]
-matmul_tests_tma = ["cubecl-matmul/matmul_tests_tma"]
-matmul_tests_double = ["cubecl-matmul/matmul_tests_double"]
-matmul_tests_simple = ["cubecl-matmul/matmul_tests_simple"]
-matmul_tests_ordered = ["cubecl-matmul/matmul_tests_ordered"]
-matmul_tests_cyclic = ["cubecl-matmul/matmul_tests_cyclic"]
-matmul_tests_strided = ["cubecl-matmul/matmul_tests_strided"]
-matmul_tests_tilewise = ["cubecl-matmul/matmul_tests_tilewise"]
-matmul_tests_hybrid = ["cubecl-matmul/matmul_tests_hybrid"]
-matmul_tests_barrier = ["cubecl-matmul/matmul_tests_barrier"]
-matmul_tests_specialized = ["cubecl-matmul/matmul_tests_specialized"]
-matmul_tests_f16 = ["cubecl-matmul/matmul_tests_f16"]
-matmul_tests_f32 = ["cubecl-matmul/matmul_tests_f32"]
-matmul_tests_layouts = ["cubecl-matmul/matmul_tests_layouts"]
-matmul_tests_alt_shapes = ["cubecl-matmul/matmul_tests_alt_shapes"]
-matmul_tests_partition_buffering = [
-    "cubecl-matmul/matmul_tests_partition_buffering",
-]
-matmul_tests_hypercube = ["cubecl-matmul/matmul_tests_hypercube"]
-matmul_tests_base = [
-    "matmul_tests_plane",
-    "matmul_tests_vecmat",
-    "matmul_tests_double",
-    "matmul_tests_simple",
-    "matmul_tests_ordered",
-    "matmul_tests_cyclic",
-    "matmul_tests_f16",
-]
+attention_tests = ["cubecl-attention/attention_tests"]
+conv_tests = ["cubecl-convolution/conv_tests"]
 matmul_tests_all = [
     "matmul_tests_unit",
     "matmul_tests_plane",
@@ -77,8 +49,36 @@ matmul_tests_all = [
     "matmul_tests_partition_buffering",
     "matmul_tests_hypercube",
 ]
-conv_tests = ["cubecl-convolution/conv_tests"]
-attention_tests = ["cubecl-attention/attention_tests"]
+matmul_tests_alt_shapes = ["cubecl-matmul/matmul_tests_alt_shapes"]
+matmul_tests_barrier = ["cubecl-matmul/matmul_tests_barrier"]
+matmul_tests_base = [
+    "matmul_tests_plane",
+    "matmul_tests_vecmat",
+    "matmul_tests_double",
+    "matmul_tests_simple",
+    "matmul_tests_ordered",
+    "matmul_tests_cyclic",
+    "matmul_tests_f16",
+]
+matmul_tests_cyclic = ["cubecl-matmul/matmul_tests_cyclic"]
+matmul_tests_double = ["cubecl-matmul/matmul_tests_double"]
+matmul_tests_f16 = ["cubecl-matmul/matmul_tests_f16"]
+matmul_tests_f32 = ["cubecl-matmul/matmul_tests_f32"]
+matmul_tests_hybrid = ["cubecl-matmul/matmul_tests_hybrid"]
+matmul_tests_hypercube = ["cubecl-matmul/matmul_tests_hypercube"]
+matmul_tests_layouts = ["cubecl-matmul/matmul_tests_layouts"]
+matmul_tests_ordered = ["cubecl-matmul/matmul_tests_ordered"]
+matmul_tests_partition_buffering = [
+    "cubecl-matmul/matmul_tests_partition_buffering",
+]
+matmul_tests_plane = ["cubecl-matmul/matmul_tests_plane"]
+matmul_tests_simple = ["cubecl-matmul/matmul_tests_simple"]
+matmul_tests_specialized = ["cubecl-matmul/matmul_tests_specialized"]
+matmul_tests_strided = ["cubecl-matmul/matmul_tests_strided"]
+matmul_tests_tilewise = ["cubecl-matmul/matmul_tests_tilewise"]
+matmul_tests_tma = ["cubecl-matmul/matmul_tests_tma"]
+matmul_tests_unit = ["cubecl-matmul/matmul_tests_unit"]
+matmul_tests_vecmat = ["cubecl-matmul/matmul_tests_vecmat"]
 
 [dependencies]
 cubecl-common = { path = "../cubecl-common", version = "0.7.0", default-features = false }
@@ -129,19 +129,16 @@ wgpu = { version = "26.0.0", features = [
 # wgpu = { path = "../../../../tracel/wgpu/wgpu", features = ["vulkan-portability", "fragile-send-sync-non-atomic-wasm"]}
 
 [dev-dependencies]
-cubecl-core = { path = "../cubecl-core", version = "0.7.0", features = [
-    "export_tests",
-] }
-cubecl-matmul = { path = "../cubecl-matmul", version = "0.7.0", features = [
-    "export_tests",
-] }
 cubecl-attention = { path = "../cubecl-attention", version = "0.7.0", features = [
     "export_tests",
 ] }
 cubecl-convolution = { path = "../cubecl-convolution", version = "0.7.0", features = [
     "export_tests",
 ] }
-cubecl-reduce = { path = "../cubecl-reduce", version = "0.7.0", features = [
+cubecl-core = { path = "../cubecl-core", version = "0.7.0", features = [
+    "export_tests",
+] }
+cubecl-matmul = { path = "../cubecl-matmul", version = "0.7.0", features = [
     "export_tests",
 ] }
 cubecl-quant = { path = "../cubecl-quant", version = "0.7.0", features = [
@@ -149,6 +146,9 @@ cubecl-quant = { path = "../cubecl-quant", version = "0.7.0", features = [
     "kernels",
 ] }
 cubecl-random = { path = "../cubecl-random", version = "0.7.0", features = [
+    "export_tests",
+] }
+cubecl-reduce = { path = "../cubecl-reduce", version = "0.7.0", features = [
     "export_tests",
 ] }
 cubecl-std = { path = "../cubecl-std", version = "0.7.0", features = [

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use cubecl_core::{ExecutionMode, Feature, WgpuCompilationOptions, prelude::CompiledKernel};
+use cubecl_core::{ExecutionMode, WgpuCompilationOptions, prelude::CompiledKernel};
 use cubecl_runtime::DeviceProperties;
 use wgpu::{
     Adapter, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BufferBindingType,
@@ -174,7 +174,7 @@ pub async fn request_device(adapter: &Adapter) -> (Device, Queue) {
 #[cfg(all(not(feature = "spirv"), not(feature = "msl")))]
 pub fn register_features(
     adapter: &Adapter,
-    props: &mut DeviceProperties<Feature>,
+    props: &mut DeviceProperties,
     comp_options: &mut WgpuCompilationOptions,
 ) {
     wgsl::register_wgsl_features(adapter, props, comp_options);
@@ -183,7 +183,7 @@ pub fn register_features(
 #[cfg(feature = "spirv")]
 pub fn register_features(
     adapter: &Adapter,
-    props: &mut DeviceProperties<Feature>,
+    props: &mut DeviceProperties,
     comp_options: &mut WgpuCompilationOptions,
 ) {
     if is_vulkan(adapter) {

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -196,7 +196,7 @@ pub fn register_features(
 #[cfg(all(feature = "msl", target_os = "macos"))]
 pub fn register_features(
     adapter: &Adapter,
-    props: &mut DeviceProperties<Feature>,
+    props: &mut DeviceProperties,
     comp_options: &mut WgpuCompilationOptions,
 ) {
     if is_metal(adapter) {

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -73,6 +73,7 @@ fn register_features(
 ) {
     register_types(props);
     register_cmma(props);
+    props.features.plane.insert(Plane::Ops);
     props.features.plane.insert(Plane::Sync);
 }
 

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -1,10 +1,10 @@
-use cubecl_core::{Feature, WgpuCompilationOptions, ir::UIntKind};
+use cubecl_core::{WgpuCompilationOptions, ir::UIntKind};
 use cubecl_cpp::{
     DialectWmmaCompiler,
     metal::{MslDialect, arch::MetalArchitecture},
     shared::register_wmma_features,
 };
-use cubecl_runtime::DeviceProperties;
+use cubecl_runtime::{DeviceProperties, EnumSet, Plane, TypeUsage};
 use wgpu::{
     DeviceDescriptor, Features, Limits,
     hal::{self, Adapter, metal},
@@ -54,7 +54,7 @@ fn request_device(
 
 pub fn register_metal_features(
     adapter: &wgpu::Adapter,
-    props: &mut cubecl_runtime::DeviceProperties<cubecl_core::Feature>,
+    props: &mut cubecl_runtime::DeviceProperties,
     comp_options: &mut WgpuCompilationOptions,
 ) {
     let features = adapter.features();
@@ -67,20 +67,20 @@ pub fn register_metal_features(
 
 fn register_features(
     _adapter: &metal::Adapter,
-    props: &mut cubecl_runtime::DeviceProperties<cubecl_core::Feature>,
+    props: &mut cubecl_runtime::DeviceProperties,
     _features: Features,
     _comp_options: &mut WgpuCompilationOptions,
 ) {
     register_types(props);
     register_cmma(props);
-    props.register_feature(Feature::SyncPlane);
+    props.features.plane.insert(Plane::Sync);
 }
 
-fn register_types(props: &mut DeviceProperties<Feature>) {
+fn register_types(props: &mut DeviceProperties) {
     use cubecl_core::ir::{ElemType, FloatKind, IntKind, StorageType};
 
-    let mut register = |elem: StorageType| {
-        props.register_feature(Feature::Type(elem));
+    let mut register = |elem: StorageType, usage: EnumSet<TypeUsage>| {
+        props.register_type_usage(elem, usage);
     };
 
     let types = [
@@ -105,15 +105,18 @@ fn register_types(props: &mut DeviceProperties<Feature>) {
     ];
 
     for ty in types {
-        register(ty.into());
+        register(ty.into(), TypeUsage::all_scalar());
     }
 
     for ty in atomic_types {
-        register(StorageType::Atomic(ty))
+        register(
+            StorageType::Atomic(ty),
+            TypeUsage::AtomicAdd | TypeUsage::AtomicLoadStore,
+        )
     }
 }
 
-fn register_cmma(props: &mut DeviceProperties<Feature>) {
+fn register_cmma(props: &mut DeviceProperties) {
     let combinations = MslDialect::supported_wmma_combinations(&MetalArchitecture::Metal3);
     register_wmma_features(combinations, props);
 }

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -310,7 +310,7 @@ fn register_cmma(ash: &InstanceShared, adapter: &vulkan::Adapter, props: &mut De
     log::debug!("Supported CMMA sizes: {sizes:#?}");
 
     for size in sizes {
-        props.features.mma.insert(size);
+        props.features.cmma.insert(size);
     }
 }
 

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -3,13 +3,13 @@ use ash::{
     vk::{ComponentTypeKHR, DeviceCreateInfo, DeviceQueueCreateInfo, ScopeKHR, TRUE},
 };
 use cubecl_core::{
-    AtomicFeature, ExecutionMode, Feature, WgpuCompilationOptions,
+    ExecutionMode, WgpuCompilationOptions,
     compute::Visibility,
     ir::{ElemType, FloatKind, IntKind, UIntKind},
     prelude::CompiledKernel,
     server::ComputeServer,
 };
-use cubecl_runtime::DeviceProperties;
+use cubecl_runtime::{DeviceProperties, EnumSet, MmaConfig, Plane, TypeUsage};
 use cubecl_spirv::{GLCompute, SpirvCompiler, SpirvKernel};
 use features::ExtendedFeatures;
 use wgpu::{
@@ -49,7 +49,7 @@ pub async fn request_vulkan_device(adapter: &wgpu::Adapter) -> (wgpu::Device, wg
 
 pub fn register_vulkan_features(
     adapter: &wgpu::Adapter,
-    props: &mut cubecl_runtime::DeviceProperties<cubecl_core::Feature>,
+    props: &mut cubecl_runtime::DeviceProperties,
     comp_options: &mut WgpuCompilationOptions,
 ) {
     let features = adapter.features();
@@ -147,7 +147,7 @@ fn request_device(
 /// Request device's supported features
 fn register_features(
     adapter: &vulkan::Adapter,
-    props: &mut cubecl_runtime::DeviceProperties<cubecl_core::Feature>,
+    props: &mut cubecl_runtime::DeviceProperties,
     features: Features,
     comp_options: &mut WgpuCompilationOptions,
 ) {
@@ -158,35 +158,12 @@ fn register_features(
 
     register_types(props, &extended_feat);
     comp_options.supports_u64 = true;
-    props.register_feature(Feature::SyncPlane);
+    props.features.plane.insert(Plane::Sync);
 
-    if let Some(atomic_float) = &extended_feat.atomic_float {
-        if atomic_float.shader_buffer_float32_atomics == TRUE {
-            props.register_feature(Feature::AtomicFloat(AtomicFeature::LoadStore));
-        }
-        if atomic_float.shader_buffer_float32_atomic_add == TRUE {
-            props.register_feature(Feature::AtomicFloat(AtomicFeature::Add));
-        }
-    }
-
-    #[allow(
-        clippy::collapsible_if,
-        reason = "if let chain only supported in newest Rust"
-    )]
-    if let Some(atomic_float2) = &extended_feat.atomic_float2 {
-        if atomic_float2.shader_buffer_float32_atomic_min_max == TRUE {
-            props.register_feature(Feature::AtomicFloat(AtomicFeature::MinMax));
-        }
-    }
-
-    #[allow(
-        clippy::collapsible_if,
-        reason = "if let chain only supported in newest Rust"
-    )]
-    if let Some(float_controls2) = &extended_feat.float_controls2 {
-        if float_controls2.shader_float_controls2 == TRUE {
-            comp_options.supports_fp_fast_math = true;
-        }
+    if let Some(float_controls2) = &extended_feat.float_controls2
+        && float_controls2.shader_float_controls2 == TRUE
+    {
+        comp_options.supports_fp_fast_math = true;
     }
 
     if extended_feat.cmma.is_some() {
@@ -194,11 +171,11 @@ fn register_features(
     }
 }
 
-fn register_types(props: &mut DeviceProperties<Feature>, ext_feat: &ExtendedFeatures<'_>) {
+fn register_types(props: &mut DeviceProperties, ext_feat: &ExtendedFeatures<'_>) {
     use cubecl_core::ir::{ElemType, FloatKind, IntKind, StorageType};
 
-    let mut register = |elem: StorageType| {
-        props.register_feature(Feature::Type(elem));
+    let mut register = |elem: StorageType, usage: EnumSet<TypeUsage>| {
+        props.register_type_usage(elem, usage);
     };
 
     let default_types = [
@@ -221,47 +198,86 @@ fn register_types(props: &mut DeviceProperties<Feature>, ext_feat: &ExtendedFeat
     ];
 
     for ty in default_types {
-        register(ty.into());
+        register(ty.into(), TypeUsage::all_scalar());
     }
 
     for ty in default_atomic_types {
-        register(StorageType::Atomic(ty))
+        register(StorageType::Atomic(ty), TypeUsage::all_atomic())
     }
 
     if ext_feat.float16_int8.shader_float16 == TRUE {
-        register(ElemType::Float(FloatKind::F16).into());
+        register(
+            ElemType::Float(FloatKind::F16).into(),
+            TypeUsage::all_scalar(),
+        );
     }
     if ext_feat.float16_int8.shader_int8 == TRUE {
-        register(ElemType::Int(IntKind::I8).into());
-        register(ElemType::UInt(UIntKind::U8).into());
+        register(ElemType::Int(IntKind::I8).into(), TypeUsage::all_scalar());
+        register(ElemType::UInt(UIntKind::U8).into(), TypeUsage::all_scalar());
     }
 
-    #[allow(
-        clippy::collapsible_if,
-        reason = "if let chain only supported in newest Rust"
-    )]
     if let Some(atomic_float) = ext_feat.atomic_float {
         if atomic_float.shader_buffer_float32_atomics == TRUE {
-            register(StorageType::Atomic(ElemType::Float(FloatKind::F32)));
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F32)),
+                TypeUsage::AtomicLoadStore.into(),
+            );
+        }
+        if atomic_float.shader_buffer_float32_atomic_add == TRUE {
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F32)),
+                TypeUsage::AtomicAdd.into(),
+            );
+        }
+        if atomic_float.shader_buffer_float64_atomics == TRUE {
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F64)),
+                TypeUsage::AtomicLoadStore.into(),
+            );
+        }
+        if atomic_float.shader_buffer_float64_atomic_add == TRUE {
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F64)),
+                TypeUsage::AtomicAdd.into(),
+            );
         }
     }
 
-    #[allow(
-        clippy::collapsible_if,
-        reason = "if let chain only supported in newest Rust"
-    )]
     if let Some(atomic_float) = ext_feat.atomic_float2 {
         if atomic_float.shader_buffer_float16_atomics == TRUE {
-            register(StorageType::Atomic(ElemType::Float(FloatKind::F16)));
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F16)),
+                TypeUsage::AtomicLoadStore.into(),
+            );
+        }
+        if atomic_float.shader_buffer_float16_atomic_add == TRUE {
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F16)),
+                TypeUsage::AtomicAdd.into(),
+            );
+        }
+        if atomic_float.shader_buffer_float16_atomic_min_max == TRUE {
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F16)),
+                TypeUsage::AtomicMinMax.into(),
+            );
+        }
+        if atomic_float.shader_buffer_float32_atomic_min_max == TRUE {
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F32)),
+                TypeUsage::AtomicMinMax.into(),
+            );
+        }
+        if atomic_float.shader_buffer_float64_atomic_min_max == TRUE {
+            register(
+                StorageType::Atomic(ElemType::Float(FloatKind::F64)),
+                TypeUsage::AtomicMinMax.into(),
+            );
         }
     }
 }
 
-fn register_cmma(
-    ash: &InstanceShared,
-    adapter: &vulkan::Adapter,
-    props: &mut DeviceProperties<Feature>,
-) {
+fn register_cmma(ash: &InstanceShared, adapter: &vulkan::Adapter, props: &mut DeviceProperties) {
     let cmma = cooperative_matrix::Instance::new(ash.entry(), ash.raw_instance());
     let properties = unsafe {
         cmma.get_physical_device_cooperative_matrix_properties(adapter.raw_physical_device())
@@ -281,20 +297,20 @@ fn register_cmma(
             min_current = u32::min(min_current, it.k_size);
             props.hardware.min_tensor_cores_dim = Some(min_current);
 
-            Some(Feature::Cmma {
-                a: convert_type(it.a_type)?.into(),
-                b: convert_type(it.b_type)?.into(),
-                c: convert_type(it.c_type)?.into(),
-                m: it.m_size as u8,
-                k: it.k_size as u8,
-                n: it.n_size as u8,
+            Some(MmaConfig {
+                a_type: convert_type(it.a_type)?.into(),
+                b_type: convert_type(it.b_type)?.into(),
+                cd_type: convert_type(it.c_type)?.into(),
+                m: it.m_size,
+                k: it.k_size,
+                n: it.n_size,
             })
         })
         .collect::<Vec<_>>();
     log::debug!("Supported CMMA sizes: {sizes:#?}");
 
     for size in sizes {
-        props.register_feature(size);
+        props.features.mma.insert(size);
     }
 }
 

--- a/crates/cubecl-wgpu/src/backend/wgsl.rs
+++ b/crates/cubecl-wgpu/src/backend/wgsl.rs
@@ -6,7 +6,6 @@ use cubecl_core::{
 };
 #[cfg(not(all(target_os = "macos", feature = "msl")))]
 use cubecl_runtime::DeviceProperties;
-use cubecl_runtime::EnumSet;
 #[cfg(not(all(target_os = "macos", feature = "msl")))]
 use wgpu::Features;
 
@@ -70,7 +69,7 @@ pub fn register_wgsl_features(
 #[cfg(not(all(target_os = "macos", feature = "msl")))]
 pub fn register_types(props: &mut DeviceProperties, adapter: &wgpu::Adapter) {
     use cubecl_core::ir::{ElemType, FloatKind, IntKind, StorageType};
-    use cubecl_runtime::TypeUsage;
+    use cubecl_runtime::{EnumSet, TypeUsage};
 
     let supported_types = [
         ElemType::UInt(UIntKind::U32),

--- a/crates/cubecl-wgpu/src/compiler/wgsl/extension.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/extension.rs
@@ -58,7 +58,7 @@ impl Display for Extension {
                 SAFE_TANH_PRIMITIVE,
                 &[VectorIdent {
                     name: "x",
-                    item: item.clone(),
+                    item: *item,
                 }],
                 *item,
             ),

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -6,7 +6,7 @@ use cubecl_common::profile::{ProfileDuration, TimingMethod};
 use cubecl_core::future::DynFut;
 use cubecl_core::server::{DataTransferService, ProfileError, ProfilingToken};
 use cubecl_core::{
-    Feature, MemoryConfiguration, WgpuCompilationOptions,
+    MemoryConfiguration, WgpuCompilationOptions,
     prelude::*,
     server::{Binding, Bindings, CopyDescriptor},
 };
@@ -120,7 +120,6 @@ impl DataTransferService for WgpuServer {}
 impl ComputeServer for WgpuServer {
     type Kernel = Box<dyn CubeTask<AutoCompiler>>;
     type Storage = WgpuStorage;
-    type Feature = Feature;
     type Info = wgpu::Backend;
 
     fn create(

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -4,10 +4,8 @@ use crate::{
 };
 use cubecl_common::{future, profile::TimingMethod};
 
-use cubecl_core::Feature;
 use cubecl_core::{CubeCount, CubeDim, Runtime, ir::TargetProperties};
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
-use cubecl_runtime::memory_management::MemoryDeviceProperties;
 use cubecl_runtime::{
     ComputeRuntime,
     channel::MutexComputeChannel,
@@ -15,6 +13,7 @@ use cubecl_runtime::{
     logging::{ProfileLevel, ServerLogger},
 };
 use cubecl_runtime::{DeviceProperties, memory_management::HardwareProperties};
+use cubecl_runtime::{Plane, memory_management::MemoryDeviceProperties};
 use wgpu::{InstanceFlags, RequestAdapterOptions};
 
 /// Runtime that uses the [wgpu] crate with the wgsl compiler. This is used in the Wgpu backend.
@@ -254,8 +253,12 @@ pub(crate) fn create_client_on_setup(
         TimingMethod::System
     };
 
-    let mut device_props =
-        DeviceProperties::new(&[], mem_props.clone(), hardware_props, time_measurement);
+    let mut device_props = DeviceProperties::new(
+        Default::default(),
+        mem_props.clone(),
+        hardware_props,
+        time_measurement,
+    );
 
     #[cfg(not(all(target_os = "macos", feature = "msl")))]
     {
@@ -269,7 +272,9 @@ pub(crate) fn create_client_on_setup(
             && setup.adapter.get_info().device_type != wgpu::DeviceType::Cpu
             && !fake_plane_info
         {
-            device_props.register_feature(Feature::Plane);
+            use cubecl_runtime::Plane;
+
+            device_props.features.plane.insert(Plane::Ops);
         }
     }
 
@@ -289,35 +294,16 @@ pub(crate) fn create_client_on_setup(
 
     #[cfg(not(all(target_os = "macos", feature = "msl")))]
     if features.contains(wgpu::Features::SHADER_FLOAT32_ATOMIC) {
-        use cubecl_core::AtomicFeature;
         use cubecl_core::ir::{ElemType, FloatKind, StorageType};
+        use cubecl_runtime::TypeUsage;
 
-        device_props.register_feature(Feature::Type(StorageType::Atomic(ElemType::Float(
-            FloatKind::F32,
-        ))));
-
-        device_props.register_feature(Feature::AtomicFloat(AtomicFeature::LoadStore));
-        device_props.register_feature(Feature::AtomicFloat(AtomicFeature::Add));
+        device_props.register_type_usage(
+            StorageType::Atomic(ElemType::Float(FloatKind::F32)),
+            TypeUsage::AtomicLoadStore | TypeUsage::AtomicAdd,
+        );
     }
 
-    #[cfg(not(all(target_os = "macos", feature = "msl")))]
-    {
-        use cubecl_core::AtomicFeature;
-        use cubecl_core::ir::{ElemType, IntKind, StorageType, UIntKind};
-
-        device_props.register_feature(Feature::Type(StorageType::Atomic(ElemType::Int(
-            IntKind::I32,
-        ))));
-        device_props.register_feature(Feature::Type(StorageType::Atomic(ElemType::UInt(
-            UIntKind::U32,
-        ))));
-        device_props.register_feature(Feature::AtomicInt(AtomicFeature::LoadStore));
-        device_props.register_feature(Feature::AtomicInt(AtomicFeature::Add));
-        device_props.register_feature(Feature::AtomicUInt(AtomicFeature::LoadStore));
-        device_props.register_feature(Feature::AtomicUInt(AtomicFeature::Add));
-    }
-
-    device_props.register_feature(Feature::PlaneOps);
+    device_props.features.plane.insert(Plane::Ops);
 
     ComputeClient::new(channel, device_props, setup.backend)
 }

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -6,6 +6,7 @@ use cubecl_common::{future, profile::TimingMethod};
 
 use cubecl_core::{CubeCount, CubeDim, Runtime, ir::TargetProperties};
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
+use cubecl_runtime::memory_management::MemoryDeviceProperties;
 use cubecl_runtime::{
     ComputeRuntime,
     channel::MutexComputeChannel,
@@ -13,7 +14,6 @@ use cubecl_runtime::{
     logging::{ProfileLevel, ServerLogger},
 };
 use cubecl_runtime::{DeviceProperties, memory_management::HardwareProperties};
-use cubecl_runtime::{Plane, memory_management::MemoryDeviceProperties};
 use wgpu::{InstanceFlags, RequestAdapterOptions};
 
 /// Runtime that uses the [wgpu] crate with the wgsl compiler. This is used in the Wgpu backend.
@@ -302,8 +302,6 @@ pub(crate) fn create_client_on_setup(
             TypeUsage::AtomicLoadStore | TypeUsage::AtomicAdd,
         );
     }
-
-    device_props.features.plane.insert(Plane::Ops);
 
     ComputeClient::new(channel, device_props, setup.backend)
 }

--- a/crates/cubecl/src/lib.rs
+++ b/crates/cubecl/src/lib.rs
@@ -1,6 +1,7 @@
 pub use cubecl_core::*;
 
 pub use cubecl_runtime::config;
+pub use cubecl_runtime::features;
 pub use cubecl_runtime::memory_management::MemoryAllocationMode;
 
 #[cfg(feature = "wgpu")]

--- a/examples/sum_things/src/lib.rs
+++ b/examples/sum_things/src/lib.rs
@@ -1,4 +1,4 @@
-use cubecl::{prelude::*, server::Handle};
+use cubecl::{features::Plane, prelude::*, server::Handle};
 use std::marker::PhantomData;
 
 #[cube(launch_unchecked)]
@@ -132,7 +132,7 @@ fn launch_subgroup<R: Runtime>(
             CubeDim::new(len as u32, 1, 1),
             ArrayArg::from_raw_parts::<f32>(input, len, 1),
             ArrayArg::from_raw_parts::<f32>(output, len, 1),
-            client.properties().feature_enabled(cubecl::Feature::Plane),
+            client.properties().features.plane.contains(Plane::Ops),
             Some(len as u32),
         );
     }
@@ -202,14 +202,14 @@ pub fn launch<R: Runtime>(device: &R::Device) {
             KernelKind::TraitSum => {
                 // When using trait, it's normally a good idea to check if the variation can be
                 // executed.
-                if client.properties().feature_enabled(cubecl::Feature::Plane) {
+                if client.properties().features.plane.contains(Plane::Ops) {
                     launch_trait::<R, SumPlane>(&client, &input, &output, len)
                 } else {
                     launch_trait::<R, SumBasic>(&client, &input, &output, len)
                 }
             }
             KernelKind::SeriesSumThenMul => {
-                if client.properties().feature_enabled(cubecl::Feature::Plane) {
+                if client.properties().features.plane.contains(Plane::Ops) {
                     launch_series::<R, SumThenMul<SumPlane>>(&client, &input, &output, len)
                 } else {
                     launch_series::<R, SumThenMul<SumBasic>>(&client, &input, &output, len)


### PR DESCRIPTION
Refactors how runtime features are stored, to allow for easier checking and richer information for types (since types don't always support all types of operations).

# Important changes
* Features are now a struct instead of a `HashSet` of features, allowing specialized representations for certain features (i.e. types).
* Types now have a `TypeUsage` flag enum associated with them, rather than just a binary "supported" or "unsupported". This enum specifies which group of operations can be done, i.e. `Arithmetic` or `Conversion`. This new granularity allows properly implementing feature checks for Vulkan atomics, which may support float add for some types, but only load/store for others. It will also be used for `bf16` introduced in https://github.com/tracel-ai/cubecl/pull/880. An empty set is treated as no support.
* A lot of related flags (i.e. `Plane`, `PlaneOps`, `PlaneSync`) are now represented by a single field with a feature flag enum.
* Features related to sematic types are now replaced by registering the type itself.

# Testing
Features are device dependent so can't really be tested, but I did print the features for all runtimes I can execute (WGSL, Vulkan, CUDA) and they appear correct.
