### PR TITLE
feat: Unwrap unrolled loop variables

### DIFF
--- a/crates/cubecl-attention/src/components/global/dummy/read.rs
+++ b/crates/cubecl-attention/src/components/global/dummy/read.rs
@@ -135,9 +135,11 @@ impl<AP: AttentionPrecision, G: GlobalAttentionConfig> DummyKeyReader<AP, G> {
                                 let index_load = row_load_in_tile * tile_cols_load + col_load;
                                 let index_store = col_load * tile_rows_load + row_load_in_tile;
 
-                                slice[index_store + store_offset] = Line::cast_from(
-                                    view.read_checked(((tile_row_load, tile_col_load), index_load)),
-                                );
+                                slice[index_store + store_offset] =
+                                    Line::cast_from(view.read_checked((
+                                        (tile_row_load, tile_col_load).runtime(),
+                                        index_load,
+                                    )));
                             }
                         }
                     }
@@ -210,7 +212,7 @@ impl<AP: AttentionPrecision, G: GlobalAttentionConfig> DummyValueReader<AP, G> {
                                 let index = row_in_tile * tile_cols + col;
 
                                 slice[index + offset] = Line::cast_from(
-                                    view.read_checked(((tile_row, tile_col), index)),
+                                    view.read_checked(((tile_row, tile_col).runtime(), index)),
                                 );
                             }
                         }

--- a/crates/cubecl-attention/src/components/tile/dummy/attention_matmul/dummy_register/matmul.rs
+++ b/crates/cubecl-attention/src/components/tile/dummy/attention_matmul/dummy_register/matmul.rs
@@ -106,7 +106,7 @@ impl<E: Float> ArrayTile<E> {
         self.unit_size.1 * (UNIT_POS_X % self.num_units_per_row) + c
     }
 
-    fn abs_pos(&self, local_pos: Coords2d) -> Coords2d {
+    fn abs_pos(&self, #[comptime] local_pos: Coords2d) -> Coords2d {
         (
             self.abs_row_index(local_pos.0),
             self.abs_col_index(local_pos.1),

--- a/crates/cubecl-attention/src/components/tile/row/reduce/dummy_reducer.rs
+++ b/crates/cubecl-attention/src/components/tile/row/reduce/dummy_reducer.rs
@@ -25,24 +25,18 @@ impl Reducer for DummyReducer {
         let plane_offset = UNIT_POS_Y * num_vals_in_plane;
         let unit_offset = UNIT_POS_X;
 
-        let mut r = comptime![0u32];
-
         #[unroll]
-        for _ in 0..config.num_rows_per_unit() {
+        for r in 0..config.num_rows_per_unit() {
             let row_offset = r * config.plane_dim();
             let offset = plane_offset + row_offset + unit_offset;
 
             smem[offset] = local_vals.index(r);
-
-            comptime![r += 1];
         }
 
         sync_cube();
 
-        let mut r = comptime![0u32];
-
         #[unroll]
-        for _ in 0..config.num_rows_per_unit() {
+        for r in 0..config.num_rows_per_unit() {
             let mut val = vals.index(r);
 
             let row_offset = r * config.plane_dim();
@@ -56,8 +50,6 @@ impl Reducer for DummyReducer {
             }
 
             vals.replace_at(r, val);
-
-            comptime![r += 1];
         }
 
         sync_cube();

--- a/crates/cubecl-attention/src/components/tile/row/rowwise.rs
+++ b/crates/cubecl-attention/src/components/tile/row/rowwise.rs
@@ -33,13 +33,10 @@ impl<E: Float> RowWise<E> {
     }
 
     pub fn copy_from(&mut self, other: &RowWise<E>) {
-        let mut i = comptime![0u32];
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let row_val = self.vals.index_mut(i);
             row_val.val = other.index(i);
-
-            comptime![i += 1];
         }
     }
 
@@ -48,57 +45,42 @@ impl<E: Float> RowWise<E> {
     }
 
     pub fn fill(&mut self, val: E) {
-        let mut i = comptime![0u32];
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let row_val = self.vals.index_mut(i);
             row_val.val = val;
-
-            comptime![i += 1];
         }
     }
 
     pub fn add_inplace(&mut self, other: &RowWise<E>) {
-        let mut i = comptime![0u32];
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let row_val = self.vals.index_mut(i);
             row_val.val += other.index(i);
-
-            comptime![i += 1];
         }
     }
 
     pub fn mul_inplace(&mut self, other: &RowWise<E>) {
-        let mut i = comptime![0u32];
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let row_val = self.vals.index_mut(i);
             row_val.val *= other.index(i);
-
-            comptime![i += 1];
         }
     }
 
     pub fn recip_inplace(&mut self) {
-        let mut i = comptime![0u32];
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let row_val = self.vals.index_mut(i);
             row_val.val = Recip::recip(row_val.val);
-
-            comptime![i += 1];
         }
     }
 
     pub fn max_inplace(&mut self, other: &RowWise<E>) {
-        let mut i = comptime![0u32];
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let row_val = self.vals.index_mut(i);
             row_val.val = Max::max(row_val.val, other.index(i));
-
-            comptime![i += 1];
         }
     }
 
