### PR TITLE
Metal: missing space caused compilation errors

### DIFF
--- a/crates/cubecl-cpp/src/metal/dialect.rs
+++ b/crates/cubecl-cpp/src/metal/dialect.rs
@@ -311,7 +311,7 @@ struct alignas({alignment}) {item} {{"
                     shared::PointerClass::Shared => AddressSpace::ThreadGroup,
                     shared::PointerClass::Local => AddressSpace::Thread,
                 };
-                write!(f, "{constness}{address_space}")?;
+                write!(f, "{constness}{address_space} ")?;
                 Self::compile_item(f, inner.as_ref())?;
                 f.write_str("*")
             }


### PR DESCRIPTION
Used by ptr logic only present in burn, not cubek, hence the late find. 