### PR TITLE
chore(deps): bump cudarc to 0.17.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ tracel-llvm = { version = "20.1.4-5", features = ["mlir-helpers"] }
 # tracel-llvm = { path = "../tracel-llvm/crates/tracel-llvm", features = ["mlir-helpers"] }
 
 # CubeCL-CUDA
-cudarc = { version = "0.17.2", features = [
+cudarc = { version = "0.17.3", features = [
     "std",
     "driver",
     "cuda-version-from-build-system",


### PR DESCRIPTION
Routine dependency update for CubeCL workspace.

Bumped cudarc to 0.17.3

ran cargo check

Windows note:
If you’ve previously customized CUDA-related environment variables (e.g. CUDA_PATH, CUDARC_CUDA_VERSION, CUDA_COMPUTE_CAP), it can help to clear them before rebuilding so the toolchain detects only one CUDA toolkit.

# Clear session CUDA vars and refresh PATH
Remove-Item Env:CUDA_PATH, Env:CUDARC_CUDA_VERSION, Env:CUDA_COMPUTE_CAP -ErrorAction SilentlyContinue
$env:Path = [System.Environment]::GetEnvironmentVariable('Path','Machine') + ';' +
            [System.Environment]::GetEnvironmentVariable('Path','User')


This ensures cudarc binds correctly and avoids duplicate constant errors.