### PR TITLE
feat: use memory reuse marker for cpu

### DIFF
--- a/crates/cubecl-cpu/src/compiler/memref.rs
+++ b/crates/cubecl-cpu/src/compiler/memref.rs
@@ -30,4 +30,18 @@ impl LineMemRef {
             stride: [1],
         }
     }
+
+    /// Create a LineMemRef from a raw pointer and length.
+    /// # Safety
+    /// The pointer must be valid and point to at least `len` bytes of writable memory.
+    pub unsafe fn from_raw_parts(pointer: *mut u8, len: usize) -> Self {
+        let pointer = pointer as *mut c_void;
+        Self {
+            allocated: pointer,
+            aligned: pointer,
+            offset: 0,
+            shape: [len as c_longlong],
+            stride: [1],
+        }
+    }
 }


### PR DESCRIPTION
This PR uses the `free` memory reuse marker with a similar implementation to other backends. It started as a fix for #1019, but is an enhancement following #1123. I tested it with a Burn model compiled only with the CPU backend, but it has not been stress-tested.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.