### PR TITLE
fix(opt): visit input operand of AtomicOp::CompareAndSwap

### DIFF
--- a/crates/cubecl-opt/src/instructions.rs
+++ b/crates/cubecl-opt/src/instructions.rs
@@ -261,7 +261,7 @@ impl Optimizer {
                 self.visit_unop(unary_operator, visit_read);
             }
             AtomicOp::CompareAndSwap(op) => {
-                visit_read(self, &mut op.cmp);
+                visit_read(self, &mut op.input);
                 visit_read(self, &mut op.cmp);
                 visit_read(self, &mut op.val);
             }


### PR DESCRIPTION
Fixes #1318.

`visit_atomic` for `CompareAndSwap` visited `op.cmp` twice and never visited `op.input`. The atomic pointer variable therefore wasn't tracked as read, and the optimizer could break the binding chain between the `Index` op (which registers the atomic scope) and the `CAS` op (which looks it up). The downstream effect was the `Atomic should have a scope registered` panic in `cubecl-spirv`.

This change visits `op.input` and removes the duplicate visit of `op.cmp` (a copy-paste bug).

## Testing

- `cargo xtask validate` passes.
- Existing optimizer tests pass.

## Hypothesis graph

Investigation notes and the repo-level hypothesis graph that informed this fix: https://github.com/kimjune01/sweep/blob/master/repo-hypotheses/tracel-ai-cubecl.md
