### PR TITLE
use input type for argmax output

### DIFF
--- a/crates/cubecl-reduce/src/instructions/mixed.rs
+++ b/crates/cubecl-reduce/src/instructions/mixed.rs
@@ -49,7 +49,7 @@ impl ReduceFnConfig {
             ReduceFnConfig::ArgMax | ReduceFnConfig::ArgMin => {
                 return ReduceDtypes {
                     input: input.into(),
-                    output: i32::as_type_native_unchecked(),
+                    output: input.into(),
                     accumulation: input.into(),
                 };
             }


### PR DESCRIPTION
Hi,

This PR fixes the output of ArgMax to use the given input tensor dtype. I ran into this using e.g. `max_dim_with_indices` in burn. I tried to call `to_data().into_vec()` on the tensor, which failed cause even though I was using i64 as int type, the data type was i32 (error `TypeMismatch("Invalid target element type (expected I32, got I64)")`).

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here: https://github.com/tracel-ai/burn/pull/4124
