### PR TITLE
fix(metal): gate bf16 support to Apple Silicon and fix bf16 literals

### DIFF
--- a/crates/cubecl-cpp/src/metal/dialect.rs
+++ b/crates/cubecl-cpp/src/metal/dialect.rs
@@ -969,13 +969,18 @@ impl DialectInstructions<Self> for MslDialect {
     }
 
     /// MSL has no `rhypot` intrinsic; emit `1.0 / hypot(...)` instead.
+    /// Use `1.0f` for f32/bf16/f16 to avoid implicit promotion to double.
     fn compile_instruction_rhypot(
         f: &mut std::fmt::Formatter<'_>,
         lhs: &str,
         rhs: &str,
-        _elem: Elem<Self>,
+        elem: Elem<Self>,
     ) -> std::fmt::Result {
-        write!(f, "1.0 / hypot({lhs}, {rhs})")
+        let one = match elem {
+            Elem::F64 => "1.0",
+            _ => "1.0f",
+        };
+        write!(f, "{one} / hypot({lhs}, {rhs})")
     }
 
     /// Metal's `bfloat` type has no native transcendental functions (exp, sin, cos, etc.).

--- a/crates/cubecl-cpp/src/metal/dialect.rs
+++ b/crates/cubecl-cpp/src/metal/dialect.rs
@@ -958,6 +958,26 @@ impl DialectInstructions<Self> for MslDialect {
         ""
     }
 
+    /// MSL uses overloaded `hypot()` (no `f` suffix like CUDA's `hypotf()`).
+    fn compile_instruction_hypot(
+        f: &mut std::fmt::Formatter<'_>,
+        lhs: &str,
+        rhs: &str,
+        _elem: Elem<Self>,
+    ) -> std::fmt::Result {
+        write!(f, "hypot({lhs}, {rhs})")
+    }
+
+    /// MSL has no `rhypot` intrinsic; emit `1.0 / hypot(...)` instead.
+    fn compile_instruction_rhypot(
+        f: &mut std::fmt::Formatter<'_>,
+        lhs: &str,
+        rhs: &str,
+        _elem: Elem<Self>,
+    ) -> std::fmt::Result {
+        write!(f, "1.0 / hypot({lhs}, {rhs})")
+    }
+
     /// Metal's `bfloat` type has no native transcendental functions (exp, sin, cos, etc.).
     /// Only `half` (f16) and `float` (f32) do. The GPU's Special Function Units are wired
     /// for f32 and f16 only, so bf16 must be cast through f32.

--- a/crates/cubecl-cpp/src/shared/dialect.rs
+++ b/crates/cubecl-cpp/src/shared/dialect.rs
@@ -693,6 +693,15 @@ pub trait DialectInstructions<D: Dialect> {
         "h2"
     }
 
