### PR TITLE
fix: Feature gate fast tanh

### DIFF
--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -39,6 +39,7 @@ pub struct CppSupportedFeatures {
     pub grid_constants: bool,
     pub clusters: bool,
     pub fast_math: bool,
+    pub fast_tanh: bool,
     pub elect_sync: bool,
 }
 
@@ -1100,13 +1101,17 @@ impl<D: Dialect> CppCompiler<D> {
                 let op = self.compile_unary(op, out);
                 let instruction = Instruction::Tanh(op);
                 D::register_instruction_extension(&mut self.extensions, &instruction);
-                instructions.push(self.select_fast_float(
-                    out.ty,
-                    modes,
-                    FastMath::ReducedPrecision | FastMath::NotNaN | FastMath::NotInf,
-                    instruction,
-                    Instruction::FastTanh(op),
-                ))
+                if self.compilation_options.supports_features.fast_tanh {
+                    instructions.push(self.select_fast_float(
+                        out.ty,
+                        modes,
+                        FastMath::ReducedPrecision | FastMath::NotNaN | FastMath::NotInf,
+                        instruction,
+                        Instruction::FastTanh(op),
+                    ))
+                } else {
+                    instructions.push(instruction);
+                }
             }
             gpu::Arithmetic::Sinh(op) => {
                 let instruction = Instruction::Sinh(self.compile_unary(op, out));

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -30,7 +30,7 @@ use cubecl_runtime::{
     logging::ServerLogger,
     memory_management::{HardwareProperties, MemoryDeviceProperties},
 };
-use cudarc::driver::sys::cuDeviceTotalMem_v2;
+use cudarc::driver::sys::{CUDA_VERSION, cuDeviceTotalMem_v2};
 use std::{mem::MaybeUninit, sync::Arc};
 
 /// Options configuring the CUDA runtime.
@@ -191,6 +191,7 @@ impl DeviceState for CudaServer {
                 .features
                 .ldmatrix
                 .insert(ElemType::Float(FloatKind::BF16).into());
+            comp_opts.supports_features.fast_tanh = CUDA_VERSION >= 12080;
         }
 
         // NOTE: I commented that since I observed synchronisation issues with atomic add for bf16.


### PR DESCRIPTION
The intrinsic for fast approximate tanh was only added in CUDA 12.8 and requires sm_75, so it needs an extra feature gate apart from the main `fast_math` feature.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