@@ -109,14 +91,11 @@ impl<E: Float> RowWise<E> {
 
     pub fn cast_from<E2: Float>(&self) -> RowWise<E2> {
         let mut vals = Sequence::new();
-        let mut i = comptime![0u32];
 
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let val = E2::cast_from(self.index(i));
             vals.push(RowVal::<E2> { val });
-
-            comptime![i += 1];
         }
 
         RowWise::<E2> {
@@ -127,14 +106,11 @@ impl<E: Float> RowWise<E> {
 
     pub fn exp_m_diff(&self, other: &RowWise<E>) -> RowWise<E> {
         let mut vals = Sequence::new();
-        let mut i = comptime![0u32];
 
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let val = Exp::exp(self.index(i) - other.index(i));
             vals.push(RowVal::<E> { val });
-
-            comptime![i += 1];
         }
 
         RowWise::<E> {
@@ -145,14 +121,11 @@ impl<E: Float> RowWise<E> {
 
     pub fn mul(&self, other: &RowWise<E>) -> RowWise<E> {
         let mut vals = Sequence::new();
-        let mut i = comptime![0u32];
 
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let val = self.index(i) * other.index(i);
             vals.push(RowVal::<E> { val });
-
-            comptime![i += 1];
         }
 
         RowWise::<E> {
@@ -163,14 +136,11 @@ impl<E: Float> RowWise<E> {
 
     pub fn add(&self, other: &RowWise<E>) -> RowWise<E> {
         let mut vals = Sequence::new();
-        let mut i = comptime![0u32];
 
         #[unroll]
-        for _ in 0..self.num_rows {
+        for i in 0..self.num_rows {
             let val = self.index(i) + other.index(i);
             vals.push(RowVal::<E> { val });
-
-            comptime![i += 1];
         }
 
         RowWise::<E> {

--- a/crates/cubecl-convolution/src/components/global/layout/im2col.rs
+++ b/crates/cubecl-convolution/src/components/global/layout/im2col.rs
@@ -12,10 +12,7 @@ use cubecl_std::{
 use crate::{
     components::{
         ConvGemmConfig, ConvolutionConfig, ConvolutionParams, ConvolutionProblem,
-        global::{
-            layout::{NhwcCoords, unwrap},
-            read::im2col_tma::div_mod_seq,
-        },
+        global::{layout::NhwcCoords, read::im2col_tma::div_mod_seq},
     },
     kernels::layered::selector::RuntimeArgs,
 };
@@ -80,7 +77,6 @@ impl Layout for Im2colLayout {
 
         #[unroll]
         for i in 0..spatial_dims {
-            let i = unwrap(i);
             let dim = comptime![spatial_dims - i - 1];
             let ksize = comptime![params.kernel_size[dim as usize]];
             let k_pos = rem % ksize;

--- a/crates/cubecl-convolution/src/components/global/layout/spatial.rs
+++ b/crates/cubecl-convolution/src/components/global/layout/spatial.rs
@@ -1,5 +1,5 @@
 use cubecl::prelude::*;
-use cubecl_core::{self as cubecl, intrinsic};
+use cubecl_core::{self as cubecl};
 use cubecl_std::tensor::{
     layout::{Coordinates, Coords1d, Layout, LayoutExpand},
     r#virtual::VirtualTensor,
@@ -154,7 +154,6 @@ impl Layout for NhwcLayout {
 
         #[unroll]
         for i in 0..spatial_dims {
-            let i = unwrap(i);
             read_pos += *spatial.index(i) as u32 * *self.strides_spatial.index(i);
         }
 
@@ -172,7 +171,6 @@ impl Layout for NhwcLayout {
 
             #[unroll]
             for i in 0..spatial_dims {
-                let i = unwrap(i);
                 let pos = *pos.spatial.index(i);
                 spatial_in_bounds &= pos >= 0 && (pos as u32) < *self.shapes_spatial.index(i);
             }
@@ -192,12 +190,6 @@ impl Layout for NhwcLayout {
     }
 }
 
-#[allow(unused_variables)]
-#[cube]
-pub(crate) fn unwrap(v: u32) -> comptime_type!(u32) {
-    intrinsic!(|_| v.constant().expect("Must be constant").as_u32())
-}
-
 #[cube]
 pub(crate) fn cast_seq<From: CubePrimitive, To: CubePrimitive>(
     seq: Sequence<From>,
@@ -206,7 +198,6 @@ pub(crate) fn cast_seq<From: CubePrimitive, To: CubePrimitive>(
     let mut out_seq = Sequence::new();
     #[unroll]
     for i in 0..num_elems {
-        let i = unwrap(i);
         let elem = To::cast_from(*seq.index(i));
         out_seq.push(elem);
     }

--- a/crates/cubecl-convolution/src/components/global/layout/weight.rs
+++ b/crates/cubecl-convolution/src/components/global/layout/weight.rs
@@ -12,7 +12,7 @@ use cubecl_std::{
 use crate::{
     components::{
         ConvGemmConfig, ConvolutionConfig, ConvolutionParams, ConvolutionProblem,
-        global::layout::{NhwcCoords, unwrap},
+        global::layout::NhwcCoords,
     },
     kernels::layered::selector::RuntimeArgs,
 };
@@ -69,7 +69,6 @@ impl Layout for WeightLayout {
 
         #[unroll]
         for i in 0..spatial_dims {
-            let i = unwrap(i);
             let dim = comptime![spatial_dims - i - 1];
             let ksize = comptime![params.kernel_size[dim as usize]];
             let k_pos = rem % ksize;

--- a/crates/cubecl-convolution/src/components/global/multi_stage/tma/convolution.rs
+++ b/crates/cubecl-convolution/src/components/global/multi_stage/tma/convolution.rs
@@ -111,12 +111,10 @@ where
         let (mut tile_lhs, mut tile_rhs) = SMM::init_tile_inputs(stage_config);
         let partition_scheduler = SMM::init_scheduler(config.stage_config());
 
-        let mut stage = comptime![0u32];
-
         // Create barriers and prefetch each stage
         #[unroll]
         #[allow(clippy::explicit_counter_loop)]
-        for _ in 0..num_stages {
+        for stage in 0..num_stages {
             let barrier = Barrier::new_with_tma_proxy(BarrierLevel::cube_coop(0u32));
 
             lhs_reader.fill_stage(&barrier, stage);
@@ -128,19 +126,15 @@ where
             rhs_reader.advance_view();
 
             barriers.push(barrier);
-
-            comptime![stage += 1];
         }
 
         for k in 0..num_loops {
             let k = k * num_stages;
 
-            let mut stage = comptime![0u32];
-
             // Loop through all stages
             #[unroll]
             #[allow(clippy::explicit_counter_loop)]
-            for _ in 0..num_stages {
+            for stage in 0..num_stages {
                 let k = k + stage;
                 let next_k = k + num_stages;
 
@@ -175,8 +169,6 @@ where
                         rhs_reader.advance_view();
                     }
                 }
-
-                comptime![stage += 1];
             }
         }
 

--- a/crates/cubecl-convolution/src/components/global/read/reader/im2col_tma.rs
+++ b/crates/cubecl-convolution/src/components/global/read/reader/im2col_tma.rs
@@ -1,5 +1,5 @@
+use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl, prelude::barrier::Barrier};
-use cubecl_core::{intrinsic, prelude::*};
 
 use cubecl_matmul::components::{MatrixPrecision, StageIdent, stage::StageMemoryConfig};
 use cubecl_std::FastDivmod;
@@ -73,7 +73,6 @@ impl<IP: MatrixPrecision> TmaIm2colGlobalReader<IP> {
 
             #[unroll]
             for dim in 0..spatial_dims {
-                let dim = unwrap(dim);
                 let offs =
                     self.map.spatial_offsets.index(dim) * comptime![params.stride[dim as usize]];
                 let offs = offs as i32 - comptime![params.padding[dim as usize]];
@@ -171,7 +170,6 @@ pub(crate) fn div_mod_seq(pos: u32, shape: &Sequence<FastDivmod>) -> (u32, Seque
 
     #[unroll]
     for i in 0..rank {
-        let i = unwrap(i);
         let dim = comptime![rank - i - 1];
         let (rem, offs_local) = shape.index(dim).div_mod(offs);
         out.push(offs_local);
@@ -179,10 +177,4 @@ pub(crate) fn div_mod_seq(pos: u32, shape: &Sequence<FastDivmod>) -> (u32, Seque
     }
 
     (offs, out.rev())
-}
-
-#[allow(unused_variables)]
-#[cube]
-fn unwrap(v: u32) -> comptime_type!(u32) {
-    intrinsic!(|_| v.constant().expect("Must be constant").as_u32())
 }

--- a/crates/cubecl-core/src/frontend/container/line/base.rs
+++ b/crates/cubecl-core/src/frontend/container/line/base.rs
@@ -8,7 +8,7 @@ use crate::{
     prelude::{Dot, Numeric, binary_expand_fixed_output},
     unexpanded,
 };
-use cubecl_ir::{Comparison, ExpandElement, StorageType};
+use cubecl_ir::{Comparison, ConstantScalarValue, ExpandElement, StorageType};
 use cubecl_macros::{cube, intrinsic};
 use derive_more::derive::Neg;
 /// A contiguous list of elements that supports auto-vectorized operations.
@@ -264,6 +264,10 @@ impl<P: CubePrimitive> CubePrimitive for Line<P> {
 
     fn size() -> Option<usize> {
         P::size()
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        Self::new(P::from_const_value(value))
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/atomic.rs
+++ b/crates/cubecl-core/src/frontend/element/atomic.rs
@@ -1,4 +1,4 @@
-use cubecl_ir::{AtomicOp, ExpandElement, StorageType};
+use cubecl_ir::{AtomicOp, ConstantScalarValue, ExpandElement, StorageType};
 
 use super::{ExpandElementIntoMut, ExpandElementTyped, Int, Numeric, into_mut_expand_element};
 use crate::{
@@ -305,6 +305,10 @@ impl<Inner: CubePrimitive> CubePrimitive for Atomic<Inner> {
 
     fn from_expand_elem(elem: ExpandElement) -> Self::ExpandType {
         ExpandElementTyped::new(elem)
+    }
+
+    fn from_const_value(_value: ConstantScalarValue) -> Self {
+        panic!("Can't have constant atomic");
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -342,6 +342,11 @@ impl<T: CubePrimitive> ExpandElementTyped<T> {
             _ => None,
         }
     }
+
+    pub fn __expand_into_lit_unchecked_method(self, _scope: &mut Scope) -> T {
+        let value = self.constant().unwrap();
+        T::from_const_value(value)
+    }
 }
 
 pub(crate) fn into_runtime_expand_element<E: Into<ExpandElement>>(

--- a/crates/cubecl-core/src/frontend/element/bool.rs
+++ b/crates/cubecl-core/src/frontend/element/bool.rs
@@ -1,4 +1,4 @@
-use cubecl_ir::{ExpandElement, Scope, StorageType};
+use cubecl_ir::{ConstantScalarValue, ExpandElement, Scope, StorageType};
 
 use crate::frontend::{CubePrimitive, CubeType};
 use crate::ir::ElemType;
@@ -30,6 +30,13 @@ impl CubeType for bool {
 impl CubePrimitive for bool {
     fn as_type_native() -> Option<StorageType> {
         Some(StorageType::Scalar(ElemType::Bool))
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        let ConstantScalarValue::Bool(value) = value else {
+            unreachable!()
+        };
+        value
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/cube_elem.rs
+++ b/crates/cubecl-core/src/frontend/element/cube_elem.rs
@@ -1,4 +1,4 @@
-use cubecl_ir::{ExpandElement, StorageType};
+use cubecl_ir::{ConstantScalarValue, ExpandElement, StorageType};
 use cubecl_runtime::{
     TypeUsage, channel::ComputeChannel, client::ComputeClient, server::ComputeServer,
 };
@@ -49,6 +49,12 @@ pub trait CubePrimitive:
 
     fn from_expand_elem(elem: ExpandElement) -> Self::ExpandType {
         ExpandElementTyped::new(elem)
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self;
+
+    fn into_lit_unchecked(self) -> Self {
+        self
     }
 
     fn supported_uses<S: ComputeServer, C: ComputeChannel<S>>(

--- a/crates/cubecl-core/src/frontend/element/float.rs
+++ b/crates/cubecl-core/src/frontend/element/float.rs
@@ -1,4 +1,4 @@
-use cubecl_ir::{Scope, StorageType};
+use cubecl_ir::{ConstantScalarValue, Scope, StorageType};
 use half::{bf16, f16};
 
 use crate::{
@@ -73,7 +73,7 @@ pub trait Float:
 
 macro_rules! impl_float {
     (half $primitive:ident, $kind:ident) => {
-        impl_float!($primitive, $kind, |val| $primitive::from_f32(val));
+        impl_float!($primitive, $kind, |val| $primitive::from_f64(val));
     };
     ($primitive:ident, $kind:ident) => {
         impl_float!($primitive, $kind, |val| val as $primitive);
@@ -87,6 +87,13 @@ macro_rules! impl_float {
             /// Return the element type to use on GPU
             fn as_type_native() -> Option<StorageType> {
                 Some(StorageType::Scalar(ElemType::Float(FloatKind::$kind)))
+            }
+
+            fn from_const_value(value: ConstantScalarValue) -> Self {
+                let ConstantScalarValue::Float(value, _) = value else {
+                    unreachable!()
+                };
+                $new(value)
             }
         }
 
@@ -133,7 +140,7 @@ macro_rules! impl_float {
             const RADIX: u32 = $primitive::RADIX;
 
             fn new(val: f32) -> Self {
-                $new(val)
+                $new(val as f64)
             }
         }
     };

--- a/crates/cubecl-core/src/frontend/element/float/fp4.rs
+++ b/crates/cubecl-core/src/frontend/element/float/fp4.rs
@@ -1,5 +1,5 @@
 use cubecl_common::{e2m1, e2m1x2};
-use cubecl_ir::{ElemType, ExpandElement, FloatKind, Scope, StorageType};
+use cubecl_ir::{ConstantScalarValue, ElemType, ExpandElement, FloatKind, Scope, StorageType};
 
 use crate::{
     Runtime,
@@ -18,6 +18,13 @@ impl CubePrimitive for e2m1 {
     /// Return the element type to use on GPU
     fn as_type_native() -> Option<StorageType> {
         Some(StorageType::Scalar(ElemType::Float(FloatKind::E2M1)))
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        let ConstantScalarValue::Float(value, _) = value else {
+            unreachable!()
+        };
+        e2m1::from_f64(value)
     }
 }
 
@@ -42,6 +49,15 @@ impl CubePrimitive for e2m1x2 {
     /// Return the element type to use on GPU
     fn as_type_native() -> Option<StorageType> {
         Some(StorageType::Packed(ElemType::Float(FloatKind::E2M1), 2))
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        let ConstantScalarValue::Float(value, _) = value else {
+            unreachable!()
+        };
+        let val = e2m1::from_f64(value).to_bits();
+        // Fill both values, not sure this is ever useful but it works
+        e2m1x2::from_bits(val | (val << 4))
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/float/fp6.rs
+++ b/crates/cubecl-core/src/frontend/element/float/fp6.rs
@@ -1,5 +1,5 @@
 use cubecl_common::{e2m3, e3m2};
-use cubecl_ir::{ElemType, ExpandElement, FloatKind, Scope, StorageType};
+use cubecl_ir::{ConstantScalarValue, ElemType, ExpandElement, FloatKind, Scope, StorageType};
 
 use crate::prelude::{
     CubePrimitive, CubeType, ExpandElementIntoMut, ExpandElementTyped, IntoRuntime,
@@ -14,6 +14,10 @@ impl CubePrimitive for e2m3 {
     /// Return the element type to use on GPU
     fn as_type_native() -> Option<StorageType> {
         Some(ElemType::Float(FloatKind::E2M3).into())
+    }
+
+    fn from_const_value(_value: ConstantScalarValue) -> Self {
+        unimplemented!("e2m3 doesn't yet support conversion");
     }
 }
 
@@ -38,6 +42,10 @@ impl CubePrimitive for e3m2 {
     /// Return the element type to use on GPU
     fn as_type_native() -> Option<StorageType> {
         Some(ElemType::Float(FloatKind::E3M2).into())
+    }
+
+    fn from_const_value(_value: ConstantScalarValue) -> Self {
+        unimplemented!("e3m2 doesn't yet support conversion");
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/float/fp8.rs
+++ b/crates/cubecl-core/src/frontend/element/float/fp8.rs
@@ -1,5 +1,5 @@
 use cubecl_common::{e4m3, e5m2, ue8m0};
-use cubecl_ir::{ElemType, ExpandElement, FloatKind, Scope, StorageType};
+use cubecl_ir::{ConstantScalarValue, ElemType, ExpandElement, FloatKind, Scope, StorageType};
 
 use crate::{
     Runtime,
@@ -18,6 +18,13 @@ impl CubePrimitive for e4m3 {
     /// Return the element type to use on GPU
     fn as_type_native() -> Option<StorageType> {
         Some(ElemType::Float(FloatKind::E4M3).into())
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        let ConstantScalarValue::Float(value, _) = value else {
+            unreachable!()
+        };
+        e4m3::from_f64(value)
     }
 }
 
@@ -58,6 +65,13 @@ impl CubePrimitive for e5m2 {
     fn as_type_native() -> Option<StorageType> {
         Some(ElemType::Float(FloatKind::E5M2).into())
     }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        let ConstantScalarValue::Float(value, _) = value else {
+            unreachable!()
+        };
+        e5m2::from_f64(value)
+    }
 }
 
 impl IntoRuntime for e5m2 {
@@ -96,6 +110,13 @@ impl CubePrimitive for ue8m0 {
     /// Return the element type to use on GPU
     fn as_type_native() -> Option<StorageType> {
         Some(ElemType::Float(FloatKind::UE8M0).into())
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        let ConstantScalarValue::Float(value, _) = value else {
+            unreachable!()
+        };
+        ue8m0::from_f64(value)
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/float/relaxed.rs
+++ b/crates/cubecl-core/src/frontend/element/float/relaxed.rs
@@ -1,5 +1,5 @@
 use cubecl_common::flex32;
-use cubecl_ir::{ElemType, ExpandElement, FloatKind, Scope, StorageType};
+use cubecl_ir::{ConstantScalarValue, ElemType, ExpandElement, FloatKind, Scope, StorageType};
 
 use crate::prelude::{Numeric, into_runtime_expand_element};
 
@@ -16,6 +16,13 @@ impl CubePrimitive for flex32 {
     /// Return the element type to use on GPU
     fn as_type_native() -> Option<StorageType> {
         Some(ElemType::Float(FloatKind::Flex32).into())
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        let ConstantScalarValue::Float(value, _) = value else {
+            unreachable!()
+        };
+        flex32::from_f64(value)
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/float/tensor_float.rs
+++ b/crates/cubecl-core/src/frontend/element/float/tensor_float.rs
@@ -1,5 +1,5 @@
 use cubecl_common::tf32;
-use cubecl_ir::{ElemType, ExpandElement, FloatKind, Scope, StorageType};
+use cubecl_ir::{ConstantScalarValue, ElemType, ExpandElement, FloatKind, Scope, StorageType};
 use half::f16;
 
 use crate::prelude::{Numeric, into_runtime_expand_element};
@@ -17,6 +17,13 @@ impl CubePrimitive for tf32 {
     /// Return the element type to use on GPU
     fn as_type_native() -> Option<StorageType> {
         Some(ElemType::Float(FloatKind::TF32).into())
+    }
+
+    fn from_const_value(value: ConstantScalarValue) -> Self {
+        let ConstantScalarValue::Float(value, _) = value else {
+            unreachable!()
+        };
+        tf32::from_f64(value)
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/float/typemap.rs
+++ b/crates/cubecl-core/src/frontend/element/float/typemap.rs
@@ -184,6 +184,10 @@ impl<const POS: u8> CubePrimitive for ElemExpand<POS> {
     fn as_type(scope: &Scope) -> StorageType {
         scope.resolve_type::<Self>().expect("Type to be registered")
     }
+
+    fn from_const_value(_value: ConstantScalarValue) -> Self {
+        unimplemented!("Can't turn `ElemExpand` into a constant value")
+    }
 }
 
 impl<const POS: u8> From<ElemExpand<POS>> for Variable {

--- a/crates/cubecl-core/src/frontend/element/int.rs
+++ b/crates/cubecl-core/src/frontend/element/int.rs
@@ -1,4 +1,4 @@
-use cubecl_ir::{ExpandElement, StorageType};
+use cubecl_ir::{ConstantScalarValue, ExpandElement, StorageType};
 
 use crate::Runtime;
 use crate::frontend::{CubeType, Numeric};
@@ -69,6 +69,13 @@ macro_rules! impl_int {
         impl CubePrimitive for $type {
             fn as_type_native() -> Option<StorageType> {
                 Some(ElemType::Int(IntKind::$kind).into())
+            }
+
+            fn from_const_value(value: ConstantScalarValue) -> Self {
+                let ConstantScalarValue::Int(value, _) = value else {
+                    unreachable!()
+                };
+                value as $type
             }
         }
 

--- a/crates/cubecl-core/src/frontend/element/int/typemap.rs
+++ b/crates/cubecl-core/src/frontend/element/int/typemap.rs
@@ -1,6 +1,8 @@
 use bytemuck::{Pod, Zeroable};
 use core::ops::*;
-use cubecl_ir::{ElemType, ExpandElement, IntKind, Scope, StorageType, Variable};
+use cubecl_ir::{
+    ConstantScalarValue, ElemType, ExpandElement, IntKind, Scope, StorageType, Variable,
+};
 use derive_more::derive::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Display, Div,
     DivAssign, Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub,
@@ -140,6 +142,10 @@ impl<const POS: u8> CubePrimitive for IntExpand<POS> {
     /// Return the element type to use on GPU
     fn as_type(scope: &Scope) -> StorageType {
         scope.resolve_type::<Self>().expect("Type to be registered")
+    }
+
+    fn from_const_value(_value: ConstantScalarValue) -> Self {
+        unimplemented!("Can't turn `IntExpand` into a constant value")
     }
 }
 

--- a/crates/cubecl-core/src/frontend/element/uint.rs
+++ b/crates/cubecl-core/src/frontend/element/uint.rs
@@ -1,4 +1,4 @@
-use cubecl_ir::{ExpandElement, Scope, StorageType, UIntKind};
+use cubecl_ir::{ConstantScalarValue, ExpandElement, Scope, StorageType, UIntKind};
 
 use crate::Runtime;
 use crate::frontend::{CubePrimitive, CubeType, Numeric};
@@ -19,6 +19,13 @@ macro_rules! declare_uint {
         impl CubePrimitive for $primitive {
             fn as_type_native() -> Option<StorageType> {
                 Some(ElemType::UInt(UIntKind::$kind).into())
+            }
+
+            fn from_const_value(value: ConstantScalarValue) -> Self {
+                let ConstantScalarValue::UInt(value, _) = value else {
+                    unreachable!()
+                };
+                value as $primitive
             }
         }
 

--- a/crates/cubecl-core/src/runtime_tests/unroll.rs
+++ b/crates/cubecl-core/src/runtime_tests/unroll.rs
@@ -14,7 +14,7 @@ pub fn unroll_add<F: Float>(output: &mut Array<Line<F>>) {
 
     let mut out = Line::empty(4u32);
     #[unroll]
-    for i in 0..4 {
+    for i in 0..4u32 {
         out[i] = c[i];
     }
 

--- a/crates/cubecl-macros/src/parse/helpers.rs
+++ b/crates/cubecl-macros/src/parse/helpers.rs
@@ -8,6 +8,7 @@ use crate::{expression::Expression, paths::prelude_path, scope::Context};
 
 pub struct Unroll {
     pub value: Expression,
+    pub always_true: bool,
 }
 
 impl Unroll {
@@ -29,16 +30,23 @@ impl Unroll {
         let res = match &attr.meta {
             syn::Meta::Path(_) => Self {
                 value: Expression::from_expr(parse_quote![true], context).unwrap(),
+                always_true: true,
             },
             syn::Meta::List(list) => {
                 let expr = syn::parse2(list.tokens.clone())?;
                 let expr = Expression::from_expr(expr, context)?;
-                Self { value: expr }
+                Self {
+                    value: expr,
+                    always_true: false,
+                }
             }
             meta => {
                 let expr = NameVal::from_meta(meta)?;
                 let expr = Expression::from_expr(expr.value, context)?;
-                Self { value: expr }
+                Self {
+                    value: expr,
+                    always_true: false,
+                }
             }
         };
         Ok(Some(res))

--- a/crates/cubecl-matmul/src/components/global/read/reader/sync_full_reader.rs
+++ b/crates/cubecl-matmul/src/components/global/read/reader/sync_full_reader.rs
@@ -110,11 +110,10 @@ impl<IP: MatrixPrecision, G: GlobalConfig, L: SyncFullLoadingStrategy>
         };
 
         let len = L::Job::task_count(&loading_job);
-        let mut task_id = comptime![0u32];
 
         #[allow(clippy::explicit_counter_loop)]
         #[unroll]
-        for _ in 0..len {
+        for task_id in 0..len {
             L::Job::<IP>::execute_task::<G>(
                 &mut loading_job,
                 task_id,
@@ -122,7 +121,6 @@ impl<IP: MatrixPrecision, G: GlobalConfig, L: SyncFullLoadingStrategy>
                 &mut self.stage,
                 config,
             );
-            comptime![task_id += 1];
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/global/read/reader/sync_partial_reader.rs
+++ b/crates/cubecl-matmul/src/components/global/read/reader/sync_partial_reader.rs
@@ -120,11 +120,9 @@ impl<IP: MatrixPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy>
 
         let len = L::Job::task_count(&loading_job);
 
-        let mut task_id = comptime![0u32];
-
         #[allow(clippy::explicit_counter_loop)]
         #[unroll]
-        for _ in 0..len {
+        for task_id in 0..len {
             L::Job::<IP>::execute_task::<G>(
                 &mut loading_job,
                 task_id,
@@ -132,7 +130,6 @@ impl<IP: MatrixPrecision, G: GlobalConfig, L: SyncPartialLoadingStrategy>
                 &mut self.stage_memory,
                 config,
             );
-            comptime![task_id += 1];
         }
     }
 }

--- a/crates/cubecl-matmul/src/components/stage/matmul/partition/fragments.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/partition/fragments.rs
@@ -4,7 +4,7 @@ use crate::components::stage::StageConfig;
 use crate::components::{AccS, stage::Stage, tile::TileMatmul};
 use crate::components::{MatmulPrecision, MatrixPrecision};
 use cubecl::prelude::*;
-use cubecl_core::{self as cubecl, intrinsic};
+use cubecl_core::{self as cubecl};
 
 #[derive(CubeType)]
 /// Wrapper over a sequence of Tile Matmul accumulators
@@ -62,8 +62,8 @@ impl<
         for m in 0..size_m {
             #[unroll]
             for n in 0..size_n {
-                let acc = self.get_at_mut(unwrap(m), unwrap(n), config);
-                let tile = R::tile(stage, (m, n));
+                let acc = self.get_at_mut(m, n, config);
+                let tile = R::tile(stage, (m, n).runtime());
                 TM::load_acc(&tile, acc, config.tile_config());
             }
         }
@@ -99,10 +99,4 @@ impl<
 pub enum RhsTile<Rhs: CubeType> {
     Single(Rhs),
     Double((Rhs, Rhs)),
-}
-
-#[cube]
-#[allow(unused)]
-fn unwrap(i: u32) -> comptime_type!(u32) {
-    intrinsic!(|_| i.constant().unwrap().as_u32())
 }

--- a/crates/cubecl-matmul/src/components/stage/matmul/partition/matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/partition/matmul.rs
@@ -146,7 +146,6 @@ where
         let n_iterations = config.tiling_scheme().tiles_in_stage_partition_n();
         let k_iterations = config.tiling_scheme().tiles_in_stage_partition_k();
 
-        let mut k_iter = comptime![0u32];
         let mut lhs_load_counter = comptime![0];
         let mut rhs_load_counter = comptime![0];
         let mut execute_counter = comptime![0];
@@ -156,13 +155,12 @@ where
 
         #[allow(clippy::explicit_counter_loop)]
         #[unroll]
-        for _ in 0..k_iterations {
-            let mut m_iter = comptime![0u32];
+        for k_iter in 0..k_iterations {
             let k_load_iter = partition_scheduler.map_k(k_iter);
 
             #[allow(clippy::explicit_counter_loop)]
             #[unroll]
-            for _ in 0..m_iterations {
+            for m_iter in 0..m_iterations {
                 let m_load_iter = partition_scheduler.map_m(m_iter);
 
                 let tile_lhs = StageLhs::tile(lhs_stage, (m_load_iter, k_load_iter));
@@ -180,15 +178,11 @@ where
                     config,
                 );
                 comptime!(lhs_load_counter += 1);
-
-                comptime![m_iter += 1];
             }
-
-            let mut n_iter = comptime![0u32];
 
             #[unroll]
             #[allow(clippy::explicit_counter_loop)]
-            for _ in 0..n_iterations {
+            for n_iter in 0..n_iterations {
                 let n_load_iter = partition_scheduler.map_n(n_iter);
 
                 let rhs_tile_next = StageRhs::tile(rhs_stage, (k_load_iter, n_load_iter));
@@ -203,11 +197,9 @@ where
                 );
                 comptime!(rhs_load_counter += 1);
 
-                let mut m_iter = comptime![0u32];
-
                 #[allow(clippy::explicit_counter_loop)]
                 #[unroll]
-                for _ in 0..m_iterations {
+                for m_iter in 0..m_iterations {
                     let accumulator =
                         Accumulators::<MP, TM, S>::get_at_mut(acc, m_iter, n_iter, config);
                     TM::execute(
@@ -225,14 +217,8 @@ where
                         config,
                     );
                     comptime!(execute_counter += 1);
-
-                    comptime![m_iter += 1];
                 }
-
-                comptime![n_iter += 1];
             }
-
-            comptime![k_iter += 1];
         }
 
         assert!(lhs_load_counter == lhs_load_total);
@@ -261,8 +247,6 @@ where
         let n_iterations = config.tiling_scheme().tiles_in_stage_partition_n();
         let k_iterations = config.tiling_scheme().tiles_in_stage_partition_k();
 
-        let mut k_iter = comptime![0u32];
-
         let mut lhs_load_counter = comptime![0];
         let mut rhs_load_counter = comptime![0];
         let mut execute_counter = comptime![0];
@@ -272,13 +256,12 @@ where
 
         #[allow(clippy::explicit_counter_loop)]
         #[unroll]
-        for _ in 0..k_iterations {
-            let mut m_iter = comptime![0u32];
+        for k_iter in 0..k_iterations {
             let k_load_iter = partition_scheduler.map_k(k_iter);
 
             #[allow(clippy::explicit_counter_loop)]
             #[unroll]
-            for _ in 0..m_iterations {
+            for m_iter in 0..m_iterations {
                 let m_load_iter = partition_scheduler.map_m(m_iter);
 
                 let tile_lhs = StageLhs::tile(lhs_stage, (m_load_iter, k_load_iter));
@@ -296,8 +279,6 @@ where
                     config,
                 );
                 comptime!(lhs_load_counter += 1);
-
-                comptime![m_iter += 1];
             }
 
             let mut n_iter = comptime![0u32];
@@ -337,11 +318,9 @@ where
                 );
                 comptime!(rhs_load_counter += 1);
 
-                let mut m_iter = comptime![0u32];
-
                 #[allow(clippy::explicit_counter_loop)]
                 #[unroll]
-                for _ in 0..m_iterations {
+                for m_iter in 0..m_iterations {
                     let accumulator =
                         Accumulators::<MP, TM, S>::get_at_mut(acc, m_iter, n_iter, config);
 
@@ -360,8 +339,6 @@ where
                         config,
                     );
                     comptime!(execute_counter += 1);
-
-                    comptime![m_iter += 1];
                 }
 
                 comptime![n_iter += 1];
@@ -373,11 +350,9 @@ where
                 &mut rhs_fragments.1
             };
 
-            let mut m_iter = comptime![0u32];
-
             #[allow(clippy::explicit_counter_loop)]
             #[unroll]
-            for _ in 0..m_iterations {
+            for m_iter in 0..m_iterations {
                 let accumulator =
                     Accumulators::<MP, TM, S>::get_at_mut(acc, m_iter, n_iter, config);
                 TM::execute(
@@ -395,11 +370,7 @@ where
                     config,
                 );
                 comptime!(execute_counter += 1);
-
-                comptime![m_iter += 1];
             }
-
-            comptime![k_iter += 1];
         }
 
         assert!(lhs_load_counter == lhs_load_total);

--- a/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
+++ b/crates/cubecl-matmul/src/components/stage/matmul/partitioned_matmul.rs
@@ -173,20 +173,17 @@ where
         let m_iterations = global_config.tiling_scheme().tiles_in_stage_partition_m();
         let n_iterations = global_config.tiling_scheme().tiles_in_stage_partition_n();
 
-        let mut m_iter = comptime![0u32];
-
         W::on_event(listener, global::WriteEvent::new_Begin());
 
         // Iterate over each tile in the partition
         #[unroll]
         #[allow(clippy::explicit_counter_loop)]
-        for _ in 0..comptime![m_iterations] {
+        for m_iter in 0..m_iterations {
             let m_load_iter = partition_scheduler.map_m(m_iter);
-            let mut n_iter = comptime![0u32];
 
             #[unroll]
             #[allow(clippy::explicit_counter_loop)]
-            for _ in 0..comptime![n_iterations] {
+            for n_iter in 0..n_iterations {
                 let n_load_iter = partition_scheduler.map_n(n_iter);
 
                 let tile_accumulator =
@@ -199,10 +196,7 @@ where
                 // all tiles in the partition
                 TM::write_results(&mut tile, tile_accumulator, stage_config.tile_config());
                 W::on_event(listener, global::WriteEvent::new_TileStored(tile_pos));
-
-                comptime![n_iter += 1];
             }
-            comptime![m_iter += 1];
         }
 
         W::on_event(listener, global::WriteEvent::new_Finish());

--- a/crates/cubecl-quant/src/layout/scales.rs
+++ b/crates/cubecl-quant/src/layout/scales.rs
@@ -1,5 +1,5 @@
 use cubecl::prelude::*;
-use cubecl_core::{self as cubecl, intrinsic};
+use cubecl_core::{self as cubecl};
 use cubecl_std::{
     FastDivmod, FastDivmodArgs,
     tensor::{
@@ -149,7 +149,6 @@ impl Layout for BlockScaledLayout {
 
         #[unroll]
         for i in 0..rank {
-            let i = unwrap(i);
             let dim = comptime![rank - i - 1];
             let block_size_local = comptime![self.block_size[dim as usize] as u32];
             let (rem, offs_local) = self.tensor_shape.index(dim).div_mod(offs);
@@ -185,7 +184,6 @@ impl BlockScaledLayout {
 
         #[unroll]
         for i in 0..rank {
-            let i = unwrap(i);
             let dim = comptime![rank - i - 1];
             let block_size_local = comptime![self.block_size[dim as usize] as u32];
             let (rem, offs_local) = self.tensor_shape.index(dim).div_mod(offs);
@@ -195,12 +193,6 @@ impl BlockScaledLayout {
 
         is_start
     }
-}
-
-#[allow(unused_variables)]
-#[cube]
-fn unwrap(v: u32) -> comptime_type!(u32) {
-    intrinsic!(|_| v.constant().expect("Must be constant").as_u32())
 }
 
 /// [TensorView] with a linear layout inferred from the shape/strides at launch.


### PR DESCRIPTION
Unwraps loop variables for always-unrolled (expressionless) loops into a comptime value. There's no good way to check if an expression is constant and true, so any conditional unroll is treated as maybe-unrolled.

# Regressions
This may add requirements to specify a type suffix for loops where the start and end are literals and the value is never used in a comptime function. This only happens in two places (the unrolled loop test, and `deform_col2im` in burn).

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
