### PR TITLE
Fix try_into_vec for SharedBytesAllocationController

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,7 @@ web-time = "1.1.0"
 rstest = "0.25.0"
 serial_test = "3.1.1"
 
-# extra-platforms enables portable-atomic for targets without native atomics (e.g., thumbv6m-none-eabi)
-bytes = { version = "1.10", default-features = false, features = ["extra-platforms"] }
+bytes = { version = "1.10", default-features = false }
 bytemuck = "1.16.1"
 float4 = "0.1"
 float8 = { version = "0.4", default-features = false }

--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -32,7 +32,6 @@ std = [
 
 [dependencies]
 # ** Please make sure all dependencies support no_std when std is disabled **
-bytes = { workspace = true, optional = true }
 bytemuck = { workspace = true, features = ["derive"] }
 derive-new = { workspace = true }
 derive_more = { workspace = true, features = [
@@ -72,6 +71,7 @@ backtrace = { version = "0.3", optional = true, features = ["std"] }
 
 [target.'cfg(target_has_atomic = "ptr")'.dependencies]
 spin = { workspace = true, features = ["mutex", "spin_mutex"] }
+bytes = { workspace = true, optional = true }
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic-util = { workspace = true }
@@ -81,6 +81,8 @@ spin = { workspace = true, features = [
     "spin_mutex",
     "portable_atomic",
 ] }
+# Enable extra-platforms for bytes on targets without native atomics
+bytes = { workspace = true, features = ["extra-platforms"], optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen-futures = { workspace = true }


### PR DESCRIPTION
### Summary

Fixes SharedBytesAllocationController so that Bytes::try_into_vec::<E>() works for all element types (u8 through f64) when the source data is properly aligned.

This is required for https://github.com/tracel-ai/burn/pull/4154

### Problem

Previously, try_into_vec() always failed for Bytes backed by SharedBytesAllocationController:

1. alloc_align() returned 1 before mutation → alignment check failed for f32, f64, etc.
2. try_detach() always returned None → couldn't transfer memory ownership

This caused burn's TensorData::into_vec() to fall back to a less efficient copy path.

### Solution

1. alloc_align() now returns MAX_ALIGN (16) always, because that's what try_detach() will provide
2. try_detach() now triggers init_mutable() first, then delegates to the inner NativeAllocationController
3. init_mutable() uses alloc_with_data(data, MAX_ALIGN) instead of vec![] to ensure proper alignment

### How it works

- `try_into_vec::<f32>()`
-   `alloc_align()` returns 16 >= 4 
-   bytemuck checks actual data alignment 
-   `try_detach()`
    -  `init_mutable()` copies data with MAX_ALIGN alignment
    -  delegates to `NativeAllocationController::try_detach()`
    -  returns owned pointer 
- `Vec::from_raw_parts()`

### Testing

- Updated test_alignment_reports_max_align
- Updated test_try_detach_always_succeeds
- Added test_try_into_vec_succeeds_for_u8/f32/f64

  | DType               | Alignment | Covered by MAX_ALIGN (16)? |
  |---------------------|-----------|----------------------------|
  | u8, i8, bool        | 1         | Yes                          |
  | u16, i16, f16, bf16 | 2         | Yes                          |
  | u32, i32, f32       | 4         | Yes                          |
  | u64, i64, f64       | 8         | Yes                          |
  | u128                | 16        | Yes                          |

### Note

Added extra-platforms feature to bytes dependency, which enables portable-atomic for targets without native atomics (e.g., thumbv6m-none-eabi, thumbv7m-none-eabi).