### PR TITLE
[needs upstream feature] refactor: Buffer device address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,8 @@ ash = "0.38"
 # tracel-ash = "0.38.0"
 tracel-ash = "0.39"
 
-wgpu = "^29.0.1"
+wgpu = { git = "https://github.com/wingertge/wgpu.git", rev = "96a985c2b35f25157c510e47523aa01dd49c0968" }
+# wgpu = "^29.0.1"
 wgpu-hal = "^29.0.1"
 
 # Build deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,8 @@ wgpu = { git = "https://github.com/wingertge/wgpu.git", rev = "96a985c2b35f25157
 # wgpu = "^29.0.1"
 wgpu-hal = "^29.0.1"
 
+renderdoc = "0.12"
+
 # Build deps
 cfg_aliases = "0.2.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,8 @@ ash = "0.38"
 # tracel-ash = "0.38.0"
 tracel-ash = "0.39"
 
-wgpu = "29"
+wgpu = "^29.0.1"
+wgpu-hal = "^29.0.1"
 
 # Build deps
 cfg_aliases = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,16 +146,16 @@ cudarc = { version = "0.19.0", features = [
 ], default-features = false } # CubeCL-CUDA
 
 # CubeCL-SPIR-V
-rspirv = { package = "tracel-rspirv", version = "0.12.1" }
+rspirv = { package = "tracel-rspirv", version = "0.13.0" }
 
 # CubeCL-WGPU
 ash = "0.38"
 # tracel-ash = "0.38.0"
 tracel-ash = "0.39"
 
-wgpu = { git = "https://github.com/wingertge/wgpu.git", rev = "96a985c2b35f25157c510e47523aa01dd49c0968" }
+wgpu = { git = "https://github.com/gfx-rs/wgpu.git", rev = "bde709122f8320571ab1733ab055dcb54415a483" }
 # wgpu = "^29.0.1"
-wgpu-hal = "^29.0.1"
+wgpu-hal = { git = "https://github.com/gfx-rs/wgpu.git", rev = "bde709122f8320571ab1733ab055dcb54415a483" }
 
 renderdoc = "0.12"
 

--- a/crates/cubecl-core/src/codegen/compiler.rs
+++ b/crates/cubecl-core/src/codegen/compiler.rs
@@ -17,4 +17,5 @@ pub struct VulkanCompilationOptions {
     pub supports_uniform_unsized_array: bool,
 
     pub max_spirv_version: (u8, u8),
+    pub push_constant_size: usize,
 }

--- a/crates/cubecl-core/src/codegen/compiler.rs
+++ b/crates/cubecl-core/src/codegen/compiler.rs
@@ -3,7 +3,7 @@
 pub struct WgpuCompilationOptions {
     pub supports_u64: bool,
     /// Whether the Vulkan compiler is supported or we need to fall back to WGSL
-    pub supports_vulkan: bool,
+    pub supports_vulkan_compiler: bool,
 
     pub vulkan: VulkanCompilationOptions,
 }

--- a/crates/cubecl-cpp/src/metal/address_space.rs
+++ b/crates/cubecl-cpp/src/metal/address_space.rs
@@ -57,6 +57,7 @@ impl<D: Dialect> From<&KernelArg<D>> for AddressSpace {
         match value.vis {
             Visibility::Read => AddressSpace::ConstDevice,
             Visibility::ReadWrite => AddressSpace::Device,
+            Visibility::Uniform => AddressSpace::Constant,
         }
     }
 }

--- a/crates/cubecl-cpp/src/metal/binding.rs
+++ b/crates/cubecl-cpp/src/metal/binding.rs
@@ -6,18 +6,14 @@ use crate::{
     shared::{Component, KernelArg, MslComputeKernel, Variable},
 };
 
