### PR TITLE
Support const in match patterns for #[cube] macro

### DIFF
--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -105,7 +105,7 @@ pub enum Expression {
     },
     Switch {
         value: Box<Expression>,
-        cases: Vec<(Lit, Block)>,
+        cases: Vec<(Expression, Block)>,
         default: Block,
     },
     Range {

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -391,8 +391,11 @@ impl Expression {
                 let blocks = cases
                     .iter()
                     .map(|(val, block)| {
+                        let val_tokens = val
+                            .as_const(context)
+                            .unwrap_or_else(|| val.to_tokens(context));
                         let block = block.to_tokens(context);
-                        quote![.case(scope, #val, |scope| #block)]
+                        quote![.case(scope, #val_tokens, |scope| #block)]
                     })
                     .collect::<Vec<_>>();
                 quote! {

--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -406,7 +406,7 @@ fn add_variables_from_pat(pat: &Pat, context: &mut Context) {
     }
 }
 
-fn lit_ty(lit: &Lit) -> syn::Result<Type> {
+pub fn lit_ty(lit: &Lit) -> syn::Result<Type> {
     let res = match lit {
         Lit::Int(int) => (!int.suffix().is_empty())
             .then(|| int.suffix())


### PR DESCRIPTION
Previously, only literals were supported in match patterns within the `#[cube]` macro.
This change enables support for constants by updating the parser to recognize `Pat::Path` and `Pat::Ident` as constants.
This grammar support is essential to reduce hard-coded constants in code.

Making it possible to compile below example:
```rust
const CASE_0: u32 = 0;
const CASE_1: u32 = 1;

#[cube(launch)]
pub fn kernel_switch_const<F: Float>(output: &mut Array<F>, case: u32) {
    if UNIT_POS == 0 {
        let value = match case {
            CASE_0 => F::new(1.0f32),
            CASE_1 => F::new(3.0f32),
            _ => F::new(5.0f32),
        };
        output[0] = value;
    }
}
```

Detailed changes:
- `crates/cubecl-macros/src/parse/branch.rs`:
    - Updated `numeric_match` to parse patterns into `Vec<Expression>` instead of `Vec<Lit>`.
    - Implemented logic to handle `Pat::Path` and `Pat::Ident` as constants.
    - Used `lit_ty` to properly type literals.
- `crates/cubecl-macros/src/expression.rs`:
    - Updated `Expression::Switch` to store cases as `Vec<(Expression, Block)>`.
- `crates/cubecl-macros/src/generate/expression.rs`:
    - Updated `Switch` generation to use `as_const` or `to_tokens` for case values.
- `crates/cubecl-macros/src/parse/expression.rs`:
    - Made `lit_ty` public for use in `branch.rs`.
- `crates/cubecl-core/src/runtime_tests/branch.rs`:
    - Added `test_switch_const` to verify the new functionality.