### PR TITLE
Enable cubecl-cpu on all OSes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ tracy-client = { version = "0.18.0" }
 
 ### For xtask crate ###
 strum = { version = "0.27.1", features = ["derive"] }
-tracel-xtask = { version = "=1.1.9" }
+tracel-xtask = { version = "=2.1.8" }
 
 portable-atomic = { version = "1.10", default-features = false, features = [
     "serde",
@@ -97,6 +97,9 @@ futures-lite = { version = "2.3.0", default-features = false }
 
 # CubeCL-CPU
 sysinfo = "0.36.1"
+# [target.'cfg(target_os = "linux")'.dependencies]
+# tracel-llvm = { git = "https://github.com/tracel-ai/tracel-llvm", rev = "75780fbe097cce2ce11e3520e902d1784bfbd1d3" }
+mlir-rs = { path = "../tracel-llvm/crates/mlir-rs" }
 
 # CubeCL-CUDA
 cudarc = { version = "0.17.2", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,7 @@ futures-lite = { version = "2.3.0", default-features = false }
 
 # CubeCL-CPU
 sysinfo = "0.36.1"
-# [target.'cfg(target_os = "linux")'.dependencies]
-# tracel-llvm = { git = "https://github.com/tracel-ai/tracel-llvm", rev = "75780fbe097cce2ce11e3520e902d1784bfbd1d3" }
-mlir-rs = { path = "../tracel-llvm/crates/mlir-rs" }
+tracel-llvm = { version = "20.1.4-1", features = ["mlir-helpers"] }
 
 # CubeCL-CUDA
 cudarc = { version = "0.17.2", features = [

--- a/crates/cubecl-cpu/Cargo.toml
+++ b/crates/cubecl-cpu/Cargo.toml
@@ -96,9 +96,7 @@ half = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 sysinfo = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-tracel-llvm = { git = "https://github.com/tracel-ai/tracel-llvm", rev = "75780fbe097cce2ce11e3520e902d1784bfbd1d3" }
+tracel-llvm = { workspace = true }
 
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "0.7.0", features = [
@@ -115,3 +113,6 @@ cubecl-std = { path = "../cubecl-std", version = "0.7.0", features = [
 ] }
 paste = { workspace = true }
 pretty_assertions = { workspace = true }
+
+[build-dependencies]
+tracel-llvm-bundler = { version = "20.1.4-1"  }

--- a/crates/cubecl-cpu/build.rs
+++ b/crates/cubecl-cpu/build.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // required on macos
+    tracel_llvm_bundler::config::set_homebrew_library_path()?;
+    Ok(())
+}

--- a/crates/cubecl-cpu/src/compiler/external_function.rs
+++ b/crates/cubecl-cpu/src/compiler/external_function.rs
@@ -1,4 +1,4 @@
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     Context, ExecutionEngine,
     dialect::{
         func,
@@ -26,7 +26,7 @@ pub fn register_external_function(execution_engine: &ExecutionEngine) {
 
 pub fn add_external_function_to_module<'a>(
     context: &'a Context,
-    module: &tracel_llvm::melior::ir::Module<'a>,
+    module: &tracel_llvm::mlir_rs::ir::Module<'a>,
 ) {
     let integer_type = IntegerType::new(context, 32).into();
     let func_type = TypeAttribute::new(llvm::r#type::function(

--- a/crates/cubecl-cpu/src/compiler/mlir_engine.rs
+++ b/crates/cubecl-cpu/src/compiler/mlir_engine.rs
@@ -12,7 +12,7 @@ use std::{
 
 use super::module::Module;
 use cubecl_core::prelude::KernelDefinition;
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     Context, ExecutionEngine,
     dialect::DialectRegistry,
     utility::{register_all_dialects, register_all_llvm_translations, register_all_passes},

--- a/crates/cubecl-cpu/src/compiler/module.rs
+++ b/crates/cubecl-cpu/src/compiler/module.rs
@@ -1,6 +1,6 @@
 use cubecl_core::prelude::KernelDefinition;
 use cubecl_opt::Optimizer;
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     Context, ExecutionEngine,
     ir::{Location, operation::OperationLike},
     pass::{self, PassManager},
@@ -9,7 +9,7 @@ use tracel_llvm::melior::{
 use super::{passes::shared_memories::SharedMemories, visitor::Visitor};
 
 pub(super) struct Module<'a> {
-    module: tracel_llvm::melior::ir::Module<'a>,
+    module: tracel_llvm::mlir_rs::ir::Module<'a>,
     #[allow(unused)]
     name: String,
     location: Location<'a>,
@@ -19,7 +19,7 @@ pub(super) struct Module<'a> {
 impl<'a> Module<'a> {
     pub(super) fn new(context: &'a Context, name: String) -> Self {
         let location = Location::unknown(context);
-        let module = tracel_llvm::melior::ir::Module::new(location);
+        let module = tracel_llvm::mlir_rs::ir::Module::new(location);
         Self {
             module,
             context,
@@ -50,7 +50,7 @@ impl<'a> Module<'a> {
         #[cfg(feature = "mlir-dump")]
         if let Ok(dir) = std::env::var("CUBECL_DEBUG_MLIR") {
             use std::path::PathBuf;
-            use tracel_llvm::melior::{
+            use tracel_llvm::mlir_rs::{
                 ir::operation::OperationPrintingFlags, pass::PassIrPrintingOptions,
             };
 

--- a/crates/cubecl-cpu/src/compiler/visitor/args_manager.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/args_manager.rs
@@ -6,7 +6,7 @@ use cubecl_core::{
     ir::{Builtin, StorageType},
     prelude::KernelDefinition,
 };
-use tracel_llvm::melior::ir::{
+use tracel_llvm::mlir_rs::ir::{
     Block, BlockRef, Location, Region,
     r#type::{FunctionType, IntegerType, MemRefType},
 };

--- a/crates/cubecl-cpu/src/compiler/visitor/block.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/block.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use cubecl_opt::{ControlFlow, NodeIndex};
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     dialect::cf,
     ir::{Block, BlockLike, BlockRef, RegionLike},
 };

--- a/crates/cubecl-cpu/src/compiler/visitor/elem.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/elem.rs
@@ -1,6 +1,6 @@
 use cubecl_core::ir::{ElemType, FloatKind, IntKind, StorageType, UIntKind};
 use cubecl_runtime::{DeviceProperties, TypeUsage};
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     dialect::index,
     ir::{ValueLike, r#type::IntegerType},
 };

--- a/crates/cubecl-cpu/src/compiler/visitor/item.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/item.rs
@@ -1,5 +1,5 @@
 use cubecl_core::ir::{self, ConstantScalarValue, VariableKind};
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     Context,
     dialect::{arith, ods::vector},
     ir::{

--- a/crates/cubecl-cpu/src/compiler/visitor/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/mod.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use args_manager::{ArgsManager, ArgsManagerBuilder};
 use cubecl_core::{ir::Builtin, prelude::KernelDefinition};
 use cubecl_opt::{NodeIndex, Optimizer};
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     Context,
     dialect::{
         func,
@@ -148,7 +148,7 @@ impl<'a> Visitor<'a> {
         context: &'a Context,
         location: Location<'a>,
         kernel: &'b KernelDefinition,
-        module: &tracel_llvm::melior::ir::Module<'a>,
+        module: &tracel_llvm::mlir_rs::ir::Module<'a>,
         opt: &Optimizer,
         shared_memories: &SharedMemories,
     ) {
@@ -213,7 +213,7 @@ impl<'a> Visitor<'a> {
 
     pub(self) fn insert_builtin_loop(
         block: BlockRef<'a, 'a>,
-        module: &tracel_llvm::melior::ir::Module<'a>,
+        module: &tracel_llvm::mlir_rs::ir::Module<'a>,
         opt: &Optimizer,
         context: &'a Context,
         location: Location<'a>,

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/arithmetic.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/arithmetic.rs
@@ -1,5 +1,5 @@
 use cubecl_core::ir::{self, Arithmetic};
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     dialect::{
         arith::{self},
         llvm,

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/bitwise.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/bitwise.rs
@@ -1,5 +1,5 @@
 use cubecl_core::ir::{Bitwise, ElemType, IntKind, UIntKind};
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     dialect::arith::{self, CmpiPredicate},
     dialect::llvm,
     ir::r#type::IntegerType,

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/comparison.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/comparison.rs
@@ -1,5 +1,5 @@
 use cubecl_core::ir::Comparison;
-use tracel_llvm::melior::dialect::arith::{self, CmpfPredicate, CmpiPredicate};
+use tracel_llvm::mlir_rs::dialect::arith::{self, CmpfPredicate, CmpiPredicate};
 
 use crate::compiler::visitor::prelude::*;
 

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/metadata.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/metadata.rs
@@ -1,5 +1,5 @@
 use cubecl_core::ir::Metadata;
-use tracel_llvm::melior::dialect::{arith, index, memref};
+use tracel_llvm::mlir_rs::dialect::{arith, index, memref};
 
 use crate::compiler::visitor::prelude::*;
 

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
@@ -6,7 +6,7 @@ pub(super) mod operator;
 pub(super) mod synchronization;
 
 use cubecl_core::ir::{NonSemantic, Operation};
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     dialect::{llvm, ods::llvm as llvm_ods},
     ir::{
         attribute::{FlatSymbolRefAttribute, TypeAttribute},

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/operator.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/operator.rs
@@ -1,5 +1,5 @@
 use cubecl_core::ir::{IndexAssignOperator, IndexOperator, Operator, StorageType, VariableKind};
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     dialect::{
         arith, index, memref,
         ods::{self, llvm, vector},

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
@@ -1,5 +1,5 @@
 use cubecl_core::ir::Synchronization;
-use tracel_llvm::melior::{dialect::func, ir::attribute::FlatSymbolRefAttribute};
+use tracel_llvm::mlir_rs::{dialect::func, ir::attribute::FlatSymbolRefAttribute};
 
 use crate::compiler::visitor::prelude::*;
 

--- a/crates/cubecl-cpu/src/compiler/visitor/prelude.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/prelude.rs
@@ -1,7 +1,7 @@
 pub use super::Visitor;
 pub use cubecl_core::ir::Variable;
 pub use cubecl_opt::Optimizer;
-pub use tracel_llvm::melior::{
+pub use tracel_llvm::mlir_rs::{
     Context, Error,
     helpers::{ArithBlockExt, BuiltinBlockExt},
     ir::{BlockLike, RegionLike, Type, TypeLike, Value, ValueLike, operation::OperationLike},

--- a/crates/cubecl-cpu/src/compiler/visitor/variables.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/variables.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use cubecl_core::ir::{
     self, Builtin, ConstantScalarValue, FloatKind, IntKind, UIntKind, VariableKind,
 };
-use tracel_llvm::melior::{
+use tracel_llvm::mlir_rs::{
     dialect::{
         index, memref,
         ods::{arith, vector},

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "linux")]
-
 #[macro_use]
 extern crate derive_new;
 
@@ -19,8 +17,7 @@ mod tests {
     cubecl_convolution::testgen_conv2d_accelerated!([f16: f16, f32: f32]);
     cubecl_reduce::testgen_shared_sum!([f16, f32, f64]);
 
-    // Deactivated for now as it makes the CI hang
-    // cubecl_reduce::testgen_reduce!([f16, f32, f64]);
+    cubecl_reduce::testgen_reduce!([f16, f32, f64]);
 }
 
 pub mod compiler;

--- a/crates/cubecl/Cargo.toml
+++ b/crates/cubecl/Cargo.toml
@@ -20,7 +20,7 @@ default = [
     "convolution",
     "cubecl-core/default",
     "cubecl-cuda?/default",
-    "cubecl-cpu?/default",
+    "cubecl-cpu/default",
     "cubecl-hip?/default",
     "cubecl-wgpu?/default",
 ]

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -7,13 +7,17 @@ pub struct CubeCLBuildCmdArgs {
     pub ci: bool,
 }
 
-pub(crate) fn handle_command(mut args: CubeCLBuildCmdArgs) -> anyhow::Result<()> {
+pub(crate) fn handle_command(
+    mut args: CubeCLBuildCmdArgs,
+    env: Environment,
+    context: Context,
+) -> anyhow::Result<()> {
     if args.ci {
         // Exclude crates that are not supported on CI
         args.exclude
             .extend(vec!["cubecl-cuda".to_string(), "cubecl-hip".to_string()]);
     }
-    base_commands::build::handle_command(args.try_into().unwrap())?;
+    base_commands::build::handle_command(args.try_into().unwrap(), env, context)?;
     // Specific additional commands to test specific features
     // burn-wgpu with SPIR-V
     helpers::custom_crates_build(

--- a/xtask/src/commands/check.rs
+++ b/xtask/src/commands/check.rs
@@ -7,13 +7,17 @@ pub struct CubeCLCheckCmdArgs {
     pub ci: bool,
 }
 
-pub(crate) fn handle_command(mut args: CubeCLCheckCmdArgs) -> anyhow::Result<()> {
+pub(crate) fn handle_command(
+    mut args: CubeCLCheckCmdArgs,
+    env: Environment,
+    context: Context,
+) -> anyhow::Result<()> {
     if args.ci {
         // Exclude crates that are not supported on CI
         args.exclude
             .extend(vec!["cubecl-cuda".to_string(), "cubecl-hip".to_string()]);
     }
-    base_commands::check::handle_command(args.try_into().unwrap())?;
+    base_commands::check::handle_command(args.try_into().unwrap(), env, context)?;
     // Specific additional commands to test specific features
     // cubecl-wgpu with SPIR-V
     // cubecl-wgpu with exclusive-memory-only

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -7,13 +7,17 @@ pub struct CubeCLTestCmdArgs {
     pub ci: bool,
 }
 
-pub(crate) fn handle_command(mut args: CubeCLTestCmdArgs) -> anyhow::Result<()> {
+pub(crate) fn handle_command(
+    mut args: CubeCLTestCmdArgs,
+    env: Environment,
+    context: Context,
+) -> anyhow::Result<()> {
     if args.ci {
         // Exclude crates that are not supported on CI
         args.exclude
             .extend(vec!["cubecl-cuda".to_string(), "cubecl-hip".to_string()]);
     }
-    base_commands::test::handle_command(args.try_into().unwrap())?;
+    base_commands::test::handle_command(args.try_into().unwrap(), env, context)?;
     // Specific additional commands to test specific features
     // cubecl-wgpu with exclusive-memory-only
     helpers::custom_crates_tests(

--- a/xtask/src/commands/validate.rs
+++ b/xtask/src/commands/validate.rs
@@ -2,7 +2,11 @@ use tracel_xtask::prelude::*;
 
 use crate::commands::{build::CubeCLBuildCmdArgs, test::CubeCLTestCmdArgs};
 
-pub fn handle_command(args: &ValidateCmdArgs) -> anyhow::Result<()> {
+pub fn handle_command(
+    args: &ValidateCmdArgs,
+    env: Environment,
+    context: Context,
+) -> anyhow::Result<()> {
     let target = Target::Workspace;
     let exclude = vec![];
     let only = vec![];
@@ -14,48 +18,69 @@ pub fn handle_command(args: &ValidateCmdArgs) -> anyhow::Result<()> {
         CheckSubCommand::Lint,
         CheckSubCommand::Typos,
     ]
-    .iter()
-    .try_for_each(|c| {
-        base_commands::check::handle_command(CheckCmdArgs {
-            target: target.clone(),
-            exclude: exclude.clone(),
-            only: only.clone(),
-            command: Some(c.clone()),
-            ignore_audit: args.ignore_audit,
-        })
+        .iter()
+        .try_for_each(|c| {
+            base_commands::check::handle_command(
+                CheckCmdArgs {
+                    command: Some(c.clone()),
+                    exclude: exclude.clone(),
+                    ignore_audit: args.ignore_audit,
+                    only: only.clone(),
+                    target: target.clone(),
+                },
+                env.clone(),
+                context.clone(),
+        )
     })?;
 
     // build
-    super::build::handle_command(CubeCLBuildCmdArgs {
-        target: target.clone(),
-        exclude: exclude.clone(),
-        only: only.clone(),
-        ci: true,
-    })?;
+    super::build::handle_command(
+         CubeCLBuildCmdArgs {
+             ci: true,
+             exclude: exclude.clone(),
+             only: only.clone(),
+             release: false,
+             target: target.clone(),
+         },
+        env.clone(),
+        context.clone(),
+    )?;
 
     // tests
-    super::test::handle_command(CubeCLTestCmdArgs {
-        target: target.clone(),
-        exclude: exclude.clone(),
-        only: only.clone(),
-        threads: None,
-        jobs: None,
-        command: Some(TestSubCommand::All),
-        ci: true,
-        features: None,
-        no_default_features: false,
-    })?;
+    super::test::handle_command(
+        CubeCLTestCmdArgs {
+            ci: true,
+            command: Some(TestSubCommand::All),
+            exclude: exclude.clone(),
+            features: None,
+            force: false,
+            jobs: None,
+            no_capture: false,
+            no_default_features: false,
+            only: only.clone(),
+            release: args.release,
+            target: target.clone(),
+            test: None,
+            threads: None,
+        },
+        env.clone(),
+        context.clone(),
+    )?;
 
     // documentation
     [DocSubCommand::Build, DocSubCommand::Tests]
         .iter()
         .try_for_each(|c| {
-            base_commands::doc::handle_command(DocCmdArgs {
-                target: target.clone(),
-                exclude: exclude.clone(),
-                only: only.clone(),
-                command: Some(c.clone()),
-            })
+            base_commands::doc::handle_command(
+                DocCmdArgs {
+                    target: target.clone(),
+                    exclude: exclude.clone(),
+                    only: only.clone(),
+                    command: Some(c.clone()),
+                },
+                env.clone(),
+                context.clone(),
+            )
         })?;
 
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,7 +3,6 @@ mod commands;
 #[macro_use]
 extern crate log;
 
-use std::time::Instant;
 use tracel_xtask::prelude::*;
 
 #[macros::base_commands(
@@ -31,21 +30,15 @@ pub enum Command {
 }
 
 fn main() -> anyhow::Result<()> {
-    let start = Instant::now();
-    let args = init_xtask::<Command>()?;
+    let args = init_xtask::<Command>(parse_args::<Command>()?)?;
     match args.command {
-        Command::Build(cmd_args) => commands::build::handle_command(cmd_args),
-        Command::Check(cmd_args) => commands::check::handle_command(cmd_args),
-        Command::Test(cmd_args) => commands::test::handle_command(cmd_args),
+        Command::Build(cmd_args) => commands::build::handle_command(cmd_args, args.environment, args.context),
+        Command::Check(cmd_args) => commands::check::handle_command(cmd_args, args.environment, args.context),
+        Command::Test(cmd_args) => commands::test::handle_command(cmd_args, args.environment, args.context),
         Command::Book(cmd_args) => cmd_args.parse(),
         Command::Profile(cmd_args) => cmd_args.run(),
-        Command::Validate(cmd_args) => commands::validate::handle_command(&cmd_args),
+        Command::Validate(cmd_args) => commands::validate::handle_command(&cmd_args, args.environment, args.context),
         _ => dispatch_base_commands(args),
     }?;
-    let duration = start.elapsed();
-    info!(
-        "\x1B[32;1mTime elapsed for the current execution: {}\x1B[0m",
-        format_duration(&duration)
-    );
     Ok(())
 }


### PR DESCRIPTION
Tracel crates for LLVM are now published and should work on Linux, MacOS and Windows.

To test the branch and the Tracel LLVM bundler:

```
cd crates/cubecl-cpu
cargo test
```

The crate `tracel-llvm` uses `tracel-llvm-bundler` to download the corresponding archive and checksum from [tracel-llvm releases](https://github.com/tracel-ai/tracel-llvm/releases) and install it.

## Validate your PR with burn.

TO BE DONE

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