-pub fn bindings(
-    repr: &MslComputeKernel,
-    args: &KernelArguments,
-) -> (Vec<Visibility>, Option<Visibility>, bool) {
-    let mut bindings: Vec<Visibility> = vec![];
-    // must be in the same order as the compilation order: inputs, outputs and named
-    for b in repr.buffers.iter() {
-        bindings.push(b.vis);
-    }
-    let info = (!args.info.data.is_empty()).then_some(Visibility::Read);
+pub fn bindings(repr: &MslComputeKernel, args: &KernelArguments) -> Vec<Visibility> {
+    let buffers = repr.buffers.iter().map(|it| it.vis);
     let uniform = args.info.dynamic_metadata_offset >= args.info.data.len();
-    (bindings, info, uniform)
+    let info_vis = (!args.info.data.is_empty()).then_some(match uniform {
+        true => Visibility::Uniform,
+        false => Visibility::Read,
+    });
+    buffers.chain(info_vis).collect()
 }
 
 pub fn format_global_binding_arg<D: Dialect>(

--- a/crates/cubecl-cpp/src/metal/binding.rs
+++ b/crates/cubecl-cpp/src/metal/binding.rs
@@ -6,14 +6,14 @@ use crate::{
     shared::{Component, KernelArg, MslComputeKernel, Variable},
 };
 
-pub fn bindings(repr: &MslComputeKernel, args: &KernelArguments) -> Vec<Visibility> {
+pub fn bindings(repr: &MslComputeKernel, args: &KernelArguments) -> (Vec<Visibility>, usize) {
     let buffers = repr.buffers.iter().map(|it| it.vis);
     let uniform = args.info.dynamic_metadata_offset >= args.info.data.len();
     let info_vis = (!args.info.data.is_empty()).then_some(match uniform {
         true => Visibility::Uniform,
         false => Visibility::Read,
     });
-    buffers.chain(info_vis).collect()
+    (buffers.chain(info_vis).collect(), 0)
 }
 
 pub fn format_global_binding_arg<D: Dialect>(

--- a/crates/cubecl-cpp/src/shared/kernel.rs
+++ b/crates/cubecl-cpp/src/shared/kernel.rs
@@ -242,13 +242,10 @@ pub fn compile_bindings<D: Dialect>(
             .iter()
             .chain(buffers.iter())
             .map(|binding| match binding.vis {
-                Visibility::Read if !binding.item.is_atomic() => {
+                Visibility::Read | Visibility::Uniform if !binding.item.is_atomic() => {
                     format!("const {}* __restrict__ buffer_{}", binding.item, binding.id)
                 }
-                Visibility::Read => {
-                    format!("{}* buffer_{}", binding.item, binding.id)
-                }
-                Visibility::ReadWrite => {
+                _ => {
                     format!("{}* buffer_{}", binding.item, binding.id)
                 }
             }),

--- a/crates/cubecl-runtime/src/kernel.rs
+++ b/crates/cubecl-runtime/src/kernel.rs
@@ -82,6 +82,7 @@ pub struct ScalarKernelArg {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub enum Visibility {
+    Uniform,
     Read,
     ReadWrite,
 }

--- a/crates/cubecl-runtime/src/server/base.rs
+++ b/crates/cubecl-runtime/src/server/base.rs
@@ -1033,6 +1033,8 @@ pub enum ExecutionMode {
     Validate,
     /// Unchecked kernels are unsafe.
     Unchecked,
+    /// Validate OOB and alert if OOB access occurs
+    Validate,
 }
 
 fn cube_count_spread(max: &(u32, u32, u32), num_cubes: u32) -> [u32; 3] {

--- a/crates/cubecl-runtime/src/server/base.rs
+++ b/crates/cubecl-runtime/src/server/base.rs
@@ -1033,8 +1033,6 @@ pub enum ExecutionMode {
     Validate,
     /// Unchecked kernels are unsafe.
     Unchecked,
-    /// Validate OOB and alert if OOB access occurs
-    Validate,
 }
 
 fn cube_count_spread(max: &(u32, u32, u32), num_cubes: u32) -> [u32; 3] {

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -409,7 +409,7 @@ impl<K: AutotuneKey> Tuner<K> {
 
             if tunable_indices.is_empty() {
                 return Err(AutotuneError::NoValidKernelFound {
-                    context: format!("{:?}", &Context { plan, results }),
+                    context: format!("{:?}", Context { plan, results }),
                 });
             }
 

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -14,7 +14,7 @@ use cubecl_core::{
         checked_io::CheckedIoProcessor, saturating::SaturatingArithmeticProcessor,
         unroll::UnrollProcessor,
     },
-    prelude::{FastMath, KernelDefinition},
+    prelude::{FastMath, KernelDefinition, Visibility},
     server::ExecutionMode,
 };
 use cubecl_opt::{BasicBlock, NodeIndex, Optimizer, OptimizerBuilder, SharedLiveness, Uniformity};
@@ -197,7 +197,10 @@ impl<T: SpirvTarget> Compiler for SpirvCompiler<T> {
         self.ext_meta_pos = ext_meta_pos;
 
         let (module, optimizer, shared_size) = self.compile_kernel(value);
-        let uniform_info = matches!(T::info_storage_class(self), StorageClass::Uniform);
+        let info_visibility = match T::info_storage_class(self) {
+            StorageClass::Uniform => Visibility::Uniform,
+            _ => Visibility::Read,
+        };
 
         Ok(SpirvKernel {
             assembled_module: module.assemble(),
@@ -205,7 +208,7 @@ impl<T: SpirvTarget> Compiler for SpirvCompiler<T> {
             optimizer: Some(Arc::new(optimizer)),
             bindings: bindings.iter().map(|it| it.visibility).collect(),
             shared_size,
-            uniform_info,
+            info_visibility,
         })
     }
 
@@ -254,7 +257,6 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
         self.shared_liveness = opt.analysis::<SharedLiveness>();
         self.opt = Rc::new(opt);
 
-        self.init_state(kernel.clone());
         self.init_debug();
 
         let cube_dims = vec![kernel.cube_dim.x, kernel.cube_dim.y, kernel.cube_dim.z];
@@ -268,7 +270,8 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
 
         let entry = self.opt.entry();
         let body = self.label(entry);
-        let setup_block = self.setup(setup, debug_setup);
+
+        let setup_block = self.setup(setup, kernel.clone(), debug_setup);
         self.setup_block = setup_block;
         self.compile_block(entry);
 
@@ -306,13 +309,20 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
         (module, self.opt.as_ref().clone(), shared_size)
     }
 
-    fn setup(&mut self, label: Word, debug_setup: impl Fn(&mut Self)) -> usize {
+    fn setup(
+        &mut self,
+        label: Word,
+        kernel: KernelDefinition,
+        debug_setup: impl Fn(&mut Self),
+    ) -> usize {
         self.begin_block(Some(label)).unwrap();
 
         let opt = self.opt.clone();
         for const_arr in opt.const_arrays() {
             self.register_const_array(const_arr);
         }
+
+        self.init_state(kernel);
 
         debug_setup(self);
 
@@ -422,12 +432,12 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
             .insert(Capability::WorkgroupMemoryExplicitLayoutKHR);
 
         for (index, memory) in shared_arrays {
-            let item_size = memory.item.size();
-            shared_size = shared_size.max(memory.offset + memory.len * item_size);
+            let ty_size = memory.item.size();
+            shared_size = shared_size.max(memory.offset + memory.len * ty_size);
 
             // It's safe to assume that if 8-bit/16-bit types are supported, they're supported for
             // explicit layout as well.
-            match item_size {
+            match ty_size {
                 1 => {
                     self.capabilities
                         .insert(Capability::WorkgroupMemoryExplicitLayout8BitAccessKHR);
@@ -439,20 +449,16 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
                 _ => {}
             }
 
-            let arr_ty = Item::Array(Box::new(memory.item), memory.len);
-            let arr_id = arr_ty.id(self);
+            let arr_id = self.id();
+            let item_id = memory.item.id(self);
+            let len_id = self.const_u32(memory.len);
 
-            if !self.state.decorated_types.contains(&arr_id) {
-                self.decorate(
-                    arr_id,
-                    Decoration::ArrayStride,
-                    [Operand::LiteralBit32(item_size)],
-                );
-                self.state.decorated_types.insert(arr_id);
-            }
+            self.type_array_id(Some(arr_id), item_id, len_id);
+            self.decorate(arr_id, Decoration::ArrayStride, [ty_size.into()]);
 
-            let block_ty = Item::Struct(vec![arr_ty]);
-            let block_id = block_ty.id(self);
+            let block_id = self.id();
+
+            self.type_struct_id(Some(block_id), [arr_id]);
 
             self.decorate(block_id, Decoration::Block, []);
             self.member_decorate(
@@ -470,12 +476,12 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
         }
 
         for (index, memory) in shared {
-            let item_size = memory.item.size();
-            shared_size = shared_size.max(memory.offset + item_size);
+            let ty_size = memory.item.size();
+            shared_size = shared_size.max(memory.offset + ty_size);
 
             // It's safe to assume that if 8-bit/16-bit types are supported, they're supported for
             // explicit layout as well.
-            match item_size {
+            match ty_size {
                 1 => {
                     self.capabilities
                         .insert(Capability::WorkgroupMemoryExplicitLayout8BitAccessKHR);
@@ -487,16 +493,13 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
                 _ => {}
             }
 
-            let block_ty = Item::Struct(vec![memory.item]);
-            let block_id = block_ty.id(self);
+            let item_id = memory.item.id(self);
+            let block_id = self.id();
+
+            self.type_struct_id(Some(block_id), [item_id]);
 
             self.decorate(block_id, Decoration::Block, []);
-            self.member_decorate(
-                block_id,
-                0,
-                Decoration::Offset,
-                [Operand::LiteralBit32(memory.offset)],
-            );
+            self.member_decorate(block_id, 0, Decoration::Offset, [memory.offset.into()]);
 
             let ptr_ty = self.type_pointer(None, StorageClass::Workgroup, block_id);
 
@@ -514,8 +517,12 @@ impl<Target: SpirvTarget> SpirvCompiler<Target> {
         for (index, memory) in shared_memories {
             shared_size += memory.len * memory.item.size();
 
-            let arr_ty = Item::Array(Box::new(memory.item), memory.len);
-            let ptr_ty = Item::Pointer(StorageClass::Workgroup, Box::new(arr_ty)).id(self);
+            let item_id = memory.item.id(self);
+            let arr_ty = self.id();
+            let len_id = self.const_u32(memory.len);
+
+            self.type_array_id(Some(arr_ty), item_id, len_id);
+            let ptr_ty = self.type_pointer(None, StorageClass::Workgroup, arr_ty);
 
             self.debug_shared(memory.id, index);
             self.variable(ptr_ty, Some(memory.id), StorageClass::Workgroup, None);

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -202,7 +202,7 @@ impl<T: SpirvTarget> Compiler for SpirvCompiler<T> {
             _ => Visibility::Read,
         };
         let immediate_size = match T::params_storage_class(self, bindings.len()) {
-            StorageClass::PushConstant => Some(bindings.len() * size_of::<u64>()),
+            StorageClass::PushConstant => Some((bindings.len() + 1) * size_of::<u64>()),
             _ => None,
         };
 

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -201,6 +201,10 @@ impl<T: SpirvTarget> Compiler for SpirvCompiler<T> {
             StorageClass::Uniform => Visibility::Uniform,
             _ => Visibility::Read,
         };
+        let immediate_size = match T::params_storage_class(self, bindings.len()) {
+            StorageClass::PushConstant => Some(bindings.len() * size_of::<u64>()),
+            _ => None,
+        };
 
         Ok(SpirvKernel {
             assembled_module: module.assemble(),
@@ -208,6 +212,7 @@ impl<T: SpirvTarget> Compiler for SpirvCompiler<T> {
             optimizer: Some(Arc::new(optimizer)),
             bindings: bindings.iter().map(|it| it.visibility).collect(),
             shared_size,
+            immediate_size,
             info_visibility,
         })
     }

--- a/crates/cubecl-spirv/src/instruction.rs
+++ b/crates/cubecl-spirv/src/instruction.rs
@@ -2,7 +2,7 @@ use cubecl_core::ir::{
     self as core, BinaryOperator, Comparison, Instruction, InstructionModes, Operation, Operator,
     UnaryOperator,
 };
-use rspirv::spirv::{Capability, Decoration, Word};
+use rspirv::spirv::{Capability, Decoration, MemoryAccess, Word};
 
 use crate::{
     SpirvCompiler, SpirvTarget,
@@ -280,10 +280,18 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                 let out = self.compile_variable(out);
                 let out_index = self.compile_variable(op.out_index);
 
+                let align = input.item().size().max(out.item().size());
+
                 let in_ptr = self.index_ptr(&input, &in_index);
                 let out_ptr = self.index_ptr(&out, &out_index);
-                self.copy_memory(out_ptr, in_ptr, None, None, vec![])
-                    .unwrap();
+                self.copy_memory(
+                    out_ptr,
+                    in_ptr,
+                    None,
+                    Some(MemoryAccess::ALIGNED),
+                    [align.into()],
+                )
+                .unwrap();
             }
             Operator::CopyMemoryBulk(op) => {
                 self.capabilities.insert(Capability::Addresses);
@@ -292,12 +300,21 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                 let out = self.compile_variable(out);
                 let out_index = self.compile_variable(op.out_index);
                 let len = op.len;
+                let size = len as u32 * out.item().size();
 
                 let source = self.index_ptr(&input, &in_index);
                 let target = self.index_ptr(&out, &out_index);
-                let size = self.const_u32(len as u32 * out.item().size());
-                self.copy_memory_sized(target, source, size, None, None, vec![])
-                    .unwrap();
+                let size_id = self.const_u32(size);
+
+                self.copy_memory_sized(
+                    target,
+                    source,
+                    size_id,
+                    None,
+                    Some(MemoryAccess::ALIGNED),
+                    [size.into()],
+                )
+                .unwrap();
             }
             Operator::Select(op) => self.compile_select(op.cond, op.then, op.or_else, out, uniform),
         }

--- a/crates/cubecl-spirv/src/instruction.rs
+++ b/crates/cubecl-spirv/src/instruction.rs
@@ -287,9 +287,10 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                 self.copy_memory(
                     out_ptr,
                     in_ptr,
-                    None,
                     Some(MemoryAccess::ALIGNED),
                     [align.into()],
+                    None,
+                    [],
                 )
                 .unwrap();
             }
@@ -310,9 +311,10 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                     target,
                     source,
                     size_id,
-                    None,
                     Some(MemoryAccess::ALIGNED),
                     [size.into()],
+                    None,
+                    [],
                 )
                 .unwrap();
             }

--- a/crates/cubecl-spirv/src/item.rs
+++ b/crates/cubecl-spirv/src/item.rs
@@ -200,6 +200,13 @@ impl Item {
                 (Elem::Float(_, _), Elem::Int(_, true)) | (Elem::Relaxed, Elem::Int(_, true)) => {
                     b.convert_f_to_s(ty, out_id, obj).unwrap()
                 }
+                (Elem::Float(32, _), Elem::Relaxed) | (Elem::Relaxed, Elem::Float(32, _)) => {
+                    if out_id.is_some() {
+                        b.copy_object(ty, out_id, obj).unwrap()
+                    } else {
+                        obj
+                    }
+                }
                 (Elem::Float(_, _), Elem::Float(_, _))
                 | (Elem::Float(_, _), Elem::Relaxed)
                 | (Elem::Relaxed, Elem::Float(_, _)) => b.f_convert(ty, out_id, obj).unwrap(),

--- a/crates/cubecl-spirv/src/item.rs
+++ b/crates/cubecl-spirv/src/item.rs
@@ -9,9 +9,6 @@ pub enum Item {
     Scalar(Elem),
     // Vector of scalars. Must be 2, 3, or 4, or 8/16 for OpenCL only
     Vector(Elem, u32),
-    Array(Box<Item>, u32),
-    RuntimeArray(Box<Item>),
-    Struct(Vec<Item>),
     Pointer(StorageClass, Box<Item>),
     CoopMatrix {
         ty: Elem,
@@ -28,20 +25,6 @@ impl Item {
             Item::Vector(elem, vec) => {
                 let elem = elem.id(b);
                 b.type_vector(elem, *vec)
-            }
-            Item::Array(item, len) => {
-                let item = item.id(b);
-                let len = b.const_u32(*len);
-                b.type_array(item, len)
-            }
-            Item::RuntimeArray(item) => {
-                let item = item.id(b);
-                b.type_runtime_array(item)
-            }
-            Item::Struct(vec) => {
-                let items: Vec<_> = vec.iter().map(|item| item.id(b)).collect();
-                let id = b.id(); // Avoid deduplicating this struct, because of decorations
-                b.type_struct_id(Some(id), items)
             }
             Item::Pointer(storage_class, item) => {
                 let item = item.id(b);
@@ -74,9 +57,6 @@ impl Item {
         match self {
             Item::Scalar(elem) => elem.size(),
             Item::Vector(elem, factor) => elem.size() * *factor,
-            Item::Array(item, len) => item.size() * *len,
-            Item::RuntimeArray(item) => item.size(),
-            Item::Struct(vec) => vec.iter().map(|it| it.size()).sum(),
             Item::Pointer(_, item) => item.size(),
             Item::CoopMatrix { ty, .. } => ty.size(),
         }
@@ -86,9 +66,6 @@ impl Item {
         match self {
             Item::Scalar(elem) => *elem,
             Item::Vector(elem, _) => *elem,
-            Item::Array(item, _) => item.elem(),
-            Item::RuntimeArray(item) => item.elem(),
-            Item::Struct(_) => Elem::Void,
             Item::Pointer(_, item) => item.elem(),
             Item::CoopMatrix { ty, .. } => *ty,
         }
@@ -115,18 +92,6 @@ impl Item {
         match self {
             Item::Scalar(_) => scalar,
             Item::Vector(_, vec) => b.constant_composite(ty, (0..*vec).map(|_| scalar)),
-            Item::Array(item, len) => {
-                let elem = item.constant(b, value);
-                b.constant_composite(ty, (0..*len).map(|_| elem))
-            }
-            Item::RuntimeArray(_) => unimplemented!("Can't create constant runtime array"),
-            Item::Struct(elems) => {
-                let items = elems
-                    .iter()
-                    .map(|item| item.constant(b, value))
-                    .collect::<Vec<_>>();
-                b.constant_composite(ty, items)
-            }
             Item::Pointer(_, _) => unimplemented!("Can't create constant pointer"),
             Item::CoopMatrix { .. } => unimplemented!("Can't create constant cmma matrix"),
         }
@@ -462,15 +427,6 @@ impl std::fmt::Display for Item {
         match self {
             Item::Scalar(elem) => write!(f, "{elem}"),
             Item::Vector(elem, factor) => write!(f, "vec{factor}<{elem}>"),
-            Item::Array(item, len) => write!(f, "array<{item}, {len}>"),
-            Item::RuntimeArray(item) => write!(f, "array<{item}>"),
-            Item::Struct(members) => {
-                write!(f, "struct<")?;
-                for item in members {
-                    write!(f, "{item}")?;
-                }
-                f.write_str(">")
-            }
             Item::Pointer(class, item) => write!(f, "ptr<{class:?}, {item}>"),
             Item::CoopMatrix { ty, ident, .. } => write!(f, "matrix<{ty}, {ident:?}>"),
         }

--- a/crates/cubecl-spirv/src/lib.rs
+++ b/crates/cubecl-spirv/src/lib.rs
@@ -42,7 +42,7 @@ pub struct SpirvKernel {
     pub assembled_module: Vec<u32>,
     pub bindings: Vec<Visibility>,
     pub shared_size: usize,
-    pub uniform_info: bool,
+    pub info_visibility: Visibility,
 }
 
 impl Eq for SpirvKernel {}

--- a/crates/cubecl-spirv/src/lib.rs
+++ b/crates/cubecl-spirv/src/lib.rs
@@ -42,6 +42,7 @@ pub struct SpirvKernel {
     pub assembled_module: Vec<u32>,
     pub bindings: Vec<Visibility>,
     pub shared_size: usize,
+    pub immediate_size: Option<usize>,
     pub info_visibility: Visibility,
 }
 

--- a/crates/cubecl-spirv/src/lookups.rs
+++ b/crates/cubecl-spirv/src/lookups.rs
@@ -21,8 +21,9 @@ use crate::{
 
 #[derive(Clone, Debug, Default)]
 pub struct LookupTables {
-    pub buffers: Vec<Word>,
+    pub buffers: Vec<Buffer>,
     pub scalar_bindings: HashMap<ir::StorageType, u32>,
+    pub params: Word,
     pub info: Word,
     pub cube_dims: Vec<Word>,
     pub cube_size: Word,
@@ -38,7 +39,6 @@ pub struct LookupTables {
     pub used_builtins: HashMap<BuiltIn, (Word, Item)>,
 
     pub scalars: HashMap<(Id, ir::StorageType), Word>,
-    pub array_types: HashSet<Word>,
     pub constants: HashMap<(ConstVal, Item), Word>,
     pub bindings: HashMap<Id, Word>,
     pub variables: HashMap<Id, Word>,
@@ -53,8 +53,6 @@ pub struct LookupTables {
     // For break, continue
     pub loops: VecDeque<Loop>,
 
-    // Explicitly decorated types, to avoid double decorating
-    pub decorated_types: HashSet<Word>,
     pub debug_types: HashSet<Word>,
 }
 
@@ -130,27 +128,30 @@ pub struct Loop {
     pub post: Word,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Buffer {
+    pub id: Word,
+    pub struct_ty_id: Word,
+    pub struct_ptr_ty_id: Word,
+    pub storage_class: StorageClass,
+}
+
 impl<T: SpirvTarget> SpirvCompiler<T> {
-    pub fn init_state(&mut self, kernel: KernelDefinition) {
+    pub fn init_state(&mut self, mut kernel: KernelDefinition) {
         let mut target = self.target.clone();
 
-        self.state.buffers = kernel
-            .buffers
-            .into_iter()
-            .map(|mut binding| {
-                // This is safe when combined with the unroll transform that adjusts all indices.
-                // Must not be used alone
-                if binding.ty.vector_size() > MAX_VECTORIZATION {
-                    binding.ty = binding.ty.with_vector_size(MAX_VECTORIZATION);
-                }
-                let var = ir::Variable::new(VariableKind::GlobalInputArray(binding.id), binding.ty);
-                let name = self.name_of_var(var);
-                target.generate_binding(self, binding, name.into())
-            })
-            .collect();
+        for binding in &mut kernel.buffers {
+            // This is safe when combined with the unroll transform that adjusts all indices.
+            // Must not be used alone
+            if binding.ty.vector_size() > MAX_VECTORIZATION {
+                binding.ty = binding.ty.with_vector_size(MAX_VECTORIZATION);
+            }
+        }
+
+        self.state.buffers = target.generate_storage_bindings(self, &kernel.buffers);
 
         if self.info.has_info() {
-            self.state.info = target.generate_info_binding(self, self.state.buffers.len() as u32);
+            self.state.info = target.generate_info_binding(self);
         }
 
         self.state.scalar_bindings = kernel
@@ -286,6 +287,14 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         id
     }
 
+    pub fn insert_in_root(&mut self, insert: impl FnOnce(&mut Self) -> Word) -> Word {
+        let current_block = self.selected_block();
+        self.select_block(None).unwrap();
+        let id = insert(self);
+        self.select_block(current_block).unwrap();
+        id
+    }
+
     pub fn get_local(&mut self, id: Id, item: &Item, var: ir::Variable) -> Word {
         if let Some(existing) = self.state.variables.get(&id) {
             *existing
@@ -386,10 +395,15 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             },
             arr.item,
         );
+
         let item = self.compile_type(arr.item);
-        let array_ty = Item::Array(Box::new(item.clone()), arr.length as u32);
-        let pointer_ty = Item::Pointer(StorageClass::Function, Box::new(array_ty.clone())).id(self);
-        let array_ty = array_ty.id(self);
+        let item_id = item.id(self);
+        let array_ty = self.id();
+        let len_id = self.const_u32(arr.length as u32);
+
+        self.type_array_id(Some(array_ty), item_id, len_id);
+        let pointer_ty = self.type_pointer(None, StorageClass::Function, array_ty);
+
         let values = arr
             .values
             .into_iter()

--- a/crates/cubecl-spirv/src/lookups.rs
+++ b/crates/cubecl-spirv/src/lookups.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use cubecl_core::{
     ir::{self, Builtin, Id, Type, VariableKind},
-    prelude::KernelDefinition,
+    prelude::{KernelDefinition, Visibility},
 };
 use cubecl_opt::{ConstArray, NodeIndex, SharedMemory};
 use hashbrown::{HashMap, HashSet};
@@ -135,6 +135,7 @@ pub struct Buffer {
     pub struct_ty_id: Word,
     pub struct_ptr_ty_id: Word,
     pub storage_class: StorageClass,
+    pub visibility: Visibility,
 }
 
 impl<T: SpirvTarget> SpirvCompiler<T> {

--- a/crates/cubecl-spirv/src/lookups.rs
+++ b/crates/cubecl-spirv/src/lookups.rs
@@ -9,7 +9,8 @@ use hashbrown::{HashMap, HashSet};
 use rspirv::{
     dr,
     spirv::{
-        self, BuiltIn, CooperativeMatrixLayout, CooperativeMatrixUse, Scope, StorageClass, Word,
+        self, BuiltIn, CooperativeMatrixLayout, CooperativeMatrixUse, MemoryAccess, Scope,
+        StorageClass, Word,
     },
 };
 
@@ -148,13 +149,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             }
         }
 
-        let info_offset = T::info_offset(self, kernel.buffers.len());
-
         self.state.buffers = target.generate_storage_bindings(self, &kernel.buffers);
-
-        if self.info.has_info() {
-            self.state.info = target.generate_info_binding(self, info_offset);
-        }
 
         self.state.scalar_bindings = kernel
             .scalars
@@ -371,6 +366,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             let field_id = self.const_u32(self.state.scalar_bindings[&ty]);
             let offset = self.const_u32(id);
             let item = self.compile_type(ir::Type::new(ty));
+            let align = item.size();
             let elem = item.elem();
             let ty_id = item.id(self);
             let storage_class = T::info_storage_class(self);
@@ -379,7 +375,15 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             let access = self
                 .access_chain(ptr_ty, None, info, [field_id, offset])
                 .unwrap();
-            let read_id = self.load(ty_id, None, access, None, []).unwrap();
+            let read_id = self
+                .load(
+                    ty_id,
+                    None,
+                    access,
+                    Some(MemoryAccess::ALIGNED),
+                    [align.into()],
+                )
+                .unwrap();
             let var = Variable::GlobalScalar(read_id, elem);
             self.debug_var_name(read_id, ir_var);
             self.select_block(current_block).unwrap();

--- a/crates/cubecl-spirv/src/lookups.rs
+++ b/crates/cubecl-spirv/src/lookups.rs
@@ -148,10 +148,12 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             }
         }
 
+        let info_offset = T::info_offset(self, kernel.buffers.len());
+
         self.state.buffers = target.generate_storage_bindings(self, &kernel.buffers);
 
         if self.info.has_info() {
-            self.state.info = target.generate_info_binding(self);
+            self.state.info = target.generate_info_binding(self, info_offset);
         }
 
         self.state.scalar_bindings = kernel

--- a/crates/cubecl-spirv/src/metadata.rs
+++ b/crates/cubecl-spirv/src/metadata.rs
@@ -1,6 +1,6 @@
 use cubecl_core::ir as core;
 use cubecl_core::ir::Metadata;
-use rspirv::spirv::Word;
+use rspirv::spirv::{MemoryAccess, Word};
 
 use crate::{SpirvCompiler, SpirvTarget, item::Item, variable::Variable};
 
@@ -144,6 +144,7 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
 
     pub fn load_const_metadata(&mut self, index: u32, out: Option<Word>, ty: Item) -> Word {
         self.insert_in_setup(|b| {
+            let align = ty.size();
             let ty_id = ty.id(b);
             let storage_class = T::info_storage_class(b);
             let ptr_ty = Item::Pointer(storage_class, Box::new(ty)).id(b);
@@ -153,11 +154,19 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             let info_ptr = b
                 .access_chain(ptr_ty, None, info, vec![offset, index])
                 .unwrap();
-            b.load(ty_id, out, info_ptr, None, vec![]).unwrap()
+            b.load(
+                ty_id,
+                out,
+                info_ptr,
+                Some(MemoryAccess::ALIGNED),
+                [align.into()],
+            )
+            .unwrap()
         })
     }
 
     pub fn load_dyn_metadata(&mut self, index: &Variable, out: Option<Word>, ty: Item) -> Word {
+        let align = ty.size();
         let ty_id = ty.id(self);
         let storage_class = T::info_storage_class(self);
         let ptr_ty = Item::Pointer(storage_class, Box::new(ty)).id(self);
@@ -167,7 +176,14 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         let info_ptr = self
             .access_chain(ptr_ty, None, info, vec![offset, index])
             .unwrap();
-        self.load(ty_id, out, info_ptr, None, vec![]).unwrap()
+        self.load(
+            ty_id,
+            out,
+            info_ptr,
+            Some(MemoryAccess::ALIGNED),
+            [align.into()],
+        )
+        .unwrap()
     }
 
     fn ext_pos(&self, var: &Variable) -> u32 {

--- a/crates/cubecl-spirv/src/target.rs
+++ b/crates/cubecl-spirv/src/target.rs
@@ -1,4 +1,4 @@
-use cubecl_core::prelude::KernelArg;
+use cubecl_core::prelude::{KernelArg, Visibility};
 use rspirv::{
     dr::Operand,
     spirv::{
@@ -204,6 +204,9 @@ impl SpirvTarget for GLCompute {
                 Decoration::Offset,
                 [offset.into()],
             );
+            if buffer.visibility == Visibility::Read {
+                b.member_decorate(params_struct_id, i as u32, Decoration::NonWritable, []);
+            }
 
             // uniform/push constant pointer to physical storage buffer pointer
             let field_ptr_ty = b.type_pointer(None, params_class, buffer.struct_ptr_ty_id);
@@ -225,6 +228,7 @@ impl SpirvTarget for GLCompute {
                 Decoration::Offset,
                 [offset.into()],
             );
+            b.member_decorate(params_struct_id, i as u32, Decoration::NonWritable, []);
 
             // uniform/push constant pointer to physical storage buffer pointer
             let field_ptr_ty = b.type_pointer(None, params_class, info.struct_ptr_ty_id);
@@ -301,6 +305,7 @@ impl GLCompute {
             struct_ty_id,
             struct_ptr_ty_id,
             storage_class,
+            visibility: binding.visibility,
         }
     }
 
@@ -402,6 +407,7 @@ impl GLCompute {
             struct_ty_id,
             struct_ptr_ty_id,
             storage_class,
+            visibility: Visibility::Read,
         }
     }
 }

--- a/crates/cubecl-spirv/src/target.rs
+++ b/crates/cubecl-spirv/src/target.rs
@@ -1,4 +1,4 @@
-use cubecl_core::prelude::{KernelArg, Visibility};
+use cubecl_core::prelude::KernelArg;
 use rspirv::{
     dr::Operand,
     spirv::{
@@ -8,7 +8,7 @@ use rspirv::{
 };
 use std::{fmt::Debug, iter};
 
-use crate::{SpirvCompiler, extensions::TargetExtensions, item::Item};
+use crate::{SpirvCompiler, extensions::TargetExtensions, item::Item, lookups::Buffer};
 
 pub trait SpirvTarget:
     TargetExtensions<Self> + Debug + Clone + Default + Send + Sync + 'static
@@ -20,13 +20,12 @@ pub trait SpirvTarget:
         builtins: Vec<Word>,
         cube_dims: Vec<u32>,
     );
-    fn generate_binding(
+    fn generate_storage_bindings(
         &mut self,
         b: &mut SpirvCompiler<Self>,
-        binding: KernelArg,
-        name: String,
-    ) -> Word;
-    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>, offset: u32) -> Word;
+        bindings: &[KernelArg],
+    ) -> Vec<Buffer>;
+    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>) -> Word;
     fn info_storage_class(b: &mut SpirvCompiler<Self>) -> StorageClass;
 
     fn set_kernel_name(&mut self, name: impl Into<String>);
@@ -61,8 +60,8 @@ impl SpirvTarget for GLCompute {
     ) {
         let interface: Vec<u32> = builtins
             .into_iter()
-            .chain(b.state.buffers.iter().copied())
-            .chain(iter::once(b.state.info))
+            .chain(iter::once(b.state.params))
+            .chain((b.state.info != 0).then_some(b.state.info))
             .chain(b.state.shared_arrays.values().map(|it| it.id))
             .chain(b.state.shared.values().map(|it| it.id))
             .collect();
@@ -70,6 +69,7 @@ impl SpirvTarget for GLCompute {
         let version = b.compilation_options.vulkan.max_spirv_version;
 
         b.capability(Capability::Shader);
+        b.capability(Capability::PhysicalStorageBufferAddresses);
         b.capability(Capability::VulkanMemoryModel);
         b.capability(Capability::VulkanMemoryModelDeviceScope);
         b.capability(Capability::GroupNonUniform);
@@ -136,21 +136,21 @@ impl SpirvTarget for GLCompute {
         }
 
         if version < (1, 5) {
+            b.extension("SPV_KHR_physical_storage_buffer");
             b.extension("SPV_KHR_vulkan_memory_model");
             if caps.contains(&Capability::StorageBuffer8BitAccess) {
                 b.extension("SPV_KHR_8bit_storage");
             }
         }
 
-        if version < (1, 3) {
-            b.extension("SPV_KHR_storage_buffer_storage_class");
-
-            if caps.contains(&Capability::StorageBuffer16BitAccess) {
-                b.extension("SPV_KHR_16bit_storage");
-            }
+        if version < (1, 3) && caps.contains(&Capability::StorageBuffer16BitAccess) {
+            b.extension("SPV_KHR_16bit_storage");
         }
 
-        b.memory_model(AddressingModel::Logical, MemoryModel::Vulkan);
+        b.memory_model(
+            AddressingModel::PhysicalStorageBuffer64,
+            MemoryModel::Vulkan,
+        );
         b.entry_point(
             ExecutionModel::GLCompute,
             main,
@@ -160,62 +160,65 @@ impl SpirvTarget for GLCompute {
         b.execution_mode(main, spirv::ExecutionMode::LocalSize, cube_dims);
     }
 
-    fn generate_binding(
+    fn generate_storage_bindings(
         &mut self,
         b: &mut SpirvCompiler<Self>,
-        binding: KernelArg,
-        name: String,
-    ) -> Word {
-        let index = binding.id;
-        let item = b.compile_type(binding.ty);
-        let item_size = item.size();
-        match item.elem().size() {
-            1 => {
-                b.capabilities.insert(Capability::StorageBuffer8BitAccess);
-            }
-            2 => {
-                b.capabilities.insert(Capability::StorageBuffer16BitAccess);
-            }
-            _ => {}
+        bindings: &[KernelArg],
+    ) -> Vec<Buffer> {
+        let params_struct_id = b.id();
+        let uniform_ptr_id = b.id();
+
+        let buffers = bindings
+            .iter()
+            .map(|binding| self.generate_storage_buffer(b, binding))
+            .collect::<Vec<_>>();
+
+        b.type_struct_id(
+            Some(params_struct_id),
+            buffers.iter().map(|it| it.struct_ptr_ty_id),
+        );
+        b.type_pointer(
+            Some(uniform_ptr_id),
+            StorageClass::Uniform,
+            params_struct_id,
+        );
+
+        b.decorate(params_struct_id, Decoration::Block, []);
+
+        let params =
+            b.insert_in_root(|b| b.variable(uniform_ptr_id, None, StorageClass::Uniform, None));
+        b.state.params = params;
+
+        b.decorate(params, Decoration::DescriptorSet, [0u32.into()]);
+        b.decorate(params, Decoration::Binding, [0u32.into()]);
+
+        for (i, buffer) in buffers.iter().enumerate() {
+            let offset = (size_of::<u64>() * i) as u32;
+            b.member_decorate(
+                params_struct_id,
+                i as u32,
+                Decoration::Offset,
+                [offset.into()],
+            );
+
+            // uniform pointer to physical storage buffer pointer
+            let field_ptr_ty = b.type_pointer(None, StorageClass::Uniform, buffer.struct_ptr_ty_id);
+            let field_idx = b.const_u32(i as u32);
+            let ptr = b
+                .access_chain(field_ptr_ty, None, params, [field_idx])
+                .unwrap();
+            b.load(buffer.struct_ptr_ty_id, Some(buffer.id), ptr, None, [])
+                .unwrap();
         }
 
-        let item = match binding.size {
-            Some(size) => Item::Array(Box::new(item), size as u32),
-            None => Item::RuntimeArray(Box::new(item)),
-        };
-        let arr = item.id(b); // pre-generate type
-
-        if !b.state.array_types.contains(&arr) {
-            b.decorate(arr, Decoration::ArrayStride, [item_size.into()]);
-            b.state.array_types.insert(arr);
-        }
-
-        let struct_ty = b.id();
-        b.type_struct_id(Some(struct_ty), vec![arr]);
-
-        let storage_class = StorageClass::StorageBuffer;
-        let ptr_ty = b.type_pointer(None, storage_class, struct_ty);
-        let var = b.variable(ptr_ty, None, storage_class, None);
-
-        b.debug_name(var, name);
-
-        if matches!(binding.visibility, Visibility::Read) {
-            b.decorate(var, Decoration::NonWritable, vec![]);
-        }
-
-        b.decorate(var, Decoration::DescriptorSet, vec![0u32.into()]);
-        b.decorate(var, Decoration::Binding, vec![index.into()]);
-        b.decorate(struct_ty, Decoration::Block, vec![]);
-        b.member_decorate(struct_ty, 0, Decoration::Offset, vec![0u32.into()]);
-
-        var
+        buffers
     }
 
     /// Generate info binding struct and variable.
     /// SPIR-V structs have explicit offsets so unlike other targets we don't need to pad the length.
-    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>, index: u32) -> Word {
+    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>) -> Word {
         let address_type = b.addr_type;
-        let struct_ty = b.id();
+        let struct_ty_id = b.id();
 
         let mut fields = Vec::new();
 
@@ -237,23 +240,16 @@ impl SpirvTarget for GLCompute {
                 _ => {}
             }
 
-            let arr_ty = Item::Array(
-                Box::new(Item::Scalar(scalar_ty)),
-                scalar.padded_size() as u32,
-            );
-            let arr_ty_id = arr_ty.id(b);
+            let ty_size = scalar_ty.size();
+            let scalar_ty_id = Item::Scalar(scalar_ty).id(b);
+            let arr_ty_id = b.id();
+            let len_id = b.const_u32(scalar.padded_size() as u32);
 
-            if !b.state.array_types.contains(&arr_ty_id) {
-                b.decorate(
-                    arr_ty_id,
-                    Decoration::ArrayStride,
-                    [(scalar.ty.size() as u32).into()],
-                );
-                b.state.array_types.insert(arr_ty_id);
-            }
+            b.type_array_id(Some(arr_ty_id), scalar_ty_id, len_id);
+            b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
 
             b.member_decorate(
-                struct_ty,
+                struct_ty_id,
                 fields.len() as u32,
                 Decoration::Offset,
                 [(scalar.offset as u32).into()],
@@ -263,20 +259,17 @@ impl SpirvTarget for GLCompute {
 
         if let Some(field) = b.info.sized_meta {
             let scalar_ty = b.compile_storage_type(field.ty);
-            let arr_ty = Item::Array(Box::new(Item::Scalar(scalar_ty)), field.size as u32);
-            let arr_ty_id = arr_ty.id(b);
 
-            if !b.state.array_types.contains(&arr_ty_id) {
-                b.decorate(
-                    arr_ty_id,
-                    Decoration::ArrayStride,
-                    [(address_type.size() as u32).into()],
-                );
-                b.state.array_types.insert(arr_ty_id);
-            }
+            let ty_size = scalar_ty.size();
+            let scalar_ty_id = Item::Scalar(scalar_ty).id(b);
+            let arr_ty_id = b.id();
+            let len_id = b.const_u32(field.size as u32);
+
+            b.type_array_id(Some(arr_ty_id), scalar_ty_id, len_id);
+            b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
 
             b.member_decorate(
-                struct_ty,
+                struct_ty_id,
                 fields.len() as u32,
                 Decoration::Offset,
                 [(field.offset as u32).into()],
@@ -287,20 +280,16 @@ impl SpirvTarget for GLCompute {
         if b.info.has_dynamic_meta {
             let offset = b.info.dynamic_meta_offset;
             let scalar_ty = b.compile_storage_type(address_type);
-            let arr_ty = Item::RuntimeArray(Box::new(Item::Scalar(scalar_ty)));
-            let arr_ty_id = arr_ty.id(b);
 
-            if !b.state.array_types.contains(&arr_ty_id) {
-                b.decorate(
-                    arr_ty_id,
-                    Decoration::ArrayStride,
-                    [(address_type.size() as u32).into()],
-                );
-                b.state.array_types.insert(arr_ty_id);
-            }
+            let ty_size = scalar_ty.size();
+            let scalar_ty_id = Item::Scalar(scalar_ty).id(b);
+            let arr_ty_id = b.id();
+
+            b.type_runtime_array_id(Some(arr_ty_id), scalar_ty_id);
+            b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
 
             b.member_decorate(
-                struct_ty,
+                struct_ty_id,
                 fields.len() as u32,
                 Decoration::Offset,
                 [Operand::LiteralBit32(offset as u32)],
@@ -308,18 +297,18 @@ impl SpirvTarget for GLCompute {
             fields.push(arr_ty_id);
         }
 
-        b.type_struct_id(Some(struct_ty), fields);
+        b.type_struct_id(Some(struct_ty_id), fields);
 
         let location = Self::info_storage_class(b);
-        let ptr_ty = b.type_pointer(None, location, struct_ty);
-        let var = b.variable(ptr_ty, None, location, None);
+        let ptr_ty = b.type_pointer(None, location, struct_ty_id);
+        let var = b.insert_in_root(|b| b.variable(ptr_ty, None, location, None));
 
         b.debug_name(var, "info");
         b.decorate(var, Decoration::NonWritable, vec![]);
 
         b.decorate(var, Decoration::DescriptorSet, vec![0u32.into()]);
-        b.decorate(var, Decoration::Binding, vec![index.into()]);
-        b.decorate(struct_ty, Decoration::Block, vec![]);
+        b.decorate(var, Decoration::Binding, vec![1u32.into()]);
+        b.decorate(struct_ty_id, Decoration::Block, vec![]);
 
         var
     }
@@ -342,5 +331,47 @@ impl SpirvTarget for GLCompute {
 
     fn set_kernel_name(&mut self, name: impl Into<String>) {
         self.kernel_name = name.into();
+    }
+}
+
+impl GLCompute {
+    fn generate_storage_buffer(
+        &mut self,
+        b: &mut SpirvCompiler<Self>,
+        binding: &KernelArg,
+    ) -> Buffer {
+        let item = b.compile_type(binding.ty);
+        let item_id = item.id(b);
+        match item.elem().size() {
+            1 => {
+                b.capabilities.insert(Capability::StorageBuffer8BitAccess);
+            }
+            2 => {
+                b.capabilities.insert(Capability::StorageBuffer16BitAccess);
+            }
+            _ => {}
+        }
+
+        let ty_size = item.size();
+
+        let arr_ty_id = b.id();
+        let struct_ty_id = b.id();
+        let storage_class = StorageClass::PhysicalStorageBuffer;
+
+        b.type_runtime_array_id(Some(arr_ty_id), item_id);
+        b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
+
+        b.type_struct_id(Some(struct_ty_id), [arr_ty_id]);
+        b.decorate(struct_ty_id, Decoration::Block, []);
+        b.member_decorate(struct_ty_id, 0, Decoration::Offset, [0u32.into()]);
+
+        let struct_ptr_ty_id = b.type_pointer(None, storage_class, struct_ty_id);
+
+        Buffer {
+            id: b.id(),
+            struct_ty_id,
+            struct_ptr_ty_id,
+            storage_class,
+        }
     }
 }

--- a/crates/cubecl-spirv/src/target.rs
+++ b/crates/cubecl-spirv/src/target.rs
@@ -25,9 +25,7 @@ pub trait SpirvTarget:
         b: &mut SpirvCompiler<Self>,
         bindings: &[KernelArg],
     ) -> Vec<Buffer>;
-    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>, offset: u32) -> Word;
     fn info_storage_class(b: &mut SpirvCompiler<Self>) -> StorageClass;
-    fn info_offset(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> u32;
     fn params_storage_class(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> StorageClass;
 
     fn set_kernel_name(&mut self, name: impl Into<String>);
@@ -63,7 +61,6 @@ impl SpirvTarget for GLCompute {
         let interface: Vec<u32> = builtins
             .into_iter()
             .chain(iter::once(b.state.params))
-            .chain((b.state.info != 0).then_some(b.state.info))
             .chain(b.state.shared_arrays.values().map(|it| it.id))
             .chain(b.state.shared.values().map(|it| it.id))
             .collect();
@@ -176,10 +173,14 @@ impl SpirvTarget for GLCompute {
             .iter()
             .map(|binding| self.generate_storage_buffer(b, binding))
             .collect::<Vec<_>>();
+        let info = b.info.has_info().then(|| self.generate_info_binding(b));
 
         b.type_struct_id(
             Some(params_struct_id),
-            buffers.iter().map(|it| it.struct_ptr_ty_id),
+            buffers
+                .iter()
+                .chain(info.iter())
+                .map(|it| it.struct_ptr_ty_id),
         );
         b.type_pointer(Some(params_ptr_id), params_class, params_struct_id);
 
@@ -212,14 +213,100 @@ impl SpirvTarget for GLCompute {
                 .unwrap();
         }
 
+        if let Some(info) = info {
+            let i = buffers.len();
+            let offset = (size_of::<u64>() * i) as u32;
+            b.member_decorate(
+                params_struct_id,
+                i as u32,
+                Decoration::Offset,
+                [offset.into()],
+            );
+
+            // uniform/push constant pointer to physical storage buffer pointer
+            let field_ptr_ty = b.type_pointer(None, params_class, info.struct_ptr_ty_id);
+            let field_idx = b.const_u32(i as u32);
+            let ptr = b
+                .access_chain(field_ptr_ty, None, params, [field_idx])
+                .unwrap();
+            b.load(info.struct_ptr_ty_id, Some(info.id), ptr, None, [])
+                .unwrap();
+            b.debug_name(info.id, "info");
+
+            b.state.info = info.id;
+        }
+
         buffers
+    }
+
+    fn info_storage_class(_b: &mut SpirvCompiler<Self>) -> StorageClass {
+        StorageClass::PhysicalStorageBuffer
+    }
+
+    fn params_storage_class(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> StorageClass {
+        let num_addresses = match b.info.has_info() {
+            true => num_buffers + 1,
+            false => num_buffers,
+        };
+        if num_addresses > b.compilation_options.vulkan.push_constant_size / size_of::<u64>() {
+            StorageClass::Uniform
+        } else {
+            StorageClass::PushConstant
+        }
+    }
+
+    fn set_kernel_name(&mut self, name: impl Into<String>) {
+        self.kernel_name = name.into();
+    }
+}
+
+impl GLCompute {
+    fn generate_storage_buffer(
+        &mut self,
+        b: &mut SpirvCompiler<Self>,
+        binding: &KernelArg,
+    ) -> Buffer {
+        let item = b.compile_type(binding.ty);
+        let item_id = item.id(b);
+        match item.elem().size() {
+            1 => {
+                b.capabilities.insert(Capability::StorageBuffer8BitAccess);
+            }
+            2 => {
+                b.capabilities.insert(Capability::StorageBuffer16BitAccess);
+            }
+            _ => {}
+        }
+
+        let ty_size = item.size();
+
+        let arr_ty_id = b.id();
+        let struct_ty_id = b.id();
+        let storage_class = StorageClass::PhysicalStorageBuffer;
+
+        b.type_runtime_array_id(Some(arr_ty_id), item_id);
+        b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
+
+        b.type_struct_id(Some(struct_ty_id), [arr_ty_id]);
+        b.decorate(struct_ty_id, Decoration::Block, []);
+        b.member_decorate(struct_ty_id, 0, Decoration::Offset, [0u32.into()]);
+
+        let struct_ptr_ty_id = b.type_pointer(None, storage_class, struct_ty_id);
+
+        Buffer {
+            id: b.id(),
+            struct_ty_id,
+            struct_ptr_ty_id,
+            storage_class,
+        }
     }
 
     /// Generate info binding struct and variable.
     /// SPIR-V structs have explicit offsets so unlike other targets we don't need to pad the length.
-    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>, offset: u32) -> Word {
+    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>) -> Buffer {
         let address_type = b.addr_type;
         let struct_ty_id = b.id();
+        let storage_class = StorageClass::PhysicalStorageBuffer;
 
         let mut fields = Vec::new();
 
@@ -299,87 +386,7 @@ impl SpirvTarget for GLCompute {
         }
 
         b.type_struct_id(Some(struct_ty_id), fields);
-
-        let location = Self::info_storage_class(b);
-        let ptr_ty = b.type_pointer(None, location, struct_ty_id);
-        let var = b.insert_in_root(|b| b.variable(ptr_ty, None, location, None));
-
-        b.debug_name(var, "info");
-        b.decorate(var, Decoration::NonWritable, vec![]);
-
-        b.decorate(var, Decoration::DescriptorSet, vec![0u32.into()]);
-        b.decorate(var, Decoration::Binding, vec![offset.into()]);
         b.decorate(struct_ty_id, Decoration::Block, vec![]);
-
-        var
-    }
-
-    fn params_storage_class(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> StorageClass {
-        if num_buffers > b.compilation_options.vulkan.push_constant_size / size_of::<u64>() {
-            StorageClass::Uniform
-        } else {
-            StorageClass::PushConstant
-        }
-    }
-
-    fn info_offset(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> u32 {
-        match Self::params_storage_class(b, num_buffers) {
-            StorageClass::PushConstant => 0,
-            _ => 1,
-        }
-    }
-
-    fn info_storage_class(b: &mut SpirvCompiler<Self>) -> StorageClass {
-        if !b
-            .compilation_options
-            .vulkan
-            .supports_uniform_standard_layout
-        {
-            return StorageClass::StorageBuffer;
-        }
-        let is_dynamic = b.info.metadata.num_extended_meta() > 0;
-        if b.compilation_options.vulkan.supports_uniform_unsized_array || !is_dynamic {
-            StorageClass::Uniform
-        } else {
-            StorageClass::StorageBuffer
-        }
-    }
-
-    fn set_kernel_name(&mut self, name: impl Into<String>) {
-        self.kernel_name = name.into();
-    }
-}
-
-impl GLCompute {
-    fn generate_storage_buffer(
-        &mut self,
-        b: &mut SpirvCompiler<Self>,
-        binding: &KernelArg,
-    ) -> Buffer {
-        let item = b.compile_type(binding.ty);
-        let item_id = item.id(b);
-        match item.elem().size() {
-            1 => {
-                b.capabilities.insert(Capability::StorageBuffer8BitAccess);
-            }
-            2 => {
-                b.capabilities.insert(Capability::StorageBuffer16BitAccess);
-            }
-            _ => {}
-        }
-
-        let ty_size = item.size();
-
-        let arr_ty_id = b.id();
-        let struct_ty_id = b.id();
-        let storage_class = StorageClass::PhysicalStorageBuffer;
-
-        b.type_runtime_array_id(Some(arr_ty_id), item_id);
-        b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
-
-        b.type_struct_id(Some(struct_ty_id), [arr_ty_id]);
-        b.decorate(struct_ty_id, Decoration::Block, []);
-        b.member_decorate(struct_ty_id, 0, Decoration::Offset, [0u32.into()]);
 
         let struct_ptr_ty_id = b.type_pointer(None, storage_class, struct_ty_id);
 

--- a/crates/cubecl-spirv/src/target.rs
+++ b/crates/cubecl-spirv/src/target.rs
@@ -25,8 +25,10 @@ pub trait SpirvTarget:
         b: &mut SpirvCompiler<Self>,
         bindings: &[KernelArg],
     ) -> Vec<Buffer>;
-    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>) -> Word;
+    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>, offset: u32) -> Word;
     fn info_storage_class(b: &mut SpirvCompiler<Self>) -> StorageClass;
+    fn info_offset(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> u32;
+    fn params_storage_class(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> StorageClass;
 
     fn set_kernel_name(&mut self, name: impl Into<String>);
 }
@@ -165,8 +167,10 @@ impl SpirvTarget for GLCompute {
         b: &mut SpirvCompiler<Self>,
         bindings: &[KernelArg],
     ) -> Vec<Buffer> {
+        let params_class = Self::params_storage_class(b, bindings.len());
+
         let params_struct_id = b.id();
-        let uniform_ptr_id = b.id();
+        let params_ptr_id = b.id();
 
         let buffers = bindings
             .iter()
@@ -177,20 +181,17 @@ impl SpirvTarget for GLCompute {
             Some(params_struct_id),
             buffers.iter().map(|it| it.struct_ptr_ty_id),
         );
-        b.type_pointer(
-            Some(uniform_ptr_id),
-            StorageClass::Uniform,
-            params_struct_id,
-        );
+        b.type_pointer(Some(params_ptr_id), params_class, params_struct_id);
 
         b.decorate(params_struct_id, Decoration::Block, []);
 
-        let params =
-            b.insert_in_root(|b| b.variable(uniform_ptr_id, None, StorageClass::Uniform, None));
+        let params = b.insert_in_root(|b| b.variable(params_ptr_id, None, params_class, None));
         b.state.params = params;
 
-        b.decorate(params, Decoration::DescriptorSet, [0u32.into()]);
-        b.decorate(params, Decoration::Binding, [0u32.into()]);
+        if !matches!(params_class, StorageClass::PushConstant) {
+            b.decorate(params, Decoration::DescriptorSet, vec![0u32.into()]);
+            b.decorate(params, Decoration::Binding, vec![0u32.into()]);
+        }
 
         for (i, buffer) in buffers.iter().enumerate() {
             let offset = (size_of::<u64>() * i) as u32;
@@ -201,8 +202,8 @@ impl SpirvTarget for GLCompute {
                 [offset.into()],
             );
 
-            // uniform pointer to physical storage buffer pointer
-            let field_ptr_ty = b.type_pointer(None, StorageClass::Uniform, buffer.struct_ptr_ty_id);
+            // uniform/push constant pointer to physical storage buffer pointer
+            let field_ptr_ty = b.type_pointer(None, params_class, buffer.struct_ptr_ty_id);
             let field_idx = b.const_u32(i as u32);
             let ptr = b
                 .access_chain(field_ptr_ty, None, params, [field_idx])
@@ -216,7 +217,7 @@ impl SpirvTarget for GLCompute {
 
     /// Generate info binding struct and variable.
     /// SPIR-V structs have explicit offsets so unlike other targets we don't need to pad the length.
-    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>) -> Word {
+    fn generate_info_binding(&mut self, b: &mut SpirvCompiler<Self>, offset: u32) -> Word {
         let address_type = b.addr_type;
         let struct_ty_id = b.id();
 
@@ -307,10 +308,25 @@ impl SpirvTarget for GLCompute {
         b.decorate(var, Decoration::NonWritable, vec![]);
 
         b.decorate(var, Decoration::DescriptorSet, vec![0u32.into()]);
-        b.decorate(var, Decoration::Binding, vec![1u32.into()]);
+        b.decorate(var, Decoration::Binding, vec![offset.into()]);
         b.decorate(struct_ty_id, Decoration::Block, vec![]);
 
         var
+    }
+
+    fn params_storage_class(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> StorageClass {
+        if num_buffers > b.compilation_options.vulkan.push_constant_size / size_of::<u64>() {
+            StorageClass::Uniform
+        } else {
+            StorageClass::PushConstant
+        }
+    }
+
+    fn info_offset(b: &mut SpirvCompiler<Self>, num_buffers: usize) -> u32 {
+        match Self::params_storage_class(b, num_buffers) {
+            StorageClass::PushConstant => 0,
+            _ => 1,
+        }
     }
 
     fn info_storage_class(b: &mut SpirvCompiler<Self>) -> StorageClass {

--- a/crates/cubecl-spirv/src/target.rs
+++ b/crates/cubecl-spirv/src/target.rs
@@ -185,8 +185,10 @@ impl SpirvTarget for GLCompute {
         b.type_pointer(Some(params_ptr_id), params_class, params_struct_id);
 
         b.decorate(params_struct_id, Decoration::Block, []);
+        b.name(params_struct_id, "Params");
 
         let params = b.insert_in_root(|b| b.variable(params_ptr_id, None, params_class, None));
+        b.name(params, "params");
         b.state.params = params;
 
         if !matches!(params_class, StorageClass::PushConstant) {
@@ -211,6 +213,7 @@ impl SpirvTarget for GLCompute {
                 .unwrap();
             b.load(buffer.struct_ptr_ty_id, Some(buffer.id), ptr, None, [])
                 .unwrap();
+            b.name(buffer.id, "buffers");
         }
 
         if let Some(info) = info {
@@ -231,7 +234,7 @@ impl SpirvTarget for GLCompute {
                 .unwrap();
             b.load(info.struct_ptr_ty_id, Some(info.id), ptr, None, [])
                 .unwrap();
-            b.debug_name(info.id, "info");
+            b.name(info.id, "info");
 
             b.state.info = info.id;
         }
@@ -335,6 +338,7 @@ impl GLCompute {
 
             b.type_array_id(Some(arr_ty_id), scalar_ty_id, len_id);
             b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
+            b.name(arr_ty_id, format!("Scalars<{}>", scalar.ty));
 
             b.member_decorate(
                 struct_ty_id,
@@ -355,6 +359,7 @@ impl GLCompute {
 
             b.type_array_id(Some(arr_ty_id), scalar_ty_id, len_id);
             b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
+            b.name(arr_ty_id, "StaticMeta");
 
             b.member_decorate(
                 struct_ty_id,
@@ -375,6 +380,7 @@ impl GLCompute {
 
             b.type_runtime_array_id(Some(arr_ty_id), scalar_ty_id);
             b.decorate(arr_ty_id, Decoration::ArrayStride, [ty_size.into()]);
+            b.name(arr_ty_id, "DynamicMeta");
 
             b.member_decorate(
                 struct_ty_id,
@@ -387,6 +393,7 @@ impl GLCompute {
 
         b.type_struct_id(Some(struct_ty_id), fields);
         b.decorate(struct_ty_id, Decoration::Block, vec![]);
+        b.name(struct_ty_id, "Info");
 
         let struct_ptr_ty_id = b.type_pointer(None, storage_class, struct_ty_id);
 

--- a/crates/cubecl-spirv/src/variable.rs
+++ b/crates/cubecl-spirv/src/variable.rs
@@ -10,7 +10,7 @@ use crate::{
 use cubecl_core::ir::{self, ConstantValue, Id};
 use rspirv::{
     dr::Builder,
-    spirv::{self, FPEncoding, StorageClass, Word},
+    spirv::{self, FPEncoding, MemoryAccess, StorageClass, Word},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -313,12 +313,12 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                 }
             }
             ir::VariableKind::GlobalInputArray(pos) => {
-                let id = self.state.buffers[pos as usize];
-                Variable::GlobalInputArray(id, self.compile_type(item), pos)
+                let buffer = self.state.buffers[pos as usize];
+                Variable::GlobalInputArray(buffer.id, self.compile_type(item), pos)
             }
             ir::VariableKind::GlobalOutputArray(pos) => {
-                let id = self.state.buffers[pos as usize];
-                Variable::GlobalOutputArray(id, self.compile_type(item), pos)
+                let buffer = self.state.buffers[pos as usize];
+                Variable::GlobalOutputArray(buffer.id, self.compile_type(item), pos)
             }
             ir::VariableKind::GlobalScalar(id) => self.global_scalar(id, item.storage_type()),
             ir::VariableKind::LocalMut { id } => {
@@ -363,8 +363,13 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                 let id = if let Some(arr) = self.state.local_arrays.get(&id) {
                     arr.id
                 } else {
-                    let arr_ty = Item::Array(Box::new(item.clone()), length as u32);
-                    let ptr_ty = Item::Pointer(StorageClass::Function, Box::new(arr_ty)).id(self);
+                    let item_id = item.id(self);
+                    let arr_ty = self.id();
+                    let len_id = self.const_u32(length as u32);
+
+                    self.type_array_id(Some(arr_ty), item_id, len_id);
+                    let ptr_ty = self.type_pointer(None, StorageClass::Function, arr_ty);
+
                     let arr_id = self.declare_function_variable(ptr_ty);
                     self.debug_var_name(arr_id, variable);
                     let arr = Array {
@@ -404,12 +409,20 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             Variable::Shared(id, item)
                 if self.compilation_options.vulkan.supports_explicit_smem =>
             {
+                let align = item.size();
                 let ty = item.id(self);
                 let ptr_ty =
                     Item::Pointer(StorageClass::Workgroup, Box::new(item.clone())).id(self);
-                let index = vec![self.const_u32(0)];
-                let access = self.access_chain(ptr_ty, None, *id, index).unwrap();
-                self.load(ty, None, access, None, []).unwrap()
+                let index = self.const_u32(0);
+                let access = self.access_chain(ptr_ty, None, *id, [index]).unwrap();
+                self.load(
+                    ty,
+                    None,
+                    access,
+                    Some(MemoryAccess::ALIGNED),
+                    [align.into()],
+                )
+                .unwrap()
             }
             Variable::Local { id, item } | Variable::Shared(id, item) => {
                 let ty = item.id(self);
@@ -441,9 +454,10 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         };
         let index_id = self.read(index);
         match variable {
-            Variable::GlobalInputArray(id, item, _) | Variable::GlobalOutputArray(id, item, _) => {
-                let ptr_ty =
-                    Item::Pointer(StorageClass::StorageBuffer, Box::new(item.clone())).id(self);
+            Variable::GlobalInputArray(id, item, pos)
+            | Variable::GlobalOutputArray(id, item, pos) => {
+                let storage_class = self.state.buffers[*pos as usize].storage_class;
+                let ptr_ty = Item::Pointer(storage_class, Box::new(item.clone())).id(self);
                 let zero = self.const_u32(0);
                 let id = access_chain(self, ptr_ty, None, *id, vec![zero, index_id]).unwrap();
 
@@ -560,9 +574,17 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
 
         let read = |b: &mut Self| match indexed {
             IndexedVariable::Pointer(ptr, item) => {
+                let align = item.size();
                 let ty = item.id(b);
                 let out_id = b.write_id(out);
-                b.load(ty, Some(out_id), ptr, None, vec![]).unwrap()
+                b.load(
+                    ty,
+                    Some(out_id),
+                    ptr,
+                    Some(MemoryAccess::ALIGNED),
+                    [align.into()],
+                )
+                .unwrap()
             }
             IndexedVariable::Composite(var, index, item) => {
                 let elem = item.elem();
@@ -601,9 +623,17 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
 
         match indexed {
             IndexedVariable::Pointer(ptr, item) => {
+                let align = item.size();
                 let ty = item.id(self);
                 let out_id = self.write_id(out);
-                self.load(ty, Some(out_id), ptr, None, vec![]).unwrap()
+                self.load(
+                    ty,
+                    Some(out_id),
+                    ptr,
+                    Some(MemoryAccess::ALIGNED),
+                    [align.into()],
+                )
+                .unwrap()
             }
             IndexedVariable::Composite(var, index, item) => {
                 let elem = item.elem();
@@ -662,11 +692,13 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             Variable::Shared(id, item)
                 if self.compilation_options.vulkan.supports_explicit_smem =>
             {
+                let align = item.size();
                 let ptr_ty =
                     Item::Pointer(StorageClass::Workgroup, Box::new(item.clone())).id(self);
-                let index = vec![self.const_u32(0)];
-                let access = self.access_chain(ptr_ty, None, *id, index).unwrap();
-                self.store(access, value, None, []).unwrap()
+                let index = self.const_u32(0);
+                let access = self.access_chain(ptr_ty, None, *id, [index]).unwrap();
+                self.store(access, value, Some(MemoryAccess::ALIGNED), [align.into()])
+                    .unwrap()
             }
             Variable::Local { id, .. } | Variable::Shared(id, _) => {
                 self.store(*id, value, None, []).unwrap()
@@ -682,7 +714,11 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         let variable = self.index(out, index, always_in_bounds);
 
         let write = |b: &mut Self| match variable {
-            IndexedVariable::Pointer(ptr, _) => b.store(ptr, value, None, vec![]).unwrap(),
+            IndexedVariable::Pointer(ptr, item) => {
+                let align = item.size();
+                b.store(ptr, value, Some(MemoryAccess::ALIGNED), [align.into()])
+                    .unwrap()
+            }
             IndexedVariable::Composite(var, index, item) => {
                 let ty = item.id(b);
                 let id = b
@@ -707,7 +743,11 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
         let variable = self.index(out, index, true);
 
         match variable {
-            IndexedVariable::Pointer(ptr, _) => self.store(ptr, value, None, vec![]).unwrap(),
+            IndexedVariable::Pointer(ptr, item) => {
+                let align = item.size();
+                self.store(ptr, value, Some(MemoryAccess::ALIGNED), [align.into()])
+                    .unwrap()
+            }
             IndexedVariable::Composite(var, index, item) => {
                 let ty = item.id(self);
                 let out_id = self

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -39,6 +39,7 @@ spirv = [
     "cubecl-common/hash",
 ]
 
+deny-validation-errors = ["wgpu-hal/validation_canary"]
 spirv-dump = ["std"]
 vulkan-validate = []
 
@@ -86,6 +87,7 @@ cfg-if = { workspace = true }
 ## wgpu dependency for platforms other than macOS
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 wgpu = { workspace = true, features = ["fragile-send-sync-non-atomic-wasm"] }
+
 ## Uncomment if targeting metal through msl feature
 # wgpu = { git = "https://github.com/tracel-ai/wgpu", features = ["fragile-send-sync-non-atomic-wasm"], rev = "624db2ae762b83446693020ae637e2c5879b3af9" }
 ## For development on wgpu uncomment this one and make it point to your local wgpu repo
@@ -113,6 +115,7 @@ half = { workspace = true }
 paste = { workspace = true }
 pretty_assertions = { workspace = true }
 test-log = { workspace = true, features = ["trace"] }
+wgpu-hal = { workspace = true }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -43,6 +43,7 @@ deny-validation-errors = ["wgpu-hal/validation_canary"]
 spirv-dump = ["std"]
 vulkan-validate = []
 
+renderdoc = ["std"]
 tracing = [
     "dep:tracing",
     "cubecl-runtime/tracing",
@@ -53,6 +54,7 @@ tracing = [
 [dependencies]
 # Runtime Deps
 log = { workspace = true }
+renderdoc = { workspace = true }
 tracing = { workspace = true, features = ["attributes"], optional = true }
 
 cubecl-common = { path = "../cubecl-common", version = "=0.10.0-pre.2", default-features = false }

--- a/crates/cubecl-wgpu/build.rs
+++ b/crates/cubecl-wgpu/build.rs
@@ -21,6 +21,10 @@ fn main() {
         println!("cargo:rustc-cfg=feature=\"vulkan-validate\"");
     }
 
+    if env::var("CUBECL_ENABLE_RENDERDOC").is_ok() {
+        println!("cargo:rustc-cfg=feature=\"renderdoc\"");
+    }
+
     // Check if we are on macOS
     // Errors out on MacOS when the "spirv" feature is enabled and the Vulkan SDK is not installed.
     // To install Vulkan SDK visit https://vulkan.lunarg.com/sdk/home#mac

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -167,37 +167,46 @@ impl WgpuServer {
         };
 
         let layout = bindings_info.map(|(bindings, immediate_size)| {
-            let bindings = bindings
-                .into_iter()
-                .map(|visibility| match visibility {
-                    Visibility::Uniform => BufferBindingType::Uniform,
-                    Visibility::Read => BufferBindingType::Storage { read_only: true },
-                    Visibility::ReadWrite => BufferBindingType::Storage { read_only: false },
-                })
-                .enumerate()
-                .map(|(i, ty)| BindGroupLayoutEntry {
-                    binding: i as u32,
-                    visibility: ShaderStages::COMPUTE,
-                    ty: BindingType::Buffer {
-                        ty,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                })
-                .collect::<Vec<_>>();
-            let layout = self
-                .device
-                .create_bind_group_layout(&BindGroupLayoutDescriptor {
-                    label: None,
-                    entries: &bindings,
-                });
-            self.device
-                .create_pipeline_layout(&PipelineLayoutDescriptor {
-                    label: None,
-                    bind_group_layouts: &[Some(&layout)],
-                    immediate_size: immediate_size as u32,
-                })
+            if !bindings.is_empty() {
+                let bindings = bindings
+                    .into_iter()
+                    .map(|visibility| match visibility {
+                        Visibility::Uniform => BufferBindingType::Uniform,
+                        Visibility::Read => BufferBindingType::Storage { read_only: true },
+                        Visibility::ReadWrite => BufferBindingType::Storage { read_only: false },
+                    })
+                    .enumerate()
+                    .map(|(i, ty)| BindGroupLayoutEntry {
+                        binding: i as u32,
+                        visibility: ShaderStages::COMPUTE,
+                        ty: BindingType::Buffer {
+                            ty,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    })
+                    .collect::<Vec<_>>();
+                let layout = self
+                    .device
+                    .create_bind_group_layout(&BindGroupLayoutDescriptor {
+                        label: None,
+                        entries: &bindings,
+                    });
+                self.device
+                    .create_pipeline_layout(&PipelineLayoutDescriptor {
+                        label: None,
+                        bind_group_layouts: &[Some(&layout)],
+                        immediate_size: immediate_size as u32,
+                    })
+            } else {
+                self.device
+                    .create_pipeline_layout(&PipelineLayoutDescriptor {
+                        label: None,
+                        bind_group_layouts: &[],
+                        immediate_size: immediate_size as u32,
+                    })
+            }
         });
 
         let pipeline = self

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -1,6 +1,6 @@
 use super::wgsl;
 use crate::WgpuServer;
-use crate::{AutoRepresentationRef, CompilerKind};
+use crate::{AutoRepresentationRef, CompilerInfo};
 use cubecl_core::{
     ExecutionMode, WgpuCompilationOptions, hash::StableHash, server::KernelArguments,
 };
@@ -37,7 +37,7 @@ impl WgpuServer {
         bindings: &KernelArguments,
         mode: ExecutionMode,
     ) -> Result<
-        Option<Result<(Arc<ComputePipeline>, CompilerKind), (u64, StableHash)>>,
+        Option<Result<(Arc<ComputePipeline>, CompilerInfo), (u64, StableHash)>>,
         CompilationError,
     > {
         #[cfg(not(feature = "spirv"))]
@@ -46,13 +46,22 @@ impl WgpuServer {
         let res = if let Some(cache) = &self.spirv_cache {
             let key = (self.utilities.properties_hash, kernel_id.stable_hash());
             if let Some(entry) = cache.get(&key) {
+                use crate::ParamsTransfer;
+
                 log::trace!("Using SPIR-V cache");
 
+                let params_transfer = match entry.kernel.immediate_size {
+                    Some(_) => ParamsTransfer::Immediate,
+                    None => ParamsTransfer::Uniform,
+                };
                 let repr = AutoRepresentationRef::SpirV(&entry.kernel);
                 let module = self.create_module(&entry.entrypoint_name, Some(repr), "", mode)?;
                 let pipeline =
                     self.create_pipeline(&entry.entrypoint_name, Some(repr), module, bindings);
-                Ok(Some(Ok((pipeline, CompilerKind::Vulkan))))
+                Ok(Some(Ok((
+                    pipeline,
+                    CompilerInfo::Vulkan { params_transfer },
+                ))))
             } else {
                 Ok(Some(Err(key)))
             }
@@ -157,7 +166,7 @@ impl WgpuServer {
             _ => None,
         };
 
-        let layout = bindings_info.map(|bindings| {
+        let layout = bindings_info.map(|(bindings, immediate_size)| {
             let bindings = bindings
                 .into_iter()
                 .map(|visibility| match visibility {
@@ -187,7 +196,7 @@ impl WgpuServer {
                 .create_pipeline_layout(&PipelineLayoutDescriptor {
                     label: None,
                     bind_group_layouts: &[Some(&layout)],
-                    immediate_size: 0,
+                    immediate_size: immediate_size as u32,
                 })
         });
 

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -121,6 +121,7 @@ impl WgpuServer {
             },
             _ => {
                 let _ = entrypoint_name; // otherwise unused
+                let _ = cube_dim;
                 let checks = wgpu::ShaderRuntimeChecks {
                     // Cube does not need wgpu bounds checks - OOB behaviour is instead
                     // checked by cube (if enabled).

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -1,10 +1,10 @@
 use super::wgsl;
-use crate::AutoRepresentationRef;
 use crate::WgpuServer;
-use cubecl_core::MemoryConfiguration;
+use crate::{AutoRepresentationRef, CompilerKind};
 use cubecl_core::{
     ExecutionMode, WgpuCompilationOptions, hash::StableHash, server::KernelArguments,
 };
+use cubecl_core::{MemoryConfiguration, prelude::Visibility};
 use cubecl_ir::DeviceProperties;
 use cubecl_runtime::{compiler::CompilationError, id::KernelId};
 use std::{borrow::Cow, sync::Arc};
@@ -36,7 +36,10 @@ impl WgpuServer {
         kernel_id: &KernelId,
         bindings: &KernelArguments,
         mode: ExecutionMode,
-    ) -> Result<Option<Result<Arc<ComputePipeline>, (u64, StableHash)>>, CompilationError> {
+    ) -> Result<
+        Option<Result<(Arc<ComputePipeline>, CompilerKind), (u64, StableHash)>>,
+        CompilationError,
+    > {
         #[cfg(not(feature = "spirv"))]
         let res = Ok(None);
         #[cfg(feature = "spirv")]
@@ -49,7 +52,7 @@ impl WgpuServer {
                 let module = self.create_module(&entry.entrypoint_name, Some(repr), "", mode)?;
                 let pipeline =
                     self.create_pipeline(&entry.entrypoint_name, Some(repr), module, bindings);
-                Ok(Some(Ok(pipeline)))
+                Ok(Some(Ok((pipeline, CompilerKind::Vulkan))))
             } else {
                 Ok(Some(Err(key)))
             }
@@ -155,24 +158,13 @@ impl WgpuServer {
         };
 
         let layout = bindings_info.map(|bindings| {
-            let (mut bindings, info, uniform_info) = bindings;
-            // When slices are shared, it needs to be read-write if ANY of the slices is read-write,
-            // and since we can't be sure, we'll assume everything is read-write.
-            if !cfg!(exclusive_memory_only) {
-                bindings.fill(cubecl_runtime::kernel::Visibility::ReadWrite);
-            }
-
-            let info = info.map(|_| match uniform_info {
-                true => BufferBindingType::Uniform,
-                false => BufferBindingType::Storage { read_only: true },
-            });
-
             let bindings = bindings
                 .into_iter()
-                .map(|visibility| BufferBindingType::Storage {
-                    read_only: matches!(visibility, cubecl_runtime::kernel::Visibility::Read),
+                .map(|visibility| match visibility {
+                    Visibility::Uniform => BufferBindingType::Uniform,
+                    Visibility::Read => BufferBindingType::Storage { read_only: true },
+                    Visibility::ReadWrite => BufferBindingType::Storage { read_only: false },
                 })
-                .chain(info)
                 .enumerate()
                 .map(|(i, ty)| BindGroupLayoutEntry {
                     binding: i as u32,

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -2,7 +2,7 @@ use super::wgsl;
 use crate::WgpuServer;
 use crate::{AutoRepresentationRef, CompilerInfo};
 use cubecl_core::{
-    ExecutionMode, WgpuCompilationOptions, hash::StableHash, server::KernelArguments,
+    CubeDim, ExecutionMode, WgpuCompilationOptions, hash::StableHash, server::KernelArguments,
 };
 use cubecl_core::{MemoryConfiguration, prelude::Visibility};
 use cubecl_ir::DeviceProperties;
@@ -55,7 +55,13 @@ impl WgpuServer {
                     None => ParamsTransfer::Uniform,
                 };
                 let repr = AutoRepresentationRef::SpirV(&entry.kernel);
-                let module = self.create_module(&entry.entrypoint_name, Some(repr), "", mode)?;
+                let module = self.create_module(
+                    &entry.entrypoint_name,
+                    kernel_id.cube_dim,
+                    Some(repr),
+                    "",
+                    mode,
+                )?;
                 let pipeline =
                     self.create_pipeline(&entry.entrypoint_name, Some(repr), module, bindings);
                 Ok(Some(Ok((
@@ -75,6 +81,7 @@ impl WgpuServer {
     pub fn create_module(
         &self,
         entrypoint_name: &str,
+        cube_dim: CubeDim,
         repr: Option<AutoRepresentationRef<'_>>,
         source: &str,
         mode: ExecutionMode,
@@ -90,6 +97,10 @@ impl WgpuServer {
                     wgpu::ShaderModuleDescriptorPassthrough {
                         label: Some(entrypoint_name),
                         spirv: Some(Cow::Borrowed(&repr.assembled_module)),
+                        entry_points: Cow::Borrowed(&[wgpu::PassthroughShaderEntryPoint {
+                            name: entrypoint_name.into(),
+                            workgroup_size: cube_dim.into(),
+                        }]),
                         ..Default::default()
                     },
                 ))
@@ -100,7 +111,10 @@ impl WgpuServer {
                     wgpu::ShaderModuleDescriptorPassthrough {
                         label: Some(entrypoint_name),
                         msl: Some(Cow::Borrowed(source)),
-                        num_workgroups: (repr.cube_dim.x, repr.cube_dim.y, repr.cube_dim.z),
+                        entry_points: Cow::Borrowed(&[wgpu::PassthroughShaderEntryPoint {
+                            name: entrypoint_name.into(),
+                            workgroup_size: cube_dim.into(),
+                        }]),
                         ..Default::default()
                     },
                 ))

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -1,9 +1,15 @@
-use ash::vk::{API_VERSION_1_1, KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_NAME, MemoryHeapFlags};
+use ash::vk::{
+    self, API_VERSION_1_1, BufferDeviceAddressInfo, BufferUsageFlags,
+    KHR_GET_PHYSICAL_DEVICE_PROPERTIES2_NAME, MemoryAllocateFlags, MemoryAllocateFlagsInfo,
+    MemoryAllocateInfo, MemoryHeap, MemoryHeapFlags, MemoryPropertyFlags, PhysicalDevice,
+    SharingMode,
+};
 use cubecl_core::{
     ExecutionMode, MemoryConfiguration, WgpuCompilationOptions,
+    backtrace::BackTrace,
     ir::{AddressType, ElemType, FloatKind, IntKind, UIntKind},
     prelude::{CompiledKernel, Visibility},
-    server::{ComputeServer, KernelArguments},
+    server::{ComputeServer, IoError, KernelArguments},
 };
 use cubecl_ir::{DeviceProperties, Type, features::*};
 use cubecl_runtime::compiler::CompilationError;
@@ -167,6 +173,94 @@ fn request_device(
     }
 }
 
+pub(crate) fn create_storage_buffer(
+    wgpu_device: &wgpu::Device,
+    desc: &wgpu::BufferDescriptor,
+) -> Result<(wgpu::Buffer, u64), IoError> {
+    let device: &vulkan::Device = unsafe { &wgpu_device.as_hal::<hal::api::Vulkan>().unwrap() };
+    let instance = device.shared_instance().raw_instance();
+    let phys_device = device.raw_physical_device();
+    let device = device.raw_device();
+
+    let vk_info = ash::vk::BufferCreateInfo::default()
+        .size(desc.size)
+        .usage(
+            BufferUsageFlags::TRANSFER_SRC
+                | BufferUsageFlags::TRANSFER_DST
+                | BufferUsageFlags::STORAGE_BUFFER
+                | BufferUsageFlags::SHADER_DEVICE_ADDRESS,
+        )
+        .sharing_mode(SharingMode::EXCLUSIVE);
+
+    let buffer = unsafe {
+        device
+            .create_buffer(&vk_info, None)
+            .map_err(|err| as_io_error(err, desc.size))?
+    };
+
+    let requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
+
+    let memory_props = unsafe { instance.get_physical_device_memory_properties(phys_device) };
+    let num_types = memory_props.memory_type_count as usize;
+    let memory_types = memory_props.memory_types.iter().take(num_types);
+
+    let (memory_type_idx, _) = memory_types
+        .enumerate()
+        .filter(|(i, _)| requirements.memory_type_bits & (1 << *i) != 0)
+        .find(|(_, it)| {
+            it.property_flags
+                .contains(MemoryPropertyFlags::DEVICE_LOCAL)
+        })
+        .ok_or_else(|| IoError::Unknown {
+            description: "No device local heap found".into(),
+            backtrace: BackTrace::capture(),
+        })?;
+
+    let mut alloc_flags =
+        MemoryAllocateFlagsInfo::default().flags(MemoryAllocateFlags::DEVICE_ADDRESS);
+
+    let alloc_info = MemoryAllocateInfo::default()
+        .allocation_size(requirements.size)
+        .memory_type_index(memory_type_idx as u32)
+        .push_next(&mut alloc_flags);
+
+    let memory = unsafe {
+        device
+            .allocate_memory(&alloc_info, None)
+            .map_err(|err| as_io_error(err, desc.size))?
+    };
+    unsafe {
+        device
+            .bind_buffer_memory(buffer, memory, 0)
+            .map_err(|err| as_io_error(err, desc.size))?
+    };
+
+    let addr_info = BufferDeviceAddressInfo::default().buffer(buffer);
+    let device_address = unsafe { device.get_buffer_device_address(&addr_info) };
+
+    let buffer = unsafe {
+        wgpu::hal::vulkan::Buffer::from_raw_managed(buffer, memory, 0, requirements.size)
+    };
+    let buffer = unsafe { wgpu_device.create_buffer_from_hal::<hal::api::Vulkan>(buffer, desc) };
+
+    Ok((buffer, device_address))
+}
+
+fn as_io_error(result: vk::Result, size: u64) -> IoError {
+    match result {
+        vk::Result::ERROR_OUT_OF_HOST_MEMORY | vk::Result::ERROR_OUT_OF_DEVICE_MEMORY => {
+            IoError::BufferTooBig {
+                size,
+                backtrace: BackTrace::capture(),
+            }
+        }
+        err => IoError::Unknown {
+            description: err.to_string(),
+            backtrace: BackTrace::capture(),
+        },
+    }
+}
+
 /// Request device's supported features
 fn register_features(
     adapter: &vulkan::Adapter,
@@ -196,7 +290,7 @@ fn register_features(
 
     register_types(props, &extended_feat);
 
-    comp_options.supports_vulkan = true;
+    comp_options.supports_vulkan_compiler = true;
     comp_options.supports_u64 = extended_feat.core.shader_int64 == TRUE;
     comp_options.vulkan.max_spirv_version = extended_feat.max_spirv_version;
 
@@ -234,22 +328,17 @@ fn register_features(
 
     if let Some(index_64) = &extended_feat.index_64
         && index_64.shader64_bit_indexing == TRUE
+        && let Some(heap) =
+            device_local_heap(adapter.shared_instance(), adapter.raw_physical_device())
     {
-        let instance = adapter.shared_instance().raw_instance();
-        let device = adapter.raw_physical_device();
-        let memory_props = unsafe { instance.get_physical_device_memory_properties(device) };
-        let num_heaps = memory_props.memory_heap_count as usize;
-        let mut heaps = memory_props.memory_heaps.iter().take(num_heaps);
-        if let Some(heap) = heaps.find(|it| it.flags.contains(MemoryHeapFlags::DEVICE_LOCAL)) {
-            let heap_size = heap.size;
-            let max_page_size = match memory_config {
-                #[cfg(not(exclusive_memory_only))]
-                MemoryConfiguration::SubSlices => heap_size / 4,
-                MemoryConfiguration::ExclusivePages => heap_size,
-                MemoryConfiguration::Custom { .. } => heap_size,
-            };
-            props.memory.max_page_size = max_page_size;
-        }
+        let heap_size = heap.size;
+        let max_page_size = match memory_config {
+            #[cfg(not(exclusive_memory_only))]
+            MemoryConfiguration::SubSlices => heap_size / 4,
+            MemoryConfiguration::ExclusivePages => heap_size,
+            MemoryConfiguration::Custom { .. } => heap_size,
+        };
+        props.memory.max_page_size = max_page_size;
     }
 
     if extended_feat.cooperative_matrix.is_some() {
@@ -257,6 +346,19 @@ fn register_features(
     }
 
     true
+}
+
+fn device_local_heap(instance: &InstanceShared, device: PhysicalDevice) -> Option<MemoryHeap> {
+    let memory_props = unsafe {
+        instance
+            .raw_instance()
+            .get_physical_device_memory_properties(device)
+    };
+    let num_heaps = memory_props.memory_heap_count as usize;
+    let mut heaps = memory_props.memory_heaps.iter().take(num_heaps);
+    heaps
+        .find(|it| it.flags.contains(MemoryHeapFlags::DEVICE_LOCAL))
+        .copied()
 }
 
 fn register_types(props: &mut DeviceProperties, ext_feat: &ExtendedFeatures<'_>) {

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -33,11 +33,12 @@ mod features;
 
 pub type VkSpirvCompiler = SpirvCompiler<GLCompute>;
 
-pub fn bindings(repr: &SpirvKernel, bindings: &KernelArguments) -> Vec<Visibility> {
-    if !bindings.info.data.is_empty() {
-        vec![Visibility::Uniform, repr.info_visibility]
-    } else {
-        vec![Visibility::Uniform]
+pub fn bindings(repr: &SpirvKernel, bindings: &KernelArguments) -> (Vec<Visibility>, usize) {
+    match (repr.immediate_size, bindings.info.data.is_empty()) {
+        (Some(immediate_size), true) => (vec![], immediate_size),
+        (Some(immediate_size), false) => (vec![repr.info_visibility], immediate_size),
+        (None, true) => (vec![Visibility::Uniform], 0),
+        (None, false) => (vec![Visibility::Uniform, repr.info_visibility], 0),
     }
 }
 
@@ -279,6 +280,7 @@ fn register_features(
         return false;
     }
 
+    let properties = adapter.physical_device_capabilities().properties();
     let extended_feat = ExtendedFeatures::from_adapter(ash.raw_instance(), adapter, features);
 
     if !extended_feat.has_required_features() {
@@ -292,6 +294,7 @@ fn register_features(
     comp_options.supports_vulkan_compiler = true;
     comp_options.supports_u64 = extended_feat.core.shader_int64 == TRUE;
     comp_options.vulkan.max_spirv_version = extended_feat.max_spirv_version;
+    comp_options.vulkan.push_constant_size = properties.limits.max_push_constants_size as usize;
 
     props.features.plane.insert(Plane::Sync);
 

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -33,13 +33,12 @@ mod features;
 
 pub type VkSpirvCompiler = SpirvCompiler<GLCompute>;
 
-pub fn bindings(
-    repr: &SpirvKernel,
-    bindings: &KernelArguments,
-) -> (Vec<Visibility>, Option<Visibility>, bool) {
-    let buffers: Vec<_> = repr.bindings.clone();
-    let meta = (!bindings.info.data.is_empty()).then_some(Visibility::Read);
-    (buffers, meta, repr.uniform_info)
+pub fn bindings(repr: &SpirvKernel, bindings: &KernelArguments) -> Vec<Visibility> {
+    if !bindings.info.data.is_empty() {
+        vec![Visibility::Uniform, repr.info_visibility]
+    } else {
+        vec![Visibility::Uniform]
+    }
 }
 
 pub async fn request_vulkan_device(adapter: &wgpu::Adapter) -> Option<(wgpu::Device, wgpu::Queue)> {

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -20,7 +20,7 @@ use tracel_ash::{
     vk::{ComponentTypeKHR, DeviceCreateInfo, DeviceQueueCreateInfo, ScopeKHR, TRUE},
 };
 use wgpu::{
-    DeviceDescriptor, Features, Limits,
+    BufferUsages, BufferUses, DeviceDescriptor, Features, Limits,
     hal::{
         self,
         vulkan::{self, InstanceShared},
@@ -33,12 +33,10 @@ mod features;
 
 pub type VkSpirvCompiler = SpirvCompiler<GLCompute>;
 
-pub fn bindings(repr: &SpirvKernel, bindings: &KernelArguments) -> (Vec<Visibility>, usize) {
-    match (repr.immediate_size, bindings.info.data.is_empty()) {
-        (Some(immediate_size), true) => (vec![], immediate_size),
-        (Some(immediate_size), false) => (vec![repr.info_visibility], immediate_size),
-        (None, true) => (vec![Visibility::Uniform], 0),
-        (None, false) => (vec![Visibility::Uniform, repr.info_visibility], 0),
+pub fn bindings(repr: &SpirvKernel, _bindings: &KernelArguments) -> (Vec<Visibility>, usize) {
+    match repr.immediate_size {
+        Some(immediate_size) => (vec![], immediate_size),
+        None => (vec![Visibility::Uniform], 0),
     }
 }
 
@@ -182,14 +180,12 @@ pub(crate) fn create_storage_buffer(
     let phys_device = device.raw_physical_device();
     let device = device.raw_device();
 
+    let uses = map_buffer_usage(desc.usage);
+    let usage_flags = wgpu::hal::vulkan::conv::map_buffer_usage(uses);
+
     let vk_info = ash::vk::BufferCreateInfo::default()
         .size(desc.size)
-        .usage(
-            BufferUsageFlags::TRANSFER_SRC
-                | BufferUsageFlags::TRANSFER_DST
-                | BufferUsageFlags::STORAGE_BUFFER
-                | BufferUsageFlags::SHADER_DEVICE_ADDRESS,
-        )
+        .usage(usage_flags | BufferUsageFlags::SHADER_DEVICE_ADDRESS)
         .sharing_mode(SharingMode::EXCLUSIVE);
 
     let buffer = unsafe {
@@ -259,6 +255,38 @@ fn as_io_error(result: vk::Result, size: u64) -> IoError {
             backtrace: BackTrace::capture(),
         },
     }
+}
+
+fn map_buffer_usage(usage: BufferUsages) -> BufferUses {
+    let mut u = BufferUses::empty();
+    u.set(BufferUses::MAP_READ, usage.contains(BufferUsages::MAP_READ));
+    u.set(
+        BufferUses::MAP_WRITE,
+        usage.contains(BufferUsages::MAP_WRITE),
+    );
+    u.set(BufferUses::COPY_SRC, usage.contains(BufferUsages::COPY_SRC));
+    u.set(BufferUses::COPY_DST, usage.contains(BufferUsages::COPY_DST));
+    u.set(BufferUses::INDEX, usage.contains(BufferUsages::INDEX));
+    u.set(BufferUses::VERTEX, usage.contains(BufferUsages::VERTEX));
+    u.set(BufferUses::UNIFORM, usage.contains(BufferUsages::UNIFORM));
+    u.set(
+        BufferUses::STORAGE_READ_ONLY | BufferUses::STORAGE_READ_WRITE,
+        usage.contains(BufferUsages::STORAGE),
+    );
+    u.set(BufferUses::INDIRECT, usage.contains(BufferUsages::INDIRECT));
+    u.set(
+        BufferUses::QUERY_RESOLVE,
+        usage.contains(BufferUsages::QUERY_RESOLVE),
+    );
+    u.set(
+        BufferUses::BOTTOM_LEVEL_ACCELERATION_STRUCTURE_INPUT,
+        usage.contains(BufferUsages::BLAS_INPUT),
+    );
+    u.set(
+        BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT,
+        usage.contains(BufferUsages::TLAS_INPUT),
+    );
+    u
 }
 
 /// Request device's supported features

--- a/crates/cubecl-wgpu/src/backend/wgsl.rs
+++ b/crates/cubecl-wgpu/src/backend/wgsl.rs
@@ -11,7 +11,7 @@ use crate::WgslCompiler;
 pub fn bindings(
     repr: &<WgslCompiler as Compiler>::Representation,
     args: &KernelArguments,
-) -> Vec<Visibility> {
+) -> (Vec<Visibility>, usize) {
     let mut bindings = repr
         .buffers
         .iter()
@@ -28,7 +28,7 @@ pub fn bindings(
     if !args.info.data.is_empty() {
         bindings.push(Visibility::Read);
     }
-    bindings
+    (bindings, 0)
 }
 
 pub async fn request_device(adapter: &wgpu::Adapter) -> (wgpu::Device, wgpu::Queue) {

--- a/crates/cubecl-wgpu/src/backend/wgsl.rs
+++ b/crates/cubecl-wgpu/src/backend/wgsl.rs
@@ -18,7 +18,7 @@ pub fn bindings(
         .map(|it| {
             // When slices are shared, it needs to be read-write if ANY of the slices is read-write,
             // and since we can't be sure, we'll assume everything is read-write.
-            if cfg!(exclusive_memory_only) {
+            if cfg!(exclusive_memory_only) && !it.item.elem().is_atomic() {
                 it.visibility
             } else {
                 Visibility::ReadWrite

--- a/crates/cubecl-wgpu/src/backend/wgsl.rs
+++ b/crates/cubecl-wgpu/src/backend/wgsl.rs
@@ -11,20 +11,24 @@ use crate::WgslCompiler;
 pub fn bindings(
     repr: &<WgslCompiler as Compiler>::Representation,
     args: &KernelArguments,
-) -> (Vec<Visibility>, Option<Visibility>, bool) {
-    let bindings = repr
+) -> Vec<Visibility> {
+    let mut bindings = repr
         .buffers
         .iter()
         .map(|it| {
-            if it.item.elem().is_atomic() {
-                Visibility::ReadWrite
-            } else {
+            // When slices are shared, it needs to be read-write if ANY of the slices is read-write,
+            // and since we can't be sure, we'll assume everything is read-write.
+            if cfg!(exclusive_memory_only) {
                 it.visibility
+            } else {
+                Visibility::ReadWrite
             }
         })
         .collect::<Vec<_>>();
-    let meta = (!args.info.data.is_empty()).then_some(Visibility::Read);
-    (bindings, meta, false)
+    if !args.info.data.is_empty() {
+        bindings.push(Visibility::Read);
+    }
+    bindings
 }
 
 pub async fn request_device(adapter: &wgpu::Adapter) -> (wgpu::Device, wgpu::Queue) {

--- a/crates/cubecl-wgpu/src/compute/controller.rs
+++ b/crates/cubecl-wgpu/src/compute/controller.rs
@@ -62,7 +62,7 @@ impl WgpuAllocController {
         // Needs immutable as of wgpu v29, mutable doesn't allow dereferencing as slice.
         // This only affects wgpu's internal overlap checks so it should be fine as long as we
         // map the whole buffer anyways.
-        let buf_view = buffer.get_mapped_range(..);
+        let buf_view = buffer.get_mapped_range(..).unwrap();
 
         Self {
             view: Some(buf_view),

--- a/crates/cubecl-wgpu/src/compute/mem_manager.rs
+++ b/crates/cubecl-wgpu/src/compute/mem_manager.rs
@@ -72,7 +72,7 @@ impl WgpuMemManager {
                 memory_properties.alignment as usize,
                 device.clone(),
                 BufferUsages::UNIFORM | BufferUsages::STORAGE | BufferUsages::COPY_DST,
-                false,
+                use_vulkan_compiler,
             ),
             &memory_properties,
             MemoryConfiguration::ExclusivePages,

--- a/crates/cubecl-wgpu/src/compute/mem_manager.rs
+++ b/crates/cubecl-wgpu/src/compute/mem_manager.rs
@@ -29,6 +29,7 @@ impl WgpuMemManager {
         memory_properties: MemoryDeviceProperties,
         memory_config: MemoryConfiguration,
         logger: Arc<ServerLogger>,
+        use_vulkan_compiler: bool,
     ) -> Self {
         // Allocate storage & memory management for the main memory buffers. Any calls
         // to empty() or create() with a small enough size will be allocated from this
@@ -41,6 +42,7 @@ impl WgpuMemManager {
                     | BufferUsages::COPY_SRC
                     | BufferUsages::COPY_DST
                     | BufferUsages::INDIRECT,
+                use_vulkan_compiler,
             ),
             &memory_properties,
             memory_config,
@@ -53,6 +55,7 @@ impl WgpuMemManager {
                 wgpu::COPY_BUFFER_ALIGNMENT as usize,
                 device.clone(),
                 wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                false,
             ),
             &memory_properties,
             // Unfortunately, we can't reuse a different part of a buffer for different reads, so we
@@ -69,6 +72,7 @@ impl WgpuMemManager {
                 memory_properties.alignment as usize,
                 device.clone(),
                 BufferUsages::UNIFORM | BufferUsages::STORAGE | BufferUsages::COPY_DST,
+                false,
             ),
             &memory_properties,
             MemoryConfiguration::ExclusivePages,

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -55,7 +55,7 @@ pub struct BindingsResource {
     pub info: MetadataBindingInfo,
     /// Which compiler was used. This determines the passing strategy of params.
     /// WGSL and metal use bindings, Vulkan uses buffer addresses sent via a uniform buffer.
-    pub compiler_kind: CompilerInfo,
+    pub compiler_info: CompilerInfo,
 }
 
 /// Represents a WGPU backend for scheduling tasks on streams.
@@ -137,7 +137,7 @@ impl BindingsResource {
     ) -> (Vec<WgpuResource>, Vec<WgpuResource>, Option<Addresses>) {
         let info = (!self.info.data.is_empty())
             .then(|| stream.create_uniform(bytemuck::cast_slice(&self.info.data)));
-        match self.compiler_kind {
+        match self.compiler_info {
             CompilerInfo::Vulkan { params_transfer } => {
                 let addresses = self
                     .resources

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -72,6 +72,7 @@ pub struct WgpuStreamFactory {
     tasks_max: usize,
     logger: Arc<ServerLogger>,
     count: u64,
+    use_vulkan_compiler: bool,
 }
 
 impl StreamFactory for WgpuStreamFactory {
@@ -88,12 +89,14 @@ impl StreamFactory for WgpuStreamFactory {
             self.timing_method,
             self.tasks_max,
             self.logger.clone(),
+            self.use_vulkan_compiler,
         )
     }
 }
 
 impl ScheduledWgpuBackend {
     /// Creates a new `ScheduledWgpuBackend` with the given WGPU device, queue, and configurations.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         device: wgpu::Device,
         queue: wgpu::Queue,
@@ -102,6 +105,7 @@ impl ScheduledWgpuBackend {
         timing_method: TimingMethod,
         tasks_max: usize,
         logger: Arc<ServerLogger>,
+        use_vulkan_compiler: bool,
     ) -> Self {
         Self {
             factory: WgpuStreamFactory {
@@ -113,6 +117,7 @@ impl ScheduledWgpuBackend {
                 tasks_max,
                 logger,
                 count: 0,
+                use_vulkan_compiler,
             },
         }
     }

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -135,16 +135,6 @@ impl BindingsResource {
         let (mut resources, extra) = match self.compiler_kind {
             #[cfg(feature = "spirv")]
             CompilerKind::Vulkan => {
-                let buffer_transitions =
-                    self.resources
-                        .iter()
-                        .map(|resource| wgpu::BufferTransition {
-                            buffer: &resource.buffer,
-                            state: wgpu::BufferUses::STORAGE_READ_WRITE,
-                        });
-                stream
-                    .encoder
-                    .transition_resources(buffer_transitions, core::iter::empty());
                 let addresses = self
                     .resources
                     .iter()

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -1,9 +1,10 @@
-use crate::{WgpuResource, stream::WgpuStream};
+use crate::{CompilerKind, WgpuResource, stream::WgpuStream};
 use alloc::sync::Arc;
 use cubecl_common::{bytes::Bytes, profile::TimingMethod};
 use cubecl_core::{
     CubeCount, MemoryConfiguration,
     server::{MetadataBindingInfo, StreamErrorMode},
+    zspace::SmallVec,
 };
 use cubecl_ir::MemoryDeviceProperties;
 use cubecl_runtime::{
@@ -52,6 +53,9 @@ pub struct BindingsResource {
     pub resources: Vec<WgpuResource>,
     /// Metadata for uniform bindings.
     pub info: MetadataBindingInfo,
+    /// Which compiler was used. This determines the passing strategy of params.
+    /// WGSL and metal use bindings, Vulkan uses buffer addresses sent via a uniform buffer.
+    pub compiler_kind: CompilerKind,
 }
 
 /// Represents a WGPU backend for scheduling tasks on streams.
@@ -123,17 +127,31 @@ impl ScheduledWgpuBackend {
     }
 }
 
+type Addresses = SmallVec<[u64; 8]>;
+
 impl BindingsResource {
     /// Converts metadata and scalar bindings into WGPU resources for a stream.
-    pub fn into_resources(mut self, stream: &mut WgpuStream) -> Vec<WgpuResource> {
+    pub fn into_resources(self, stream: &mut WgpuStream) -> Vec<WgpuResource> {
+        let mut resources = match self.compiler_kind {
+            CompilerKind::Vulkan => {
+                let addresses = self
+                    .resources
+                    .iter()
+                    .map(|it| it.address.unwrap().get() + it.offset)
+                    .collect::<Addresses>();
+                let params = stream.create_uniform(bytemuck::cast_slice(&addresses));
+                vec![params]
+            }
+            _ => self.resources,
+        };
         // If metadata contains data, create a uniform buffer for it.
         if !self.info.data.is_empty() {
             let info = stream.create_uniform(bytemuck::cast_slice(&self.info.data));
-            self.resources.push(info);
+            resources.push(info);
         }
 
         // Return the complete list of resources.
-        self.resources
+        resources
     }
 }
 

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -132,16 +132,22 @@ pub type Addresses = SmallVec<[u64; 8]>;
 impl BindingsResource {
     /// Converts metadata and scalar bindings into WGPU resources for a stream.
     pub fn into_resources(
-        self,
+        mut self,
         stream: &mut WgpuStream,
     ) -> (Vec<WgpuResource>, Vec<WgpuResource>, Option<Addresses>) {
-        let (mut resources, extra, addresses) = match self.compiler_kind {
+        let info = (!self.info.data.is_empty())
+            .then(|| stream.create_uniform(bytemuck::cast_slice(&self.info.data)));
+        match self.compiler_kind {
             CompilerInfo::Vulkan { params_transfer } => {
                 let addresses = self
                     .resources
                     .iter()
+                    .chain(info.iter())
                     .map(|it| it.address.unwrap().get() + it.offset)
                     .collect::<Addresses>();
+                if let Some(info) = info {
+                    self.resources.push(info);
+                }
                 match params_transfer {
                     ParamsTransfer::Immediate => (vec![], self.resources, Some(addresses)),
                     ParamsTransfer::Uniform => {
@@ -151,16 +157,13 @@ impl BindingsResource {
                     }
                 }
             }
-            _ => (self.resources, vec![], None),
-        };
-        // If metadata contains data, create a uniform buffer for it.
-        if !self.info.data.is_empty() {
-            let info = stream.create_uniform(bytemuck::cast_slice(&self.info.data));
-            resources.push(info);
+            _ => {
+                if let Some(info) = info {
+                    self.resources.push(info);
+                }
+                (self.resources, vec![], None)
+            }
         }
-
-        // Return the complete list of resources.
-        (resources, extra, addresses)
     }
 }
 

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -131,18 +131,29 @@ type Addresses = SmallVec<[u64; 8]>;
 
 impl BindingsResource {
     /// Converts metadata and scalar bindings into WGPU resources for a stream.
-    pub fn into_resources(self, stream: &mut WgpuStream) -> Vec<WgpuResource> {
-        let mut resources = match self.compiler_kind {
+    pub fn into_resources(self, stream: &mut WgpuStream) -> (Vec<WgpuResource>, Vec<WgpuResource>) {
+        let (mut resources, extra) = match self.compiler_kind {
+            #[cfg(feature = "spirv")]
             CompilerKind::Vulkan => {
+                let buffer_transitions =
+                    self.resources
+                        .iter()
+                        .map(|resource| wgpu::BufferTransition {
+                            buffer: &resource.buffer,
+                            state: wgpu::BufferUses::STORAGE_READ_WRITE,
+                        });
+                stream
+                    .encoder
+                    .transition_resources(buffer_transitions, core::iter::empty());
                 let addresses = self
                     .resources
                     .iter()
                     .map(|it| it.address.unwrap().get() + it.offset)
                     .collect::<Addresses>();
                 let params = stream.create_uniform(bytemuck::cast_slice(&addresses));
-                vec![params]
+                (vec![params], self.resources)
             }
-            _ => self.resources,
+            _ => (self.resources, vec![]),
         };
         // If metadata contains data, create a uniform buffer for it.
         if !self.info.data.is_empty() {
@@ -151,7 +162,7 @@ impl BindingsResource {
         }
 
         // Return the complete list of resources.
-        resources
+        (resources, extra)
     }
 }
 

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -1,4 +1,4 @@
-use crate::{CompilerKind, WgpuResource, stream::WgpuStream};
+use crate::{CompilerInfo, ParamsTransfer, WgpuResource, stream::WgpuStream};
 use alloc::sync::Arc;
 use cubecl_common::{bytes::Bytes, profile::TimingMethod};
 use cubecl_core::{
@@ -55,7 +55,7 @@ pub struct BindingsResource {
     pub info: MetadataBindingInfo,
     /// Which compiler was used. This determines the passing strategy of params.
     /// WGSL and metal use bindings, Vulkan uses buffer addresses sent via a uniform buffer.
-    pub compiler_kind: CompilerKind,
+    pub compiler_kind: CompilerInfo,
 }
 
 /// Represents a WGPU backend for scheduling tasks on streams.
@@ -127,22 +127,31 @@ impl ScheduledWgpuBackend {
     }
 }
 
-type Addresses = SmallVec<[u64; 8]>;
+pub type Addresses = SmallVec<[u64; 8]>;
 
 impl BindingsResource {
     /// Converts metadata and scalar bindings into WGPU resources for a stream.
-    pub fn into_resources(self, stream: &mut WgpuStream) -> (Vec<WgpuResource>, Vec<WgpuResource>) {
-        let (mut resources, extra) = match self.compiler_kind {
-            CompilerKind::Vulkan => {
+    pub fn into_resources(
+        self,
+        stream: &mut WgpuStream,
+    ) -> (Vec<WgpuResource>, Vec<WgpuResource>, Option<Addresses>) {
+        let (mut resources, extra, addresses) = match self.compiler_kind {
+            CompilerInfo::Vulkan { params_transfer } => {
                 let addresses = self
                     .resources
                     .iter()
                     .map(|it| it.address.unwrap().get() + it.offset)
                     .collect::<Addresses>();
-                let params = stream.create_uniform(bytemuck::cast_slice(&addresses));
-                (vec![params], self.resources)
+                match params_transfer {
+                    ParamsTransfer::Immediate => (vec![], self.resources, Some(addresses)),
+                    ParamsTransfer::Uniform => {
+                        let address_buffer =
+                            stream.create_uniform(bytemuck::cast_slice(&addresses));
+                        (vec![address_buffer], self.resources, None)
+                    }
+                }
             }
-            _ => (self.resources, vec![]),
+            _ => (self.resources, vec![], None),
         };
         // If metadata contains data, create a uniform buffer for it.
         if !self.info.data.is_empty() {
@@ -151,7 +160,7 @@ impl BindingsResource {
         }
 
         // Return the complete list of resources.
-        (resources, extra)
+        (resources, extra, addresses)
     }
 }
 

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -133,7 +133,6 @@ impl BindingsResource {
     /// Converts metadata and scalar bindings into WGPU resources for a stream.
     pub fn into_resources(self, stream: &mut WgpuStream) -> (Vec<WgpuResource>, Vec<WgpuResource>) {
         let (mut resources, extra) = match self.compiler_kind {
-            #[cfg(feature = "spirv")]
             CompilerKind::Vulkan => {
                 let addresses = self
                     .resources

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -80,6 +80,7 @@ impl WgpuServer {
             timing_method,
             tasks_max,
             utilities.logger.clone(),
+            compilation_options.supports_vulkan_compiler,
         );
 
         let config = GlobalConfig::get();
@@ -448,7 +449,9 @@ fn compiler(backend: wgpu::Backend, options: &WgpuCompilationOptions) -> AutoCom
     let _ = options; // Unused without `spirv` feature
     match backend {
         #[cfg(feature = "spirv")]
-        wgpu::Backend::Vulkan if options.supports_vulkan => AutoCompiler::SpirV(Default::default()),
+        wgpu::Backend::Vulkan if options.supports_vulkan_compiler => {
+            AutoCompiler::SpirV(Default::default())
+        }
         #[cfg(feature = "msl")]
         wgpu::Backend::Metal => AutoCompiler::Msl(Default::default()),
         _ => AutoCompiler::Wgsl(Default::default()),

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -141,7 +141,7 @@ impl WgpuServer {
     fn prepare_bindings(
         &mut self,
         bindings: KernelArguments,
-        compiler_kind: CompilerInfo,
+        compiler_info: CompilerInfo,
     ) -> Result<BindingsResource, IoError> {
         // Store all the resources we'll be using. This could be eliminated if
         // there was a way to tie the lifetime of the resource to the memory handle.
@@ -156,7 +156,7 @@ impl WgpuServer {
         Ok(BindingsResource {
             resources,
             info: bindings.info,
-            compiler_kind,
+            compiler_kind: compiler_info,
         })
     }
 
@@ -397,7 +397,7 @@ impl ComputeServer for WgpuServer {
         mode: ExecutionMode,
         stream_id: StreamId,
     ) {
-        let (pipeline, compiler_kind) = match self.pipeline(kernel, &args, mode) {
+        let (pipeline, compiler_info) = match self.pipeline(kernel, &args, mode) {
             Ok(val) => val,
             Err(err) => {
                 // We make the stream that would execute the kernel in error.
@@ -412,7 +412,7 @@ impl ComputeServer for WgpuServer {
             .iter()
             .for_each(|b| self.streams_pool.push(b.stream));
 
-        let resources = match self.prepare_bindings(args, compiler_kind) {
+        let resources = match self.prepare_bindings(args, compiler_info) {
             Ok(val) => val,
             Err(err) => {
                 // We make the stream that would execute the kernel in error.

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -156,7 +156,7 @@ impl WgpuServer {
         Ok(BindingsResource {
             resources,
             info: bindings.info,
-            compiler_kind: compiler_info,
+            compiler_info,
         })
     }
 
@@ -220,7 +220,7 @@ impl WgpuServer {
         //     // std::process::exit(status.code().unwrap());
         // }
         let repr = compiled.repr.as_ref().map(|it| it.as_ref());
-        let compiler_kind = match &repr {
+        let compiler_info = match &repr {
             #[cfg(feature = "spirv")]
             Some(AutoRepresentationRef::SpirV(repr)) => CompilerInfo::Vulkan {
                 params_transfer: match repr.immediate_size {
@@ -237,7 +237,7 @@ impl WgpuServer {
         let module = self.create_module(&compiled.entrypoint_name, repr, &compiled.source, mode)?;
         let pipeline = self.create_pipeline(&compiled.entrypoint_name, repr, module, bindings);
         self.pipelines
-            .insert(kernel_id.clone(), (pipeline.clone(), compiler_kind));
+            .insert(kernel_id.clone(), (pipeline.clone(), compiler_info));
 
         #[cfg(feature = "spirv")]
         if let Some(Err(key)) = cached
@@ -253,7 +253,7 @@ impl WgpuServer {
             }
         }
 
-        Ok((pipeline, compiler_kind))
+        Ok((pipeline, compiler_info))
     }
 
     fn validate_shared(&self, repr: &Option<crate::AutoRepresentation>) -> Result<(), LaunchError> {

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -1,6 +1,9 @@
 use super::storage::{WgpuResource, WgpuStorage};
-use crate::schedule::{BindingsResource, ScheduleTask, ScheduledWgpuBackend};
 use crate::{AutoCompiler, AutoRepresentation};
+use crate::{
+    AutoRepresentationRef,
+    schedule::{BindingsResource, ScheduleTask, ScheduledWgpuBackend},
+};
 use alloc::sync::Arc;
 use cubecl_common::{
     backtrace::BackTrace,
@@ -38,13 +41,22 @@ use cubecl_runtime::{
 use hashbrown::HashMap;
 use wgpu::ComputePipeline;
 
+/// Compiler kind used when compiling a specific kernel. Used to determine parameter passing strategies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompilerKind {
+    Vulkan,
+    Metal,
+    WGSL,
+    None,
+}
+
 /// Wgpu compute server.
 #[derive(Debug)]
 pub struct WgpuServer {
     pub(crate) device: wgpu::Device,
     // A buffer that can be used to store stream id without extra allocations.
     streams_pool: Vec<StreamId>,
-    pipelines: HashMap<KernelId, Arc<ComputePipeline>>,
+    pipelines: HashMap<KernelId, (Arc<ComputePipeline>, CompilerKind)>,
     scheduler: SchedulerMultiStream<ScheduledWgpuBackend>,
     #[cfg(feature = "spirv")]
     pub(crate) spirv_cache:
@@ -118,7 +130,11 @@ impl WgpuServer {
         }
     }
 
-    fn prepare_bindings(&mut self, bindings: KernelArguments) -> Result<BindingsResource, IoError> {
+    fn prepare_bindings(
+        &mut self,
+        bindings: KernelArguments,
+        compiler_kind: CompilerKind,
+    ) -> Result<BindingsResource, IoError> {
         // Store all the resources we'll be using. This could be eliminated if
         // there was a way to tie the lifetime of the resource to the memory handle.
         let mut resources = Vec::with_capacity(bindings.buffers.len());
@@ -132,6 +148,7 @@ impl WgpuServer {
         Ok(BindingsResource {
             resources,
             info: bindings.info,
+            compiler_kind,
         })
     }
 
@@ -140,7 +157,7 @@ impl WgpuServer {
         kernel: <Self as ComputeServer>::Kernel,
         bindings: &KernelArguments,
         mode: ExecutionMode,
-    ) -> Result<Arc<ComputePipeline>, LaunchError> {
+    ) -> Result<(Arc<ComputePipeline>, CompilerKind), LaunchError> {
         let mut kernel_id = kernel.id();
         kernel_id.mode(mode);
 
@@ -195,9 +212,19 @@ impl WgpuServer {
         //     // std::process::exit(status.code().unwrap());
         // }
         let repr = compiled.repr.as_ref().map(|it| it.as_ref());
+        let compiler_kind = match &repr {
+            #[cfg(feature = "spirv")]
+            Some(AutoRepresentationRef::SpirV(_)) => CompilerKind::Vulkan,
+            #[cfg(feature = "msl")]
+            Some(AutoRepresentationRef::Msl(_)) => CompilerKind::Metal,
+            Some(AutoRepresentationRef::Wgsl(_)) => CompilerKind::WGSL,
+            None => CompilerKind::None,
+        };
+
         let module = self.create_module(&compiled.entrypoint_name, repr, &compiled.source, mode)?;
         let pipeline = self.create_pipeline(&compiled.entrypoint_name, repr, module, bindings);
-        self.pipelines.insert(kernel_id.clone(), pipeline.clone());
+        self.pipelines
+            .insert(kernel_id.clone(), (pipeline.clone(), compiler_kind));
 
         #[cfg(feature = "spirv")]
         if let Some(Err(key)) = cached
@@ -213,7 +240,7 @@ impl WgpuServer {
             }
         }
 
-        Ok(pipeline)
+        Ok((pipeline, compiler_kind))
     }
 
     fn validate_shared(&self, repr: &Option<crate::AutoRepresentation>) -> Result<(), LaunchError> {
@@ -357,7 +384,7 @@ impl ComputeServer for WgpuServer {
         mode: ExecutionMode,
         stream_id: StreamId,
     ) {
-        let pipeline = match self.pipeline(kernel, &args, mode) {
+        let (pipeline, compiler_kind) = match self.pipeline(kernel, &args, mode) {
             Ok(val) => val,
             Err(err) => {
                 // We make the stream that would execute the kernel in error.
@@ -372,7 +399,7 @@ impl ComputeServer for WgpuServer {
             .iter()
             .for_each(|b| self.streams_pool.push(b.stream));
 
-        let resources = match self.prepare_bindings(args) {
+        let resources = match self.prepare_bindings(args, compiler_kind) {
             Ok(val) => val,
             Err(err) => {
                 // We make the stream that would execute the kernel in error.

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -234,7 +234,13 @@ impl WgpuServer {
             None => CompilerInfo::None,
         };
 
-        let module = self.create_module(&compiled.entrypoint_name, repr, &compiled.source, mode)?;
+        let module = self.create_module(
+            &compiled.entrypoint_name,
+            kernel_id.cube_dim,
+            repr,
+            &compiled.source,
+            mode,
+        )?;
         let pipeline = self.create_pipeline(&compiled.entrypoint_name, repr, module, bindings);
         self.pipelines
             .insert(kernel_id.clone(), (pipeline.clone(), compiler_info));

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -41,10 +41,16 @@ use cubecl_runtime::{
 use hashbrown::HashMap;
 use wgpu::ComputePipeline;
 
-/// Compiler kind used when compiling a specific kernel. Used to determine parameter passing strategies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CompilerKind {
-    Vulkan,
+pub enum ParamsTransfer {
+    Immediate,
+    Uniform,
+}
+
+/// Compiler kind and info used when compiling a specific kernel. Used to determine parameter passing strategies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompilerInfo {
+    Vulkan { params_transfer: ParamsTransfer },
     Metal,
     WGSL,
     None,
@@ -56,7 +62,7 @@ pub struct WgpuServer {
     pub(crate) device: wgpu::Device,
     // A buffer that can be used to store stream id without extra allocations.
     streams_pool: Vec<StreamId>,
-    pipelines: HashMap<KernelId, (Arc<ComputePipeline>, CompilerKind)>,
+    pipelines: HashMap<KernelId, (Arc<ComputePipeline>, CompilerInfo)>,
     scheduler: SchedulerMultiStream<ScheduledWgpuBackend>,
     #[cfg(feature = "spirv")]
     pub(crate) spirv_cache:
@@ -84,6 +90,8 @@ impl WgpuServer {
         timing_method: TimingMethod,
         utilities: ServerUtilities<Self>,
     ) -> Self {
+        #[cfg(feature = "spirv")]
+        let adapter_info = device.adapter_info();
         let backend_scheduler = ScheduledWgpuBackend::new(
             device.clone(),
             queue.clone(),
@@ -118,7 +126,7 @@ impl WgpuServer {
                 if let Some(cache) = &config.compilation.cache {
                     let root = cache.root();
                     Some(CompilationCache::new(
-                        "spirv",
+                        format!("spirv_{}_{}", adapter_info.vendor, adapter_info.device),
                         CacheOption::default().name("vulkan").root(root),
                     ))
                 } else {
@@ -133,7 +141,7 @@ impl WgpuServer {
     fn prepare_bindings(
         &mut self,
         bindings: KernelArguments,
-        compiler_kind: CompilerKind,
+        compiler_kind: CompilerInfo,
     ) -> Result<BindingsResource, IoError> {
         // Store all the resources we'll be using. This could be eliminated if
         // there was a way to tie the lifetime of the resource to the memory handle.
@@ -157,7 +165,7 @@ impl WgpuServer {
         kernel: <Self as ComputeServer>::Kernel,
         bindings: &KernelArguments,
         mode: ExecutionMode,
-    ) -> Result<(Arc<ComputePipeline>, CompilerKind), LaunchError> {
+    ) -> Result<(Arc<ComputePipeline>, CompilerInfo), LaunchError> {
         let mut kernel_id = kernel.id();
         kernel_id.mode(mode);
 
@@ -214,11 +222,16 @@ impl WgpuServer {
         let repr = compiled.repr.as_ref().map(|it| it.as_ref());
         let compiler_kind = match &repr {
             #[cfg(feature = "spirv")]
-            Some(AutoRepresentationRef::SpirV(_)) => CompilerKind::Vulkan,
+            Some(AutoRepresentationRef::SpirV(repr)) => CompilerInfo::Vulkan {
+                params_transfer: match repr.immediate_size {
+                    Some(_) => ParamsTransfer::Immediate,
+                    None => ParamsTransfer::Uniform,
+                },
+            },
             #[cfg(feature = "msl")]
-            Some(AutoRepresentationRef::Msl(_)) => CompilerKind::Metal,
-            Some(AutoRepresentationRef::Wgsl(_)) => CompilerKind::WGSL,
-            None => CompilerKind::None,
+            Some(AutoRepresentationRef::Msl(_)) => CompilerInfo::Metal,
+            Some(AutoRepresentationRef::Wgsl(_)) => CompilerInfo::WGSL,
+            None => CompilerInfo::None,
         };
 
         let module = self.create_module(&compiled.entrypoint_name, repr, &compiled.source, mode)?;

--- a/crates/cubecl-wgpu/src/compute/storage.rs
+++ b/crates/cubecl-wgpu/src/compute/storage.rs
@@ -11,10 +11,11 @@ const MIN_BUFFER_SIZE: u64 = 32;
 
 /// Buffer storage for wgpu.
 pub struct WgpuStorage {
-    memory: HashMap<StorageId, wgpu::Buffer>,
+    memory: HashMap<StorageId, WgpuMemory>,
     device: wgpu::Device,
     buffer_usages: BufferUsages,
     mem_alignment: usize,
+    vk_storage: bool,
 }
 
 impl core::fmt::Debug for WgpuStorage {
@@ -28,6 +29,8 @@ impl core::fmt::Debug for WgpuStorage {
 pub struct WgpuResource {
     /// The wgpu buffer.
     pub buffer: wgpu::Buffer,
+    /// The buffer device address, if supported
+    pub address: Option<NonZeroU64>,
     /// The buffer offset.
     pub offset: u64,
     /// The size of the resource.
@@ -36,6 +39,15 @@ pub struct WgpuResource {
     ///
     /// The result considers the offset.
     pub size: u64,
+}
+
+/// The memory that can be allocated for wgpu.
+#[derive(new, Debug)]
+pub struct WgpuMemory {
+    /// The wgpu buffer.
+    pub buffer: wgpu::Buffer,
+    /// The buffer device address, if supported
+    pub address: Option<NonZeroU64>,
 }
 
 impl WgpuResource {
@@ -64,12 +76,18 @@ impl WgpuResource {
 /// Keeps actual wgpu buffer references in a hashmap with ids as key.
 impl WgpuStorage {
     /// Create a new storage on the given [device](wgpu::Device).
-    pub fn new(mem_alignment: usize, device: wgpu::Device, usages: BufferUsages) -> Self {
+    pub fn new(
+        mem_alignment: usize,
+        device: wgpu::Device,
+        usages: BufferUsages,
+        vk_storage: bool,
+    ) -> Self {
         Self {
             memory: HashMap::new(),
             device,
             buffer_usages: usages,
             mem_alignment,
+            vk_storage,
         }
     }
 }
@@ -82,8 +100,13 @@ impl ComputeStorage for WgpuStorage {
     }
 
     fn get(&mut self, handle: &StorageHandle) -> Self::Resource {
-        let buffer = self.memory.get(&handle.id).unwrap();
-        WgpuResource::new(buffer.clone(), handle.offset(), handle.size())
+        let memory = self.memory.get(&handle.id).unwrap();
+        WgpuResource::new(
+            memory.buffer.clone(),
+            memory.address,
+            handle.offset(),
+            handle.size(),
+        )
     }
 
     #[cfg_attr(
@@ -95,14 +118,14 @@ impl ComputeStorage for WgpuStorage {
 
         let alloc_size = size.max(MIN_BUFFER_SIZE);
 
-        let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+        let memory = self.create_buffer(&wgpu::BufferDescriptor {
             label: None,
             size: alloc_size,
             usage: self.buffer_usages,
             mapped_at_creation: false,
-        });
+        })?;
 
-        self.memory.insert(id, buffer);
+        self.memory.insert(id, memory);
         Ok(StorageHandle::new(
             id,
             StorageUtilization { offset: 0, size },
@@ -116,5 +139,27 @@ impl ComputeStorage for WgpuStorage {
 
     fn flush(&mut self) {
         // We don't wait for dealloc
+    }
+}
+
+impl WgpuStorage {
+    #[cfg(feature = "spirv")]
+    fn create_buffer(&self, desc: &wgpu::BufferDescriptor<'_>) -> Result<WgpuMemory, IoError> {
+        if self.vk_storage {
+            // wgpu currently doesn't expose this, even though it's used internally for acceleration
+            // structures. While we could use the acceleration structure input flag, that would
+            // then require ray tracing to be supported. So we need to allocate manually, then import
+            // the native buffer into wgpu using `from_raw_managed`.
+            // This actually skips some of the buffer batching stuff we don't really want in `gpu_allocator`.
+            let (buffer, addr) = crate::backend::vulkan::create_storage_buffer(&self.device, desc)?;
+            Ok(WgpuMemory::new(buffer, NonZeroU64::new(addr)))
+        } else {
+            Ok(WgpuMemory::new(self.device.create_buffer(desc), None))
+        }
+    }
+
+    #[cfg(not(feature = "spirv"))]
+    fn create_buffer(&self, desc: &wgpu::BufferDescriptor<'_>) -> Result<WgpuMemory, IoError> {
+        Ok(WgpuMemory::new(self.device.create_buffer(desc), None))
     }
 }

--- a/crates/cubecl-wgpu/src/compute/storage.rs
+++ b/crates/cubecl-wgpu/src/compute/storage.rs
@@ -15,6 +15,7 @@ pub struct WgpuStorage {
     device: wgpu::Device,
     buffer_usages: BufferUsages,
     mem_alignment: usize,
+    #[allow(unused, reason = "keep it simple")]
     vk_storage: bool,
 }
 

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -46,6 +46,7 @@ pub struct WgpuStream {
 
 impl WgpuStream {
     /// Creates a new WGPU stream.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         device: wgpu::Device,
         queue: wgpu::Queue,
@@ -54,6 +55,7 @@ impl WgpuStream {
         timing_method: TimingMethod,
         tasks_max: usize,
         logger: Arc<ServerLogger>,
+        use_vulkan_compiler: bool,
     ) -> Self {
         let timings = if timing_method == TimingMethod::Device {
             Timings::Device(QueryProfiler::new(&queue, &device))
@@ -71,8 +73,13 @@ impl WgpuStream {
         let poll = WgpuPoll::new(device.clone());
 
         #[allow(unused_mut)]
-        let mut mem_manage =
-            WgpuMemManager::new(device.clone(), memory_properties, memory_config, logger);
+        let mut mem_manage = WgpuMemManager::new(
+            device.clone(),
+            memory_properties,
+            memory_config,
+            logger,
+            use_vulkan_compiler,
+        );
 
         Self {
             mem_manage,

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -1,5 +1,9 @@
 use super::{mem_manager::WgpuMemManager, poll::WgpuPoll, timings::QueryProfiler};
-use crate::{WgpuResource, controller::WgpuAllocController, schedule::ScheduleTask};
+use crate::{
+    WgpuResource,
+    controller::WgpuAllocController,
+    schedule::{Addresses, ScheduleTask},
+};
 use core::iter;
 use cubecl_common::{
     backtrace::BackTrace,
@@ -126,8 +130,14 @@ impl WgpuStream {
                 count,
                 resources,
             } => {
-                let (resources, custom_handles) = resources.into_resources(self);
-                self.register_pipeline(pipeline, resources.iter(), &custom_handles, &count);
+                let (resources, custom_handles, addresses) = resources.into_resources(self);
+                self.register_pipeline(
+                    pipeline,
+                    resources.iter(),
+                    &custom_handles,
+                    addresses,
+                    &count,
+                );
             }
         }
     }
@@ -545,6 +555,7 @@ impl WgpuStream {
         pipeline: Arc<ComputePipeline>,
         resources: impl Iterator<Item = &'a WgpuResource>,
         custom_resources: &[WgpuResource],
+        addresses: Option<Addresses>,
         dispatch: &CubeCount,
     ) {
         if dispatch.is_empty() {
@@ -593,6 +604,10 @@ impl WgpuStream {
 
         pass.set_pipeline(&pipeline);
         pass.set_bind_group(0, &bind_group, &[]);
+
+        if let Some(addresses) = addresses {
+            pass.set_immediates(0, bytemuck::cast_slice(&addresses));
+        }
 
         if !custom_resources.is_empty() {
             let buffer_transitions =

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -4,7 +4,9 @@ use crate::{
     controller::WgpuAllocController,
     schedule::{Addresses, ScheduleTask},
 };
-use core::{cell::LazyCell, iter, ptr::null};
+use core::iter;
+#[cfg(feature = "renderdoc")]
+use core::{cell::LazyCell, ptr::null};
 use cubecl_common::{
     backtrace::BackTrace,
     bytes::Bytes,

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -1,5 +1,6 @@
 use super::{mem_manager::WgpuMemManager, poll::WgpuPoll, timings::QueryProfiler};
 use crate::{WgpuResource, controller::WgpuAllocController, schedule::ScheduleTask};
+use core::iter;
 use cubecl_common::{
     backtrace::BackTrace,
     bytes::Bytes,
@@ -35,14 +36,13 @@ pub struct WgpuStream {
     tasks_count: usize,
     tasks_max: usize,
     queue: wgpu::Queue,
-    pub encoder: wgpu::CommandEncoder,
+    encoder: wgpu::CommandEncoder,
     poll: WgpuPoll,
     submission_load: SubmissionLoad,
     /// Number of consecutive `write_buffer` calls without a `queue.submit()`.
     /// Used to prevent wgpu staging buffer pool exhaustion during bulk writes
     /// (e.g. model loading with hundreds of tensors).
     pending_write_count: usize,
-    use_buffer_device_address: bool,
 }
 
 impl WgpuStream {
@@ -99,7 +99,6 @@ impl WgpuStream {
             poll,
             submission_load: SubmissionLoad::default(),
             pending_write_count: 0,
-            use_buffer_device_address: use_vulkan_compiler,
         }
     }
 
@@ -127,8 +126,8 @@ impl WgpuStream {
                 count,
                 resources,
             } => {
-                let (resources, _extra_handles) = resources.into_resources(self);
-                self.register_pipeline(pipeline, resources.iter(), &count);
+                let (resources, custom_handles) = resources.into_resources(self);
+                self.register_pipeline(pipeline, resources.iter(), &custom_handles, &count);
             }
         }
     }
@@ -545,6 +544,7 @@ impl WgpuStream {
         &mut self,
         pipeline: Arc<ComputePipeline>,
         resources: impl Iterator<Item = &'a WgpuResource>,
+        custom_resources: &[WgpuResource],
         dispatch: &CubeCount,
     ) {
         if dispatch.is_empty() {
@@ -594,6 +594,17 @@ impl WgpuStream {
         pass.set_pipeline(&pipeline);
         pass.set_bind_group(0, &bind_group, &[]);
 
+        if !custom_resources.is_empty() {
+            let buffer_transitions =
+                custom_resources
+                    .iter()
+                    .map(|resource| wgpu::BufferTransition {
+                        buffer: &resource.buffer,
+                        state: wgpu::BufferUses::STORAGE_READ_WRITE,
+                    });
+            pass.transition_resources(buffer_transitions, iter::empty())
+        }
+
         match dispatch.clone() {
             CubeCount::Static(x, y, z) => {
                 pass.dispatch_workgroups(x, y, z);
@@ -602,10 +613,6 @@ impl WgpuStream {
                 let res = self.mem_manage.get_resource(binding).unwrap();
                 pass.dispatch_workgroups_indirect(&res.buffer, res.offset);
             }
-        }
-
-        if self.use_buffer_device_address {
-            self.compute_pass = None;
         }
 
         self.flush_if_needed();

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -35,13 +35,14 @@ pub struct WgpuStream {
     tasks_count: usize,
     tasks_max: usize,
     queue: wgpu::Queue,
-    encoder: wgpu::CommandEncoder,
+    pub encoder: wgpu::CommandEncoder,
     poll: WgpuPoll,
     submission_load: SubmissionLoad,
     /// Number of consecutive `write_buffer` calls without a `queue.submit()`.
     /// Used to prevent wgpu staging buffer pool exhaustion during bulk writes
     /// (e.g. model loading with hundreds of tensors).
     pending_write_count: usize,
+    use_buffer_device_address: bool,
 }
 
 impl WgpuStream {
@@ -98,6 +99,7 @@ impl WgpuStream {
             poll,
             submission_load: SubmissionLoad::default(),
             pending_write_count: 0,
+            use_buffer_device_address: use_vulkan_compiler,
         }
     }
 
@@ -125,7 +127,7 @@ impl WgpuStream {
                 count,
                 resources,
             } => {
-                let resources = resources.into_resources(self);
+                let (resources, _extra_handles) = resources.into_resources(self);
                 self.register_pipeline(pipeline, resources.iter(), &count);
             }
         }
@@ -363,6 +365,17 @@ impl WgpuStream {
                 });
             }
 
+            #[cfg(all(test, feature = "deny-validation-errors"))]
+            {
+                let validation_errors = wgpu_hal::VALIDATION_CANARY.get_and_reset();
+                if !validation_errors.is_empty() {
+                    return Err(ServerError::Generic {
+                        reason: validation_errors.join("\n"),
+                        backtrace: BackTrace::capture(),
+                    });
+                }
+            }
+
             match flush_error {
                 Some(err) => Err(err),
                 None => Ok(()),
@@ -590,6 +603,11 @@ impl WgpuStream {
                 pass.dispatch_workgroups_indirect(&res.buffer, res.offset);
             }
         }
+
+        if self.use_buffer_device_address {
+            self.compute_pass = None;
+        }
+
         self.flush_if_needed();
     }
 

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -131,13 +131,7 @@ impl WgpuStream {
                 resources,
             } => {
                 let (resources, custom_handles, addresses) = resources.into_resources(self);
-                self.register_pipeline(
-                    pipeline,
-                    resources.iter(),
-                    &custom_handles,
-                    addresses,
-                    &count,
-                );
+                self.register_pipeline(pipeline, &resources, &custom_handles, addresses, &count);
             }
         }
     }
@@ -550,10 +544,10 @@ impl WgpuStream {
         Ok(())
     }
 
-    fn register_pipeline<'a>(
+    fn register_pipeline(
         &mut self,
         pipeline: Arc<ComputePipeline>,
-        resources: impl Iterator<Item = &'a WgpuResource>,
+        resources: &[WgpuResource],
         custom_resources: &[WgpuResource],
         addresses: Option<Addresses>,
         dispatch: &CubeCount,
@@ -563,6 +557,7 @@ impl WgpuStream {
         }
 
         let entries = resources
+            .iter()
             .enumerate()
             .map(|(i, r)| wgpu::BindGroupEntry {
                 binding: i as u32,
@@ -595,15 +590,18 @@ impl WgpuStream {
 
         self.tasks_count += 1;
 
-        let group_layout = pipeline.get_bind_group_layout(0);
-        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: None,
-            layout: &group_layout,
-            entries: &entries,
-        });
-
         pass.set_pipeline(&pipeline);
-        pass.set_bind_group(0, &bind_group, &[]);
+
+        if !resources.is_empty() {
+            let group_layout = pipeline.get_bind_group_layout(0);
+            let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &group_layout,
+                entries: &entries,
+            });
+
+            pass.set_bind_group(0, &bind_group, &[]);
+        }
 
         if let Some(addresses) = addresses {
             pass.set_immediates(0, bytemuck::cast_slice(&addresses));

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -4,12 +4,14 @@ use crate::{
     controller::WgpuAllocController,
     schedule::{Addresses, ScheduleTask},
 };
-use core::iter;
+use core::{cell::LazyCell, iter, ptr::null};
 use cubecl_common::{
     backtrace::BackTrace,
     bytes::Bytes,
     profile::{ProfileDuration, TimingMethod},
 };
+#[cfg(feature = "renderdoc")]
+use cubecl_core::stub::Mutex;
 use cubecl_core::{
     CubeCount, MemoryConfiguration,
     future::{self, DynFut},
@@ -21,8 +23,15 @@ use cubecl_runtime::{
     logging::ServerLogger, memory_management::ManagedMemoryHandle,
     timestamp_profiler::TimestampProfiler,
 };
+#[cfg(feature = "renderdoc")]
+use renderdoc::{RenderDoc, V100};
 use std::{future::Future, num::NonZero, pin::Pin, sync::Arc};
 use wgpu::ComputePipeline;
+
+#[cfg(feature = "renderdoc")]
+thread_local! {
+    static RENDERDOC: LazyCell<Option<Mutex<RenderDoc<V100>>>> = LazyCell::new(|| RenderDoc::new().ok().map(Mutex::new));
+}
 
 #[derive(Debug)]
 enum Timings {
@@ -74,6 +83,14 @@ impl WgpuStream {
             }
             Timings::System(TimestampProfiler::default())
         };
+
+        #[cfg(feature = "renderdoc")]
+        RENDERDOC.with(|renderdoc| {
+            if let Some(renderdoc) = &**renderdoc {
+                let mut renderdoc = renderdoc.lock().unwrap();
+                renderdoc.start_frame_capture(null(), null());
+            }
+        });
 
         let poll = WgpuPoll::new(device.clone());
 
@@ -515,6 +532,15 @@ impl WgpuStream {
         // Cleanup allocations and deallocations.
         self.mem_manage.memory_cleanup(false);
         self.mem_manage.release_uniforms();
+
+        #[cfg(feature = "renderdoc")]
+        RENDERDOC.with(|renderdoc| {
+            if let Some(renderdoc) = &**renderdoc {
+                let mut renderdoc = renderdoc.lock().unwrap();
+                renderdoc.end_frame_capture(null(), null());
+                renderdoc.start_frame_capture(null(), null());
+            }
+        });
 
         self.tasks_count = 0;
         self.pending_write_count = 0;

--- a/crates/cubecl-wgpu/src/compute/timings.rs
+++ b/crates/cubecl-wgpu/src/compute/timings.rs
@@ -119,7 +119,7 @@ fn get_cur_timestamp(queue: &wgpu::Queue, device: &wgpu::Device) -> u64 {
         })
         .unwrap();
 
-    let view = map_buffer.slice(..).get_mapped_range();
+    let view = map_buffer.slice(..).get_mapped_range().unwrap();
     u64::from_le_bytes((*view).try_into().unwrap())
 }
 
@@ -253,7 +253,7 @@ impl QueryProfiler {
                 // Can stop polling now.
                 core::mem::drop(poll_signal);
 
-                let binding = map_buffer.slice(..).get_mapped_range();
+                let binding = map_buffer.slice(..).get_mapped_range().unwrap();
                 let data: &[u64] = bytemuck::try_cast_slice(&binding).unwrap();
 
                 // Get nr. of ticks since epoch.

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -393,8 +393,7 @@ pub(crate) async fn create_setup_for_device(
     let (device, queue) = backend::request_device(&adapter).await;
 
     log::info!(
-        "Created wgpu compute server on device {:?} => {:?}",
-        device,
+        "Created wgpu compute server on device {:?}",
         adapter.get_info()
     );
 

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -505,6 +505,7 @@ async fn request_adapter_with_preference(
             power_preference,
             force_fallback_adapter: false,
             compatible_surface: None,
+            ..RequestAdapterOptions::default()
         })
         .await
         .expect("No possible adapter available for backend. Falling back to first available.")


### PR DESCRIPTION
Migrates Vulkan to `PhysicalStorageBuffer` / `bufferDeviceAddress` for improved performance and extra feature support in the future.
Needs an upstream feature for synchronization, but I'm creating this PR so I can point back to it and keep track.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
