### PR TITLE
Ensure we propagate the return index when a return block is folded into an existing block

### DIFF
--- a/crates/cubecl-opt/src/passes/dead_code.rs
+++ b/crates/cubecl-opt/src/passes/dead_code.rs
@@ -286,6 +286,9 @@ pub fn update_references(opt: &mut Optimizer, from: NodeIndex, to: NodeIndex) {
         }
     };
 
+    update(&mut opt.program.root);
+    update(&mut opt.ret);
+
     for node in opt.node_ids() {
         for phi in opt.program[node].phi_nodes.borrow_mut().iter_mut() {
             for entry in phi.entries.iter_mut() {

--- a/crates/cubecl-opt/src/passes/inlined_if_to_select.rs
+++ b/crates/cubecl-opt/src/passes/inlined_if_to_select.rs
@@ -82,9 +82,6 @@ impl OptimizerPass for EmptyBranchToSelect {
                         for merge_successor in merge_successors {
                             opt.program.add_edge(block, merge_successor, 0);
                         }
-                        if opt.ret == merge {
-                            opt.ret = block;
-                        }
                         *opt.program[block].control_flow.borrow_mut() = merge_control;
                         opt.invalidate_structure();
                         update_references(opt, merge, block);


### PR DESCRIPTION
# Ensure we propagate the return index when a return block is folded into an existing block

Without this change, my trivial program that I scaled down to in order to debug something failed to compile.
The trivial program was something like this
```rust
#[cube(launch_unchecked)]
pub fn minimal_reproduction(
    mut output: Tensor<Line<f32>>,
){
    let row = ABSOLUTE_POS;
    let rows = output.shape(0);
    let cols = output.shape(1);
    if row >= rows {
        terminate!()
    }
}
```

During cubecl's optimization passes, this would eventually look for post dominators during GVN

```rust
impl Analysis for PostDominators {
    fn init(opt: &mut crate::Optimizer) -> Self {
        let mut reversed = opt.program.graph.clone();
        reversed.reverse();
        PostDominators(dominators::simple_fast(&reversed, opt.ret))
    }
}
```
Since the whole program had been folded into a single basic block, but the opt.ret index had not been updated, this would attempt to traverse the graph starting from a non-existent index, leading to a panic.

This change ensures that the opt.ret index is updated if we remove the block it was previously pointing to, at least in this pass.