### PR TITLE
Disable ahash default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ num-traits = { version = "0.2.19", default-features = false, features = [
 
 cfg-if = "1.0.0"
 darling = "0.23.0"
-enumset = { version = "1.1.10", default-features = false }
+enumset = { version = "1.1.12", default-features = false }
 ident_case = "1"
 paste = "1"
 proc-macro2 = "1"

--- a/crates/cubecl-core/src/runtime_tests/binary.rs
+++ b/crates/cubecl-core/src/runtime_tests/binary.rs
@@ -53,7 +53,7 @@ expected: {:?}",
 
 // Needs lazy because const trait fns aren't stable
 static FAST_MATH: Lazy<EnumSet<FastMath>> =
-    Lazy::new(|| FastMath::all().difference(FastMath::NotNaN.into()));
+    Lazy::new(|| FastMath::all().difference(FastMath::NotNaN));
 
 macro_rules! test_binary_impl {
     (

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -58,7 +58,7 @@ toml = { workspace = true, optional = true }
 web-time = { workspace = true }
 
 thiserror = { workspace = true }
-ahash = "0.8.12"
+ahash = { version = "0.8.12", default-features = false }
 md5 = { workspace = true }
 
 # Persistent cache deps - has to match the cfg(std_io) cfg.


### PR DESCRIPTION
Breaks `no_std` builds on WASM (e.g. burn's `mnist-inference-web`). It pulls `getrandom` with default features.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
