### PR TITLE
Add workgroupUniformLoad primitive

### DIFF
--- a/crates/cubecl-core/src/frontend/synchronization.rs
+++ b/crates/cubecl-core/src/frontend/synchronization.rs
@@ -1,7 +1,10 @@
 use crate::{
-    ir::{Scope, Synchronization},
+    frontend::{NativeExpand, element::Atomic},
+    ir::{Instruction, Scope, Synchronization},
+    prelude::{CubePrimitive, Numeric},
     unexpanded,
 };
+use cubecl_ir::Operation;
 
 // Among all backends, the memory order guarantee of WebGPU is the weakest
 // So Cubecl's memory order cannot be stronger than that of WebGPU
@@ -66,5 +69,59 @@ pub mod sync_async_proxy_shared {
 
     pub fn expand(scope: &Scope) {
         scope.register(Synchronization::SyncAsyncProxyShared)
+    }
+}
+
+/// Barrier, then load `reference` with the result marked workgroup-uniform —
+/// mirrors WGSL's `workgroupUniformLoad`. Lets a workgroup-shared value gate
+/// control flow that contains barriers. Non-WGSL backends lower it to
+/// [`sync_cube`] plus a plain load.
+///
+/// Use [`workgroup_uniform_load_atomic`] for `Atomic<E>`.
+#[allow(unused_variables)]
+pub fn workgroup_uniform_load<E: CubePrimitive>(reference: &E) -> E {
+    unexpanded!()
+}
+
+/// Module containing the expand function for [`workgroup_uniform_load()`].
+pub mod workgroup_uniform_load {
+    use super::*;
+
+    /// Expand method of [`workgroup_uniform_load()`].
+    pub fn expand<E: CubePrimitive>(scope: &Scope, reference: &NativeExpand<E>) -> NativeExpand<E> {
+        let out = scope.create_local(E::__expand_as_type(scope));
+        scope.register(Instruction::new(
+            Operation::WorkgroupUniformLoad(reference.expand),
+            out,
+        ));
+        out.into()
+    }
+}
+
+/// Atomic counterpart of [`workgroup_uniform_load`]: barrier + atomic load,
+/// returning the underlying numeric (WGSL's atomic `workgroupUniformLoad`
+/// overload).
+#[allow(unused_variables)]
+pub fn workgroup_uniform_load_atomic<E: CubePrimitive<Scalar: Numeric>>(
+    reference: &Atomic<E>,
+) -> E {
+    unexpanded!()
+}
+
+/// Module containing the expand function for [`workgroup_uniform_load_atomic()`].
+pub mod workgroup_uniform_load_atomic {
+    use super::*;
+
+    /// Expand method of [`workgroup_uniform_load_atomic()`].
+    pub fn expand<E: CubePrimitive<Scalar: Numeric>>(
+        scope: &Scope,
+        reference: &NativeExpand<Atomic<E>>,
+    ) -> NativeExpand<E> {
+        let out = scope.create_local(E::__expand_as_type(scope));
+        scope.register(Instruction::new(
+            Operation::WorkgroupUniformLoad(reference.expand),
+            out,
+        ));
+        out.into()
     }
 }

