### PR TITLE
feat(streaming): add stream priority hint, wire into CUDA backend

### DIFF
--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -545,13 +545,11 @@ impl CudaServer {
     ) -> Self {
         let config = CubeClRuntimeConfig::get();
         let max_streams = config.streaming.max_streams;
+        let stream_priority = config.streaming.priority;
 
         ctx.unsafe_set_current().unwrap();
 
-        let comm_stream = cudarc::driver::result::stream::create(
-            cudarc::driver::result::stream::StreamKind::NonBlocking,
-        )
-        .expect("Can create a new stream.");
+        let comm_stream = crate::compute::stream::create_cuda_stream(stream_priority);
 
         Self {
             ctx,
@@ -563,6 +561,7 @@ impl CudaServer {
                     mem_config,
                     mem_alignment,
                     utilities.logger.clone(),
+                    stream_priority,
                 ),
                 max_streams,
             ),

--- a/crates/cubecl-cuda/src/compute/stream.rs
+++ b/crates/cubecl-cuda/src/compute/stream.rs
@@ -11,13 +11,14 @@ use cubecl_core::{
     server::{Binding, ServerError},
 };
 use cubecl_runtime::{
+    config::streaming::StreamPriority,
     logging::ServerLogger,
     memory_management::{
         MemoryAllocationMode, MemoryManagement, MemoryManagementOptions, drop_queue,
     },
     stream::EventStreamBackend,
 };
-use std::sync::Arc;
+use std::{mem::MaybeUninit, sync::Arc};
 
 #[derive(Debug)]
 pub struct Stream {
@@ -40,6 +41,50 @@ pub struct CudaStreamBackend {
     mem_config: MemoryConfiguration,
     mem_alignment: usize,
     logger: Arc<ServerLogger>,
+    priority: StreamPriority,
+}
+
+/// Create a non-blocking CUDA stream, applying the requested priority hint.
+///
+/// `StreamPriority::Default` preserves the historical `cuStreamCreate` path so
+/// existing users see no change. `Low`/`High` go through
+/// `cuStreamCreateWithPriority` and are clamped to the device's supported
+/// range queried via `cuCtxGetStreamPriorityRange` (CUDA convention: lower
+/// number = higher priority, so `greatest` is the most-aggressive value and
+/// `least` is the lowest).
+pub(crate) fn create_cuda_stream(priority: StreamPriority) -> cudarc::driver::sys::CUstream {
+    use cudarc::driver::sys::{self, CUstream_flags};
+
+    match priority {
+        StreamPriority::Default => cudarc::driver::result::stream::create(
+            cudarc::driver::result::stream::StreamKind::NonBlocking,
+        )
+        .expect("Can create a new stream."),
+        StreamPriority::Low | StreamPriority::High => unsafe {
+            let mut least: i32 = 0;
+            let mut greatest: i32 = 0;
+            sys::cuCtxGetStreamPriorityRange(&mut least, &mut greatest)
+                .result()
+                .expect("Can query CUDA stream priority range.");
+            // CUDA: lower number = higher priority. `greatest` is the most
+            // aggressive (numerically smallest) value, `least` is the least
+            // aggressive (numerically largest).
+            let value = match priority {
+                StreamPriority::High => greatest,
+                StreamPriority::Low => least,
+                StreamPriority::Default => unreachable!(),
+            };
+            let mut stream = MaybeUninit::uninit();
+            sys::cuStreamCreateWithPriority(
+                stream.as_mut_ptr(),
+                CUstream_flags::CU_STREAM_NON_BLOCKING as u32,
+                value,
+            )
+            .result()
+            .expect("Can create a new CUDA stream with priority.");
+            stream.assume_init()
+        },
+    }
 }
 
 impl EventStreamBackend for CudaStreamBackend {
@@ -47,10 +92,7 @@ impl EventStreamBackend for CudaStreamBackend {
     type Event = Fence;
 
     fn create_stream(&self) -> Self::Stream {
-        let stream = cudarc::driver::result::stream::create(
-            cudarc::driver::result::stream::StreamKind::NonBlocking,
-        )
-        .expect("Can create a new stream.");
+        let stream = create_cuda_stream(self.priority);
 
         let storage = GpuStorage::new(self.mem_alignment, stream);
         let memory_management_gpu = MemoryManagement::from_configuration(

--- a/crates/cubecl-cuda/src/compute/stream.rs
+++ b/crates/cubecl-cuda/src/compute/stream.rs
@@ -48,42 +48,53 @@ pub struct CudaStreamBackend {
 ///
 /// `StreamPriority::Default` preserves the historical `cuStreamCreate` path so
 /// existing users see no change. `Low`/`High` go through
-/// `cuStreamCreateWithPriority` and are clamped to the device's supported
-/// range queried via `cuCtxGetStreamPriorityRange` (CUDA convention: lower
-/// number = higher priority, so `greatest` is the most-aggressive value and
-/// `least` is the lowest).
+/// `cuStreamCreateWithPriority` using the device's range as queried via
+/// `cuCtxGetStreamPriorityRange`. CUDA convention: lower number = higher
+/// priority, so the queried `greatest` is numerically smallest (most
+/// aggressive) and `least` is numerically largest (least aggressive). On
+/// devices without priority support both values are 0 and CUDA silently
+/// ignores the priority argument — equivalent to the default path.
+///
+/// Both calls require a current CUDA context; callers in this crate always
+/// set the context before invoking stream creation.
 pub(crate) fn create_cuda_stream(priority: StreamPriority) -> cudarc::driver::sys::CUstream {
     use cudarc::driver::sys::{self, CUstream_flags};
 
-    match priority {
-        StreamPriority::Default => cudarc::driver::result::stream::create(
-            cudarc::driver::result::stream::StreamKind::NonBlocking,
-        )
-        .expect("Can create a new stream."),
-        StreamPriority::Low | StreamPriority::High => unsafe {
-            let mut least: i32 = 0;
-            let mut greatest: i32 = 0;
-            sys::cuCtxGetStreamPriorityRange(&mut least, &mut greatest)
-                .result()
-                .expect("Can query CUDA stream priority range.");
-            // CUDA: lower number = higher priority. `greatest` is the most
-            // aggressive (numerically smallest) value, `least` is the least
-            // aggressive (numerically largest).
-            let value = match priority {
-                StreamPriority::High => greatest,
-                StreamPriority::Low => least,
-                StreamPriority::Default => unreachable!(),
-            };
-            let mut stream = MaybeUninit::uninit();
-            sys::cuStreamCreateWithPriority(
-                stream.as_mut_ptr(),
-                CUstream_flags::CU_STREAM_NON_BLOCKING as u32,
-                value,
+    let use_greatest = match priority {
+        StreamPriority::Default => {
+            return cudarc::driver::result::stream::create(
+                cudarc::driver::result::stream::StreamKind::NonBlocking,
             )
+            .expect("Can create a new stream.");
+        }
+        StreamPriority::High => true,
+        StreamPriority::Low => false,
+    };
+
+    // SAFETY: `cuCtxGetStreamPriorityRange` writes through both pointers on
+    // success; we only read the locals after the `.expect()` confirms success.
+    let value = unsafe {
+        let mut least: i32 = 0;
+        let mut greatest: i32 = 0;
+        sys::cuCtxGetStreamPriorityRange(&mut least, &mut greatest)
             .result()
-            .expect("Can create a new CUDA stream with priority.");
-            stream.assume_init()
-        },
+            .expect("Can query CUDA stream priority range.");
+        if use_greatest { greatest } else { least }
+    };
+
+    // SAFETY: `cuStreamCreateWithPriority` writes the new stream handle through
+    // the out pointer on success; `.expect()` ensures we only `assume_init` on
+    // success.
+    unsafe {
+        let mut stream = MaybeUninit::uninit();
+        sys::cuStreamCreateWithPriority(
+            stream.as_mut_ptr(),
+            CUstream_flags::CU_STREAM_NON_BLOCKING as u32,
+            value,
+        )
+        .result()
+        .expect("Can create a new CUDA stream with priority.");
+        stream.assume_init()
     }
 }
 

--- a/crates/cubecl-runtime/src/config/streaming.rs
+++ b/crates/cubecl-runtime/src/config/streaming.rs
@@ -9,6 +9,14 @@ pub struct StreamingConfig {
     /// The maximum number of streams to be used.
     #[serde(default = "default_max_streams")]
     pub max_streams: u8,
+    /// Backend stream priority hint.
+    ///
+    /// Backends that expose stream priorities (e.g. CUDA via
+    /// `cuStreamCreateWithPriority`) map this to their native range. Backends
+    /// without a notion of stream priority ignore it. The default is
+    /// [`StreamPriority::Default`], which preserves existing behavior.
+    #[serde(default)]
+    pub priority: StreamPriority,
 }
 
 impl Default for StreamingConfig {
@@ -16,12 +24,42 @@ impl Default for StreamingConfig {
         Self {
             logger: Default::default(),
             max_streams: default_max_streams(),
+            priority: StreamPriority::default(),
         }
     }
 }
 
 fn default_max_streams() -> u8 {
     128
+}
+
+/// Stream priority hint, mapped to the backend's native priority range.
+///
+/// CUDA convention is that lower numerical priorities run first; this enum is
+/// the portable abstraction so other runtimes can adopt it without changing
+/// their public surface. Backends clamp to their supported range — passing
+/// [`StreamPriority::Low`] on a device whose only priority bucket is the
+/// default is harmless.
+///
+/// The motivating use case is sharing a single GPU with a desktop compositor
+/// (WSL2, dev laptops, single-GPU workstations): running long compute batches
+/// on a low-priority stream lets the compositor preempt cleanly and keeps the
+/// UI responsive.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum StreamPriority {
+    /// Default backend priority — current behavior on every backend.
+    #[default]
+    #[serde(rename = "default")]
+    Default,
+    /// Lowest priority the backend supports. Useful when sharing the GPU with
+    /// an interactive workload such as a compositor; long-running compute
+    /// batches yield to higher-priority work like UI rendering.
+    #[serde(rename = "low")]
+    Low,
+    /// Highest priority the backend supports. Useful for latency-critical
+    /// foreground work that must not be preempted by background batches.
+    #[serde(rename = "high")]
+    High,
 }
 
 /// Log levels for streaming in `CubeCL`.
@@ -42,3 +80,53 @@ pub enum StreamingLogLevel {
 }
 
 impl LogLevel for StreamingLogLevel {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_priority_is_default_variant() {
+        assert_eq!(StreamingConfig::default().priority, StreamPriority::Default);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn priority_omitted_in_toml_falls_back_to_default() {
+        // Existing config files written before this field was added must
+        // continue to deserialize unchanged.
+        let cfg: StreamingConfig = toml::from_str("max_streams = 64").unwrap();
+        assert_eq!(cfg.priority, StreamPriority::Default);
+        assert_eq!(cfg.max_streams, 64);
+    }
+
+    #[test]
+    fn priority_serde_roundtrip() {
+        for p in [
+            StreamPriority::Default,
+            StreamPriority::Low,
+            StreamPriority::High,
+        ] {
+            let s = serde_json::to_string(&p).unwrap();
+            let back: StreamPriority = serde_json::from_str(&s).unwrap();
+            assert_eq!(p, back);
+        }
+    }
+
+    #[test]
+    fn priority_serde_uses_lowercase_names() {
+        // Stable on-disk representation — don't break user configs by accident.
+        assert_eq!(
+            serde_json::to_string(&StreamPriority::Low).unwrap(),
+            "\"low\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StreamPriority::High).unwrap(),
+            "\"high\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StreamPriority::Default).unwrap(),
+            "\"default\""
+        );
+    }
+}


### PR DESCRIPTION
Closes #1319.

## What

Adds a `StreamPriority` enum (`Default` / `Low` / `High`) plus a `priority` field to `StreamingConfig` in `cubecl-runtime`. Per @nathanielsimard's suggestion on the issue, the field lives on the shared streaming config so other runtimes can adopt it later without changing their public surface.

CUDA reads the hint and routes through `cuStreamCreateWithPriority`, using the device's range queried via `cuCtxGetStreamPriorityRange` (CUDA convention: lower number = higher priority — `greatest` is numerically smallest, `least` is numerically largest). Both the per-stream `CudaStreamBackend::create_stream` path and the NCCL comm stream go through a shared `create_cuda_stream(StreamPriority)` helper.

## Compatibility

Purely additive. `StreamPriority::Default` keeps the existing `cuStreamCreate(NonBlocking)` code path, so users who don't set the field get bit-identical behavior. The new field is `#[serde(default)]`, so existing TOML configs continue to deserialize.

Other runtimes (HIP, WGPU, CPU) ignore the hint until they wire it up.

## Why

Motivating use case: sharing a single GPU with a desktop compositor — WSL2, dev laptops, single-GPU workstations. A long compute batch on a default-priority stream noticeably stutters the UI; routing the same work onto a low-priority stream lets the compositor preempt cleanly and keeps the desktop responsive at near-full compute throughput. The standalone `butteraugli-cuda` crate uses the same pattern for the same reason.

## Tests

Added 4 unit tests in `streaming.rs`:
- `default_priority_is_default_variant` — `StreamingConfig::default()` round-trips.
- `priority_omitted_in_toml_falls_back_to_default` — backward compat for existing config files.
- `priority_serde_roundtrip` — JSON round-trip for all variants.
- `priority_serde_uses_lowercase_names` — locks the on-disk representation (`"default"` / `"low"` / `"high"`).

`cargo fmt` clean, `cargo clippy` clean on touched code.

I can't directly exercise `cuStreamCreateWithPriority` without a CUDA device in CI; the helper's correctness for the priority-querying path is delegated to CUDA itself (clamping happens inside the driver), and the `Default` arm is a pure passthrough verified by the existing test suite.

## Notes for review

- Used the raw `cudarc::driver::sys` FFI for `cuStreamCreateWithPriority` / `cuCtxGetStreamPriorityRange` because cudarc 0.19.4 doesn't yet expose a high-level wrapper. Happy to switch to a safe wrapper if/when cudarc adds one.
- The comm_stream in `CudaServer::new` uses the same priority — felt right since the user's intent is "this whole server should be lower priority", but happy to leave it on default if you'd rather scope this to compute streams only.
- Two commits on the branch (initial impl + a small refactor for clarity); feel free to squash on merge.