### PR TITLE
Fix performance regression rocm

### DIFF
--- a/crates/cubecl-core/src/frontend/operation/branch.rs
+++ b/crates/cubecl-core/src/frontend/operation/branch.rs
@@ -26,10 +26,12 @@ pub fn select_many<C: Scalar, N: Size>(
     then: Vector<C, N>,
     or_else: Vector<C, N>,
 ) -> Vector<C, N> {
-    intrinsic!(|scope| select::expand(scope, condition.expand.into(), then, or_else))
+    intrinsic!(|scope| { { select::expand(scope, condition.expand.into(), then, or_else) } })
 }
 
 pub mod select {
+    use cubecl_ir::VariableKind;
+
     use crate::ir::Instruction;
 
     use super::*;
@@ -41,6 +43,15 @@ pub mod select {
         or_else: NativeExpand<C>,
     ) -> NativeExpand<C> {
         let cond = condition.expand.consume();
+
+        if let VariableKind::Constant(value) = cond.kind {
+            if value.as_bool() {
+                return then;
+            } else {
+                return or_else;
+            }
+        }
+
         let then = then.expand.consume();
         let or_else = or_else.expand.consume();
 

--- a/crates/cubecl-core/src/frontend/operation/branch.rs
+++ b/crates/cubecl-core/src/frontend/operation/branch.rs
@@ -26,7 +26,7 @@ pub fn select_many<C: Scalar, N: Size>(
     then: Vector<C, N>,
     or_else: Vector<C, N>,
 ) -> Vector<C, N> {
-    intrinsic!(|scope| { { select::expand(scope, condition.expand.into(), then, or_else) } })
+    intrinsic!(|scope| select::expand(scope, condition.expand.into(), then, or_else))
 }
 
 pub mod select {

--- a/crates/cubecl-cpp/src/shared/instruction.rs
+++ b/crates/cubecl-cpp/src/shared/instruction.rs
@@ -457,14 +457,21 @@ for ({i_ty} {i} = {start}; {i} {cmp} {end}; {increment}) {{
                 let cond_elem = cond.item().elem;
                 let out = out.fmt_left();
 
-                let should_broadcast =
-                    vf_cond > 1 || item_out != item_or_else || item_out != item_then;
+                // It seems to always be faster to broadcast the select, because the compiler is
+                // able to output branchless instructions when the ternary is done on native types
+                // rather than cubecl defined types.
+
+                let vf = usize::max(vf_cond, vf_out);
+                let vf = usize::max(vf, vf_then);
+                let vf = usize::max(vf, vf_or_else);
+                let should_broadcast = vf > 1;
+
+                // Keep the condition here for future testing.
+                //
+                // let should_broadcast =
+                //     vf_cond > 1 || item_out != item_or_else || item_out != item_then;
 
                 if should_broadcast {
-                    let vf = usize::max(vf_cond, vf_out);
-                    let vf = usize::max(vf, vf_then);
-                    let vf = usize::max(vf, vf_or_else);
-
                     writeln!(f, "{out} = {item_out} {{")?;
                     for i in 0..vf {
                         let theni = then.index(i);


### PR DESCRIPTION
Broadcast select operations to per-element ternaries on native types when vectorized, avoiding branching that the HIP compiler emits for struct-level ternaries.