### PR TITLE
fix: Fix broadcasting on compare ops in SPIR-V

### DIFF
--- a/crates/cubecl-spirv/src/instruction.rs
+++ b/crates/cubecl-spirv/src/instruction.rs
@@ -375,16 +375,17 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         let lhs = self.compile_variable(op.lhs);
         let rhs = self.compile_variable(op.rhs);
         let out = self.compile_variable(out);
-        let lhs_ty = lhs.item();
 
-        let lhs_id = self.read(&lhs);
-        let rhs_id = self.read_as(&rhs, &lhs_ty);
+        let in_ty = out.item().same_vectorization(lhs.elem());
+
+        let lhs_id = self.read_as(&lhs, &in_ty);
+        let rhs_id = self.read_as(&rhs, &in_ty);
         let out_id = self.write_id(&out);
         self.mark_uniformity(out_id, uniform);
 
         let ty = out.item().id(self);
 
-        exec(self, lhs_ty, ty, lhs_id, rhs_id, out_id);
+        exec(self, in_ty, ty, lhs_id, rhs_id, out_id);
         self.write(&out, out_id);
     }
 


### PR DESCRIPTION
Fixes broadcast comparisons in SPIR-V when `lhs` is the variable being broadcast to `rhs`

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
