### PR TITLE
Fix cudarc feature flags for no default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,9 @@ cudarc = { version = "0.17.7", features = [
     "std",
     "driver",
     "nvrtc",
+    "dynamic-loading",
+    "cuda-version-from-build-system",
+    "fallback-latest",
 ], default-features = false } # CubeCL-CUDA
 
 # CubeCL-SPIR-V

--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -16,9 +16,6 @@ default = [
     "cubecl-runtime/default",
     "cubecl-common/default",
     "cubecl-core/default",
-    "cudarc/dynamic-loading",
-    "cudarc/cuda-version-from-build-system",
-    "cudarc/fallback-latest",
 ]
 ptx-wmma = []
 std = ["cubecl-runtime/std", "cubecl-common/std", "cubecl-core/std"]


### PR DESCRIPTION
Fixes cudarc build when`default-features = false`:
```
error: failed to run custom build command for `cudarc v0.17.7`

Caused by:
  process didn't exit successfully: `/home/laggui/workspace/cubecl/target/release/build/cudarc-fd5e871d347809ab/build-script-build` (exit status: 101)
  --- stderr

  thread 'main' panicked at /home/laggui/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cudarc-0.17.7/build.rs:17:5:
  None between `dynamic-loading`, `dynamic-linking` and `static-linking` features are active, this is a bug
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Will cherry-pick this fix for the patch release.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
