### PR TITLE
opt: Add automatic unrolling of unit loops

### DIFF
--- a/crates/cubecl-core/src/frontend/container/sequence/base.rs
+++ b/crates/cubecl-core/src/frontend/container/sequence/base.rs
@@ -139,6 +139,10 @@ impl<T: CubeType> Iterable<T> for SequenceExpand<T> {
             func(scope, elem);
         }
     }
+
+    fn const_len(&self) -> Option<usize> {
+        Some(self.values.borrow().len())
+    }
 }
 
 impl<T: CubeType> IntoMut for SequenceExpand<T> {


### PR DESCRIPTION
Adds a new `const_len` function similar to the `size_hint` function on `Iterator`, that returns the comptime length of an `Iterable` if applicable.
Uses this new functionality to automatically unroll loops with a comptime length of `1`.

# Performance
Seems to have a further 2-3% performance boost in Llama 3.2 Q4 on Vulkan, tested on top of the improvement from https://github.com/tracel-ai/cubecl/pull/985.
CUDA likely already unrolls these loops, but the cleaner code is still a nice benefit.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
