### PR TITLE
fix: correct tensor shape in reduce_matrix example

### DIFF
--- a/cubecl-book/src/getting-started/src/bin/v2-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v2-gpu.rs
@@ -16,7 +16,7 @@ pub fn launch<R: Runtime, F: Float + CubeElement>(device: &R::Device) {
     let client = R::client(device);
 
     let input = GpuTensor::<R, F>::arange(vec![3, 3], &client);
-    let output = GpuTensor::<R, F>::empty(vec![3, 3], &client);
+    let output = GpuTensor::<R, F>::empty(vec![3], &client);
 
     unsafe {
         reduce_matrix::launch_unchecked::<F, R>(


### PR DESCRIPTION
fix: correct output tensor shape in reduce_matrix example