### PR TITLE
Fix FastDivmod divide-by-zero on empty-tensor divisors

### DIFF
--- a/crates/cubecl-std/src/fast_math.rs
+++ b/crates/cubecl-std/src/fast_math.rs
@@ -74,6 +74,12 @@ impl<I: FastDivmodInt> FastDivmod<I> {
 }
 
 fn find_params_u32(divisor: u32) -> (u32, u32) {
+    // Empty (zero-sized) tensor dims propagate here as divisor == 0. The
+    // GPU never iterates on those, so any params will do — return zeros
+    // instead of dividing by zero.
+    if divisor == 0 {
+        return (0, 0);
+    }
     let div_64 = divisor as u64;
     let shift = divisor.next_power_of_two().trailing_zeros();
     let multiplier = ((1u64 << 32) * ((1u64 << shift) - div_64)) / div_64 + 1;
@@ -81,6 +87,9 @@ fn find_params_u32(divisor: u32) -> (u32, u32) {
 }
 
 fn find_params_u64(divisor: u64) -> (u32, u64) {
+    if divisor == 0 {
+        return (0, 0);
+    }
     let div_128 = divisor as u128;
     let shift = divisor.next_power_of_two().trailing_zeros();
     let multiplier = ((1u128 << 64) * ((1u128 << shift) - div_128)) / div_128 + 1;


### PR DESCRIPTION
`find_params_u32(divisor)` and `find_params_u64(divisor)` divide by `divisor`. Empty tensor dims propagate as `divisor == 0` (e.g. a `Sequence<FastDivmod<usize>>` over the shape of a `[0, 10]` tensor at kernel-launch time), and the host-side magic-number computation panics with `attempt to divide by zero`.

Return `(0, 0)` for `divisor == 0`. The GPU never iterates on a zero-shape tensor so the params are never used at runtime; we just need registration not to crash.

Hit in burn-cubecl's `slice_assign`, `gather`, and likely other kernels that take per-dim `FastDivmod` for shapes that may include zero. Companion burn PR (tracel-ai/burn#4878) skips those kernel launches early; either fix unbreaks the test, both together hardens the path.