### PR TITLE
Upgrade to rand 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ smallvec = { version = "1", features = ["union", "const_generics"] }
 spin = { version = "0.10.0", features = ["mutex", "spin_mutex"] }
 xxhash-rust = { version = "0.8", default-features = false }
 
-rand = { version = "0.9.2", default-features = false, features = [
+rand = { version = "0.10.0", default-features = false, features = [
     "std_rng",
 ] } # std_rng is for no_std
 

--- a/crates/cubecl-common/src/rand.rs
+++ b/crates/cubecl-common/src/rand.rs
@@ -1,4 +1,4 @@
-pub use rand::{Rng, SeedableRng, rngs::StdRng};
+pub use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
@@ -7,7 +7,9 @@ use rand::prelude::Distribution;
 #[cfg(feature = "std")]
 #[inline(always)]
 pub fn get_seeded_rng() -> StdRng {
-    StdRng::from_os_rng()
+    use rand::rngs::SysRng;
+
+    StdRng::try_from_rng(&mut SysRng).unwrap()
 }
 
 /// Returns a seeded random number generator using a pre-generated seed.


### PR DESCRIPTION
Follow-up to #1179

Fixes #1181 (incorrect root cause, but requires rand 0.10 to pull getrandom 0.4)

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
