### PR TITLE
fix: Ensure constant block args are generated in the correct block

### DIFF
--- a/crates/cubecl-cpu/build.rs
+++ b/crates/cubecl-cpu/build.rs
@@ -1,5 +1,12 @@
+use std::env;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // required on macos
     tracel_llvm_bundler::config::set_homebrew_library_path()?;
+
+    if env::var("CUBECL_DEBUG_MLIR").is_ok() && env::var("CARGO_FEATURE_STD").is_ok() {
+        println!("cargo:rustc-cfg=feature=\"mlir-dump\"");
+    }
+
     Ok(())
 }

--- a/crates/cubecl-cpu/src/compiler/visitor/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/mod.rs
@@ -91,16 +91,21 @@ impl<'a> Visitor<'a> {
     }
 
     pub fn get_block_args(
-        &self,
+        &mut self,
         block_id: NodeIndex,
         destination: NodeIndex,
     ) -> Vec<Value<'a, 'a>> {
-        self.blocks_args
+        let current_block = self.block;
+        self.block = self.blocks[&block_id];
+        let args = self
+            .blocks_args
             .get(&(block_id, destination))
             .unwrap_or(&vec![])
             .iter()
             .map(|v| self.get_variable(*v))
-            .collect()
+            .collect();
+        self.block = current_block;
+        args
     }
 
     pub fn append_global_str(&mut self, str_to_append: &str) -> String {


### PR DESCRIPTION
No idea how this wasn't hit before, MLIR was just generating constant block args in whatever block happened to be generated last, not the source block. This fixes the issue by ensuring `block` is set to the source block for the duration of `get_block_args`.