### PR TITLE
fix(metal): fix float to int narrowing

### DIFF
--- a/crates/cubecl-cpp/src/shared/instruction.rs
+++ b/crates/cubecl-cpp/src/shared/instruction.rs
@@ -915,9 +915,10 @@ impl<D: Dialect> Remainder<D> {
             out.elem(),
             Elem::I8 | Elem::I16 | Elem::I32 | Elem::U8 | Elem::U16 | Elem::U32 | Elem::U64
         );
-        let rem_expr = |lhs, rhs, floor| {
+        let out_elem = out.elem();
+        let rem_expr = |lhs, rhs, floor: &str| {
             if is_int {
-                format!("{lhs} - {rhs} * {floor}((float){lhs} / (float){rhs})")
+                format!("{lhs} - {rhs} * ({out_elem}){floor}((float){lhs} / (float){rhs})")
             } else {
                 format!("{lhs} - {rhs} * {floor}({lhs} / {rhs})")
             }


### PR DESCRIPTION
MSL's C++11 mode doesn't allow narrowing `float` to `int` in initializer lists.
Error: `error: type 'float' cannot be narrowed to 'int' in initializer list [-Wc++11-narrowing]`

Previous generated MSL: `l_10.i_0 - l_11.i_0 * floor((float)l_10.i_0 / (float)l_11.i_0)`
Now: `l_10.i_0 - l_11.i_0 * (int)floor((float)l_10.i_0 / (float)l_11.i_0)`