### PR TITLE
fix: Remove unconditional std on cubecl-runtime in cubecl-wgpu

### DIFF
--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -58,7 +58,6 @@ cubecl-core = { path = "../cubecl-core", version = "=0.10.0-pre.1", default-feat
 cubecl-ir = { path = "../cubecl-ir", version = "=0.10.0-pre.1", default-features = false }
 cubecl-runtime = { path = "../cubecl-runtime", version = "=0.10.0-pre.1", default-features = false, features = [
     "channel-mutex",
-    "std",
 ] }
 derive_more = { workspace = true }
 half = { workspace = true }


### PR DESCRIPTION
## Summary

- Remove `"std"` from the unconditional `features` list of `cubecl-runtime` in `cubecl-wgpu/Cargo.toml`
- The `[features] std` gate already includes `cubecl-runtime/std`, so it still activates when `cubecl-wgpu/std` is enabled
- Fixes wasm builds broken by the chain `cubecl-runtime/std` -> `cubecl-common/std` -> `rand/std` -> `getrandom (std)` requiring a configured backend on `wasm32-unknown-unknown`

Closes #1181

## Test plan

- [x] `cargo check -p cubecl-wgpu` (default features, includes std) passes
- [x] `cargo check -p cubecl-wgpu --no-default-features` (no std) passes