### PR TITLE
Add inverse trigonometric and hyperbolic trait impls for Line<P>

### DIFF
--- a/crates/cubecl-core/src/frontend/container/line/ops.rs
+++ b/crates/cubecl-core/src/frontend/container/line/ops.rs
@@ -8,8 +8,9 @@ use crate::{
 };
 use crate::{
     frontend::{
-        Abs, Ceil, Clamp, Cos, CubePrimitive, Erf, Exp, ExpandElementTyped, Floor, Log, Log1p, Max,
-        Min, Powf, Recip, Remainder, Round, Sin, Sqrt, Tanh,
+        Abs, ArcCos, ArcCosh, ArcSin, ArcSinh, ArcTan, ArcTanh, Ceil, Clamp, Cos, Cosh,
+        CubePrimitive, Erf, Exp, ExpandElementTyped, Floor, Log, Log1p, Max, Min, Powf, Recip,
+        Remainder, Round, Sin, Sinh, Sqrt, Tan, Tanh,
     },
     prelude::{BitwiseNot, CountOnes, FindFirstSet, LeadingZeros, ReverseBits},
     unexpanded,
@@ -250,7 +251,16 @@ impl<P: CubePrimitive + Sqrt> Sqrt for Line<P> {}
 impl<P: CubePrimitive + InverseSqrt> InverseSqrt for Line<P> {}
 impl<P: CubePrimitive + Cos> Cos for Line<P> {}
 impl<P: CubePrimitive + Sin> Sin for Line<P> {}
+impl<P: CubePrimitive + Tan> Tan for Line<P> {}
 impl<P: CubePrimitive + Tanh> Tanh for Line<P> {}
+impl<P: CubePrimitive + Sinh> Sinh for Line<P> {}
+impl<P: CubePrimitive + Cosh> Cosh for Line<P> {}
+impl<P: CubePrimitive + ArcSin> ArcSin for Line<P> {}
+impl<P: CubePrimitive + ArcCos> ArcCos for Line<P> {}
+impl<P: CubePrimitive + ArcTan> ArcTan for Line<P> {}
+impl<P: CubePrimitive + ArcSinh> ArcSinh for Line<P> {}
+impl<P: CubePrimitive + ArcCosh> ArcCosh for Line<P> {}
+impl<P: CubePrimitive + ArcTanh> ArcTanh for Line<P> {}
 impl<P: CubePrimitive + Recip> Recip for Line<P> {}
 impl<P: CubePrimitive + Remainder> Remainder for Line<P> {}
 impl<P: CubePrimitive + Round> Round for Line<P> {}


### PR DESCRIPTION
## Summary
- Add `ArcSin`, `ArcCos`, `ArcTan`, `ArcSinh`, `ArcCosh`, `ArcTanh` trait implementations for `Line<P>`
- Also adds missing `Tan`, `Sinh`, `Cosh` implementations for completeness
- Enables native GPU acceleration for inverse trigonometric operations on vectorized types

## Motivation
The `Line<P>` type was missing trait implementations for inverse trigonometric and hyperbolic functions, even though:
1. The traits are already defined in `unary.rs`
2. The IR layer supports these operations (`Arithmetic::ArcSin`, etc.)
3. All backends (CUDA, SPIR-V, WGSL) already handle code generation for these operations

This change simply exposes the existing functionality to `Line<P>`, following the same pattern used for `Sin`, `Cos`, and `Tanh`.

## Changes
**File:** `crates/cubecl-core/src/frontend/container/line/ops.rs`
- Updated imports to include the missing traits
- Added blank trait implementations that delegate to the underlying primitive type `P`

## Test plan
- [x] Existing unary tests pass (includes `test_asin`, `test_acos`, `test_atan`, `test_asinh`, `test_acosh`, `test_atanh` with vectorization levels 2 and 4)
- [x] `cargo check -p cubecl-core` passes
- [x] `cargo test -p cubecl-wgpu -- unary` passes (27 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)