### PR TITLE
opt: Make GVN side-effect free and assume loops are executed at least once

### DIFF
--- a/crates/cubecl-opt/src/gvn/numbering.rs
+++ b/crates/cubecl-opt/src/gvn/numbering.rs
@@ -190,18 +190,7 @@ impl ValueTable {
         out: Variable,
     ) -> Result<(Expression, Option<Value>), Option<Value>> {
         let (expr, val) = match operator {
-            Operator::Index(op) | Operator::UncheckedIndex(op) => {
-                let out_val = value_of_var(&out);
-                if !op.list.is_immutable() {
-                    Err(out_val)?
-                }
-                let item = out.ty;
-                let lhs = self.lookup_or_add_var(&op.list)?;
-                let rhs = self.lookup_or_add_var(&op.index)?;
-                let id = OpCode::Operator(operator.op_code());
-                let expr = Instruction::new(id, &[lhs, rhs], item);
-                (expr.into(), out_val)
-            }
+            Operator::Index(_) | Operator::UncheckedIndex(_) => Err(value_of_var(&out))?,
 
             Operator::IndexAssign(_)
             | Operator::UncheckedIndexAssign(_)


### PR DESCRIPTION
This achieves full loop invariant code motion without an additional optimization pass.
It's unsafe if any numbered values have side effects, so the only one that still has them (indexing with potential OOB) is now considered volatile.

Performance testing indicates a small but significant 2-3% performance boost in a real world model (Llama 3.2).

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
