### PR TITLE
fix(hip): use __hip_bfloat16 types and __hmax/__hmin for ROCm 7.1

### DIFF
--- a/crates/cubecl-cpp/src/hip/dialect.rs
+++ b/crates/cubecl-cpp/src/hip/dialect.rs
@@ -450,7 +450,7 @@ impl<M: DialectWmmaCompiler<Self>> DialectInstructions<Self> for HipDialect<M> {
         f: &mut std::fmt::Formatter<'_>,
         item: Item<Self>,
     ) -> std::fmt::Result {
-        let min = match item.elem() __hmin
+        let min = match item.elem() {
             Elem::F16 => "__hmin",
             Elem::BF16 => "__hmin",
             _ => "min",


### PR DESCRIPTION
## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
