### PR TITLE
Add safety docs to generated `launch_unchecked` functions

### DIFF
--- a/crates/cubecl-macros/src/generate/launch.rs
+++ b/crates/cubecl-macros/src/generate/launch.rs
@@ -99,9 +99,10 @@ impl Launch {
             let kernel_doc = format!(
                 "Launch the kernel [{}()] on the given runtime without bound checks.\n\n\
                  # Safety\n\n\
-                 Out-of-bounds reads and writes are undefined behavior. \
-                 Ensure that all tensor and buffer accesses in the kernel are within bounds.\n\n\
-                 Infinite loops may be optimized away entirely or cause other unpredictable behaviour.",
+                 The kernel must not:\n\
+                 - Contain any out of bounds reads or writes. Doing so is immediate UB.\n\
+                 - Contain any loops that never terminate. These may be optimized away entirely or cause\n\
+                   other unpredictable behaviour.",
                 self.func.sig.name
             );
             let generics = &self.launch_generics;


### PR DESCRIPTION
The `#[cube(launch_unchecked)]` proc macro generates `unsafe fn launch_unchecked` but only emits a generic doc string with no `# Safety` section. This means IDEs don't show safety requirements when hovering over the function.

This adds the safety contract (matching `KernelLauncher::launch_unchecked`) to the generated doc string so users see it inline.

Closes #217

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
