### PR TITLE
Fix wgpu staging buffer async usage

### DIFF
--- a/crates/cubecl-wgpu/src/compute/controller.rs
+++ b/crates/cubecl-wgpu/src/compute/controller.rs
@@ -4,14 +4,13 @@ use std::ptr::NonNull;
 
 /// Controller for managing wgpu staging buffers managed by a memory pool.
 pub struct WgpuAllocController {
-    staging_buffer: wgpu::Buffer,
     binding: Option<SliceBinding>,
+    buffer_data: Option<Box<[u8]>>,
 }
 
 impl AllocationController for WgpuAllocController {
     fn dealloc(&mut self, _allocation: &cubecl_common::bytes::Allocation) {
-        // We unmap the buffer and release the binding so that the same buffer can be used again.
-        self.staging_buffer.unmap();
+        self.buffer_data.take();
         self.binding = None;
     }
 }
@@ -29,21 +28,25 @@ impl WgpuAllocController {
     ///
     /// The controller and the corresponding `Allocation`.
     pub fn init(binding: SliceBinding, buffer: wgpu::Buffer, size: usize) -> (Self, Allocation) {
-        fn buffer_ptr(buffer: &wgpu::Buffer) -> NonNull<u8> {
+        let data = {
             let data = buffer.slice(..).get_mapped_range();
-            unsafe { NonNull::new_unchecked(data.as_ptr().cast_mut()) }
-        }
+            data[0..size].to_vec().into_boxed_slice()
+        };
+        let ptr = unsafe { NonNull::new_unchecked(data.as_ptr().cast_mut()) };
 
         let allocation = Allocation {
-            ptr: buffer_ptr(&buffer),
+            ptr,
             size,
             align: wgpu::COPY_BUFFER_ALIGNMENT as usize,
         };
 
+        // We unmap the buffer and release the binding so that the same buffer can be used again.
+        buffer.unmap();
+
         (
             Self {
-                staging_buffer: buffer,
                 binding: Some(binding),
+                buffer_data: Some(data),
             },
             allocation,
         )


### PR DESCRIPTION
Originally reported [on discord](https://discord.com/channels/1038839012602941528/1402343417698062366/1418249730307260496).

Changes to the mnist web example:
```rust
// Convert the model output into probability distribution using softmax formula
let output = burn::tensor::activation::softmax(output, 1);

let index = output.clone().argmax(1);
let index: i32 = index
    .into_data_async()
    .await
    // .convert::<u32>()
    .to_vec()
    .unwrap()[0];
log::info!("Index {}", index);
let index = index as u32;

// Flatten output tensor with [1, 10] shape into boxed slice of [f32]
let output = output.into_data_async().await;
log::info!("Output {}", output);
```


On WASM (async), subsequent reads caused the bytes to point to the wrong data. Buffer was being reused before async mapping completed.

```
// Reading argmax int buffer
burn-cubecl/src/ops/int_ops.rs:44 int_into_data I32
burn-cubecl/src/ops/base.rs:25 read_one_tensor_async CopyDescriptor { binding: Binding { memory: SliceBinding { value: BindingRef { id: SliceId { value: 5 }, _all: () } }, offset_start: Some(0), offset_end: Some(252), size: 256 }, shape: [1, 1], strides: [1, 1], elem_size: 4 }
cubecl-wgpu/src/compute/stream.rs:196 read_buffers 1
cubecl-wgpu/src/compute/stream.rs:199 descriptor binding: Binding { memory: SliceBinding { value: BindingRef { id: SliceId { value: 5 }, _all: () } }, offset_start: Some(0), offset_end: Some(252), size: 256 }
cubecl-wgpu/src/compute/mem_manager.rs:89 reserve staging 4
cubecl-runtime/src/memory_management/memory_manage.rs:328 pool alloc 4
cubecl-wgpu/src/compute/storage.rs:78 create_buffer 16384
cubecl-wgpu/src/compute/mem_manager.rs:91 handle SliceHandle { value: HandleRef { id: SliceId { value: 106 }, all: () } }
cubecl-wgpu/src/compute/stream.rs:207 size 4 | aligned_len 4 | src offset 0 | dst offset 0INFO cubecl-wgpu/src/compute/stream.rs:259 WgpuAllocController::init 16384
cubecl-wgpu/src/compute/controller.rs:49 controler ptr: 0x363d70
cubecl-wgpu/src/compute/stream.rs:262 Bytes::from_raw_parts 4 4 | 4
burn-cubecl/src/ops/base.rs:27 into_data Shape { dims: [1, 1] } bytes: Bytes { data: [104, 61, 54, "..."], len: 4 } | raw [104, 61, 54, 0]
mnist-inference-web/src/web.rs:86 Index 3554664

// Reading float scores buffer
burn-cubecl/src/ops/base.rs:25 read_one_tensor_async CopyDescriptor { binding: Binding { memory: SliceBinding { value: BindingRef { id: SliceId { value: 1 }, _all: () } }, offset_start: Some(0), offset_end: Some(216), size: 256 }, shape: [1, 10], strides: [10, 1], elem_size: 4 }
cubecl-wgpu/src/compute/stream.rs:196 read_buffers 1
cubecl-wgpu/src/compute/stream.rs:199 descriptor binding: Binding { memory: SliceBinding { value: BindingRef { id: SliceId { value: 1 }, _all: () } }, offset_start: Some(0), offset_end: Some(216), size: 256 }
cubecl-wgpu/src/compute/mem_manager.rs:89 reserve staging 40
cubecl-runtime/src/memory_management/memory_manage.rs:324 pool reserve 40
cubecl-wgpu/src/compute/mem_manager.rs:91 handle SliceHandle { value: HandleRef { id: SliceId { value: 106 }, all: () } }
cubecl-wgpu/src/compute/stream.rs:207 size 40 | aligned_len 40 | src offset 0 | dst offset 0
cubecl-wgpu/src/compute/stream.rs:259 WgpuAllocController::init 16384
cubecl-wgpu/src/compute/controller.rs:49 controler ptr: 0x363d70
cubecl-wgpu/src/compute/stream.rs:262 Bytes::from_raw_parts 4 40 | 40
burn-cubecl/src/ops/base.rs:27 into_data Shape { dims: [1, 10] } bytes: Bytes { data: [104, 61, 54, "..."], len: 40 } | raw [104, 61, 54, 0, 104, 61, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 48, 0, 12, 0, 0, 0, 90, 215, 138, 57, 250, 231, 225, 57, 250, 207, 11, 57, 147, 71, 60, 57]
mnist-inference-web/src/web.rs:91 Output [4.981145e-39, 4.981145e-39, 0.0, 0.0, 4.408821e-39, 1.7e-44, 0.0002648186, 0.0004308818, 0.0001333355, 0.0001795574]
```

Fix: extract the data out of the staging buffer as soon as it's available.

Leaving this as draft in case anyone has other suggestions.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
