### PR TITLE
fix(spirv): Don't do copy transform if either operand is written to in between read and write

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/index.rs
+++ b/crates/cubecl-core/src/runtime_tests/index.rs
@@ -40,6 +40,42 @@ pub fn test_kernel_index_scalar<R: Runtime, F: Float + CubeElement>(client: Comp
     assert_eq!(actual[2], F::new(123.0));
 }
 
+#[cube(launch)]
+fn shuffle_kernel(orders: &mut Array<u32>) {
+    if UNIT_POS < 2 {
+        let mut order = Array::<u32>::new(2usize);
+        order[0] = 0;
+        order[1] = 1;
+
+        let i = ABSOLUTE_POS & 1;
+        let tmp = order[i];
+        order[i] = 9;
+        order[i ^ 1] = tmp;
+
+        let base = ABSOLUTE_POS * 2;
+        orders[base] = order[0];
+        orders[base + 1] = order[1];
+    }
+}
+
+// Regression test for invalid `CopyTransform`
+pub fn test_kernel_shuffle<R: Runtime>(client: ComputeClient<R>) {
+    let handle = client.empty(4 * size_of::<u32>());
+
+    shuffle_kernel::launch::<R>(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_1d(2),
+        unsafe { ArrayArg::from_raw_parts::<u32>(&handle, 4, 1) },
+    )
+    .unwrap();
+
+    let actual = client.read_one(handle);
+    let actual = u32::from_bytes(&actual);
+
+    assert_eq!(actual, [9, 0, 1, 9]);
+}
+
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! testgen_index {
@@ -52,6 +88,12 @@ macro_rules! testgen_index {
             cubecl_core::runtime_tests::index::test_kernel_index_scalar::<TestRuntime, FloatType>(
                 client,
             );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_shuffle() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::index::test_kernel_shuffle::<TestRuntime>(client);
         }
     };
 }

--- a/crates/cubecl-ir/src/variable.rs
+++ b/crates/cubecl-ir/src/variable.rs
@@ -169,6 +169,17 @@ impl Variable {
         )
     }
 
+    /// Is this an array type that is contained in concrete memory,
+    /// or a local array/scalar/vector?
+    pub fn is_memory(&self) -> bool {
+        matches!(
+            self.kind,
+            VariableKind::GlobalInputArray { .. }
+                | VariableKind::GlobalOutputArray { .. }
+                | VariableKind::SharedArray { .. }
+        )
+    }
+
     pub fn has_length(&self) -> bool {
         matches!(
             self.kind,

--- a/crates/cubecl-opt/src/passes/index_merge.rs
+++ b/crates/cubecl-opt/src/passes/index_merge.rs
@@ -21,7 +21,7 @@ impl OptimizerPass for CopyTransform {
                 let inst = ops.borrow()[idx].clone();
                 match &inst.operation {
                     Operation::Operator(Operator::Index(op))
-                        if op.list.is_array()
+                        if op.list.is_memory()
                             && op.list.ty == inst.ty()
                             && !is_reused(opt, &inst.out) =>
                     {
@@ -30,7 +30,7 @@ impl OptimizerPass for CopyTransform {
                         }
                     }
                     Operation::Operator(Operator::IndexAssign(op))
-                        if inst.out().is_array() && inst.ty() == op.value.ty =>
+                        if inst.out().is_memory() && inst.ty() == op.value.ty =>
                     {
                         if let Some(id) = as_versioned(&op.value) {
                             writes.insert(id, (idx, inst.out(), op.index));
@@ -45,6 +45,13 @@ impl OptimizerPass for CopyTransform {
             for id in copy_ids {
                 let (read_idx, input, in_index) = reads[*id];
                 let (write_idx, out, out_index) = writes[*id];
+                let valid = (read_idx..write_idx)
+                    .filter_map(|idx| ops.borrow()[idx].out)
+                    .all(|write| write != input && write != out);
+                if !valid {
+                    continue;
+                }
+
                 ops.borrow_mut().remove(read_idx);
                 let copy = Operator::CopyMemory(CopyMemoryOperator {
                     out_index,


### PR DESCRIPTION
Also fixes `copy_memory` being incorrectly used for local arrays. It should only be used for actual memory (global or shared).

Adds new regression test to ensure this keeps working.
