### PR TITLE
feat(runtime): add memory_usage_total across all streams

### DIFF
--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -840,6 +840,14 @@ impl<R: Runtime> ComputeClient<R> {
             .unwrap()
     }
 
+    /// Total memory usage across all streams, correct from any thread
+    /// (unlike [`Self::memory_usage`], which only sees the calling thread's stream).
+    pub fn memory_usage_total(&self) -> Result<MemoryUsage, ServerError> {
+        self.device
+            .submit_blocking(move |server| server.memory_usage_total())
+            .unwrap()
+    }
+
     /// Get all devices of a specific type available to this runtime
     pub fn enumerate_devices(&self, type_id: u16) -> Vec<DeviceId> {
         R::enumerate_devices(type_id, self.info())

--- a/crates/cubecl-runtime/src/memory_management/base.rs
+++ b/crates/cubecl-runtime/src/memory_management/base.rs
@@ -3,7 +3,7 @@ use alloc::string::{String, ToString};
 /// Amount of memory in use by this allocator
 /// and statistics on how much memory is reserved and
 /// wasted in total.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MemoryUsage {
     /// The number of allocations currently active.
     ///

--- a/crates/cubecl-runtime/src/server/base.rs
+++ b/crates/cubecl-runtime/src/server/base.rs
@@ -409,6 +409,12 @@ where
     /// The current memory usage of the server.
     fn memory_usage(&mut self, stream_id: StreamId) -> Result<MemoryUsage, ServerError>;
 
+    /// Total memory usage across all streams. Default reports only the
+    /// calling stream; multi-stream backends override to aggregate.
+    fn memory_usage_total(&mut self) -> Result<MemoryUsage, ServerError> {
+        self.memory_usage(StreamId::current())
+    }
+
     /// Ask the server to release memory that it can release.
     fn memory_cleanup(&mut self, stream_id: StreamId);
 

--- a/crates/cubecl-runtime/src/stream/base.rs
+++ b/crates/cubecl-runtime/src/stream/base.rs
@@ -37,6 +37,11 @@ impl<F: StreamFactory> StreamPool<F> {
         }
     }
 
+    /// Read-only iterator over initialized streams (unlike [`Self::get_mut`], never creates one).
+    pub fn streams(&self) -> impl Iterator<Item = &F::Stream> {
+        self.streams.iter().flatten()
+    }
+
     /// Retrieves a mutable reference to a stream for a given stream ID.
     pub fn get_mut(&mut self, stream_id: &StreamId) -> &mut F::Stream {
         // Calculate the index for the stream ID.

--- a/crates/cubecl-runtime/src/stream/scheduler.rs
+++ b/crates/cubecl-runtime/src/stream/scheduler.rs
@@ -114,6 +114,11 @@ impl<B: SchedulerStreamBackend> SchedulerMultiStream<B> {
         &mut stream.stream
     }
 
+    /// Read-only iterator over initialized backend streams.
+    pub fn streams(&self) -> impl Iterator<Item = &B::Stream> {
+        self.pool.streams().map(|s| &s.stream)
+    }
+
     /// Registers a task for execution on a specific stream, ensuring stream alignment.
     pub fn register(&mut self, stream_id: StreamId, task: B::Task, args_streams: &[StreamId]) {
         // Align streams to ensure dependencies are handled correctly.

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -478,6 +478,14 @@ impl ComputeServer for WgpuServer {
         Ok(stream.mem_manage.memory_usage())
     }
 
+    fn memory_usage_total(&mut self) -> Result<MemoryUsage, ServerError> {
+        Ok(self
+            .scheduler
+            .streams()
+            .map(|s| s.mem_manage.memory_usage())
+            .fold(MemoryUsage::default(), |acc, usage| acc.combine(usage)))
+    }
+
     fn memory_cleanup(&mut self, stream_id: StreamId) {
         self.scheduler.execute_streams(vec![stream_id]);
         let stream = self.scheduler.stream(&stream_id);


### PR DESCRIPTION
`memory_usage` only reports the calling thread's stream (keyed on `StreamId::current()`), so querying it from another thread sees a near-empty pool. `memory_usage_total` sums `MemoryUsage` across every stream.