### PR TITLE
fix(spirv): reuse decorated struct id for wkgrp layout(tracel-ai/burn#4355)

### DIFF
--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -451,7 +451,7 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
                 [Operand::LiteralBit32(memory.offset)],
             );
 
-            let ptr_ty = Item::Pointer(StorageClass::Workgroup, Box::new(block_ty)).id(self);
+            let ptr_ty = self.type_pointer(None, StorageClass::Workgroup, block_id);
 
             self.debug_shared(memory.id, index);
             self.variable(ptr_ty, Some(memory.id), StorageClass::Workgroup, None);
@@ -486,7 +486,7 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
                 [Operand::LiteralBit32(memory.offset)],
             );
 
-            let ptr_ty = Item::Pointer(StorageClass::Workgroup, Box::new(block_ty)).id(self);
+            let ptr_ty = self.type_pointer(None, StorageClass::Workgroup, block_id);
 
             self.debug_shared(memory.id, index);
             self.variable(ptr_ty, Some(memory.id), StorageClass::Workgroup, None);


### PR DESCRIPTION


The `SPV_KHR_workgroup_memory_explicit_layout` extension requires specific decorations (`Block`, `Offset`) on the struct type used for workgroup memory.

Previously, `declare_shared_memories_explicit` used `Item::Pointer(..., Item::Struct(..))` to generate the pointer type.

However, `Item::Struct` is designed to always generate a new Type ID to support distinct decorations.

This caused the Workgroup pointer to reference a new (undecorated) copy of the struct, while the `Block` and `Offset` decorations were applied to the original unused Type ID.

This resulted in invalid SPIR-V for strict drivers, leading to silent failures or garbage data.

This patch fixes the issue by directly using `type_pointer` with the existing, decorated `block_id`, preventing duplicate struct generation.

## Validate your PR with burn.

i tested with MWE provided with original issue


attached generated spirv asm, which includes issues described above

| decorated | undecorated(duplicate) |
|-----------|-------------|
| struct_2428         | struct_2429           |
| struct_2433         | struct_2434           |
| struct_2436        | struct_2437           |

[matmul_kernel.spvasm.txt](https://github.com/user-attachments/files/24748262/matmul_kernel.spvasm.txt)

