### PR TITLE
[Fix] Poll while syncing on wgpu

### DIFF
--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -253,11 +253,13 @@ impl WgpuStream {
 
         let queue = self.queue.clone();
 
+        let poll = self.poll.start_polling();
         Box::pin(async move {
             let (sender, receiver) = async_channel::bounded::<()>(1);
             queue.on_submitted_work_done(move || {
                 // Signal that we're done.
                 let _ = sender.try_send(());
+                core::mem::drop(poll);
             });
             let _ = receiver.recv().await;
         })


### PR DESCRIPTION
# wgpu's sync deadlocks in my setup
https://github.com/tracel-ai/cubecl/pull/908 broke syncing on wgpu in my setup - my diagnosis is that the queue.on_submitted_work_done callback will never be run since my setup doesn't have anything submitting or polling the wgpu runtime, thus deadlocking itself.
The proof is in the deadlock vanishing if a poll is started before the future is constructed. I don't know if this is the correct way to deal with the problem or not - I just looked at what some of the surrounding code was doing.

I haven't tested with anything in burn yet - I'd rather hear if this is even the correct direction.

As an aside, it seems to me that it would be more elegant to start the poll from within the future than outside it - say the future is constructed but not polled for a little while. In the meantime the wgpu polling thread could idle untill someone actually cares about the result of the future. The main thing blocking this right now is that WgpuPoll holds a JoinHandle<()>, making it not Clone. If this was instead put behind an Arc, the Poll struct could be cloned to the future and the polling could be started from in there.
In practice I don't expect this to have much effect though - I expect most of the futures created in cubecl are immediately awaited

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
