### PR TITLE
feat: Automatically enable `spirv-dump` if out path is set during build

### DIFF
--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -17,12 +17,17 @@ default = [
     "cubecl-core/default",
 ]
 exclusive-memory-only = ["cubecl-runtime/exclusive-memory-only"]
-std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]
+std = [
+    "cubecl-runtime/std",
+    "cubecl-common/std",
+    "cubecl-core/std",
+    "sanitize-filename",
+]
 # 'msl' and 'spirv' features are exclusive
 # TODO find a way to have wgpu runtime auto-compiler to support several compilers at the same time
 msl = ["cubecl-cpp/metal"]
 profile-tracy = ["tracy-client"]
-spirv = ["cubecl-spirv", "ash", "tracel-ash", "sanitize-filename"]
+spirv = ["cubecl-spirv", "ash", "tracel-ash"]
 
 spirv-dump = []
 

--- a/crates/cubecl-wgpu/build.rs
+++ b/crates/cubecl-wgpu/build.rs
@@ -10,7 +10,8 @@ fn main() {
 
     // Automatically enable spirv-dump if an output path is set
     println!("cargo:rerun-if-env-changed=CUBECL_DEBUG_SPIRV");
-    if env::var("CUBECL_DEBUG_SPIRV").is_ok() {
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_STD");
+    if env::var("CUBECL_DEBUG_SPIRV").is_ok() && env::var("CARGO_FEATURE_STD").is_ok() {
         println!("cargo:rustc-cfg=feature=\"spirv-dump\"");
     }
 


### PR DESCRIPTION
Adds a check to the build script to automatically enable `spirv-dump` if `CUBECL_DEBUG_SPIRV` is set at build time. This makes it easier to enable when you're debugging somewhere downstream.
Makes `sanitize-filename` gated on `spirv` rather than `spirv-dump` because build scripts can't enable optional dependencies.