### PR TITLE
Enable `as_arg()` for launchable cube structs

### DIFF
--- a/crates/cubecl-core/src/frontend/container/array/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/array/launch.rs
@@ -178,6 +178,7 @@ impl<R: Runtime, C: CubePrimitive> AsArgument<R> for ArrayHandle<C, R> {
 
 impl<R: Runtime, C: CubePrimitive + CubeElement> AsHandle<R> for Vec<C> {
     type Handle = ArrayHandle<C, R>;
+    type BasicType = Vec<C>;
     fn as_handle(&self, client: &ComputeClient<R>) -> Self::Handle {
         let bytes = C::as_bytes(self.as_slice());
         ArrayHandle::<C, R> {
@@ -191,6 +192,7 @@ impl<R: Runtime, C: CubePrimitive + CubeElement> AsHandle<R> for Vec<C> {
 
 impl<R: Runtime, C: CubePrimitive + CubeElement> AsHandle<R> for Array<C> {
     type Handle = ArrayHandle<C, R>;
+    type BasicType = Vec<C>;
     fn as_handle(&self, _client: &ComputeClient<R>) -> Self::Handle {
         panic!("Cannot transform native CubeCL type into a handle. Use as_handle() on a Vec to obtain an ArrayHandle.");
     }

--- a/crates/cubecl-core/src/frontend/container/array/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/array/launch.rs
@@ -1,12 +1,14 @@
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use cubecl_runtime::runtime::Runtime;
+use cubecl_runtime::{runtime::Runtime, client::ComputeClient};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     compute::{KernelBuilder, KernelLauncher},
+    frontend::element::{AsArgument, AsHandle},
     ir::Id,
-    prelude::{CubePrimitive, LaunchArg, NativeExpand, TensorBinding},
+    prelude::{CubePrimitive, CubeElement, LaunchArg, NativeExpand, TensorBinding},
 };
 
 use super::Array;
@@ -151,6 +153,38 @@ impl<C: CubePrimitive> LaunchArg for Array<C> {
         match arg.inplace {
             Some(id) => builder.inplace_output(id).into(),
             None => builder.output_array(C::as_type(&builder.scope)).into(),
+        }
+    }
+}
+
+pub struct ArrayHandle<C: CubePrimitive, R: Runtime> {
+    pub handle: cubecl_runtime::server::Handle,
+    pub length: usize,
+    _data_type: PhantomData<C>,
+    _runtime: PhantomData<R>,
+}
+
+impl<R: Runtime, C: CubePrimitive> AsArgument<R> for ArrayHandle<C, R> {
+    type Argument = Array<C>;
+    fn as_arg(&self) -> ArrayArg<R> {
+        unsafe {
+            ArrayArg::from_raw_parts(
+                self.handle.clone(),
+                self.length,
+            )
+        }
+    }
+}
+
+impl<R: Runtime, C: CubePrimitive + CubeElement> AsHandle<R> for Vec<C> {
+    type Handle = ArrayHandle<C, R>;
+    fn as_handle(&self, client: &ComputeClient<R>) -> Self::Handle {
+        let bytes = C::as_bytes(self.as_slice());
+        ArrayHandle::<C, R> {
+            handle: client.create_from_slice(bytes),
+            length: self.len(),
+            _data_type: PhantomData,
+            _runtime: PhantomData,
         }
     }
 }

--- a/crates/cubecl-core/src/frontend/container/array/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/array/launch.rs
@@ -188,3 +188,10 @@ impl<R: Runtime, C: CubePrimitive + CubeElement> AsHandle<R> for Vec<C> {
         }
     }
 }
+
+impl<R: Runtime, C: CubePrimitive + CubeElement> AsHandle<R> for Array<C> {
+    type Handle = ArrayHandle<C, R>;
+    fn as_handle(&self, _client: &ComputeClient<R>) -> Self::Handle {
+        panic!("Cannot transform native CubeCL type into a handle. Use as_handle() on a Vec to obtain an ArrayHandle.");
+    }
+}

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -8,7 +8,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::marker::PhantomData;
 use cubecl_common::{e2m1, e2m1x2, e2m3, e3m2, e4m3, e5m2, flex32, tf32, ue8m0};
 use cubecl_ir::{ManagedVariable, VectorSize};
-use cubecl_runtime::runtime::Runtime;
+use cubecl_runtime::{runtime::Runtime, client::ComputeClient};
 use half::{bf16, f16};
 use variadics_please::{all_tuples, all_tuples_enumerated};
 
@@ -247,6 +247,20 @@ macro_rules! launch_tuple {
 }
 
 all_tuples!(launch_tuple, 2, 12, T, t);
+
+/// Defines how a struct (typically some time of Handle) can be transformed into a launch argument
+/// for launching new kernels.
+pub trait AsArgument<R: Runtime> {
+    type Argument: LaunchArg;
+    fn as_arg(&self) -> <Self::Argument as LaunchArg>::RuntimeArg<R>;
+}
+
+/// Defines how a struct (that can be derived as CubeLaunch) can be transformed into a Handle
+/// struct, i.e. a new object that contains all handles of its fields.
+pub trait AsHandle<R: Runtime> {
+    type Handle: AsArgument<R>;
+    fn as_handle(&self, client: &ComputeClient<R>) -> Self::Handle;
+}
 
 /// Expand type of a native GPU type, i.e. scalar primitives, arrays, shared memory.
 #[derive(new)]

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -248,15 +248,17 @@ macro_rules! launch_tuple {
 
 all_tuples!(launch_tuple, 2, 12, T, t);
 
-/// Defines how a struct (typically some time of Handle) can be transformed into a launch argument
-/// for launching new kernels.
+/// Defines how a struct (typically a Handle) can be transformed into an argument for
+/// launching new kernels.
 pub trait AsArgument<R: Runtime> {
     type Argument: LaunchArg;
     fn as_arg(&self) -> <Self::Argument as LaunchArg>::RuntimeArg<R>;
 }
 
-/// Defines how a struct (that can be derived as CubeLaunch) can be transformed into a Handle
-/// struct, i.e. a new object that contains all handles of its fields.
+/// Defines how a struct can be transformed into a Handle struct, i.e. a new object that
+/// contains all handles of its fields. This trait glues basic Rust types (defined under
+/// `BasicType`) and their Handles (defined under `Handle`) together, allowing to
+/// automate the creationg of launch argument for new kernels.
 pub trait AsHandle<R: Runtime> {
     type Handle: AsArgument<R>;
     type BasicType: AsHandle<R>;

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -259,6 +259,7 @@ pub trait AsArgument<R: Runtime> {
 /// struct, i.e. a new object that contains all handles of its fields.
 pub trait AsHandle<R: Runtime> {
     type Handle: AsArgument<R>;
+    type BasicType: AsHandle<R>;
     fn as_handle(&self, client: &ComputeClient<R>) -> Self::Handle;
 }
 

--- a/crates/cubecl-core/src/frontend/element/numeric.rs
+++ b/crates/cubecl-core/src/frontend/element/numeric.rs
@@ -147,6 +147,7 @@ impl<R: Runtime, T: ScalarArgSettings> AsArgument<R> for T {
 
 impl<R: Runtime, T: ScalarArgSettings> AsHandle<R> for T {
     type Handle = T;
+    type BasicType = T;
     fn as_handle(&self, _client: &cubecl_runtime::client::ComputeClient<R>) -> T {
         *self
     }

--- a/crates/cubecl-core/src/frontend/element/numeric.rs
+++ b/crates/cubecl-core/src/frontend/element/numeric.rs
@@ -9,7 +9,7 @@ use crate::{
     unexpanded,
 };
 use crate::{
-    frontend::{CubePrimitive, CubeType},
+    frontend::{CubePrimitive, CubeType, AsArgument, AsHandle},
     prelude::InputScalar,
 };
 use crate::{
@@ -135,6 +135,20 @@ impl<T: ScalarArgSettings> LaunchArg for T {
 
     fn expand(_: &(), builder: &mut KernelBuilder) -> NativeExpand<Self> {
         T::expand_scalar(builder)
+    }
+}
+
+impl<R: Runtime, T: ScalarArgSettings> AsArgument<R> for T {
+    type Argument = T;
+    fn as_arg(&self) -> T {
+        *self
+    }
+}
+
+impl<R: Runtime, T: ScalarArgSettings> AsHandle<R> for T {
+    type Handle = T;
+    fn as_handle(&self, _client: &cubecl_runtime::client::ComputeClient<R>) -> T {
+        *self
     }
 }
 

--- a/crates/cubecl-macros/src/generate/cube_type/generate_struct.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_struct.rs
@@ -150,6 +150,41 @@ impl CubeTypeStruct {
         }
     }
 
+    pub fn as_handle(&self) -> proc_macro2::TokenStream {
+        let as_handle_trait = prelude_type("AsHandle");
+        let name = &self.ident;
+        let name_handle = format_ident!("{name}Handle");
+        let name_basic = format_ident!("{name}Basic");
+        let mut expanded_generics = self.generics.clone();
+        let runtime = prelude_type("Runtime");
+        expanded_generics.params.push(parse_quote!(R: #runtime));
+        let (expanded_generics_impl, expanded_generics_use, expanded_where_clause) = expanded_generics.split_for_impl();
+        
+        let field_names = self.fields.iter().map(TypeField::split).map(|(_, ident, _, _)| {
+            quote!(#ident)
+        });
+        let field_types = self.fields.iter().map(TypeField::split).map(|(_, _, ty, _)| {
+            quote!(#ty)
+        });
+        let field_names2 = field_names.clone();
+        quote! {
+            pub struct #name_basic #expanded_generics_impl #expanded_where_clause {
+                #( #field_names: <#field_types as cubecl::frontend::AsHandle<R>>::BasicType, )*
+            }
+
+            impl #expanded_generics_impl #as_handle_trait<R> for #name_basic #expanded_generics_use #expanded_where_clause {
+                type Handle = #name_handle #expanded_generics_use;
+                type BasicType = #name_basic #expanded_generics_use;
+                fn as_handle(&self, client: &cubecl_runtime::client::ComputeClient<R>) -> Self::Handle {
+                    Self::Handle {
+                        #( #field_names2: self.#field_names2.as_handle(client), )*
+                        _phantom_runtime: std::marker::PhantomData,
+                    }
+                }
+            }
+        }
+    }
+
     fn register_impl(&self) -> proc_macro2::TokenStream {
         let kernel_launcher = prelude_type("KernelLauncher");
         let launch_arg = prelude_type("LaunchArg");

--- a/crates/cubecl-macros/src/generate/cube_type/generate_struct.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_struct.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{Ident, Type, Visibility, WhereClause};
+use quote::{format_ident, quote};
+use syn::{parse_quote, Ident, Type, Visibility, WhereClause};
 
 use crate::{
     generate::bounded_where_clause,
@@ -107,6 +107,43 @@ impl CubeTypeStruct {
                     Self {
                         _phantom_runtime: core::marker::PhantomData,
                         #(#fields),*
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn as_argument(&self) -> proc_macro2::TokenStream {
+        let as_arg_trait = prelude_type("AsArgument");
+        let name = &self.ident;
+        let name_launch = &self.name_launch;
+        let name_handle = format_ident!("{name}Handle");
+        let (_, generics_use, _) = self.generics.split_for_impl();
+        let mut expanded_generics = self.generics.clone();
+        let runtime = prelude_type("Runtime");
+        expanded_generics.params.push(parse_quote!(R: #runtime));
+        let (expanded_generics_impl, expanded_generics_use, expanded_where_clause) = expanded_generics.split_for_impl();
+        let field_names = self.fields.iter().map(TypeField::split).map(|(_, ident, _, _)| {
+            quote!(#ident)
+        });
+        let field_types = self.fields.iter().map(TypeField::split).map(|(_, _, ty, _)| {
+            quote!(#ty)
+        });
+        let field_names2 = field_names.clone();
+        let field_types2 = field_types.clone();
+        
+        quote! {
+            pub struct #name_handle #expanded_generics_impl #expanded_where_clause {
+                #( #field_names: <#field_types as cubecl::frontend::AsHandle<R>>::Handle, )*
+                _phantom_runtime: std::marker::PhantomData<R>,
+            }
+
+            impl #expanded_generics_impl #as_arg_trait<R> for #name_handle #expanded_generics_use #expanded_where_clause {
+                type Argument = #name #generics_use;
+                fn as_arg(&self) -> #name_launch #expanded_generics_use {
+                    #name_launch::#expanded_generics_use {
+                        #( #field_names2: <<#field_types2 as cubecl::frontend::AsHandle<R>>::Handle as cubecl::frontend::AsArgument<R>>::as_arg(&self.#field_names2), )*
+                        _phantom_runtime: std::marker::PhantomData,
                     }
                 }
             }

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -134,7 +134,7 @@ pub fn module_derive_cube_launch(input: TokenStream) -> TokenStream {
 }
 
 /// Derive macro to implement as_arg() for a launchable cube type
-#[proc_macro_derive(CubeAsArg, attributes(expand, cube))]
+#[proc_macro_derive(CubeAsArg)]
 pub fn module_derive_as_argument(input: TokenStream) -> TokenStream {
     let parsed = syn::parse(input);
 

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -150,6 +150,23 @@ pub fn module_derive_as_argument(input: TokenStream) -> TokenStream {
     cube_type.as_argument().into()
 }
 
+/// Derive macro to implement as_handle() for a launchable cube type
+#[proc_macro_derive(CubeAsHandle)]
+pub fn module_derive_as_handle(input: TokenStream) -> TokenStream {
+    let parsed = syn::parse(input);
+
+    let input = match &parsed {
+        Ok(val) => val,
+        Err(err) => return err.to_compile_error().into(),
+    };
+    let cube_type = match CubeTypeStruct::from_derive_input(input) {
+        Ok(val) => val,
+        Err(err) => return err.write_errors().into(),
+    };
+
+    cube_type.as_handle().into()
+}
+
 /// Derive macro to define a cube type that is not launched
 #[proc_macro_derive(CubeType, attributes(cube))]
 pub fn module_derive_cube_type(input: TokenStream) -> TokenStream {

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -2,11 +2,13 @@
 
 use core::panic;
 
+use darling::FromDeriveInput;
 use error::error_into_token_stream;
 use generate::autotune::generate_autotune_key;
 use parse::{
     cube_impl::CubeImpl,
     cube_trait::{CubeTrait, CubeTraitImpl},
+    cube_type::CubeTypeStruct,
     helpers::{RemoveHelpers, ReplaceIndices},
     kernel::{Launch, from_tokens},
 };
@@ -129,6 +131,23 @@ fn cube_impl(args: TokenStream, input: TokenStream) -> syn::Result<TokenStream> 
 #[proc_macro_derive(CubeLaunch, attributes(cube, launch))]
 pub fn module_derive_cube_launch(input: TokenStream) -> TokenStream {
     gen_cube_type(input, true)
+}
+
+/// Derive macro to implement as_arg() for a launchable cube type
+#[proc_macro_derive(CubeAsArg, attributes(expand, cube))]
+pub fn module_derive_as_argument(input: TokenStream) -> TokenStream {
+    let parsed = syn::parse(input);
+
+    let input = match &parsed {
+        Ok(val) => val,
+        Err(err) => return err.to_compile_error().into(),
+    };
+    let cube_type = match CubeTypeStruct::from_derive_input(input) {
+        Ok(val) => val,
+        Err(err) => return err.write_errors().into(),
+    };
+
+    cube_type.as_argument().into()
 }
 
 /// Derive macro to define a cube type that is not launched

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -133,7 +133,9 @@ pub fn module_derive_cube_launch(input: TokenStream) -> TokenStream {
     gen_cube_type(input, true)
 }
 
-/// Derive macro to implement as_arg() for a launchable cube type
+/// Derive macro to implement as_arg() and a Handle struct for a launchable cube type. Using this
+/// macro, a new struct named {struct_name}Handle will be created which implements `.as_arg()`. You
+/// may want to use this in conjunction with CubeAsHandle.
 #[proc_macro_derive(CubeAsArg)]
 pub fn module_derive_as_argument(input: TokenStream) -> TokenStream {
     let parsed = syn::parse(input);
@@ -150,7 +152,11 @@ pub fn module_derive_as_argument(input: TokenStream) -> TokenStream {
     cube_type.as_argument().into()
 }
 
-/// Derive macro to implement as_handle() for a launchable cube type
+/// Derive macro to implement as_handle() and a Basic struct for a launchable cube type. Has to be
+/// used in conjunction with CubeAsArg. Using this
+/// macro, a new struct named {struct_name}Basic will be created which implements `.as_handle()`.
+/// Before launching any kernel, you can create a Basic struct, fill it with your data, and run
+/// `.as_handle()` to obtain the corresponding Handle struct.
 #[proc_macro_derive(CubeAsHandle)]
 pub fn module_derive_as_handle(input: TokenStream) -> TokenStream {
     let parsed = syn::parse(input);


### PR DESCRIPTION
In this PR, I introduce two new traits: `AsArgument` and `AsHandle`. The former describes that a struct (typically a Handle) can be transformed to its `LaunchArg` equivalent using `.as_arg()`. The latter describes that a struct can be transformed into a Handle struct that implements `AsArgument`. I have implemented both traits for Scalars (via `ScalarArgSettings`) and `Array`s. For `Array`s, I have chosen `Vec`s from the standard Rust library as their non-cubecl counterparts.

To automate the implementation of these two traits, users can derive `CubeAsArg` and `CubeAsHandle` for structs that also derive `CubeLaunch`. This will create Handle and Basic structs. With the latter, users can create a new struct with Rust standard library types (scalars and Vecs, currently) and obtain all handles via `.as_handle()`. The result can be used a kernel launch argument via `.as_arg()`.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] ~Fix any broken tests or compilation errors in burn.~
- [x] ~Submit a PR in burn with your fixes and link it here.~

Note on the latter two action points: I ran the checks but got errors which originate from the commit that I based my PR on. According to [a discussion on discord](https://discord.com/channels/1038839012602941528/1286391740739358802/1486681965045354497), these errors are probably due to a version mismatch from a recent refactor. This PR does not introduce any additional errors.