--- a/crates/cubecl-core/src/post_processing/visitor.rs
+++ b/crates/cubecl-core/src/post_processing/visitor.rs
@@ -124,6 +124,7 @@ impl<T> Visitor<T> {
 
         match op {
             Operation::Copy(variable) => visit_read(self, variable),
+            Operation::WorkgroupUniformLoad(variable) => visit_read(self, variable),
             Operation::Memory(memory) => self.visit_memory(memory, visit_read),
             Operation::Arithmetic(arithmetic) => self.visit_arithmetic(arithmetic, visit_read),
             Operation::Comparison(comparison) => self.visit_compare(comparison, visit_read),

--- a/crates/cubecl-core/src/runtime_tests/synchronization.rs
+++ b/crates/cubecl-core/src/runtime_tests/synchronization.rs
@@ -2,7 +2,7 @@ use alloc::{vec, vec::Vec};
 
 use crate::prelude::*;
 use crate::{self as cubecl};
-use cubecl_ir::features::Plane;
+use cubecl_ir::features::{AtomicUsage, Plane};
 
 #[cube(launch)]
 /// First 32 elements should be 1, while last 32 elements may or may not be 1
@@ -145,6 +145,100 @@ pub fn test_sync_cube_shared<R: Runtime>(client: ComputeClient<R>) {
     assert_eq!(&actual[0..64], expected);
 }
 
+#[cube(launch)]
+fn kernel_test_workgroup_uniform_load(out: &mut [u32]) {
+    let mut count = SharedMemory::<u32>::new(1usize);
+    if UNIT_POS == 0 {
+        count[0] = 3u32;
+    }
+    sync_cube();
+
+    let n = workgroup_uniform_load(&count[0]);
+    if n > 0 {
+        sync_cube();
+    }
+    out[UNIT_POS as usize] = n;
+}
+
+pub fn test_workgroup_uniform_load<R: Runtime>(client: ComputeClient<R>) {
+    let handle = client.empty(64 * core::mem::size_of::<u32>());
+
+    kernel_test_workgroup_uniform_load::launch(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_2d(32, 2),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 64) },
+    );
+
+    let actual = client.read_one_unchecked(handle);
+    assert_eq!(u32::from_bytes(&actual), &[3u32; 64]);
+}
+
+#[cube(launch)]
+fn kernel_test_workgroup_uniform_load_atomic(out: &mut [u32]) {
+    let count = SharedMemory::<Atomic<u32>>::new(1usize);
+    if UNIT_POS == 0 {
+        count[0].store(3u32);
+    }
+    sync_cube();
+
+    let n = workgroup_uniform_load_atomic(&count[0]);
+    if n > 0 {
+        sync_cube();
+    }
+    out[UNIT_POS as usize] = n;
+}
+
+pub fn test_workgroup_uniform_load_atomic<R: Runtime>(client: ComputeClient<R>) {
+    let ty = Type::atomic(u32::as_type_native_unchecked());
+    if !client
+        .properties()
+        .atomic_type_usage(ty)
+        .contains(AtomicUsage::LoadStore)
+    {
+        return;
+    }
+
+    let handle = client.empty(64 * core::mem::size_of::<u32>());
+
+    kernel_test_workgroup_uniform_load_atomic::launch(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_2d(32, 2),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 64) },
+    );
+
+    let actual = client.read_one_unchecked(handle);
+    assert_eq!(u32::from_bytes(&actual), &[3u32; 64]);
+}
+
+#[cube(launch)]
+fn kernel_test_workgroup_uniform_load_vec<N: Size>(out: &mut [Vector<f32, N>]) {
+    let mut smem = SharedMemory::<Vector<f32, N>>::new(1usize);
+    if UNIT_POS == 0 {
+        smem[0] = Vector::new(7.0f32);
+    }
+    sync_cube();
+
+    out[UNIT_POS as usize] = workgroup_uniform_load(&smem[0]);
+}
+
+pub fn test_workgroup_uniform_load_vec<R: Runtime>(client: ComputeClient<R>) {
+    let lanes = 4usize;
+    let output = client.create_from_slice(f32::as_bytes(&vec![0.0f32; 64 * lanes]));
+
+    kernel_test_workgroup_uniform_load_vec::launch(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_2d(32, 2),
+        lanes,
+        unsafe { BufferArg::from_raw_parts(output.clone(), 64) },
+    );
+
+    let actual = client.read_one_unchecked(output);
+    assert!(f32::from_bytes(&actual).iter().all(|&x| x == 7.0f32));
+}
+
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! testgen_sync_plane {
@@ -177,6 +271,30 @@ macro_rules! testgen_sync_plane {
             cubecl_core::runtime_tests::synchronization::test_sync_cube_shared::<TestRuntime>(
                 client,
             );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_workgroup_uniform_load() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::synchronization::test_workgroup_uniform_load::<TestRuntime>(
+                client,
+            );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_workgroup_uniform_load_atomic() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::synchronization::test_workgroup_uniform_load_atomic::<
+                TestRuntime,
+            >(client);
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_workgroup_uniform_load_vec() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::synchronization::test_workgroup_uniform_load_vec::<
+                TestRuntime,
+            >(client);
         }
     };
 }

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -426,6 +426,19 @@ impl<D: Dialect> CppCompiler<D> {
                     instructions.push(Instruction::ProxyAsyncToSharedFence)
                 }
             },
