### PR TITLE
fix: error driver not found! in CI and update to Tracel GH action v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
           - rust: stable
             toolchain: stable
     steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      # --------------------------------------------------------------------------------
       - name: Setup Rust
         uses: tracel-ai/github-actions/setup-rust@v8
         with:
@@ -84,6 +87,9 @@ jobs:
           - rust: stable
             toolchain: stable
     steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      # --------------------------------------------------------------------------------
       - name: Setup Rust
         uses: tracel-ai/github-actions/setup-rust@v8
         with:
@@ -117,6 +123,8 @@ jobs:
           - rust: prev
             toolchain: ${{ needs.prepare-checks.outputs.rust-prev-version }}
     steps:
+      - name: checkout
+        uses: actions/checkout@v6
       # --------------------------------------------------------------------------------
       - name: Setup Linux runner
         uses: tracel-ai/github-actions/setup-linux@v8
@@ -145,6 +153,9 @@ jobs:
   #         - rust: stable
   #           toolchain: stable
   #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v6
+  #     # --------------------------------------------------------------------------------
   #     - name: Setup Rust
   #       uses: tracel-ai/github-actions/setup-rust@v8
   #       with:
@@ -174,6 +185,9 @@ jobs:
   #         - rust: stable
   #           toolchain: stable
   #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v6
+  #     # --------------------------------------------------------------------------------
   #     - name: Setup Rust
   #       uses: tracel-ai/github-actions/setup-rust@v8
   #       with:


### PR DESCRIPTION
The regression is due to an old bad decision from me to bake the git checkout GH action into the `setup-rust` tracel GH action. This is a terrible idea because if `setup-rust` action is not the first step of the job then it effectively does a `git resert --hard` on the checked out repo deleting any temporary files built by previous steps.

I also updated out Tracel GH action to match the latest GH action of `wgpu`.
