### PR TITLE
Perf/lighter cubecl cpu runtime

### DIFF
--- a/crates/cubecl-cpu/src/compiler/builtin.rs
+++ b/crates/cubecl-cpu/src/compiler/builtin.rs
@@ -2,21 +2,19 @@ use cubecl_core::{CubeDim, ir::Builtin};
 
 const NB_PASSED_BUILTIN: usize = 9;
 
+///[
+///  cube_dim_x
+///  cube_dim_y
+///  cube_dim_z
+///  cube_count_x
+///  cube_count_y
+///  cube_count_z
+///  unit_pos_x
+///  unit_pos_y
+///  unit_pos_z
+///]
 #[derive(Default, Debug, Clone)]
-pub struct BuiltinArray {
-    pub dims: [u32; NB_PASSED_BUILTIN],
-    //[
-    //  cube_dim_x
-    //  cube_dim_y
-    //  cube_dim_z
-    //  cube_count_x
-    //  cube_count_y
-    //  cube_count_z
-    //  unit_pos_x
-    //  unit_pos_y
-    //  unit_pos_z
-    //]
-}
+pub struct BuiltinArray(pub [u32; NB_PASSED_BUILTIN]);
 
 impl BuiltinArray {
     pub(crate) const fn builtin_order() -> [Builtin; 9] {
@@ -32,20 +30,23 @@ impl BuiltinArray {
             Builtin::UnitPosZ,
         ]
     }
-    pub(crate) fn set_cube_dim(&mut self, cube_dim: CubeDim) {
-        self.dims[0] = cube_dim.x;
-        self.dims[1] = cube_dim.y;
-        self.dims[2] = cube_dim.z;
-    }
-    pub(crate) fn set_cube_count(&mut self, cube_count: [u32; 3]) {
-        self.dims[3] = cube_count[0];
-        self.dims[4] = cube_count[1];
-        self.dims[5] = cube_count[2];
+    pub fn new(cube_dim: CubeDim, cube_count: [u32; 3]) -> BuiltinArray {
+        Self([
+            cube_dim.x,
+            cube_dim.y,
+            cube_dim.z,
+            cube_count[0],
+            cube_count[1],
+            cube_count[2],
+            0,
+            0,
+            0,
+        ])
     }
     pub(crate) fn set_unit_pos(&mut self, unit_pos: [u32; 3]) {
-        self.dims[6] = unit_pos[0];
-        self.dims[7] = unit_pos[1];
-        self.dims[8] = unit_pos[2];
+        self.0[6] = unit_pos[0];
+        self.0[7] = unit_pos[1];
+        self.0[8] = unit_pos[2];
     }
     pub(crate) const fn len() -> usize {
         NB_PASSED_BUILTIN

--- a/crates/cubecl-cpu/src/compiler/builtin.rs
+++ b/crates/cubecl-cpu/src/compiler/builtin.rs
@@ -3,15 +3,15 @@ use cubecl_core::{CubeDim, ir::Builtin};
 const NB_PASSED_BUILTIN: usize = 9;
 
 ///[
-///  cube_dim_x
-///  cube_dim_y
-///  cube_dim_z
-///  cube_count_x
-///  cube_count_y
-///  cube_count_z
-///  unit_pos_x
-///  unit_pos_y
-///  unit_pos_z
+///  `cube_dim_x`
+///  `cube_dim_y`
+///  `cube_dim_z`
+///  `cube_count_x`
+///  `cube_count_y`
+///  `cube_count_z`
+///  `unit_pos_x`
+///  `unit_pos_y`
+///  `unit_pos_z`
 ///]
 #[derive(Default, Debug, Clone)]
 pub struct BuiltinArray(pub [u32; NB_PASSED_BUILTIN]);

--- a/crates/cubecl-cpu/src/compiler/mlir_data.rs
+++ b/crates/cubecl-cpu/src/compiler/mlir_data.rs
@@ -3,6 +3,7 @@ use crate::{
     compiler::{builtin::BuiltinArray, memref::LineMemRef, passes::shared_memories::SharedMemory},
     compute::schedule::BindingsResource,
 };
+use cubecl_core::CubeDim;
 use cubecl_runtime::{memory_management::MemoryManagement, storage::BytesStorage};
 use std::sync::Arc;
 
@@ -38,10 +39,12 @@ impl MlirData {
         bindings: BindingsResource,
         shared_memories: &SharedMemories,
         memory_management_shared_memory: &mut MemoryManagement<BytesStorage>,
+        cube_dim: CubeDim,
+        cube_count: [u32; 3],
     ) -> Self {
         let BindingsResource { resources, info } = bindings;
 
-        let builtin = BuiltinArray::default();
+        let builtin = BuiltinArray::new(cube_dim, cube_count);
         let max_buffer_size = resources.len() + BuiltinArray::len();
 
         let args_zero_indirection = Vec::with_capacity(max_buffer_size);
@@ -113,7 +116,7 @@ impl MlirData {
     }
 
     pub fn push_builtin(&mut self) {
-        for arg in self.builtin.dims.iter_mut() {
+        for arg in self.builtin.0.iter_mut() {
             self.args_second_indirection
                 .push(arg as *mut u32 as *mut ());
         }

--- a/crates/cubecl-cpu/src/compute/compute_task.rs
+++ b/crates/cubecl-cpu/src/compute/compute_task.rs
@@ -1,10 +1,10 @@
 use cubecl_core::server::ExecutionMode;
 
-use crate::compiler::{mlir_data::MlirData, mlir_engine::MlirEngine};
-use std::sync::{
-    atomic::{AtomicI32, Ordering},
-    mpsc,
+use crate::{
+    compiler::{mlir_data::MlirData, mlir_engine::MlirEngine},
+    compute::notification::Notifications,
 };
+use std::sync::atomic::{AtomicI32, Ordering};
 
 pub static BARRIER_COUNTER: AtomicI32 = AtomicI32::new(0);
 pub static STOPPED_COUNTER: AtomicI32 = AtomicI32::new(0);
@@ -41,7 +41,7 @@ pub fn sync_cube() {
 
 pub enum Message {
     ComputeTask(ComputeTask),
-    EndTask(mpsc::Sender<()>),
+    EndTask(Notifications),
 }
 
 pub struct ComputeTask {

--- a/crates/cubecl-cpu/src/compute/compute_task.rs
+++ b/crates/cubecl-cpu/src/compute/compute_task.rs
@@ -37,14 +37,10 @@ pub fn sync_cube() {
     }
 }
 
-pub enum Message {
-    ComputeTask(ComputeTask),
-    EndTask(Notifications),
-}
-
 pub struct ComputeTask {
     pub mlir_engine: MlirEngine,
     pub mlir_data: MlirData,
+    pub notifications: Notifications,
 }
 
 impl ComputeTask {
@@ -54,5 +50,6 @@ impl ComputeTask {
             self.mlir_engine.run_kernel(&mut self.mlir_data);
         }
         CURRENT_CUBE_DIM.fetch_sub(1, Ordering::AcqRel);
+        self.notifications.send();
     }
 }

--- a/crates/cubecl-cpu/src/compute/compute_task.rs
+++ b/crates/cubecl-cpu/src/compute/compute_task.rs
@@ -1,5 +1,3 @@
-use cubecl_core::server::ExecutionMode;
-
 use crate::{
     compiler::{mlir_data::MlirData, mlir_engine::MlirEngine},
     compute::notification::Notifications,
@@ -47,14 +45,11 @@ pub enum Message {
 pub struct ComputeTask {
     pub mlir_engine: MlirEngine,
     pub mlir_data: MlirData,
-    pub unit_pos: [u32; 3],
-    pub kind: ExecutionMode,
 }
 
 impl ComputeTask {
     pub fn compute(mut self) {
         self.mlir_data.push_builtin();
-        self.mlir_data.builtin.set_unit_pos(self.unit_pos);
         unsafe {
             self.mlir_engine.run_kernel(&mut self.mlir_data);
         }

--- a/crates/cubecl-cpu/src/compute/mod.rs
+++ b/crates/cubecl-cpu/src/compute/mod.rs
@@ -4,6 +4,7 @@ pub mod server;
 pub mod worker;
 
 pub(crate) mod alloc_controller;
+pub(crate) mod notification;
 pub(crate) mod queue;
 pub(crate) mod schedule;
 pub(crate) mod stream;

--- a/crates/cubecl-cpu/src/compute/notification.rs
+++ b/crates/cubecl-cpu/src/compute/notification.rs
@@ -1,0 +1,48 @@
+/// Struct used inside the CPUExecutionQueue to send the flush command
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, Thread},
+};
+
+#[derive(Clone)]
+pub(super) struct Notification {
+    ready: Arc<AtomicBool>,
+    current_thread: Thread,
+}
+
+const MAX_SPIN_ITERATION: u16 = 8192;
+
+impl Notification {
+    #[inline]
+    pub fn new() -> Self {
+        let ready = Arc::new(AtomicBool::new(false));
+        let current_thread = thread::current();
+        Self {
+            ready,
+            current_thread,
+        }
+    }
+
+    #[inline]
+    pub fn send(&self) {
+        self.ready.store(true, Ordering::Release);
+        self.current_thread.unpark();
+    }
+
+    #[inline]
+    pub fn wait(&self) {
+        for _ in 0..MAX_SPIN_ITERATION {
+            if self.ready.load(Ordering::Acquire) {
+                return;
+            }
+            std::hint::spin_loop();
+        }
+
+        while !self.ready.load(Ordering::Acquire) {
+            std::thread::park();
+        }
+    }
+}

--- a/crates/cubecl-cpu/src/compute/notification.rs
+++ b/crates/cubecl-cpu/src/compute/notification.rs
@@ -48,24 +48,25 @@ impl Notification {
 
 #[derive(Clone)]
 pub struct Notifications {
-    ready: Arc<AtomicU32>,
+    remaining: Arc<AtomicU32>,
     current_thread: Thread,
 }
 
 impl Notifications {
     #[inline]
-    pub fn new(max_notification: u32) -> Self {
-        let ready = Arc::new(AtomicU32::new(max_notification));
+    pub fn new(nb_notification: u32) -> Self {
+        let remaining = Arc::new(AtomicU32::new(nb_notification));
         let current_thread = thread::current();
         Self {
-            ready,
+            remaining,
             current_thread,
         }
     }
 
     #[inline]
     pub fn send(&self) {
-        let value = self.ready.fetch_sub(1, Ordering::AcqRel);
+        let value = self.remaining.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(value > 0); // Send should only be called nb_notification time
         if value == 1 {
             self.current_thread.unpark();
         }
@@ -74,13 +75,13 @@ impl Notifications {
     #[inline]
     pub fn wait(&self) {
         for _ in 0..MAX_SPIN_ITERATION {
-            if self.ready.load(Ordering::Acquire) == 0 {
+            if self.remaining.load(Ordering::Acquire) == 0 {
                 return;
             }
             std::hint::spin_loop();
         }
 
-        while self.ready.load(Ordering::Acquire) != 0 {
+        while self.remaining.load(Ordering::Acquire) != 0 {
             std::thread::park();
         }
     }

--- a/crates/cubecl-cpu/src/compute/notification.rs
+++ b/crates/cubecl-cpu/src/compute/notification.rs
@@ -1,19 +1,18 @@
-/// Struct used inside the CPUExecutionQueue to send the flush command
 use std::{
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     },
     thread::{self, Thread},
 };
 
+const MAX_SPIN_ITERATION: u16 = 8192;
+
 #[derive(Clone)]
-pub(super) struct Notification {
+pub struct Notification {
     ready: Arc<AtomicBool>,
     current_thread: Thread,
 }
-
-const MAX_SPIN_ITERATION: u16 = 8192;
 
 impl Notification {
     #[inline]
@@ -42,6 +41,46 @@ impl Notification {
         }
 
         while !self.ready.load(Ordering::Acquire) {
+            std::thread::park();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Notifications {
+    ready: Arc<AtomicU32>,
+    current_thread: Thread,
+}
+
+impl Notifications {
+    #[inline]
+    pub fn new(max_notification: u32) -> Self {
+        let ready = Arc::new(AtomicU32::new(max_notification));
+        let current_thread = thread::current();
+        Self {
+            ready,
+            current_thread,
+        }
+    }
+
+    #[inline]
+    pub fn send(&self) {
+        let value = self.ready.fetch_sub(1, Ordering::AcqRel);
+        if value == 1 {
+            self.current_thread.unpark();
+        }
+    }
+
+    #[inline]
+    pub fn wait(&self) {
+        for _ in 0..MAX_SPIN_ITERATION {
+            if self.ready.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            std::hint::spin_loop();
+        }
+
+        while self.ready.load(Ordering::Acquire) != 0 {
             std::thread::park();
         }
     }

--- a/crates/cubecl-cpu/src/compute/queue.rs
+++ b/crates/cubecl-cpu/src/compute/queue.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use cubecl_common::bytes::Bytes;
-use cubecl_core::{CubeDim, server::ExecutionMode};
+use cubecl_core::CubeDim;
 use cubecl_runtime::{logging::ServerLogger, storage::BytesResource};
 use std::sync::{Arc, OnceLock, mpsc::SyncSender};
 
@@ -82,10 +82,10 @@ impl CpuExecutionQueueServer {
             ScheduleTask::Execute {
                 mlir_engine,
                 bindings,
-                kind,
                 cube_dim,
                 cube_count,
-            } => self.kernel(mlir_engine, bindings, kind, cube_dim, cube_count),
+                ..
+            } => self.kernel(mlir_engine, bindings, cube_dim, cube_count),
         }
     }
 
@@ -97,11 +97,10 @@ impl CpuExecutionQueueServer {
         &mut self,
         mlir_engine: MlirEngine,
         bindings: BindingsResource,
-        kind: ExecutionMode,
         cube_dim: CubeDim,
         cube_count: [u32; 3],
     ) {
         self.runner
-            .execute_data(mlir_engine, bindings, kind, cube_dim, cube_count)
+            .execute_data(mlir_engine, bindings, cube_dim, cube_count)
     }
 }

--- a/crates/cubecl-cpu/src/compute/queue.rs
+++ b/crates/cubecl-cpu/src/compute/queue.rs
@@ -1,6 +1,7 @@
 use crate::{
     compiler::mlir_engine::MlirEngine,
     compute::{
+        notification::Notification,
         runner::KernelRunner,
         schedule::{BindingsResource, ScheduleTask},
     },
@@ -22,7 +23,7 @@ pub struct CpuExecutionQueue {
 
 enum QueueItem {
     Task(ScheduleTask),
-    Flush(std::sync::mpsc::SyncSender<()>),
+    Flush(Notification),
 }
 
 impl CpuExecutionQueue {
@@ -33,9 +34,11 @@ impl CpuExecutionQueue {
 
     /// Flushes the queue, making sure all enqueued tasks before this point are executed.
     pub fn flush(&self) {
-        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
-        self.sender.send(QueueItem::Flush(sender)).unwrap();
-        receiver.recv().unwrap()
+        let notification = Notification::new();
+        self.sender
+            .send(QueueItem::Flush(notification.clone()))
+            .unwrap();
+        notification.wait();
     }
 
     /// Resolves the global execution queue instance.
@@ -55,7 +58,9 @@ impl CpuExecutionQueue {
                 match receiver.recv() {
                     Ok(item) => match item {
                         QueueItem::Task(task) => server.execute_task(task),
-                        QueueItem::Flush(sender) => sender.send(()).unwrap(),
+                        QueueItem::Flush(notification) => {
+                            notification.send();
+                        }
                     },
                     Err(err) => panic!("{err:?}"),
                 }

--- a/crates/cubecl-cpu/src/compute/runner.rs
+++ b/crates/cubecl-cpu/src/compute/runner.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     CpuCompiler,
     compiler::{MlirCompiler, MlirCompilerOptions, mlir_data::MlirData, mlir_engine::MlirEngine},
-    compute::schedule::ScheduleTask,
+    compute::{notification::Notifications, schedule::ScheduleTask},
 };
 use cubecl_core::{
     CubeDim, ExecutionMode, MemoryConfiguration, ir::MemoryDeviceProperties,
@@ -24,7 +24,7 @@ use cubecl_runtime::{
 use std::{
     collections::HashMap,
     fmt::Debug,
-    sync::{Arc, atomic::Ordering, mpsc},
+    sync::{Arc, atomic::Ordering},
 };
 use sysinfo::System;
 
@@ -151,8 +151,6 @@ impl KernelRunner {
         cube_dim: CubeDim,
         cube_count: [u32; 3],
     ) {
-        let (send, receive) = mpsc::channel();
-        let mut msg_count = 0;
         let cube_dim_size = cube_dim.num_elems();
 
         BARRIER_TARGET.store(cube_dim_size as i32, Ordering::Release);
@@ -173,6 +171,7 @@ impl KernelRunner {
         mlir_data.builtin.set_cube_dim(cube_dim);
         mlir_data.builtin.set_cube_count(cube_count);
 
+        let notifications = Notifications::new(cube_dim.num_elems());
         let mut workers = self.workers.iter_mut();
         for unit_pos_x in 0..cube_dim.x {
             for unit_pos_y in 0..cube_dim.y {
@@ -188,18 +187,12 @@ impl KernelRunner {
                         unit_pos,
                         kind,
                     };
-                    msg_count += 1;
                     worker.send_task(compute_task);
-                    worker.send_stop(send.clone());
+                    worker.send_stop(notifications.clone());
                 }
             }
         }
 
-        for _ in receive.into_iter() {
-            msg_count -= 1;
-            if msg_count == 0 {
-                break;
-            }
-        }
+        notifications.wait();
     }
 }

--- a/crates/cubecl-cpu/src/compute/runner.rs
+++ b/crates/cubecl-cpu/src/compute/runner.rs
@@ -6,23 +6,18 @@ use super::{
     worker::Worker,
 };
 use crate::{
-    CpuCompiler,
-    compiler::{MlirCompiler, MlirCompilerOptions, mlir_data::MlirData, mlir_engine::MlirEngine},
-    compute::{notification::Notifications, schedule::ScheduleTask},
+    compiler::{MlirCompiler, mlir_data::MlirData, mlir_engine::MlirEngine},
+    compute::notification::Notifications,
 };
 use cubecl_core::{
-    CubeDim, ExecutionMode, MemoryConfiguration, ir::MemoryDeviceProperties,
-    prelude::CompiledKernel,
+    CubeDim, MemoryConfiguration, ir::MemoryDeviceProperties, prelude::CompiledKernel,
 };
 use cubecl_runtime::{
-    compiler::{CompilationError, CubeTask},
-    id::KernelId,
     logging::ServerLogger,
     memory_management::{MemoryManagement, MemoryManagementOptions},
     storage::BytesStorage,
 };
 use std::{
-    collections::HashMap,
     fmt::Debug,
     sync::{Arc, atomic::Ordering},
 };
@@ -34,7 +29,6 @@ use sysinfo::System;
 /// To register work, you have to use the execution queue.
 pub struct KernelRunner {
     workers: Vec<Worker>,
-    compilation_cache: HashMap<KernelId, CpuKernel>,
     memory_management_shared_memory: MemoryManagement<BytesStorage>,
 }
 
@@ -96,53 +90,11 @@ impl KernelRunner {
             .map(|_| Worker::default())
             .collect();
 
-        let compilation_cache = HashMap::new();
-
         KernelRunner {
             workers,
-            compilation_cache,
             memory_management_shared_memory,
         }
     }
-    pub fn prepare(
-        &mut self,
-        kernel: Box<dyn CubeTask<CpuCompiler>>,
-        cube_count: [u32; 3],
-        bindings: BindingsResource,
-        kind: ExecutionMode,
-    ) -> Result<ScheduleTask, CompilationError> {
-        let kernel_id = kernel.id();
-        let kernel = if let Some(kernel) = self.compilation_cache.get(&kernel_id) {
-            kernel
-        } else {
-            let kernel = kernel.compile(
-                &mut Default::default(),
-                &MlirCompilerOptions::default(),
-                kind,
-                kernel.address_type(),
-            )?;
-            self.compilation_cache
-                .insert(kernel_id.clone(), CpuKernel::new(kernel));
-            self.compilation_cache
-                .get_mut(&kernel_id)
-                .expect("Just inserted")
-        };
-
-        let cube_dim = kernel.mlir.cube_dim;
-
-        let mlir_engine = kernel.mlir.repr.clone().unwrap();
-
-        let task = ScheduleTask::Execute {
-            mlir_engine,
-            bindings,
-            cube_dim,
-            cube_count,
-            kind,
-        };
-
-        Ok(task)
-    }
-
     pub fn execute_data(
         &mut self,
         mlir_engine: MlirEngine,

--- a/crates/cubecl-cpu/src/compute/runner.rs
+++ b/crates/cubecl-cpu/src/compute/runner.rs
@@ -135,9 +135,9 @@ impl KernelRunner {
         let task = ScheduleTask::Execute {
             mlir_engine,
             bindings,
-            kind,
             cube_dim,
             cube_count,
+            kind,
         };
 
         Ok(task)
@@ -147,7 +147,6 @@ impl KernelRunner {
         &mut self,
         mlir_engine: MlirEngine,
         resources: BindingsResource,
-        kind: ExecutionMode,
         cube_dim: CubeDim,
         cube_count: [u32; 3],
     ) {
@@ -163,15 +162,15 @@ impl KernelRunner {
                 .extend((0..cube_dim_size - self.workers.len() as u32).map(|_| Worker::default()));
         }
 
-        let mut mlir_data = MlirData::new(
+        let mlir_data = MlirData::new(
             resources,
             &mlir_engine.0.shared_memories,
             &mut self.memory_management_shared_memory,
+            cube_dim,
+            cube_count,
         );
-        mlir_data.builtin.set_cube_dim(cube_dim);
-        mlir_data.builtin.set_cube_count(cube_count);
 
-        let notifications = Notifications::new(cube_dim.num_elems());
+        let notifications = Notifications::new(cube_dim_size);
         let mut workers = self.workers.iter_mut();
         for unit_pos_x in 0..cube_dim.x {
             for unit_pos_y in 0..cube_dim.y {
@@ -179,13 +178,12 @@ impl KernelRunner {
                     let unit_pos = [unit_pos_x, unit_pos_y, unit_pos_z];
                     let worker = workers.next().expect("The CubeDim are too large");
                     let mlir_engine = mlir_engine.clone();
-                    let mlir_data = mlir_data.clone();
+                    let mut mlir_data = mlir_data.clone();
+                    mlir_data.builtin.set_unit_pos(unit_pos);
 
                     let compute_task = ComputeTask {
                         mlir_engine,
                         mlir_data,
-                        unit_pos,
-                        kind,
                     };
                     worker.send_task(compute_task);
                     worker.send_stop(notifications.clone());

--- a/crates/cubecl-cpu/src/compute/runner.rs
+++ b/crates/cubecl-cpu/src/compute/runner.rs
@@ -68,7 +68,8 @@ impl Debug for KernelRunner {
 
 impl KernelRunner {
     pub fn new(logger: Arc<ServerLogger>) -> Self {
-        let system = System::new_all();
+        let mut system = System::new();
+        system.refresh_memory();
         let max_shared_memory_size = system
             .cgroup_limits()
             .map(|g| g.total_memory)

--- a/crates/cubecl-cpu/src/compute/runner.rs
+++ b/crates/cubecl-cpu/src/compute/runner.rs
@@ -181,12 +181,13 @@ impl KernelRunner {
                     let mut mlir_data = mlir_data.clone();
                     mlir_data.builtin.set_unit_pos(unit_pos);
 
+                    let notifications = notifications.clone();
                     let compute_task = ComputeTask {
                         mlir_engine,
                         mlir_data,
+                        notifications,
                     };
                     worker.send_task(compute_task);
-                    worker.send_stop(notifications.clone());
                 }
             }
         }

--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -155,9 +155,9 @@ impl CpuServer {
         let task = ScheduleTask::Execute {
             mlir_engine,
             bindings,
-            kind,
             cube_dim,
             cube_count,
+            kind,
         };
 
         Ok(task)

--- a/crates/cubecl-cpu/src/compute/worker.rs
+++ b/crates/cubecl-cpu/src/compute/worker.rs
@@ -1,6 +1,8 @@
 use std::sync::mpsc;
 use std::thread;
 
+use crate::compute::notification::Notifications;
+
 use super::compute_task::{ComputeTask, Message};
 
 pub const MAX_STACK_SIZE: usize = 16 * 1024 * 1024;
@@ -43,8 +45,8 @@ impl Worker {
         self.tx.send(Message::ComputeTask(compute_task)).unwrap();
     }
 
-    pub fn send_stop(&mut self, callback: mpsc::Sender<()>) {
-        self.tx.send(Message::EndTask(callback)).unwrap();
+    pub fn send_stop(&mut self, notifications: Notifications) {
+        self.tx.send(Message::EndTask(notifications)).unwrap();
     }
 }
 
@@ -57,7 +59,7 @@ impl InnerWorker {
         for msg in self.rx.into_iter() {
             match msg {
                 Message::ComputeTask(compute_task) => compute_task.compute(),
-                Message::EndTask(end_task) => end_task.send(()).unwrap(),
+                Message::EndTask(end_task) => end_task.send(),
             }
         }
     }

--- a/crates/cubecl-cpu/src/compute/worker.rs
+++ b/crates/cubecl-cpu/src/compute/worker.rs
@@ -1,9 +1,7 @@
 use std::sync::mpsc;
 use std::thread;
 
-use crate::compute::notification::Notifications;
-
-use super::compute_task::{ComputeTask, Message};
+use super::compute_task::ComputeTask;
 
 pub const MAX_STACK_SIZE: usize = 16 * 1024 * 1024;
 pub const DEFAULT_STACK_SIZE: usize = 64 * 1024 * 1024;
@@ -25,7 +23,7 @@ fn resolve_stack_size() -> usize {
 #[derive(Debug)]
 pub struct Worker {
     // TODO: A circular sync buffer with cache alignment would be a better fit, but for the moment a mpsc channel will do the job.
-    tx: mpsc::Sender<Message>,
+    tx: mpsc::Sender<ComputeTask>,
 }
 
 impl Default for Worker {
@@ -42,25 +40,18 @@ impl Default for Worker {
 
 impl Worker {
     pub fn send_task(&mut self, compute_task: ComputeTask) {
-        self.tx.send(Message::ComputeTask(compute_task)).unwrap();
-    }
-
-    pub fn send_stop(&mut self, notifications: Notifications) {
-        self.tx.send(Message::EndTask(notifications)).unwrap();
+        self.tx.send(compute_task).unwrap();
     }
 }
 
 struct InnerWorker {
-    rx: mpsc::Receiver<Message>,
+    rx: mpsc::Receiver<ComputeTask>,
 }
 
 impl InnerWorker {
     fn work(self) {
-        for msg in self.rx.into_iter() {
-            match msg {
-                Message::ComputeTask(compute_task) => compute_task.compute(),
-                Message::EndTask(end_task) => end_task.send(),
-            }
+        for compute_task in self.rx.into_iter() {
+            compute_task.compute();
         }
     }
 }

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -36,7 +36,8 @@ impl DeviceService for CpuServer {
         let options = RuntimeOptions::default();
         let max_cube_dim = (u32::MAX, u32::MAX, u32::MAX);
         let max_cube_count = (u32::MAX, u32::MAX, u32::MAX);
-        let system = System::new_all();
+        let mut system = System::new();
+        system.refresh_memory();
         let max_shared_memory_size = system
             .cgroup_limits()
             .map(|g| g.total_memory)


### PR DESCRIPTION
This PR replace a mpsc callback for synchronizing kernel with a faster atomic implementation with an adaptive spin lock for fast completion to avoid doing a syscall when the response is almost immediate and a thread park fallback to not spin too much when the task is taking time. This result in small kernel going faster by reducing synchronization overhead.

It simplify part of the backend and remove dead code. It also reduce startup time by about 400ms by not refreshing every info on process utilization and just extracting memory information from sysinfo.

<img width="945" height="273" alt="image" src="https://github.com/user-attachments/assets/0f1ab8f2-091a-46da-a85a-428a643e996b" />

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
