### PR TITLE
Fix one case of unsoundness, and two other potential bugs.

### DIFF
--- a/crates/cubecl-common/src/bytes/base.rs
+++ b/crates/cubecl-common/src/bytes/base.rs
@@ -393,10 +393,12 @@ impl Bytes {
         })
     }
 
-    /// Ensure the contained buffer is aligned to `align` by possibly moving it to a new buffer.
+    /// Ensure the allocation's reported alignment is at least `align`, reallocating
+    /// into a fresh controller if not. We check the controller's reported alignment
+    /// (not the raw pointer) because downstream callers such as `try_into_vec::<E>`
+    /// depend on `alloc_align()` matching the element alignment.
     fn try_enforce_runtime_align(&mut self, align: usize) -> Result<(), LayoutError> {
-        if self.as_mut_ptr().align_offset(align) == 0 {
-            // data is already aligned correctly
+        if self.controller.alloc_align() >= align {
             return Ok(());
         }
         *self = Self::try_from_data(align, self)?;
@@ -665,6 +667,20 @@ mod tests {
         let (left, right) = bytes.split(4).unwrap();
         assert_eq!(&left[..], &[10, 20, 30, 40]);
         assert_eq!(right.len(), 0);
+    }
+
+    /// `from_bytes_vec` enforces `MAX_ALIGN`, so converting the result to a Vec of
+    /// any type whose alignment is `<= MAX_ALIGN` must succeed. We iterate so the
+    /// test hits a range of underlying allocator addresses.
+    #[test_log::test]
+    fn test_from_bytes_vec_try_into_vec_aligned_type() {
+        for _ in 0..64 {
+            let bytes = Bytes::from_bytes_vec(vec![0u8; 16]);
+            let vec: Vec<u128> = bytes
+                .try_into_vec::<u128>()
+                .expect("MAX_ALIGN-aligned bytes must convert to Vec<u128>");
+            assert_eq!(vec.len(), 1);
+        }
     }
 
     #[test_log::test]

--- a/crates/cubecl-common/src/device/handle/channel.rs
+++ b/crates/cubecl-common/src/device/handle/channel.rs
@@ -461,8 +461,8 @@ mod task {
         /// `ptr::write` (UB). The boxed fallback uses `Box::new`, whose allocation
         /// satisfies any alignment.
         pub fn init<F: FnOnce() -> TaskResult + Send + 'static>(&mut self, func: F) {
-            let fits_inline =
-                size_of::<F>() <= size_of::<SmallTaskData>() && align_of::<F>() <= INLINE_SLOT_ALIGN;
+            let fits_inline = size_of::<F>() <= size_of::<SmallTaskData>()
+                && align_of::<F>() <= INLINE_SLOT_ALIGN;
             let fits_arena =
                 size_of::<F>() <= size_of::<LargeTaskData>() && align_of::<F>() <= ARENA_SLOT_ALIGN;
 
@@ -1137,9 +1137,7 @@ mod tests {
         // Mirror the 64-aligned 4KB region that `TaskBuffer::new` allocates per slot.
         #[repr(C, align(64))]
         struct TestArena([u128; GLOBAL_TASK_MAX_SIZE / 16]);
-        let mut arena = alloc::boxed::Box::new(TestArena(
-            [0u128; GLOBAL_TASK_MAX_SIZE / 16],
-        ));
+        let mut arena = alloc::boxed::Box::new(TestArena([0u128; GLOBAL_TASK_MAX_SIZE / 16]));
         let arena_ptr = arena.0.as_mut_ptr() as *mut u8;
         let mut task = Task::new(arena_ptr);
 
@@ -1165,9 +1163,7 @@ mod tests {
 
         #[repr(C, align(64))]
         struct TestArena([u128; GLOBAL_TASK_MAX_SIZE / 16]);
-        let mut arena = alloc::boxed::Box::new(TestArena(
-            [0u128; GLOBAL_TASK_MAX_SIZE / 16],
-        ));
+        let mut arena = alloc::boxed::Box::new(TestArena([0u128; GLOBAL_TASK_MAX_SIZE / 16]));
         let arena_ptr = arena.0.as_mut_ptr() as *mut u8;
         let mut task = Task::new(arena_ptr);
 

--- a/crates/cubecl-common/src/device/handle/channel.rs
+++ b/crates/cubecl-common/src/device/handle/channel.rs
@@ -407,21 +407,15 @@ mod task {
 
     /// The maximum size of a closure that can be stored without heap allocation.
     pub const GLOBAL_TASK_MAX_SIZE: usize = 4096;
+
     /// The maximum size of a closure that can be stored using inlined memory.
     const INLINE_TASK_MAX_SIZE: usize = 48;
-    /// Alignment of every task slot, inline or arena. `ArenaSlot` enforces this on its
-    /// own via `#[repr(C, align(SLOT_ALIGN))]`; `InlineSlot` inherits it from being
-    /// the first field of `Task`, which itself is `#[repr(C, align(SLOT_ALIGN))]`.
-    /// Closures with `align_of::<F>() <= SLOT_ALIGN` fit in either slot without
-    /// falling through to the boxed path.
-    pub const SLOT_ALIGN: usize = 64;
 
-    /// One arena slot. `#[repr(C, align(SLOT_ALIGN))]` makes every slot 64-byte
+    /// One arena slot. `#[repr(C, align(64))]` makes every slot 64-byte
     /// aligned on its own, so the slot alignment does not depend on the layout of any
     /// enclosing type. `GLOBAL_TASK_MAX_SIZE` is a multiple of 64, so there is no
     /// per-slot padding.
     #[repr(C, align(64))]
-    #[derive(Clone, Copy)]
     pub struct ArenaSlot {
         pub data: [u8; GLOBAL_TASK_MAX_SIZE],
     }
@@ -446,11 +440,10 @@ mod task {
     const _: () = {
         // ArenaSlot is 4096 bytes and 64-aligned on its own.
         assert!(core::mem::size_of::<ArenaSlot>() == GLOBAL_TASK_MAX_SIZE);
-        assert!(core::mem::align_of::<ArenaSlot>() == SLOT_ALIGN);
         // `Task::data` lives at offset 0 of a 64-aligned 64-byte struct, which is
         // what lets the router assume the inline slot has `SLOT_ALIGN`-byte alignment.
         assert!(core::mem::size_of::<Task>() == 64);
-        assert!(core::mem::align_of::<Task>() == SLOT_ALIGN);
+        assert!(core::mem::align_of::<Task>() == core::mem::align_of::<ArenaSlot>());
         assert!(core::mem::offset_of!(Task, data) == 0);
     };
 
@@ -469,10 +462,10 @@ mod task {
         /// `ptr::write` (UB). The boxed fallback uses `Box::new`, whose allocation
         /// satisfies any alignment.
         pub fn init<F: FnOnce() -> TaskResult + Send + 'static>(&mut self, func: F) {
-            let fits_inline =
-                size_of::<F>() <= INLINE_TASK_MAX_SIZE && align_of::<F>() <= SLOT_ALIGN;
-            let fits_arena =
-                size_of::<F>() <= GLOBAL_TASK_MAX_SIZE && align_of::<F>() <= SLOT_ALIGN;
+            let fits_inline = size_of::<F>() <= INLINE_TASK_MAX_SIZE
+                && align_of::<F>() <= align_of::<ArenaSlot>();
+            let fits_arena = size_of::<F>() <= GLOBAL_TASK_MAX_SIZE
+                && align_of::<F>() <= align_of::<ArenaSlot>();
 
             if fits_inline {
                 // SAFETY: size + align checked above, read back exactly once by fn_ptr.
@@ -732,12 +725,11 @@ mod custom_channel {
 
     impl TaskBuffer {
         fn new() -> Self {
-            let mut arena: Vec<ArenaSlot> = std::vec![
-                ArenaSlot {
+            let mut arena: Vec<ArenaSlot> =
+                Vec::from_iter((0..CHANNEL_MAX_TASK).map(|_| ArenaSlot {
                     data: [0u8; GLOBAL_TASK_MAX_SIZE],
-                };
-                CHANNEL_MAX_TASK
-            ];
+                }));
+
             let arena_ptr = arena.as_mut_ptr() as *mut u8;
             let tasks = Vec::from_iter((0..CHANNEL_MAX_TASK).map(|index| {
                 // SAFETY: Each task owns a non-overlapping `ArenaSlot` region.

--- a/crates/cubecl-common/src/device/handle/channel.rs
+++ b/crates/cubecl-common/src/device/handle/channel.rs
@@ -255,12 +255,11 @@ struct ChannelService {
 }
 
 static RUNNERS: spin::Mutex<Option<HashMap<DeviceId, DeviceClient>>> = spin::Mutex::new(None);
-/// Per-key init slot. Concurrent callers for the same `(DeviceId, TypeId)` pair
-/// serialize on the inner `spin::Mutex`, ensuring `S::init` runs exactly once per key.
-#[allow(clippy::type_complexity)]
-static CHANNELS: spin::Mutex<
-    Option<HashMap<(DeviceId, TypeId), alloc::sync::Arc<spin::Mutex<Option<ChannelDeviceState>>>>>,
-> = spin::Mutex::new(None);
+/// Device/service map. The lock is held across the entire `init` sequence so `S::init` runs
+/// once per `(DeviceId, TypeId)` pair. This serializes channel creation across all
+/// backends.
+static CHANNELS: spin::Mutex<Option<HashMap<(DeviceId, TypeId), ChannelDeviceState>>> =
+    spin::Mutex::new(None);
 
 impl ChannelDeviceState {
     pub fn init<S: DeviceService>(
@@ -270,19 +269,14 @@ impl ChannelDeviceState {
         let type_id = TypeId::of::<S>();
         let key = (device_id, type_id);
 
-        // Fetch (or create) the per-key init slot, then hold the slot lock across the
-        // rest of the init sequence so only one caller per key runs `S::init`.
-        let init_slot = {
-            let mut guard_channel = CHANNELS.lock();
-            let channels = guard_channel.get_or_insert_with(HashMap::new);
-            channels
-                .entry(key)
-                .or_insert_with(|| alloc::sync::Arc::new(spin::Mutex::new(None)))
-                .clone()
-        };
+        // Hold the `CHANNELS` lock across the entire init sequence so that the
+        // "check missing, insert new" transition is atomic. Without this, two
+        // concurrent callers for the same key would both observe a missing entry,
+        // both run `S::init`, and race to insert.
+        let mut guard_channel = CHANNELS.lock();
+        let channels = guard_channel.get_or_insert_with(HashMap::new);
 
-        let mut slot = init_slot.lock();
-        if let Some(existing) = slot.as_ref() {
+        if let Some(existing) = channels.get(&key) {
             if service.is_some() {
                 // `insert(device, service)` cannot replace an existing state.
                 return Err(ServiceCreationError::new(
@@ -353,7 +347,7 @@ impl ChannelDeviceState {
             service,
         };
 
-        *slot = Some(channel.clone());
+        channels.insert(key, channel.clone());
 
         Ok(channel)
     }
@@ -415,18 +409,22 @@ mod task {
     pub const GLOBAL_TASK_MAX_SIZE: usize = 4096;
     /// The maximum size of a closure that can be stored using inlined memory.
     const INLINE_TASK_MAX_SIZE: usize = 48;
+    /// Alignment of every task slot, inline or arena. `ArenaSlot` enforces this on its
+    /// own via `#[repr(C, align(SLOT_ALIGN))]`; `InlineSlot` inherits it from being
+    /// the first field of `Task`, which itself is `#[repr(C, align(SLOT_ALIGN))]`.
+    /// Closures with `align_of::<F>() <= SLOT_ALIGN` fit in either slot without
+    /// falling through to the boxed path.
+    pub const SLOT_ALIGN: usize = 64;
 
-    // We use u128 to force alignment.
-    pub type LargeTaskData = [u128; GLOBAL_TASK_MAX_SIZE / 16];
-    pub type SmallTaskData = [u128; INLINE_TASK_MAX_SIZE / 16];
-
-    /// Alignment of the inline `SmallTaskData` slot inside `Task`, which is
-    /// `#[repr(C, align(64))]` with `data` as its first field.
-    pub const INLINE_SLOT_ALIGN: usize = 64;
-    /// Alignment of each arena slot. Every slot is 64-byte aligned because
-    /// `TaskBuffer` stores `Vec<SlotBuffer>` where `SlotBuffer` is
-    /// `#[repr(C, align(64))]` and the per-slot stride is a multiple of 64.
-    pub const ARENA_SLOT_ALIGN: usize = 64;
+    /// One arena slot. `#[repr(C, align(SLOT_ALIGN))]` makes every slot 64-byte
+    /// aligned on its own, so the slot alignment does not depend on the layout of any
+    /// enclosing type. `GLOBAL_TASK_MAX_SIZE` is a multiple of 64, so there is no
+    /// per-slot padding.
+    #[repr(C, align(64))]
+    #[derive(Clone, Copy)]
+    pub struct ArenaSlot {
+        pub data: [u8; GLOBAL_TASK_MAX_SIZE],
+    }
 
     /// The return type of wrapped closures.
     pub type TaskResult = ();
@@ -437,19 +435,29 @@ mod task {
     /// It fits in 64 bytes, ensuring multiple threads can initialize tasks at the same time
     /// without causing false sharing.
     pub struct Task {
-        // 48 bytes
-        data: SmallTaskData,
+        // 48 bytes; 64-aligned because it is the first field of a 64-aligned struct.
+        data: [u8; INLINE_TASK_MAX_SIZE],
         // 8 bytes (usize/u64 ptr)
         data_large_ptr: AtomicPtr<u8>,
         // 8 bytes (usize/u64 ptr)
         fn_ptr: fn(&mut Task) -> TaskResult,
     }
 
+    const _: () = {
+        // ArenaSlot is 4096 bytes and 64-aligned on its own.
+        assert!(core::mem::size_of::<ArenaSlot>() == GLOBAL_TASK_MAX_SIZE);
+        assert!(core::mem::align_of::<ArenaSlot>() == SLOT_ALIGN);
+        // `Task::data` lives at offset 0 of a 64-aligned 64-byte struct, which is
+        // what lets the router assume the inline slot has `SLOT_ALIGN`-byte alignment.
+        assert!(core::mem::size_of::<Task>() == 64);
+        assert!(core::mem::align_of::<Task>() == SLOT_ALIGN);
+        assert!(core::mem::offset_of!(Task, data) == 0);
+    };
+
     impl Task {
         pub fn new(large_data_ptr: *mut u8) -> Self {
-            debug_assert!(size_of::<Self>() == 64usize);
             Self {
-                data: [0; INLINE_TASK_MAX_SIZE / 16],
+                data: [0u8; INLINE_TASK_MAX_SIZE],
                 data_large_ptr: AtomicPtr::new(large_data_ptr),
                 fn_ptr: |_| {},
             }
@@ -461,10 +469,10 @@ mod task {
         /// `ptr::write` (UB). The boxed fallback uses `Box::new`, whose allocation
         /// satisfies any alignment.
         pub fn init<F: FnOnce() -> TaskResult + Send + 'static>(&mut self, func: F) {
-            let fits_inline = size_of::<F>() <= size_of::<SmallTaskData>()
-                && align_of::<F>() <= INLINE_SLOT_ALIGN;
+            let fits_inline =
+                size_of::<F>() <= INLINE_TASK_MAX_SIZE && align_of::<F>() <= SLOT_ALIGN;
             let fits_arena =
-                size_of::<F>() <= size_of::<LargeTaskData>() && align_of::<F>() <= ARENA_SLOT_ALIGN;
+                size_of::<F>() <= GLOBAL_TASK_MAX_SIZE && align_of::<F>() <= SLOT_ALIGN;
 
             if fits_inline {
                 // SAFETY: size + align checked above, read back exactly once by fn_ptr.
@@ -589,7 +597,7 @@ mod custom_channel {
         DeviceId,
         handle::{
             CallError,
-            channel::task::{GLOBAL_TASK_MAX_SIZE, Task, TaskResult},
+            channel::task::{ArenaSlot, GLOBAL_TASK_MAX_SIZE, Task, TaskResult},
         },
     };
     use core::{
@@ -716,38 +724,23 @@ mod custom_channel {
         }
     }
 
-    /// A single arena slot. `#[repr(C, align(64))]` makes every slot 64-byte aligned,
-    /// matching the inline task slot so the router can store closures with
-    /// `align_of::<F>()` up to 64 in either location. `GLOBAL_TASK_MAX_SIZE` is a
-    /// multiple of 64, so there is no per-slot padding.
-    #[repr(C, align(64))]
-    #[derive(Clone, Copy)]
-    struct SlotBuffer {
-        data: [u128; GLOBAL_TASK_MAX_SIZE / 16],
-    }
-
-    const _: () = {
-        assert!(core::mem::size_of::<SlotBuffer>() == GLOBAL_TASK_MAX_SIZE);
-        assert!(core::mem::align_of::<SlotBuffer>() == 64);
-    };
-
     /// Owns a task buffer and its associated large-closure arena.
     struct TaskBuffer {
         tasks: Vec<Task>,
-        _arena: Vec<SlotBuffer>,
+        _arena: Vec<ArenaSlot>,
     }
 
     impl TaskBuffer {
         fn new() -> Self {
-            let mut arena: Vec<SlotBuffer> = std::vec![
-                SlotBuffer {
-                    data: [0u128; GLOBAL_TASK_MAX_SIZE / 16],
+            let mut arena: Vec<ArenaSlot> = std::vec![
+                ArenaSlot {
+                    data: [0u8; GLOBAL_TASK_MAX_SIZE],
                 };
                 CHANNEL_MAX_TASK
             ];
             let arena_ptr = arena.as_mut_ptr() as *mut u8;
             let tasks = Vec::from_iter((0..CHANNEL_MAX_TASK).map(|index| {
-                // SAFETY: Each task owns a non-overlapping `SlotBuffer` region.
+                // SAFETY: Each task owns a non-overlapping `ArenaSlot` region.
                 Task::new(unsafe { arena_ptr.add(index * GLOBAL_TASK_MAX_SIZE) })
             }));
             Self {
@@ -1002,7 +995,7 @@ mod tests {
 
     #[test]
     fn test_large_closure_uses_arena() {
-        // Closure captures > 48 bytes (SmallTaskData), forcing the arena path.
+        // Closure captures > 48 bytes (InlineSlot), forcing the arena path.
         let device_id = DeviceId {
             type_id: 0,
             index_id: 7,
@@ -1126,7 +1119,7 @@ mod tests {
     /// alignment (64) must be stored and executed soundly.
     #[test]
     fn test_task_init_arena_aligned_closure() {
-        use super::task::{GLOBAL_TASK_MAX_SIZE, Task};
+        use super::task::{ArenaSlot, GLOBAL_TASK_MAX_SIZE, Task};
 
         #[repr(align(64))]
         #[derive(Clone, Copy)]
@@ -1134,11 +1127,11 @@ mod tests {
             data: [u8; 128],
         }
 
-        // Mirror the 64-aligned 4KB region that `TaskBuffer::new` allocates per slot.
-        #[repr(C, align(64))]
-        struct TestArena([u128; GLOBAL_TASK_MAX_SIZE / 16]);
-        let mut arena = alloc::boxed::Box::new(TestArena([0u128; GLOBAL_TASK_MAX_SIZE / 16]));
-        let arena_ptr = arena.0.as_mut_ptr() as *mut u8;
+        // Mirror `TaskBuffer::new`: a 64-aligned 4KB region per slot.
+        let mut arena = alloc::boxed::Box::new(ArenaSlot {
+            data: [0u8; GLOBAL_TASK_MAX_SIZE],
+        });
+        let arena_ptr = arena.data.as_mut_ptr();
         let mut task = Task::new(arena_ptr);
 
         let data = A64 { data: [0xCD; 128] };
@@ -1153,7 +1146,7 @@ mod tests {
     /// boxed fallback.
     #[test]
     fn test_task_init_extremely_over_aligned_closure_uses_box() {
-        use super::task::{GLOBAL_TASK_MAX_SIZE, Task};
+        use super::task::{ArenaSlot, GLOBAL_TASK_MAX_SIZE, Task};
 
         #[repr(align(256))]
         #[derive(Clone, Copy)]
@@ -1161,10 +1154,10 @@ mod tests {
             data: [u8; 256],
         }
 
-        #[repr(C, align(64))]
-        struct TestArena([u128; GLOBAL_TASK_MAX_SIZE / 16]);
-        let mut arena = alloc::boxed::Box::new(TestArena([0u128; GLOBAL_TASK_MAX_SIZE / 16]));
-        let arena_ptr = arena.0.as_mut_ptr() as *mut u8;
+        let mut arena = alloc::boxed::Box::new(ArenaSlot {
+            data: [0u8; GLOBAL_TASK_MAX_SIZE],
+        });
+        let arena_ptr = arena.data.as_mut_ptr();
         let mut task = Task::new(arena_ptr);
 
         let data = A256 { data: [0xAA; 256] };

--- a/crates/cubecl-common/src/device/handle/channel.rs
+++ b/crates/cubecl-common/src/device/handle/channel.rs
@@ -255,8 +255,12 @@ struct ChannelService {
 }
 
 static RUNNERS: spin::Mutex<Option<HashMap<DeviceId, DeviceClient>>> = spin::Mutex::new(None);
-static CHANNELS: spin::Mutex<Option<HashMap<(DeviceId, TypeId), ChannelDeviceState>>> =
-    spin::Mutex::new(None);
+/// Per-key init slot. Concurrent callers for the same `(DeviceId, TypeId)` pair
+/// serialize on the inner `spin::Mutex`, ensuring `S::init` runs exactly once per key.
+#[allow(clippy::type_complexity)]
+static CHANNELS: spin::Mutex<
+    Option<HashMap<(DeviceId, TypeId), alloc::sync::Arc<spin::Mutex<Option<ChannelDeviceState>>>>>,
+> = spin::Mutex::new(None);
 
 impl ChannelDeviceState {
     pub fn init<S: DeviceService>(
@@ -265,31 +269,38 @@ impl ChannelDeviceState {
     ) -> Result<Self, ServiceCreationError> {
         let type_id = TypeId::of::<S>();
         let key = (device_id, type_id);
-        let mut guard_channel = CHANNELS.lock();
-        let channels = guard_channel.get_or_insert_with(HashMap::new);
 
-        // Most of the time the channel state is already initialized.
-        if let Some(value) = channels.get(&key) {
-            return Ok(value.clone());
+        // Fetch (or create) the per-key init slot, then hold the slot lock across the
+        // rest of the init sequence so only one caller per key runs `S::init`.
+        let init_slot = {
+            let mut guard_channel = CHANNELS.lock();
+            let channels = guard_channel.get_or_insert_with(HashMap::new);
+            channels
+                .entry(key)
+                .or_insert_with(|| alloc::sync::Arc::new(spin::Mutex::new(None)))
+                .clone()
         };
 
-        core::mem::drop(guard_channel);
+        let mut slot = init_slot.lock();
+        if let Some(existing) = slot.as_ref() {
+            if service.is_some() {
+                // `insert(device, service)` cannot replace an existing state.
+                return Err(ServiceCreationError::new(
+                    "Service already initialized.".into(),
+                ));
+            }
+            return Ok(existing.clone());
+        }
 
-        // When initializing a service, we first need to make sure the device runner is
-        // initialized.
-        //
-        // # Notes
-        //
         // A single device runner can serve multiple [`DeviceService`].
-        let mut guard = RUNNERS.lock();
-        let runners = guard.get_or_insert_with(HashMap::new);
-
-        let device_client = runners
-            .entry(device_id)
-            .or_insert_with(|| DeviceRunner::start(device_id))
-            .clone();
-
-        core::mem::drop(guard);
+        let device_client = {
+            let mut guard = RUNNERS.lock();
+            let runners = guard.get_or_insert_with(HashMap::new);
+            runners
+                .entry(device_id)
+                .or_insert_with(|| DeviceRunner::start(device_id))
+                .clone()
+        };
 
         let (callback, recv) = oneshot::channel();
 
@@ -342,9 +353,7 @@ impl ChannelDeviceState {
             service,
         };
 
-        let mut guard_channel = CHANNELS.lock();
-        let channels = guard_channel.get_or_insert_with(HashMap::new);
-        channels.insert(key, channel.clone());
+        *slot = Some(channel.clone());
 
         Ok(channel)
     }
@@ -398,7 +407,7 @@ mod task {
     use super::*;
     use core::sync::atomic::{AtomicPtr, Ordering};
     use std::{
-        mem::size_of,
+        mem::{align_of, size_of},
         panic::{AssertUnwindSafe, catch_unwind},
     };
 
@@ -410,6 +419,14 @@ mod task {
     // We use u128 to force alignment.
     pub type LargeTaskData = [u128; GLOBAL_TASK_MAX_SIZE / 16];
     pub type SmallTaskData = [u128; INLINE_TASK_MAX_SIZE / 16];
+
+    /// Alignment of the inline `SmallTaskData` slot inside `Task`, which is
+    /// `#[repr(C, align(64))]` with `data` as its first field.
+    pub const INLINE_SLOT_ALIGN: usize = 64;
+    /// Alignment of each arena slot. Every slot is 64-byte aligned because
+    /// `TaskBuffer` stores `Vec<SlotBuffer>` where `SlotBuffer` is
+    /// `#[repr(C, align(64))]` and the per-slot stride is a multiple of 64.
+    pub const ARENA_SLOT_ALIGN: usize = 64;
 
     /// The return type of wrapped closures.
     pub type TaskResult = ();
@@ -438,10 +455,19 @@ mod task {
             }
         }
 
-        /// Initializes a task based on the given closure.
+        /// Store `func` in the inline slot, the arena slot, or on the heap depending on
+        /// its size and alignment. Both checks are required: writing into a slot whose
+        /// alignment is smaller than `align_of::<F>()` would produce a misaligned
+        /// `ptr::write` (UB). The boxed fallback uses `Box::new`, whose allocation
+        /// satisfies any alignment.
         pub fn init<F: FnOnce() -> TaskResult + Send + 'static>(&mut self, func: F) {
-            if size_of::<F>() <= size_of::<SmallTaskData>() {
-                // SAFETY: size checked above, read back exactly once by fn_ptr.
+            let fits_inline =
+                size_of::<F>() <= size_of::<SmallTaskData>() && align_of::<F>() <= INLINE_SLOT_ALIGN;
+            let fits_arena =
+                size_of::<F>() <= size_of::<LargeTaskData>() && align_of::<F>() <= ARENA_SLOT_ALIGN;
+
+            if fits_inline {
+                // SAFETY: size + align checked above, read back exactly once by fn_ptr.
                 unsafe { std::ptr::write(self.data.as_mut_ptr() as *mut F, func) };
                 self.fn_ptr = |task| {
                     // SAFETY: Paired with the ptr::write to data above.
@@ -450,8 +476,8 @@ mod task {
                         log::warn!("Task failed: {err:?}");
                     }
                 };
-            } else if size_of::<F>() <= size_of::<LargeTaskData>() {
-                // SAFETY: size checked above, read back exactly once by fn_ptr.
+            } else if fits_arena {
+                // SAFETY: size + align checked above, read back exactly once by fn_ptr.
                 unsafe {
                     std::ptr::write(self.data_large_ptr.load(Ordering::Relaxed) as *mut F, func)
                 };
@@ -465,8 +491,9 @@ mod task {
                     }
                 };
             } else {
-                // Heap-allocate to make it pointer-sized, then recurse so we use this
-                // as a small task.
+                // Size or alignment exceeds both slots. Heap-allocate to get a
+                // properly-aligned, pointer-sized handle, then recurse as an inline
+                // task (the Box is a pointer so it trivially fits inline).
                 let boxed: Box<dyn FnOnce() -> TaskResult + Send> = Box::new(func);
                 self.init(boxed);
             }
@@ -689,20 +716,38 @@ mod custom_channel {
         }
     }
 
+    /// A single arena slot. `#[repr(C, align(64))]` makes every slot 64-byte aligned,
+    /// matching the inline task slot so the router can store closures with
+    /// `align_of::<F>()` up to 64 in either location. `GLOBAL_TASK_MAX_SIZE` is a
+    /// multiple of 64, so there is no per-slot padding.
+    #[repr(C, align(64))]
+    #[derive(Clone, Copy)]
+    struct SlotBuffer {
+        data: [u128; GLOBAL_TASK_MAX_SIZE / 16],
+    }
+
+    const _: () = {
+        assert!(core::mem::size_of::<SlotBuffer>() == GLOBAL_TASK_MAX_SIZE);
+        assert!(core::mem::align_of::<SlotBuffer>() == 64);
+    };
+
     /// Owns a task buffer and its associated large-closure arena.
     struct TaskBuffer {
         tasks: Vec<Task>,
-        // u128 ensures 16-byte alignment, matching LargeTaskData = [u128; ...].
-        _arena: Vec<u128>,
+        _arena: Vec<SlotBuffer>,
     }
 
     impl TaskBuffer {
         fn new() -> Self {
-            let mut arena = std::vec![0u128; CHANNEL_MAX_TASK * GLOBAL_TASK_MAX_SIZE / 16];
+            let mut arena: Vec<SlotBuffer> = std::vec![
+                SlotBuffer {
+                    data: [0u128; GLOBAL_TASK_MAX_SIZE / 16],
+                };
+                CHANNEL_MAX_TASK
+            ];
             let arena_ptr = arena.as_mut_ptr() as *mut u8;
             let tasks = Vec::from_iter((0..CHANNEL_MAX_TASK).map(|index| {
-                // SAFETY: Each task gets a non-overlapping region of the arena.
-                // arena is CHANNEL_MAX_TASK * GLOBAL_TASK_MAX_SIZE bytes total.
+                // SAFETY: Each task owns a non-overlapping `SlotBuffer` region.
                 Task::new(unsafe { arena_ptr.add(index * GLOBAL_TASK_MAX_SIZE) })
             }));
             Self {
@@ -1024,5 +1069,113 @@ mod tests {
             .unwrap();
 
         assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+    }
+
+    /// Concurrent callers racing on the same `(DeviceId, TypeId)` must share a single
+    /// `S::init` invocation.
+    #[test]
+    fn test_init_runs_exactly_once_under_contention() {
+        use alloc::vec::Vec;
+        use std::sync::Barrier;
+        use std::sync::atomic::AtomicUsize;
+        use std::thread;
+
+        static INIT_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+        struct CountingService;
+        impl DeviceService for CountingService {
+            fn init(_: DeviceId) -> Self {
+                INIT_CALLS.fetch_add(1, Ordering::SeqCst);
+                CountingService
+            }
+            fn utilities(&self) -> ServerUtilitiesHandle {
+                Arc::new(())
+            }
+        }
+
+        INIT_CALLS.store(0, Ordering::SeqCst);
+
+        const THREADS: usize = 4;
+        // Unique device_id so the global `CHANNELS` entry is independent of other tests.
+        let device_id = DeviceId {
+            type_id: 0,
+            index_id: 77,
+        };
+
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut handles = Vec::new();
+        for _ in 0..THREADS {
+            let b = barrier.clone();
+            handles.push(thread::spawn(move || {
+                b.wait();
+                ChannelDeviceHandle::<CountingService>::new(device_id)
+            }));
+        }
+        for h in handles {
+            let _ = h.join().unwrap();
+        }
+
+        assert_eq!(
+            INIT_CALLS.load(Ordering::SeqCst),
+            1,
+            "CountingService::init must run exactly once across {THREADS} racing callers"
+        );
+    }
+
+    /// A closure that spills to the arena (size > 48) and carries the maximum arena
+    /// alignment (64) must be stored and executed soundly.
+    #[test]
+    fn test_task_init_arena_aligned_closure() {
+        use super::task::{GLOBAL_TASK_MAX_SIZE, Task};
+
+        #[repr(align(64))]
+        #[derive(Clone, Copy)]
+        struct A64 {
+            data: [u8; 128],
+        }
+
+        // Mirror the 64-aligned 4KB region that `TaskBuffer::new` allocates per slot.
+        #[repr(C, align(64))]
+        struct TestArena([u128; GLOBAL_TASK_MAX_SIZE / 16]);
+        let mut arena = alloc::boxed::Box::new(TestArena(
+            [0u128; GLOBAL_TASK_MAX_SIZE / 16],
+        ));
+        let arena_ptr = arena.0.as_mut_ptr() as *mut u8;
+        let mut task = Task::new(arena_ptr);
+
+        let data = A64 { data: [0xCD; 128] };
+        task.init(move || {
+            let d = core::hint::black_box(data);
+            let _: usize = d.data.iter().map(|&b| b as usize).sum();
+        });
+        task.run();
+    }
+
+    /// A closure whose alignment exceeds the arena slot alignment must take the
+    /// boxed fallback.
+    #[test]
+    fn test_task_init_extremely_over_aligned_closure_uses_box() {
+        use super::task::{GLOBAL_TASK_MAX_SIZE, Task};
+
+        #[repr(align(256))]
+        #[derive(Clone, Copy)]
+        struct A256 {
+            data: [u8; 256],
+        }
+
+        #[repr(C, align(64))]
+        struct TestArena([u128; GLOBAL_TASK_MAX_SIZE / 16]);
+        let mut arena = alloc::boxed::Box::new(TestArena(
+            [0u128; GLOBAL_TASK_MAX_SIZE / 16],
+        ));
+        let arena_ptr = arena.0.as_mut_ptr() as *mut u8;
+        let mut task = Task::new(arena_ptr);
+
+        let data = A256 { data: [0xAA; 256] };
+        task.init(move || {
+            let d = core::hint::black_box(data);
+            let _: usize = d.data.iter().map(|&b| b as usize).sum();
+        });
+        task.run();
     }
 }


### PR DESCRIPTION
Three independent bugs found by running miri against the test suite, each with a minimal regression test:

Miri UB:

`Task::init<F>` in the channel task module now validates both `size_of::<F>()` and `align_of::<F>()` when routing closures between inline, arena, and boxed storage. The arena buffer was also bumped from `Vec<u128>` to `Vec<SlotBuffer>` where `SlotBuffer` is `#[repr(C, align(64))]`, so every arena slot is 64-byte aligned and matches the inline slot's alignment. Closures with over-aligned captures previously produced a misaligned `ptr::write`, which is UB as caught by miri.

Two other issues found along the way:

1. `Bytes::try_enforce_runtime_align` now checks the controller's reported `alloc_align()` instead of the raw pointer's alignment offset. The raw pointer could happen to be aligned while the controller still reported a lower alignment, causing downstream `try_into_vec::<E>` to wrongly reject valid conversions.

2. `ChannelDeviceState::init` serializes on a per-key `spin::Mutex` so that `S::init` runs exactly once per `(DeviceId, TypeId)`. The previous check-drop-work-lock pattern let concurrent callers each construct their own `S` instance; the losers were immediately dropped.

Each fix has a minimal regression test.