### PR TITLE
fix: Fix several panics occuring with unrolled line sizes in `matmul`

### DIFF
--- a/crates/cubecl-core/src/post_processing/unroll.rs
+++ b/crates/cubecl-core/src/post_processing/unroll.rs
@@ -44,6 +44,10 @@ impl UnrollProcessor {
         inst: &Instruction,
         mappings: &mut Mappings,
     ) -> TransformAction {
+        if matches!(inst.operation, Operation::Free(_)) {
+            return TransformAction::Ignore;
+        }
+
         if inst.operation.args().is_none() {
             // Detect unhandled ops that can't be reflected
             match &inst.operation {
@@ -623,7 +627,7 @@ fn create_unrolled(
                 allocator.create_local_mut(item)
             }
             VariableKind::LocalConst { .. } => allocator.create_local(item),
-            _ => panic!("Out must be local"),
+            other => panic!("Out must be local, found {other:?}"),
         })
         .collect()
 }

--- a/crates/cubecl-matmul/src/components/tile/register/matmul.rs
+++ b/crates/cubecl-matmul/src/components/tile/register/matmul.rs
@@ -158,7 +158,7 @@ impl<Acc: TileKind> RegisterMatmul<Acc> {
             #[unroll(UNROLL)]
             for line_within_segment in 0..num_lines_per_segment {
                 let line = tile.get_line(segment, line_within_segment);
-                #[unroll(UNROLL)]
+                #[unroll]
                 for pos_within_line in 0..line_size {
                     array[segment * segment_size
                         + line_within_segment * line_size
@@ -182,7 +182,7 @@ impl<Acc: TileKind> RegisterMatmul<Acc> {
             #[unroll(UNROLL)]
             for line_within_segment in 0..num_lines_per_segment {
                 let line = tile.get_line(segment, line_within_segment);
-                #[unroll(UNROLL)]
+                #[unroll]
                 for pos_within_line in 0..line_size {
                     array[(line_within_segment * line_size + pos_within_line) * num_segments
                         + segment] = ER::cast_from(line[pos_within_line]);

--- a/crates/cubecl-matmul/src/components/tile/register/writer.rs
+++ b/crates/cubecl-matmul/src/components/tile/register/writer.rs
@@ -21,7 +21,7 @@ impl RegisterStageWriter {
         #[unroll(UNROLL)]
         for i in 0..comptime!(config.tile_size.mn() / out_line_size) {
             let mut line = Line::empty(out_line_size);
-            #[unroll(UNROLL)]
+            #[unroll]
             for j in 0..comptime!(out_line_size) {
                 line[j] = acc[i * out_line_size + j];
             }


### PR DESCRIPTION
Adds handling for `Free` and makes sure register matmul always unrolls the line indexing, even if the other loops aren't unrolled.
These were causing panics in `llama32-q4` with Vulkan.