### PR TITLE
Rename `try_cast_unchecked` to `downcast`

### DIFF
--- a/crates/cubecl-core/src/frontend/container/slice/base.rs
+++ b/crates/cubecl-core/src/frontend/container/slice/base.rs
@@ -128,12 +128,11 @@ impl<E: CubePrimitive, IO: SliceVisibility> Slice<E, IO> {
             }
         })
     }
-    /// Returns the same slice, but with lines of length 1.
-    /// Try to cast the slice to the given type and panic if the type isn't the same.
+    /// Downcast the slice to the given type and panic if the type isn't the same.
     ///
     /// This function should only be used to satisfy the Rust type system, when two generic
     /// types are supposed to be the same.
-    pub fn try_cast_unchecked<T: CubePrimitive>(&self) -> Slice<T, IO> {
+    pub fn downcast<T: CubePrimitive>(&self) -> Slice<T, IO> {
         intrinsic!(|scope| {
             if T::as_type(scope) != E::as_type(scope) && !is_tf32::<E, T>(scope) {
                 let elems = [T::as_type(scope).elem_type(), E::as_type(scope).elem_type()];
@@ -141,9 +140,7 @@ impl<E: CubePrimitive, IO: SliceVisibility> Slice<E, IO> {
                     && elems.contains(&ElemType::Float(FloatKind::Flex32));
 
                 if !is_flex32_cast {
-                    panic!(
-                        "Try cast unchecked should only be used to satisfy the rust type system."
-                    )
+                    panic!("Downcast should only be used to satisfy the Rust type system.")
                 }
             }
 

--- a/crates/cubecl-core/src/frontend/container/tensor/tensormap.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/tensormap.rs
@@ -362,11 +362,11 @@ mod metadata {
             unexpanded!()
         }
 
-        /// Try to cast the tensormap to the given type and panic if the type isn't the same.
+        /// Downcast the tensormap to the given type and panic if the type isn't the same.
         ///
         /// This function should only be used to satisfy the Rust type system, when two generic
         /// types are supposed to be the same.
-        pub fn try_cast_unchecked<E: CubePrimitive>(&self) -> TensorMap<E, K> {
+        pub fn downcast<E: CubePrimitive>(&self) -> TensorMap<E, K> {
             unexpanded!()
         }
 
@@ -534,13 +534,13 @@ mod metadata {
             out.into()
         }
 
-        /// Expand method of [try_cast_unchecked](Slice::try_cast_unchecked).
-        pub fn __expand_try_cast_unchecked_method<E: CubePrimitive>(
+        /// Expand method of [downcast](TensorMap::downcast).
+        pub fn __expand_downcast_method<E: CubePrimitive>(
             self,
             scope: &mut Scope,
         ) -> ExpandElementTyped<TensorMap<E, K>> {
             if T::as_type(scope) != E::as_type(scope) && !is_tf32::<E, T>(scope) {
-                panic!("Try cast unchecked should only be used to satisfy the rust type system.")
+                panic!("Downcast should only be used to satisfy the Rust type system.")
             }
 
             self.expand.into()

--- a/crates/cubecl-std/src/tensor/view/operations/tensor_map.rs
+++ b/crates/cubecl-std/src/tensor/view/operations/tensor_map.rs
@@ -72,7 +72,7 @@ macro_rules! impl_tensor_map {
                     shared_memory: SliceExpand<T, ReadWrite>,
                     pos: <$coords as CubeType>::ExpandType,
                 ) {
-                    let shared = shared_memory.__expand_try_cast_unchecked_method(scope);
+                    let shared = shared_memory.__expand_downcast_method(scope);
                     let ($($var),*) = pos;
                     let ($($var),*) = ($(i32::__expand_cast_from(scope, $var)),*);
                     barrier.[<__expand_tma_load_ $dim d_method>]::<T>(scope, self.clone(), shared, $($var),*);
@@ -115,7 +115,7 @@ macro_rules! impl_tensor_map {
                     shared_memory: SliceExpand<T, ReadOnly>,
                     pos: <$coords as CubeType>::ExpandType,
                 ) {
-                    let shared = shared_memory.__expand_try_cast_unchecked_method(scope);
+                    let shared = shared_memory.__expand_downcast_method(scope);
                     let ($($var),*) = pos;
                     let ($($var),*) = ($(i32::__expand_cast_from(scope, $var)),*);
                     [<tma_store_ $dim d>]::expand(scope, shared, self.clone(), $($var),*);
@@ -206,7 +206,7 @@ macro_rules! impl_tensor_map_im2col {
                     shared_memory: SliceExpand<T, ReadWrite>,
                     pos: <$coords as CubeType>::ExpandType,
                 ) {
-                    let shared = shared_memory.__expand_try_cast_unchecked_method(scope);
+                    let shared = shared_memory.__expand_downcast_method(scope);
                     let ($($pos),*) = pos.0;
                     let ($($pos),*) = ($(i32::__expand_cast_from(scope, $pos)),*);
                     let ($($offs),*) = pos.1;
@@ -315,7 +315,7 @@ impl<T: CubePrimitive, N: CubePrimitive + Coordinates> ViewOperationsExpand<T, S
         shared_memory: SliceExpand<T, ReadWrite>,
         pos: SequenceExpand<N>,
     ) {
-        let shared = shared_memory.__expand_try_cast_unchecked_method(scope);
+        let shared = shared_memory.__expand_downcast_method(scope);
         let rank = pos.len();
         let pos = &pos;
         match rank {
@@ -395,7 +395,7 @@ impl<T: CubePrimitive, N: CubePrimitive + Coordinates> ViewOperationsMutExpand<T
         shared_memory: SliceExpand<T, ReadOnly>,
         pos: SequenceExpand<N>,
     ) {
-        let shared = shared_memory.__expand_try_cast_unchecked_method(scope);
+        let shared = shared_memory.__expand_downcast_method(scope);
         let rank = pos.len();
         let pos = &pos;
         match rank {
@@ -505,7 +505,7 @@ impl<T: CubePrimitive, P: CubePrimitive + Coordinates, O: CubePrimitive + Coordi
         shared_memory: SliceExpand<T, ReadWrite>,
         pos: (SequenceExpand<P>, SequenceExpand<O>),
     ) {
-        let shared = shared_memory.__expand_try_cast_unchecked_method(scope);
+        let shared = shared_memory.__expand_downcast_method(scope);
         let (pos, offs) = &pos;
         let rank = pos.len();
 


### PR DESCRIPTION
The previous name was misleading: `try_` typically implies returning a Result, but this function panics on type mismatch. The operation is simply a downcast from a generic to a concrete type, so `downcast` better reflects its behavior.

Fixes #541

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn. (unrelated issues)
- [x] Submit a PR in burn with your fixes and link it here.  https://github.com/tracel-ai/burn/pull/4335