+            gpu::Operation::WorkgroupUniformLoad(input) => {
+                let is_atomic = input.ty.is_atomic();
+                instructions.push(Instruction::SyncThreads);
+                let load = UnaryInstruction {
+                    input: self.compile_variable(input),
+                    out: self.compile_variable(out.unwrap()),
+                };
+                if is_atomic {
+                    instructions.push(Instruction::AtomicLoad(load));
+                } else {
+                    instructions.push(Instruction::Load(load));
+                }
+            }
             gpu::Operation::Plane(op) => {
                 self.flags.indexes.plane_dim_checked = true;
                 let out = self.compile_variable(out.unwrap());

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
@@ -6,7 +6,8 @@ pub(super) mod operator;
 pub(super) mod synchronization;
 
 use cubecl_core::ir::{
-    BarrierLevel, BarrierOps, NonSemantic, OpaqueType, Operation, StorageType, Synchronization,
+    BarrierLevel, BarrierOps, Memory, NonSemantic, OpaqueType, Operation, StorageType,
+    Synchronization,
 };
 use tracel_llvm::mlir_rs::{
     dialect::{llvm, ods::llvm as llvm_ods},
@@ -157,6 +158,12 @@ impl<'a> Visitor<'a> {
             }
             Operation::Operator(operator) => {
                 self.visit_operator_with_out(operator, out);
+            }
+            Operation::WorkgroupUniformLoad(input) => {
+                if input.ty.is_atomic() {
+                    todo!("Atomic operations are not yet supported on CPU");
+                }
+                self.visit_memory(&Memory::Load(*input), Some(out));
             }
             Operation::CoopMma(_)
             | Operation::Plane(_)

--- a/crates/cubecl-ir/src/operation.rs
+++ b/crates/cubecl-ir/src/operation.rs
@@ -54,6 +54,15 @@ pub enum Operation {
     Branch(Branch),
     #[operation(nested)]
     Synchronization(Synchronization),
+    /// Barrier followed by a load whose result is workgroup-uniform.
+    ///
+    /// Mirrors WGSL's `workgroupUniformLoad`: the input is a reference into
+    /// workgroup-shared memory (`&list[i]`, produced by [`Memory::Index`]),
+    /// and both the non-atomic and atomic WGSL overloads map here. Other
+    /// backends lower this to a `sync_cube` followed by a regular (or atomic)
+    /// load — uniformity is implicit there.
+    #[from(ignore)]
+    WorkgroupUniformLoad(#[args(allow_ptr, ptr_read)] Variable),
     #[operation(nested)]
     Plane(Plane),
     #[operation(nested)]
@@ -170,6 +179,9 @@ impl Display for Operation {
             Operation::Metadata(metadata) => write!(f, "{metadata}"),
             Operation::Branch(branch) => write!(f, "{branch}"),
             Operation::Synchronization(synchronization) => write!(f, "{synchronization}"),
+            Operation::WorkgroupUniformLoad(var) => {
+                write!(f, "workgroup_uniform_load({var})")
+            }
             Operation::Plane(plane) => write!(f, "{plane}"),
             Operation::CoopMma(coop_mma) => write!(f, "{coop_mma}"),
             Operation::NonSemantic(non_semantic) => write!(f, "{non_semantic}"),

--- a/crates/cubecl-opt/src/gvn/numbering.rs
+++ b/crates/cubecl-opt/src/gvn/numbering.rs
@@ -121,7 +121,11 @@ impl ValueTable {
             Operation::Bitwise(bitwise) => self.create_expr_simple_op(bitwise, inst.out()),
             Operation::Operator(operator) => self.create_expr_simple_op(operator, inst.out()),
             Operation::Metadata(metadata) => self.create_expr_simple_op(metadata, inst.out()),
-            Operation::Plane(_) => Err(value_of_var(&inst.out())),
+            // Not numberable: it has a barrier side-effect and a
+            // workgroup-uniformity contract, so it must never be deduplicated.
+            Operation::Plane(_) | Operation::WorkgroupUniformLoad(_) => {
+                Err(value_of_var(&inst.out()))
+            }
             Operation::Atomic(atomic) => self.create_expr_atomic(atomic, inst.out),
             Operation::Branch(_)
             | Operation::Synchronization(_)

--- a/crates/cubecl-opt/src/instructions.rs
+++ b/crates/cubecl-opt/src/instructions.rs
@@ -80,6 +80,7 @@ impl Function {
             Operation::Metadata(meta) => self.visit_meta(meta, visit_read),
             // Sync has no outputs
             Operation::Synchronization(_) => {}
+            Operation::WorkgroupUniformLoad(variable) => visit_read(self, variable),
             Operation::Plane(plane) => self.visit_plane(plane, visit_read),
             Operation::CoopMma(coop_mma) => self.visit_cmma(state, coop_mma, visit_read),
             Operation::Branch(_) => unreachable!(),

--- a/crates/cubecl-spirv/src/instruction.rs
+++ b/crates/cubecl-spirv/src/instruction.rs
@@ -45,6 +45,14 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
             Operation::Metadata(meta) => self.compile_meta(meta, inst.out, uniform),
             Operation::Plane(plane) => self.compile_plane(plane, inst.out, uniform),
             Operation::Synchronization(sync) => self.compile_sync(sync),
+            Operation::WorkgroupUniformLoad(op) => {
+                self.compile_sync(core::Synchronization::SyncCube);
+                if op.ty.is_atomic() {
+                    self.compile_atomic(core::AtomicOp::Load(op), inst.out, inst.modes);
+                } else {
+                    self.compile_memory(core::Memory::Load(op), inst.out);
+                }
+            }
             Operation::CoopMma(cmma) => self.compile_cmma(cmma, inst.out),
             Operation::TensorIndexing(tensor) => self.compile_tensor_indexing(tensor, inst.out),
             Operation::NonSemantic(debug) => self.compile_debug(debug),

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -485,6 +485,12 @@ impl WgslCompiler {
             cube::Operation::Synchronization(val) => {
                 self.compile_synchronization(instructions, val)
             }
+            cube::Operation::WorkgroupUniformLoad(op) => {
+                instructions.push(wgsl::Instruction::WorkgroupUniformLoad {
+                    input: self.compile_variable(op),
+                    out: self.compile_variable(out.unwrap()),
+                });
+            }
             cube::Operation::Plane(op) => self.compile_subgroup(instructions, op, out),
             cube::Operation::CoopMma(_) => {
                 panic!("Cooperative matrix-multiply and accumulate isn't supported on wgpu.")

--- a/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/instructions.rs
@@ -57,6 +57,10 @@ pub enum Instruction {
     Unreachable,
     WorkgroupBarrier,
     StorageBarrier,
+    WorkgroupUniformLoad {
+        input: Variable,
+        out: Variable,
+    },
     // Index handles casting to correct local variable.
     Index {
         lhs: Variable,
@@ -853,6 +857,10 @@ for (var {i}: {i_ty} = {start}; {i} {cmp} {end}; {increment}) {{
             Instruction::Break => f.write_str("break;\n"),
             Instruction::WorkgroupBarrier => f.write_str("workgroupBarrier();\n"),
             Instruction::StorageBarrier => f.write_str("storageBarrier();\n"),
+            Instruction::WorkgroupUniformLoad { input, out } => {
+                let out = out.fmt_left();
+                writeln!(f, "{out} = workgroupUniformLoad({input});")
+            }
             Instruction::Length { var, out } => {
                 let out = out.fmt_left();
 


### PR DESCRIPTION
Adds a `workgroupUniformLoad`-style primitive to CubeCL. Required for WebGPU compliance when a workgroup-shared value gates control flow that contains `workgroupBarrier` calls — per WGSL spec, plain workgroup loads return a non-uniform value, so the surrounding control flow fails Tint's uniformity analysis. WebGPU's `workgroupUniformLoad` exists specifically to mark the result as uniform. Uniformity is implicit on non-WebGPU backends, so those just need barrier + load.

This PR adds two methods on shared memory, one for atomics, one for non-atomics, matching the WebGPU overloads.

Discovered while porting brush's WGSL gaussian-splat kernels to CubeCL, the rasterize forward kernel uses workgroup-shared range + early-exit atomic to gate its inner loop, and Tint rejected the generated WGSL without this primitive.