+    /// Whether bf16 has native math functions (transcendentals like exp, sin, cos, etc.)
+    /// on this backend. When false, bf16 operands are cast through f32 for these operations.
+    ///
+    /// CUDA/HIP: true (bf16 shares f16 intrinsics via the `h` prefix).
+    /// Metal: false (MSL `bfloat` has no native transcendental support; only `half`/`float` do).
+    fn bf16_has_native_math_functions() -> bool {
+        true
+    }
+
     // warp
     fn compile_warp_shuffle(
         f: &mut std::fmt::Formatter<'_>,

--- a/crates/cubecl-cpp/src/shared/instruction.rs
+++ b/crates/cubecl-cpp/src/shared/instruction.rs
@@ -908,10 +908,13 @@ impl<D: Dialect> Remainder<D> {
         rhs: &Variable<D>,
         out: &Variable<D>,
     ) -> core::fmt::Result {
+        let bf16_native = D::bf16_has_native_math_functions();
         let floor = |elem| {
             let prefix = match elem {
-                Elem::F16 | Elem::BF16 => D::compile_instruction_half_function_name_prefix(),
-                Elem::F16x2 | Elem::BF16x2 => D::compile_instruction_half2_function_name_prefix(),
+                Elem::F16 => D::compile_instruction_half_function_name_prefix(),
+                Elem::BF16 if bf16_native => D::compile_instruction_half_function_name_prefix(),
+                Elem::F16x2 => D::compile_instruction_half2_function_name_prefix(),
+                Elem::BF16x2 if bf16_native => D::compile_instruction_half2_function_name_prefix(),
                 _ => "",
             };
             format!("{prefix}floor")
@@ -921,9 +924,11 @@ impl<D: Dialect> Remainder<D> {
             out.elem(),
             Elem::I8 | Elem::I16 | Elem::I32 | Elem::U8 | Elem::U16 | Elem::U32 | Elem::U64
         );
+        // bf16 without native math needs floor() via f32 cast, same as integers
+        let bf16_needs_cast = matches!(out.elem(), Elem::BF16 | Elem::BF16x2) && !bf16_native;
         let out_elem = out.elem();
         let rem_expr = |lhs, rhs, floor: &str| {
-            if is_int {
+            if is_int || bf16_needs_cast {
                 format!("{lhs} - {rhs} * ({out_elem}){floor}((float){lhs} / (float){rhs})")
             } else {
                 format!("{lhs} - {rhs} * {floor}({lhs} / {rhs})")

--- a/crates/cubecl-cpp/src/shared/instruction.rs
+++ b/crates/cubecl-cpp/src/shared/instruction.rs
@@ -1009,7 +1009,8 @@ impl<D: Dialect, S: FunctionFmt<D>> Magnitude<D, S> {
 
         let mag = format!("{out}_mag");
 
-        writeln!(f, "{} {mag} = 0.0;", out.item())?;
+        let item = out.item();
+        writeln!(f, "{item} {mag} = {item}(0.0);")?;
 
         for i in 0..num {
             let input_i = input.index(i);
@@ -1040,7 +1041,7 @@ impl<D: Dialect, InvS: FunctionFmt<D>> Normalize<D, InvS> {
 
         let out_item = out.item();
         let out = out.fmt_left();
-        writeln!(f, "{elem} {norm} = 0.0;")?;
+        writeln!(f, "{elem} {norm} = {elem}(0.0);")?;
 
         for i in 0..num {
             let input_i = input.index(i);

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -105,6 +105,7 @@ fn register_types(props: &mut DeviceProperties) {
         ElemType::Int(IntKind::I16),
         ElemType::Int(IntKind::I32),
         ElemType::Int(IntKind::I64),
+        ElemType::Float(FloatKind::BF16),
         ElemType::Float(FloatKind::F16),
         ElemType::Float(FloatKind::F32),
         ElemType::Bool,

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -105,7 +105,6 @@ fn register_types(props: &mut DeviceProperties) {
         ElemType::Int(IntKind::I16),
         ElemType::Int(IntKind::I32),
         ElemType::Int(IntKind::I64),
-        ElemType::Float(FloatKind::BF16),
         ElemType::Float(FloatKind::F16),
         ElemType::Float(FloatKind::F32),
         ElemType::Bool,
@@ -120,6 +119,14 @@ fn register_types(props: &mut DeviceProperties) {
     for ty in types {
         register(ty.into(), TypeUsage::all_scalar());
     }
+
+    // bf16 (bfloat) requires Apple Silicon (Apple7+ GPU family, i.e. M1 and later).
+    // Intel Macs (x86_64) do not support the bfloat type in MSL.
+    #[cfg(apple_silicon)]
+    register(
+        ElemType::Float(FloatKind::BF16).into(),
+        TypeUsage::all_scalar(),
+    );
 
     for ty in atomic_types {
         register(

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -58,9 +58,9 @@ mod tests_spirv {
 #[allow(unexpected_cfgs)]
 mod tests_msl {
     pub type TestRuntime = crate::WgpuRuntime;
-    use half::f16;
+    use half::{bf16, f16};
 
-    cubecl_core::testgen_all!(f32: [f16, f32], i32: [i16, i32], u32: [u16, u32]);
+    cubecl_core::testgen_all!(f32: [bf16, f16, f32], i32: [i16, i32], u32: [u16, u32]);
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, flex32, f32, u32]);
     cubecl_std::testgen_quantized_view!(f16);

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -58,9 +58,17 @@ mod tests_spirv {
 #[allow(unexpected_cfgs)]
 mod tests_msl {
     pub type TestRuntime = crate::WgpuRuntime;
-    use half::{bf16, f16};
 
+    // bf16 (bfloat) is only available on Apple Silicon (Apple7+ GPU family).
+    #[cfg(apple_silicon)]
+    use half::{bf16, f16};
+    #[cfg(not(apple_silicon))]
+    use half::f16;
+
+    #[cfg(apple_silicon)]
     cubecl_core::testgen_all!(f32: [bf16, f16, f32], i32: [i16, i32], u32: [u16, u32]);
+    #[cfg(not(apple_silicon))]
+    cubecl_core::testgen_all!(f32: [f16, f32], i32: [i16, i32], u32: [u16, u32]);
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, flex32, f32, u32]);
     cubecl_std::testgen_quantized_view!(f16);


### PR DESCRIPTION
Follow-up to #1203 — addresses review feedback about unconditional bf16 registration on Metal.

## Summary

#1203 added bf16 transcendental codegen support for Metal but registered `FloatKind::BF16`
unconditionally for all Metal devices. MSL's `bfloat` type is only available on Apple Silicon
(Apple7+ GPU family — M1 and later). Intel and AMD-based Macs do not support it, which would
cause shader compilation failures at runtime.

This PR:
- Gates bf16 type registration behind `#[cfg(apple_silicon)]` (`target_os = "macos"` +
  `target_arch = "aarch64"`), which maps 1:1 to Apple7+ hardware.
- Fixes bf16 zero-literal initialization in `Magnitude`/`Normalize` — uses typed constructors
  (`bfloat(0.0)`) instead of bare `0.0` which the Metal compiler rejects for bfloat. This fixes
  2 previously failing bf16 unary tests.
- Adds MSL overrides for `hypot`/`rhypot` (MSL uses overloaded names, not CUDA-style `hypotf`).

## Test plan

- [x] `cargo test -p cubecl-wgpu --features msl --lib -- tests_msl::bf16_ty::unary` — 22/22
  pass (up from 20/22 before the literal fix)
- [x] `cargo test -p cubecl-wgpu --features msl --lib -- tests_msl::bf16_ty::` — 85/131 pass
  (up from 83/131; 41 failures are pre-existing plane/warp/vector issues, 5 ignored)
- [x] `cargo test -p cubecl-wgpu --features msl --lib -- tests_msl::f16_ty::unary` — 22/22
  pass (no regressions)
- [x] `cargo test -p cubecl-wgpu --features msl --lib -- tests_msl::f32_ty::unary` — 22/22
  pass (no regressions)