### PR TITLE
fix: Fix writer stage size that was broken during the config migration

### DIFF
--- a/crates/cubecl-matmul/src/components/global/write/stage.rs
+++ b/crates/cubecl-matmul/src/components/global/write/stage.rs
@@ -30,6 +30,12 @@ pub struct PartitionedStage<ES: Numeric> {
 impl<ES: Numeric> PartitionedStage<ES> {
     /// Instantiate a new stage memory for the given identifier
     pub fn new(unit_pos: Coords2d, #[comptime] config: StageMemoryConfig) -> PartitionedStage<ES> {
+        let config = comptime![StageMemoryConfig {
+            tiles_per_partition_along_row: 1,
+            tiles_per_partition_along_col: 1,
+            ..config
+        }];
+
         let inner = StridedStageMemory::<ES, WriteTiling>::new(config);
         let tile = inner.get_tile_mut(unit_pos);
 


### PR DESCRIPTION
Fixes a regression from the config refactor.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
