### PR TITLE
Add CPU runtime and fixed gelu example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ CubeCL also comes with optimized runtimes managing memory management and lazy ex
 
 ### Supported Platforms
 
-| Platform | Runtime | Compiler    | Hardware                     |
-| -------- | ------- | ----------- | ---------------------------- |
-| WebGPU   | wgpu    | WGSL        | Most GPUs                    |
-| CUDA     | CUDA    | C++ (CUDA)  | NVIDIA GPUs                  |
-| ROCm     | HIP     | C++ (HIP)   | AMD GPUs                     |
-| Metal    | wgpu    | C++ (Metal) | Apple GPUs                   |
-| Vulkan   | wgpu    | SPIR-V      | Most GPUs on Linux & Windows |
+| Platform | Runtime | Compiler    | Hardware                      |
+| -------- | ------- | ----------- | ----------------------------- |
+| WebGPU   | wgpu    | WGSL        | Most GPUs                     |
+| CUDA     | CUDA    | C++ (CUDA)  | NVIDIA GPUs                   |
+| ROCm     | HIP     | C++ (HIP)   | AMD GPUs                      |
+| Metal    | wgpu    | C++ (Metal) | Apple GPUs                    |
+| Vulkan   | wgpu    | SPIR-V      | Most GPUs on Linux & Windows  |
+| CPU      | cpu     | Rust        | All Cpus, SIMD with most CPUs |
+
 
 Not all platforms support the same features. 
 For instance Tensor Cores acceleration isn't supported on WebGPU yet.
@@ -99,6 +101,7 @@ pub fn launch<R: Runtime>(device: &R::Device) {
 To see it in action, run the working GELU example with the following command:
 
 ```bash
+cargo run --example gelu --features cpu  # cpu/simd runtime
 cargo run --example gelu --features cuda # cuda runtime
 cargo run --example gelu --features wgpu # wgpu runtime
 ```


### PR DESCRIPTION
Super simple README updates:

1.) Added cpu as a runtime.

Tested gelu using CPU on 1 computer with avx SIMD instructions.

Note, there was a difference in rounding:
[-0.15865529, 0.0, 0.8413447, 4.9999986]

Addition assumes no SIMD instructions required, but didn't test.

2.) Fixed a couple lines of the gelu example to match the actual gelu example code.