### PR TITLE
Add aliases for backend features consistent with burn

### DIFF
--- a/crates/cubecl/Cargo.toml
+++ b/crates/cubecl/Cargo.toml
@@ -47,7 +47,11 @@ cuda = ["cubecl-cuda"]
 cuda-ptx-wmma = ["cubecl-cuda?/ptx-wmma"]
 hip = ["cubecl-hip"]
 hip-rocwmma = ["cubecl-hip?/rocwmma"]
+metal = ["wgpu-msl"]
+rocm = ["hip"]
 spirv-dump = ["cubecl-wgpu/spirv-dump"]
+vulkan = ["wgpu-spirv"]
+webgpu = ["wgpu"]
 wgpu = ["cubecl-wgpu"]
 wgpu-msl = ["wgpu", "cubecl-wgpu/msl"]
 wgpu-spirv = ["wgpu", "cubecl-wgpu/spirv"]
@@ -57,10 +61,10 @@ test-runtime = ["cubecl-wgpu"]
 
 [dependencies]
 cubecl-core = { path = "../cubecl-core", version = "=0.9.0", default-features = false }
-cubecl-ir = { path = "../cubecl-ir", version = "=0.9.0", default-features = false }
 cubecl-cpu = { path = "../cubecl-cpu", version = "=0.9.0", default-features = false, optional = true }
 cubecl-cuda = { path = "../cubecl-cuda", version = "=0.9.0", default-features = false, optional = true }
 cubecl-hip = { path = "../cubecl-hip", version = "=0.9.0", default-features = false, optional = true }
+cubecl-ir = { path = "../cubecl-ir", version = "=0.9.0", default-features = false }
 cubecl-runtime = { path = "../cubecl-runtime", version = "=0.9.0", default-features = false }
 cubecl-std = { path = "../cubecl-std", version = "=0.9.0", optional = true }
 cubecl-wgpu = { path = "../cubecl-wgpu", version = "=0.9.0", default-features = false, optional = true }


### PR DESCRIPTION
Adds a few backend feature aliases so the terminology is more consistent with burn. Retains the old feature names for now to avoid breaking things.