### PR TITLE
fix: Fix `LinearView` with 1D broadcast tensors

### DIFF
--- a/crates/cubecl-std/src/tensor/layout/linear.rs
+++ b/crates/cubecl-std/src/tensor/layout/linear.rs
@@ -56,8 +56,7 @@ impl<'a, R: Runtime> LinearLayoutArgs<'a, R> {
         strides: &[usize],
         line_size: &'a u8,
     ) -> Self {
-        let rank = shape.len();
-        if rank == 1 || is_contiguous(shape, strides) {
+        if is_contiguous(shape, strides) {
             Self::Plain(PlainLayoutLaunch::from_shape(shape, line_size))
         } else if is_contiguous_pitched(shape, strides) {
             Self::Strided(StridedLayoutLaunch::from_shape_strides(


### PR DESCRIPTION
Incorrectly assumed 1D tensors are always contiguous

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
