### PR TITLE
refactor: Add a lifetime to views

### DIFF
--- a/crates/cubecl-core/src/frontend/comptime_option.rs
+++ b/crates/cubecl-core/src/frontend/comptime_option.rs
@@ -1,19 +1,9 @@
 use crate::{self as cubecl};
 use cubecl::prelude::*;
-use cubecl_macros::derive_expand;
 
-#[derive(Default, Clone, Copy)]
-pub enum ComptimeOption<T> {
-    #[default]
-    None,
-    Some(T),
-}
-
-// Separate implementation so we don't need `CubeType` for `ComptimeOption` itself.
-// This is important because `&T where T: CubeType` does not necessarily implement
-// `CubeType`, but we need to support it in `as_ref`/`as_mut`.
-#[derive_expand(CubeType)]
+#[derive(Default, Clone, Copy, CubeType)]
 pub enum ComptimeOption<T: CubeType> {
+    #[default]
     None,
     Some(T),
 }
@@ -179,7 +169,7 @@ mod impls {
         use super::*;
         use ComptimeOption::{None, Some};
 
-        impl<T> ComptimeOption<T> {
+        impl<T: CubeType> ComptimeOption<T> {
             /// Returns `true` if the option is a [`Some`] value.
             ///
             /// # Examples
@@ -418,6 +408,7 @@ mod impls {
             pub fn map<U, F>(self, f: F) -> Option<U>
             where
                 F: FnOnce(T) -> U,
+                U: CubeType,
             {
                 match self {
                     Some(x) => Some(f(x)),
@@ -566,10 +557,10 @@ mod impls {
             /// let x: Option<String> = None;
             /// assert_eq!(x.as_deref(), None);
             /// ```
-            pub fn as_deref<'a>(&'a self) -> Option<&'a T::Target>
+            pub fn as_deref(&self) -> Option<&T::Target>
             where
                 T: Deref,
-                &'a T: CubeType,
+                T::Target: CubeType,
             {
                 self.as_ref().map(Deref::deref)
             }
@@ -588,10 +579,10 @@ mod impls {
             ///     x
             /// }), Some("HEY".to_owned().as_mut_str()));
             /// ```
-            pub fn as_deref_mut<'a>(&'a mut self) -> Option<&'a mut T::Target>
+            pub fn as_deref_mut(&mut self) -> Option<&mut T::Target>
             where
                 T: DerefMut,
-                &'a mut T: CubeType,
+                T::Target: CubeType,
             {
                 self.as_mut().map(DerefMut::deref_mut)
             }
@@ -756,8 +747,9 @@ mod impls {
             pub fn reduce<U, R, F>(self, other: Option<U>, f: F) -> Option<R>
             where
                 T: Into<R>,
-                U: Into<R>,
+                U: CubeType + Into<R>,
                 F: FnOnce(T, U) -> R,
+                R: CubeType,
             {
                 match (self, other) {
                     (Some(a), Some(b)) => Some(f(a, b)),
@@ -768,7 +760,7 @@ mod impls {
             }
         }
 
-        impl<T> ComptimeOption<T> {
+        impl<T: CubeType> ComptimeOption<T> {
             /////////////////////////////////////////////////////////////////////////
             // Querying the contained values
             /////////////////////////////////////////////////////////////////////////
@@ -1386,7 +1378,7 @@ mod impls {
         }
     }
 
-    impl<T, U> ComptimeOption<(T, U)> {
+    impl<T: CubeType, U: CubeType> ComptimeOption<(T, U)> {
         /// Unzips an option containing a tuple of two options.
         ///
         /// If `self` is `Some((a, b))` this method returns `(Some(a), Some(b))`.

--- a/crates/cubecl-core/src/frontend/container/array/base.rs
+++ b/crates/cubecl-core/src/frontend/container/array/base.rs
@@ -38,7 +38,7 @@ mod new {
     impl<T: CubePrimitive + Clone> Array<T> {
         /// Create a new array of the given length.
         #[allow(unused_variables)]
-        pub fn new(#[comptime] length: usize) -> Array<T> {
+        pub fn new(#[comptime] length: usize) -> Self {
             intrinsic!(|scope| {
                 // Allocate as a slice even though it's statically sized, so we can deref to it.
                 // Unlike Rust, we can't construct fat pointers ad-hoc without access to the scope,

--- a/crates/cubecl-core/src/frontend/container/mod.rs
+++ b/crates/cubecl-core/src/frontend/container/mod.rs
@@ -5,7 +5,7 @@ mod iter;
 mod registry;
 mod sequence;
 mod shared_memory;
-mod slice;
+pub mod slice;
 mod tensor;
 mod vector;
 

--- a/crates/cubecl-core/src/frontend/container/shared_memory.rs
+++ b/crates/cubecl-core/src/frontend/container/shared_memory.rs
@@ -18,8 +18,6 @@ use crate::{
     prelude::*,
 };
 
-pub type SharedMemory<T> = Shared<[T]>;
-pub type SharedMemoryExpand<T> = NativeExpand<Shared<[T]>>;
 pub type SharedExpand<T> = NativeExpand<Shared<T>>;
 
 pub struct Shared<E: NativeCubeType + ?Sized> {
@@ -27,10 +25,9 @@ pub struct Shared<E: NativeCubeType + ?Sized> {
 }
 
 // Treat it as a shared smart pointer
-impl<E: NativeCubeType + ?Sized> Copy for Shared<E> {}
 impl<E: NativeCubeType + ?Sized> Clone for Shared<E> {
     fn clone(&self) -> Self {
-        *self
+        Self { _val: self._val }
     }
 }
 
@@ -51,9 +48,9 @@ impl<T: NativeCubeType + ?Sized> AsMutExpand for SharedExpand<T> {
 }
 
 #[cube]
-impl<T: CubePrimitive> SharedMemory<T> {
+impl<T: CubePrimitive> Shared<[T]> {
     #[allow(unused_variables)]
-    pub fn new(#[comptime] size: usize) -> SharedMemory<T> {
+    pub fn new(#[comptime] size: usize) -> Self {
         intrinsic!(|scope| {
             let ty = Type::array(T::__expand_as_type(scope), size, AddressSpace::Shared);
             let buffer = scope.create_shared(ty, None);
@@ -73,6 +70,23 @@ impl<T: CubePrimitive> SharedMemory<T> {
     }
 }
 
+impl<T: NativeCubeType + ?Sized> Shared<T> {
+    pub fn map<U: NativeCubeType + ?Sized>(self, _map: impl FnOnce(&T) -> &U) -> Shared<U> {
+        unexpanded!()
+    }
+}
+
+impl<T: NativeCubeType + ?Sized> SharedExpand<T> {
+    pub fn __expand_map_method<U: NativeCubeType + ?Sized>(
+        self,
+        scope: &Scope,
+        map: impl for<'a> FnOnce(&Scope, &'a NativeExpand<T>) -> &'a NativeExpand<U>,
+    ) -> SharedExpand<U> {
+        let out = map(scope, self.__expand_ref_method(scope));
+        out.expand.into()
+    }
+}
+
 #[cube]
 impl<T: CubePrimitive> Shared<T> {
     pub fn new() -> Self {
@@ -83,7 +97,7 @@ impl<T: CubePrimitive> Shared<T> {
     }
 
     #[allow(unused_variables)]
-    pub fn new_array(#[comptime] size: usize) -> SharedMemory<T> {
+    pub fn new_array(#[comptime] size: usize) -> Shared<[T]> {
         intrinsic!(|scope| {
             let ty = Type::array(T::__expand_as_type(scope), size, AddressSpace::Shared);
             let buffer = scope.create_shared(ty, None);
@@ -98,10 +112,7 @@ impl<T: CubePrimitive> Shared<T> {
     }
 
     #[allow(unused_variables)]
-    pub fn new_aligned_array(
-        #[comptime] size: usize,
-        #[comptime] alignment: usize,
-    ) -> SharedMemory<T> {
+    pub fn new_aligned_array(#[comptime] size: usize, #[comptime] alignment: usize) -> Shared<[T]> {
         intrinsic!(|scope| {
             let ty = Type::array(T::__expand_as_type(scope), size, AddressSpace::Shared);
             let buffer = scope.create_shared(ty, Some(alignment));
@@ -165,22 +176,22 @@ impl<T: NativeCubeType + ?Sized> Shared<T> {
     }
 }
 
-fn len_static<T: CubePrimitive>(shared: &NativeExpand<SharedMemory<T>>) -> NativeExpand<usize> {
+fn len_static<T: CubePrimitive>(shared: &NativeExpand<Shared<[T]>>) -> NativeExpand<usize> {
     let Type::Array(_, length, _) = shared.expand.ty else {
         unreachable!("Kind of shared memory is always shared memory")
     };
     length.into()
 }
 
-impl<T: CubePrimitive> List<T> for SharedMemory<T> {}
-impl<T: CubePrimitive> ListExpand<T> for NativeExpand<SharedMemory<T>> {
+impl<T: CubePrimitive> List<T> for Shared<[T]> {}
+impl<T: CubePrimitive> ListExpand<T> for NativeExpand<Shared<[T]>> {
     fn __expand_len_method(&self, scope: &Scope) -> NativeExpand<usize> {
         Self::__expand_len_method(self, scope)
     }
 }
 
-impl<T: CubePrimitive> Vectorized for SharedMemory<T> {}
-impl<T: CubePrimitive> VectorizedExpand for NativeExpand<SharedMemory<T>> {
+impl<T: CubePrimitive> Vectorized for Shared<[T]> {}
+impl<T: CubePrimitive> VectorizedExpand for NativeExpand<Shared<[T]>> {
     fn vector_size(&self) -> VectorSize {
         self.expand.ty.vector_size()
     }
@@ -200,7 +211,7 @@ impl<T: NativeCubeType + ?Sized> DerefMut for Shared<T> {
 }
 
 impl<T: NativeCubeType + ?Sized> Deref for SharedExpand<T> {
-    type Target = T::ExpandType;
+    type Target = NativeExpand<T>;
 
     fn deref(&self) -> &Self::Target {
         unsafe { self.as_type_ref_unchecked() }
@@ -212,8 +223,20 @@ impl<T: NativeCubeType + ?Sized> DerefMut for SharedExpand<T> {
     }
 }
 
+impl<'a, T: NativeCubeType + ?Sized> From<&'a SharedExpand<T>> for &'a NativeExpand<T> {
+    fn from(value: &'a SharedExpand<T>) -> Self {
+        value
+    }
+}
+
+impl<'a, T: NativeCubeType + ?Sized> From<&'a mut SharedExpand<T>> for &'a mut NativeExpand<T> {
+    fn from(value: &'a mut SharedExpand<T>) -> Self {
+        value
+    }
+}
+
 impl<T: NativeCubeType + ?Sized> AsDerefExpand for SharedExpand<T> {
-    type Target = T::ExpandType;
+    type Target = NativeExpand<T>;
 
     fn __expand_as_deref_method(&self, _: &Scope) -> &Self::Target {
         unsafe { self.as_type_ref_unchecked::<T>() }
@@ -232,6 +255,6 @@ impl<T: CubePrimitive> Assign<NativeExpand<T>> for SharedExpand<T> {
     }
 
     fn init_mut(&self, _: &Scope) -> Self {
-        *self
+        self.clone()
     }
 }

--- a/crates/cubecl-core/src/frontend/container/shared_memory.rs
+++ b/crates/cubecl-core/src/frontend/container/shared_memory.rs
@@ -49,16 +49,41 @@ impl<T: NativeCubeType + ?Sized> AsMutExpand for SharedExpand<T> {
 
 #[cube]
 impl<T: CubePrimitive> Shared<[T]> {
+    /// Create a new shared slice.
+    ///
+    /// # Safety
+    /// Shared memory is always uninitialized by default. Reading uninitialized shared values is
+    /// undefined behavior.
     #[allow(unused_variables)]
-    pub fn new(#[comptime] size: usize) -> Self {
+    pub fn new_slice(#[comptime] len: usize) -> Self {
         intrinsic!(|scope| {
-            let ty = Type::array(T::__expand_as_type(scope), size, AddressSpace::Shared);
+            let ty = Type::array(T::__expand_as_type(scope), len, AddressSpace::Shared);
             let buffer = scope.create_shared(ty, None);
             let slice = slice::from_raw_parts::<T>(
                 scope,
                 buffer,
                 0usize.into_expand(scope),
-                size.into_expand(scope),
+                len.into_expand(scope),
+            );
+            slice.expand.into()
+        })
+    }
+
+    /// Create a new shared slice with a specified minimum alignment.
+    ///
+    /// # Safety
+    /// Shared memory is always uninitialized by default. Reading uninitialized shared values is
+    /// undefined behavior.
+    #[allow(unused_variables)]
+    pub fn new_aligned_slice(#[comptime] len: usize, #[comptime] alignment: usize) -> Self {
+        intrinsic!(|scope| {
+            let ty = Type::array(T::__expand_as_type(scope), len, AddressSpace::Shared);
+            let buffer = scope.create_shared(ty, Some(alignment));
+            let slice = slice::from_raw_parts::<T>(
+                scope,
+                buffer,
+                0usize.into_expand(scope),
+                len.into_expand(scope),
             );
             slice.expand.into()
         })
@@ -89,40 +114,15 @@ impl<T: NativeCubeType + ?Sized> SharedExpand<T> {
 
 #[cube]
 impl<T: CubePrimitive> Shared<T> {
+    /// Create a new shared object.
+    ///
+    /// # Safety
+    /// Shared memory is always uninitialized by default. Reading uninitialized shared values is
+    /// undefined behavior.
     pub fn new() -> Self {
         intrinsic!(|scope| {
             let var = scope.create_shared(T::__expand_as_type(scope), None);
             NativeExpand::new(var)
-        })
-    }
-
-    #[allow(unused_variables)]
-    pub fn new_array(#[comptime] size: usize) -> Shared<[T]> {
-        intrinsic!(|scope| {
-            let ty = Type::array(T::__expand_as_type(scope), size, AddressSpace::Shared);
-            let buffer = scope.create_shared(ty, None);
-            let slice = slice::from_raw_parts::<T>(
-                scope,
-                buffer,
-                0usize.into_expand(scope),
-                size.into_expand(scope),
-            );
-            slice.expand.into()
-        })
-    }
-
-    #[allow(unused_variables)]
-    pub fn new_aligned_array(#[comptime] size: usize, #[comptime] alignment: usize) -> Shared<[T]> {
-        intrinsic!(|scope| {
-            let ty = Type::array(T::__expand_as_type(scope), size, AddressSpace::Shared);
-            let buffer = scope.create_shared(ty, Some(alignment));
-            let slice = slice::from_raw_parts::<T>(
-                scope,
-                buffer,
-                0usize.into_expand(scope),
-                size.into_expand(scope),
-            );
-            slice.expand.into()
         })
     }
 }

--- a/crates/cubecl-core/src/frontend/container/slice/base.rs
+++ b/crates/cubecl-core/src/frontend/container/slice/base.rs
@@ -664,7 +664,7 @@ impl<E: CubePrimitive> IndexMutExpand<NativeExpand<usize>> for SliceExpand<E> {
     }
 }
 
-impl_slice_ranges!(SliceExpand);
+impl_slice_ranges!(SliceExpand<E>);
 
 impl<E: CubePrimitive> List<E> for [E] {}
 impl<E: CubePrimitive> ListExpand<E> for SliceExpand<E> {

--- a/crates/cubecl-core/src/frontend/container/slice/operator.rs
+++ b/crates/cubecl-core/src/frontend/container/slice/operator.rs
@@ -18,7 +18,6 @@ pub(crate) fn is_tf32<C: CubePrimitive, T: CubePrimitive>(scope: &Scope) -> bool
 }
 
 type ArrayExpand<E> = NativeExpand<Array<E>>;
-type SharedMemoryExpand<E> = NativeExpand<SharedMemory<E>>;
 
 impl<E: CubePrimitive, T: Deref<Target = SliceExpand<E>> + DerefMut> SliceOperatorExpand<E> for T {
     fn __expand_slice_method(
@@ -41,7 +40,7 @@ impl<E: CubePrimitive, T: Deref<Target = SliceExpand<E>> + DerefMut> SliceOperat
     }
 }
 
-impl<E: CubePrimitive> SliceOperator<E> for SharedMemory<E> {}
+impl<E: CubePrimitive> SliceOperator<E> for Shared<[E]> {}
 impl<E: CubePrimitive> SliceOperator<E> for Tensor<E> {}
 impl<E: CubePrimitive> SliceOperator<E> for Array<E> {}
 
@@ -57,7 +56,7 @@ impl<E: CubePrimitive> Array<E> {
 }
 
 #[cube]
-impl<E: CubePrimitive> SharedMemory<E> {
+impl<E: CubePrimitive> Shared<[E]> {
     pub fn as_slice(&self) -> &[E] {
         intrinsic!(|_| self.deref())
     }

--- a/crates/cubecl-core/src/frontend/container/tensor/base.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/base.rs
@@ -25,6 +25,20 @@ pub struct OwnedTensor<T: CubePrimitive> {
     pub(super) buffer: Box<[T]>,
 }
 
+impl<T: CubePrimitive> TensorExpand<T> {
+    /// Expand only because `[T]` can't be passed to a function
+    pub fn __expand_from_parts(meta: TensorMetaExpand, buffer: NativeExpand<[T]>) -> Self {
+        Self { meta, buffer }
+    }
+}
+
+#[cube]
+impl<T: CubePrimitive> OwnedTensor<T> {
+    pub fn from_parts(meta: TensorMeta, buffer: Box<[T]>) -> Self {
+        OwnedTensor::<T> { meta, buffer }
+    }
+}
+
 #[cube]
 impl<T: CubePrimitive> OwnedTensor<T> {
     pub fn as_slice(&self) -> &[T] {
@@ -190,6 +204,18 @@ impl<'a, E: CubePrimitive> From<&'a OwnedTensorExpand<E>> for &'a TensorExpand<E
 
 impl<'a, E: CubePrimitive> From<&'a mut OwnedTensorExpand<E>> for &'a mut TensorExpand<E> {
     fn from(value: &'a mut OwnedTensorExpand<E>) -> Self {
+        value.deref_mut()
+    }
+}
+
+impl<'a, E: CubePrimitive> From<&'a TensorExpand<E>> for &'a SliceExpand<E> {
+    fn from(value: &'a TensorExpand<E>) -> Self {
+        value.deref()
+    }
+}
+
+impl<'a, E: CubePrimitive> From<&'a mut TensorExpand<E>> for &'a mut SliceExpand<E> {
+    fn from(value: &'a mut TensorExpand<E>) -> Self {
         value.deref_mut()
     }
 }

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -201,6 +201,10 @@ pub trait DerefExpand {
     fn __expand_deref_method(&self, scope: &Scope) -> Self::Target;
 }
 
+pub fn __expand_deref<T: DerefExpand<Target = T>>(scope: &Scope, value: &T) -> T {
+    value.__expand_deref_method(scope)
+}
+
 pub trait AsDerefExpand {
     type Target;
     fn __expand_as_deref_method(&self, scope: &Scope) -> &Self::Target;
@@ -238,6 +242,10 @@ pub trait Assign<T = Self> {
     fn __expand_assign_method(&mut self, scope: &Scope, value: T);
     /// Create a new mutable variable of this type in `scope`.
     fn init_mut(&self, scope: &Scope) -> Self;
+}
+
+pub fn __expand_assign<T: Assign<T>>(scope: &Scope, target: &mut T, value: T) {
+    target.__expand_assign_method(scope, value);
 }
 
 impl<T: CubePrimitive> Assign for T {

--- a/crates/cubecl-core/src/frontend/list.rs
+++ b/crates/cubecl-core/src/frontend/list.rs
@@ -25,9 +25,23 @@ pub trait Vectorized: CubeType<ExpandType: VectorizedExpand> {
     }
 }
 
+impl<T: Vectorized + ?Sized> Vectorized for &T {}
+impl<T: Vectorized + ?Sized> Vectorized for &mut T {}
+
 pub trait VectorizedExpand {
     fn vector_size(&self) -> VectorSize;
     fn __expand_vector_size_method(&self, _scope: &Scope) -> VectorSize {
         self.vector_size()
+    }
+}
+
+impl<T: VectorizedExpand + ?Sized> VectorizedExpand for &T {
+    fn vector_size(&self) -> VectorSize {
+        (**self).vector_size()
+    }
+}
+impl<T: VectorizedExpand + ?Sized> VectorizedExpand for &mut T {
+    fn vector_size(&self) -> VectorSize {
+        (**self).vector_size()
     }
 }

--- a/crates/cubecl-core/src/frontend/operation/assignation.rs
+++ b/crates/cubecl-core/src/frontend/operation/assignation.rs
@@ -5,7 +5,7 @@ use core::ops::{
 use cubecl_ir::{Operator, Scope, Variable};
 
 use crate::{
-    frontend::{Array, SharedMemory, Tensor},
+    frontend::{Array, Tensor},
     prelude::*,
 };
 use crate::{ir, unexpanded};
@@ -97,44 +97,44 @@ pub mod index_mut {
     use super::*;
 
     macro_rules! impl_index {
-        ($type:ident, $expand: ty) => {
-            impl<E: CubePrimitive> IndexMut<usize> for $type<E> {
+        ($type: ty, $expand: ty) => {
+            impl<E: CubePrimitive> IndexMut<usize> for $type {
                 fn index_mut(&mut self, _idx: usize) -> &mut Self::Output {
                     unexpanded!()
                 }
             }
 
-            impl<E: CubePrimitive> IndexMut<Range<usize>> for $type<E> {
+            impl<E: CubePrimitive> IndexMut<Range<usize>> for $type {
                 fn index_mut(&mut self, _idx: Range<usize>) -> &mut Self::Output {
                     unexpanded!()
                 }
             }
 
-            impl<E: CubePrimitive> IndexMut<RangeFrom<usize>> for $type<E> {
+            impl<E: CubePrimitive> IndexMut<RangeFrom<usize>> for $type {
                 fn index_mut(&mut self, _idx: RangeFrom<usize>) -> &mut Self::Output {
                     unexpanded!()
                 }
             }
 
-            impl<E: CubePrimitive> IndexMut<RangeFull> for $type<E> {
+            impl<E: CubePrimitive> IndexMut<RangeFull> for $type {
                 fn index_mut(&mut self, _idx: RangeFull) -> &mut Self::Output {
                     unexpanded!()
                 }
             }
 
-            impl<E: CubePrimitive> IndexMut<RangeInclusive<usize>> for $type<E> {
+            impl<E: CubePrimitive> IndexMut<RangeInclusive<usize>> for $type {
                 fn index_mut(&mut self, _idx: RangeInclusive<usize>) -> &mut Self::Output {
                     unexpanded!()
                 }
             }
 
-            impl<E: CubePrimitive> IndexMut<RangeTo<usize>> for $type<E> {
+            impl<E: CubePrimitive> IndexMut<RangeTo<usize>> for $type {
                 fn index_mut(&mut self, _idx: RangeTo<usize>) -> &mut Self::Output {
                     unexpanded!()
                 }
             }
 
-            impl<E: CubePrimitive> IndexMut<RangeToInclusive<usize>> for $type<E> {
+            impl<E: CubePrimitive> IndexMut<RangeToInclusive<usize>> for $type {
                 fn index_mut(&mut self, _idx: RangeToInclusive<usize>) -> &mut Self::Output {
                     unexpanded!()
                 }
@@ -153,21 +153,21 @@ pub mod index_mut {
         };
     }
 
-    impl_index!(Array, NativeExpand<Array<E>>);
-    impl_index!(Tensor, TensorExpand<E>);
-    impl_index!(SharedMemory, NativeExpand<Shared<[E]>>);
+    impl_index!(Array<E>, NativeExpand<Array<E>>);
+    impl_index!(Tensor<E>, TensorExpand<E>);
+    impl_index!(Shared<[E]>, NativeExpand<Shared<[E]>>);
 
-    impl_slice_ranges!(ArrayExpand);
-    impl_slice_ranges!(TensorExpand);
-    impl_slice_ranges!(SharedMemoryExpand);
+    impl_slice_ranges!(ArrayExpand<E>);
+    impl_slice_ranges!(TensorExpand<E>);
+    impl_slice_ranges!(NativeExpand<Shared<[E]>>);
 }
 
 pub mod index {
     use super::*;
 
     macro_rules! impl_index {
-        ($type:ident, $expand: ident) => {
-            impl<E: CubePrimitive> Index<usize> for $type<E> {
+        ($type: ty, $expand: ty) => {
+            impl<E: CubePrimitive> Index<usize> for $type {
                 type Output = E;
 
                 fn index(&self, _idx: usize) -> &Self::Output {
@@ -175,7 +175,7 @@ pub mod index {
                 }
             }
 
-            impl<E: CubePrimitive> Index<Range<usize>> for $type<E> {
+            impl<E: CubePrimitive> Index<Range<usize>> for $type {
                 type Output = [E];
 
                 fn index(&self, _idx: Range<usize>) -> &Self::Output {
@@ -183,7 +183,7 @@ pub mod index {
                 }
             }
 
-            impl<E: CubePrimitive> Index<RangeFrom<usize>> for $type<E> {
+            impl<E: CubePrimitive> Index<RangeFrom<usize>> for $type {
                 type Output = [E];
 
                 fn index(&self, _idx: RangeFrom<usize>) -> &Self::Output {
@@ -191,7 +191,7 @@ pub mod index {
                 }
             }
 
-            impl<E: CubePrimitive> Index<RangeFull> for $type<E> {
+            impl<E: CubePrimitive> Index<RangeFull> for $type {
                 type Output = [E];
 
                 fn index(&self, _idx: RangeFull) -> &Self::Output {
@@ -199,7 +199,7 @@ pub mod index {
                 }
             }
 
-            impl<E: CubePrimitive> Index<RangeInclusive<usize>> for $type<E> {
+            impl<E: CubePrimitive> Index<RangeInclusive<usize>> for $type {
                 type Output = [E];
 
                 fn index(&self, _idx: RangeInclusive<usize>) -> &Self::Output {
@@ -207,7 +207,7 @@ pub mod index {
                 }
             }
 
-            impl<E: CubePrimitive> Index<RangeTo<usize>> for $type<E> {
+            impl<E: CubePrimitive> Index<RangeTo<usize>> for $type {
                 type Output = [E];
 
                 fn index(&self, _idx: RangeTo<usize>) -> &Self::Output {
@@ -215,7 +215,7 @@ pub mod index {
                 }
             }
 
-            impl<E: CubePrimitive> Index<RangeToInclusive<usize>> for $type<E> {
+            impl<E: CubePrimitive> Index<RangeToInclusive<usize>> for $type {
                 type Output = [E];
 
                 fn index(&self, _idx: RangeToInclusive<usize>) -> &Self::Output {
@@ -223,7 +223,7 @@ pub mod index {
                 }
             }
 
-            impl<E: CubePrimitive> IndexExpand<NativeExpand<usize>> for $expand<E> {
+            impl<E: CubePrimitive> IndexExpand<NativeExpand<usize>> for $expand {
                 type Output = NativeExpand<E>;
 
                 fn __expand_index_method(
@@ -238,7 +238,7 @@ pub mod index {
         };
     }
 
-    impl_index!(Array, ArrayExpand);
-    impl_index!(Tensor, TensorExpand);
-    impl_index!(SharedMemory, SharedMemoryExpand);
+    impl_index!(Array<E>, NativeExpand<Array<E>>);
+    impl_index!(Tensor<E>, TensorExpand<E>);
+    impl_index!(Shared<[E]>, NativeExpand<Shared<[E]>>);
 }

--- a/crates/cubecl-core/src/frontend/ranges.rs
+++ b/crates/cubecl-core/src/frontend/ranges.rs
@@ -279,8 +279,8 @@ pub(crate) trait IntoSliceIndices {
 }
 
 macro_rules! impl_slice_ranges {
-    ($ty: ident, $range: ty) => {
-        impl<E: CubePrimitive> IndexExpand<$range> for $ty<E> {
+    ($ty: ty, $range: ty) => {
+        impl<E: CubePrimitive> IndexExpand<$range> for $ty {
             type Output = SliceExpand<E>;
 
             fn __expand_index_method(&self, scope: &Scope, index: $range) -> &Self::Output {
@@ -289,7 +289,7 @@ macro_rules! impl_slice_ranges {
             }
         }
 
-        impl<E: CubePrimitive> IndexMutExpand<$range> for $ty<E> {
+        impl<E: CubePrimitive> IndexMutExpand<$range> for $ty {
             fn __expand_index_mut_method(
                 &mut self,
                 scope: &Scope,
@@ -300,7 +300,7 @@ macro_rules! impl_slice_ranges {
             }
         }
     };
-    ($ty: ident) => {
+    ($ty: ty) => {
         impl_slice_ranges!($ty, RangeExpand<usize>);
         impl_slice_ranges!($ty, RangeFromExpand<usize>);
         impl_slice_ranges!($ty, RangeFullExpand);

--- a/crates/cubecl-core/src/post_processing/visitor.rs
+++ b/crates/cubecl-core/src/post_processing/visitor.rs
@@ -3,10 +3,8 @@ use core::fmt::Debug;
 use alloc::vec::Vec;
 
 use cubecl_ir::{
-    Arithmetic, AtomicBinaryOperands, AtomicOp, BarrierOps, BinaryOperands, Bitwise, Branch,
-    Comparison, CoopMma, GlobalState, Instruction, Marker, Memory, Metadata, NonSemantic,
-    Operation, OperationReflect, Operator, Plane, Scope, TensorIndexingOps, TmaOps, UnaryOperands,
-    Variable,
+    Branch, CoopMma, GlobalState, Instruction, Marker, NonSemantic, Operation, OperationReflect,
+    Scope, TensorIndexingOps, TmaOps, Variable,
 };
 use derive_more::{Deref, DerefMut};
 
@@ -123,34 +121,23 @@ impl<T> Visitor<T> {
         }
 
         match op {
-            Operation::Copy(variable) => visit_read(self, variable),
-            Operation::WorkgroupUniformLoad(variable) => visit_read(self, variable),
-            Operation::Memory(memory) => self.visit_memory(memory, visit_read),
-            Operation::Arithmetic(arithmetic) => self.visit_arithmetic(arithmetic, visit_read),
-            Operation::Comparison(comparison) => self.visit_compare(comparison, visit_read),
-            Operation::Bitwise(bitwise) => self.visit_bitwise(bitwise, visit_read),
-            Operation::Operator(operator) => self.visit_operator(operator, visit_read),
-            Operation::Atomic(atomic) => self.visit_atomic(atomic, visit_read),
-            Operation::Metadata(meta) => self.visit_meta(meta, visit_read),
-            // Sync has no outputs
-            Operation::Synchronization(_) => {}
-            Operation::Plane(plane) => self.visit_plane(plane, visit_read),
+            Operation::Marker(Marker::Free(_)) => {}
             Operation::CoopMma(coop_mma) => self.visit_cmma(coop_mma, visit_read),
             Operation::Branch(branch) => self.visit_branch(branch, visit_read),
-            Operation::Barrier(barrier_ops) => self.visit_barrier(barrier_ops, visit_read),
             Operation::Tma(tma_ops) => self.visit_tma(tma_ops, visit_read),
             Operation::TensorIndexing(tensor_ops) => self.visit_tensor_ops(tensor_ops, visit_read),
             Operation::NonSemantic(non_semantic) => {
                 self.visit_nonsemantic(non_semantic, visit_read)
             }
-            Operation::Marker(Marker::Free(_)) => {}
-            Operation::Marker(Marker::DummyRead(variable)) => visit_read(self, variable),
-            Operation::ConstructAggregate(variables) => {
-                for variable in variables {
-                    visit_read(self, variable);
+            op => {
+                if let Some(args) = op.args_mut() {
+                    for arg in args {
+                        visit_read(self, arg);
+                    }
+                } else {
+                    panic!("Found op {op:?} which doesn't reflect. Needs special handling.");
                 }
             }
-            Operation::ExtractAggregateField(op) => visit_read(self, &mut op.aggregate),
         }
     }
 
@@ -170,252 +157,6 @@ impl<T> Visitor<T> {
                 visit_read(self, &mut range_loop.end);
             }
             Branch::Loop(_) | Branch::Return | Branch::Break | Branch::Unreachable => {}
-        }
-    }
-
-    /// Visit an operator with a set of read and write visitors. Each visitor will be called with
-    /// each read or written to variable.
-    pub fn visit_arithmetic(
-        &mut self,
-        op: &mut Arithmetic,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        match op {
-            Arithmetic::Fma(fma_operands) => {
-                visit_read(self, &mut fma_operands.a);
-                visit_read(self, &mut fma_operands.b);
-                visit_read(self, &mut fma_operands.c);
-            }
-            Arithmetic::Add(binary_operands)
-            | Arithmetic::SaturatingAdd(binary_operands)
-            | Arithmetic::Sub(binary_operands)
-            | Arithmetic::SaturatingSub(binary_operands)
-            | Arithmetic::Mul(binary_operands)
-            | Arithmetic::Div(binary_operands)
-            | Arithmetic::Powf(binary_operands)
-            | Arithmetic::Powi(binary_operands)
-            | Arithmetic::Hypot(binary_operands)
-            | Arithmetic::Rhypot(binary_operands)
-            | Arithmetic::ModFloor(binary_operands)
-            | Arithmetic::Max(binary_operands)
-            | Arithmetic::Min(binary_operands)
-            | Arithmetic::Rem(binary_operands)
-            | Arithmetic::Dot(binary_operands)
-            | Arithmetic::MulHi(binary_operands)
-            | Arithmetic::ArcTan2(binary_operands) => self.visit_binop(binary_operands, visit_read),
-
-            Arithmetic::Abs(unary_operands)
-            | Arithmetic::Exp(unary_operands)
-            | Arithmetic::Log(unary_operands)
-            | Arithmetic::Log1p(unary_operands)
-            | Arithmetic::Cos(unary_operands)
-            | Arithmetic::Sin(unary_operands)
-            | Arithmetic::Tan(unary_operands)
-            | Arithmetic::Tanh(unary_operands)
-            | Arithmetic::Sinh(unary_operands)
-            | Arithmetic::Cosh(unary_operands)
-            | Arithmetic::ArcCos(unary_operands)
-            | Arithmetic::ArcSin(unary_operands)
-            | Arithmetic::ArcTan(unary_operands)
-            | Arithmetic::ArcSinh(unary_operands)
-            | Arithmetic::ArcCosh(unary_operands)
-            | Arithmetic::ArcTanh(unary_operands)
-            | Arithmetic::Degrees(unary_operands)
-            | Arithmetic::Radians(unary_operands)
-            | Arithmetic::Sqrt(unary_operands)
-            | Arithmetic::InverseSqrt(unary_operands)
-            | Arithmetic::Round(unary_operands)
-            | Arithmetic::Floor(unary_operands)
-            | Arithmetic::Ceil(unary_operands)
-            | Arithmetic::Trunc(unary_operands)
-            | Arithmetic::Erf(unary_operands)
-            | Arithmetic::Recip(unary_operands)
-            | Arithmetic::Neg(unary_operands)
-            | Arithmetic::Magnitude(unary_operands)
-            | Arithmetic::Normalize(unary_operands)
-            | Arithmetic::VectorSum(unary_operands) => self.visit_unop(unary_operands, visit_read),
-
-            Arithmetic::Clamp(clamp_operands) => {
-                visit_read(self, &mut clamp_operands.input);
-                visit_read(self, &mut clamp_operands.min_value);
-                visit_read(self, &mut clamp_operands.max_value);
-            }
-        }
-    }
-
-    /// Visit an operator with a set of read and write visitors. Each visitor will be called with
-    /// each read or written to variable.
-    pub fn visit_compare(
-        &mut self,
-        op: &mut Comparison,
-        visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        match op {
-            Comparison::Equal(binary_operands)
-            | Comparison::NotEqual(binary_operands)
-            | Comparison::LowerEqual(binary_operands)
-            | Comparison::Greater(binary_operands)
-            | Comparison::Lower(binary_operands)
-            | Comparison::GreaterEqual(binary_operands) => {
-                self.visit_binop(binary_operands, visit_read)
-            }
-            Comparison::IsNan(unary_operands) | Comparison::IsInf(unary_operands) => {
-                self.visit_unop(unary_operands, visit_read)
-            }
-        }
-    }
-
-    /// Visit an operator with a set of read and write visitors. Each visitor will be called with
-    /// each read or written to variable.
-    pub fn visit_bitwise(
-        &mut self,
-        op: &mut Bitwise,
-        visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        match op {
-            Bitwise::BitwiseAnd(binary_operands)
-            | Bitwise::BitwiseOr(binary_operands)
-            | Bitwise::BitwiseXor(binary_operands)
-            | Bitwise::ShiftLeft(binary_operands)
-            | Bitwise::ShiftRight(binary_operands) => self.visit_binop(binary_operands, visit_read),
-
-            Bitwise::CountOnes(unary_operands)
-            | Bitwise::BitwiseNot(unary_operands)
-            | Bitwise::ReverseBits(unary_operands)
-            | Bitwise::LeadingZeros(unary_operands)
-            | Bitwise::TrailingZeros(unary_operands)
-            | Bitwise::FindFirstSet(unary_operands) => self.visit_unop(unary_operands, visit_read),
-        }
-    }
-
-    pub fn visit_memory(
-        &mut self,
-        memory: &mut Memory,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        match memory {
-            Memory::Reference(variable) => visit_read(self, variable),
-            Memory::Index(index_operands) => {
-                visit_read(self, &mut index_operands.list);
-                visit_read(self, &mut index_operands.index);
-            }
-            Memory::Load(variable) => {
-                visit_read(self, variable);
-            }
-            Memory::Store(op) => {
-                visit_read(self, &mut op.ptr);
-                visit_read(self, &mut op.value);
-            }
-            Memory::CopyMemory(op) => {
-                visit_read(self, &mut op.source);
-                visit_read(self, &mut op.target);
-            }
-        }
-    }
-
-    /// Visit an operator with a set of read and write visitors. Each visitor will be called with
-    /// each read or written to variable.
-    pub fn visit_operator(
-        &mut self,
-        op: &mut Operator,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        match op {
-            Operator::And(binary_operands)
-            | Operator::Or(binary_operands)
-            | Operator::ExtractComponent(binary_operands) => {
-                self.visit_binop(binary_operands, visit_read)
-            }
-            Operator::Not(unary_operands)
-            | Operator::Cast(unary_operands)
-            | Operator::Reinterpret(unary_operands) => self.visit_unop(unary_operands, visit_read),
-            Operator::InitVector(vector_init_operator) => {
-                for input in &mut vector_init_operator.inputs {
-                    visit_read(self, input)
-                }
-            }
-            Operator::InsertComponent(vector_insert_operands) => {
-                visit_read(self, &mut vector_insert_operands.vector);
-                visit_read(self, &mut vector_insert_operands.index);
-                visit_read(self, &mut vector_insert_operands.value);
-            }
-            Operator::Select(select_operands) => {
-                visit_read(self, &mut select_operands.cond);
-                visit_read(self, &mut select_operands.then);
-                visit_read(self, &mut select_operands.or_else);
-            }
-        }
-    }
-
-    fn visit_atomic(
-        &mut self,
-        atomic: &mut AtomicOp,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        match atomic {
-            AtomicOp::Add(atomic_binary_operands)
-            | AtomicOp::Sub(atomic_binary_operands)
-            | AtomicOp::Max(atomic_binary_operands)
-            | AtomicOp::Min(atomic_binary_operands)
-            | AtomicOp::And(atomic_binary_operands)
-            | AtomicOp::Or(atomic_binary_operands)
-            | AtomicOp::Xor(atomic_binary_operands)
-            | AtomicOp::Swap(atomic_binary_operands) => {
-                self.visit_atomic_binop(atomic_binary_operands, visit_read);
-            }
-            AtomicOp::Load(ptr) => {
-                visit_read(self, ptr);
-            }
-            AtomicOp::Store(store) => {
-                visit_read(self, &mut store.ptr);
-                visit_read(self, &mut store.value);
-            }
-            AtomicOp::CompareAndSwap(op) => {
-                visit_read(self, &mut op.ptr);
-                visit_read(self, &mut op.cmp);
-                visit_read(self, &mut op.val);
-            }
-        }
-    }
-    fn visit_meta(
-        &mut self,
-        metadata: &mut Metadata,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        match metadata {
-            Metadata::BufferLength { var } => {
-                visit_read(self, var);
-            }
-            Metadata::Stride { dim, var } => {
-                visit_read(self, dim);
-                visit_read(self, var);
-            }
-            Metadata::Shape { dim, var } => {
-                visit_read(self, dim);
-                visit_read(self, var);
-            }
-        }
-    }
-
-    fn visit_plane(&mut self, plane: &mut Plane, visit_read: impl FnMut(&mut T, &mut Variable)) {
-        match plane {
-            Plane::Elect => {}
-            Plane::Broadcast(binary_operands)
-            | Plane::Shuffle(binary_operands)
-            | Plane::ShuffleXor(binary_operands)
-            | Plane::ShuffleUp(binary_operands)
-            | Plane::ShuffleDown(binary_operands) => self.visit_binop(binary_operands, visit_read),
-            Plane::All(unary_operands)
-            | Plane::Any(unary_operands)
-            | Plane::Sum(unary_operands)
-            | Plane::InclusiveSum(unary_operands)
-            | Plane::ExclusiveSum(unary_operands)
-            | Plane::Prod(unary_operands)
-            | Plane::InclusiveProd(unary_operands)
-            | Plane::ExclusiveProd(unary_operands)
-            | Plane::Min(unary_operands)
-            | Plane::Max(unary_operands)
-            | Plane::Ballot(unary_operands) => self.visit_unop(unary_operands, visit_read),
         }
     }
 
@@ -525,133 +266,6 @@ impl<T> Visitor<T> {
         }
     }
 
-    fn visit_barrier(
-        &mut self,
-        barrier_ops: &mut BarrierOps,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        match barrier_ops {
-            BarrierOps::Declare { barrier } => visit_read(self, barrier),
-            BarrierOps::Init {
-                barrier,
-                is_elected,
-                arrival_count,
-                ..
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, is_elected);
-                visit_read(self, arrival_count);
-            }
-            BarrierOps::InitManual {
-                barrier,
-                arrival_count,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, arrival_count);
-            }
-            BarrierOps::MemCopyAsync {
-                barrier,
-                source,
-                destination,
-                source_length,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, source_length);
-                visit_read(self, source);
-                visit_read(self, destination);
-            }
-            BarrierOps::MemCopyAsyncCooperative {
-                barrier,
-                source,
-                destination,
-                source_length,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, source_length);
-                visit_read(self, source);
-                visit_read(self, destination);
-            }
-            BarrierOps::CopyAsync {
-                source,
-                source_length,
-                destination,
-                ..
-            } => {
-                visit_read(self, source_length);
-                visit_read(self, source);
-                visit_read(self, destination);
-            }
-            BarrierOps::MemCopyAsyncTx {
-                barrier,
-                source,
-                destination,
-                source_length,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, source_length);
-                visit_read(self, source);
-                visit_read(self, destination);
-            }
-            BarrierOps::TmaLoad {
-                barrier,
-                tensor_map,
-                destination,
-                indices,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, tensor_map);
-                visit_read(self, destination);
-                for index in indices {
-                    visit_read(self, index);
-                }
-            }
-            BarrierOps::TmaLoadIm2col {
-                barrier,
-                tensor_map,
-                destination,
-                indices,
-                offsets,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, tensor_map);
-                visit_read(self, destination);
-                for index in indices {
-                    visit_read(self, index);
-                }
-                for offset in offsets {
-                    visit_read(self, offset);
-                }
-            }
-            BarrierOps::ArriveAndWait { barrier } => visit_read(self, barrier),
-            BarrierOps::Arrive { barrier } => visit_read(self, barrier),
-            BarrierOps::ArriveTx {
-                barrier,
-                arrive_count_update,
-                transaction_count_update,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, arrive_count_update);
-                visit_read(self, transaction_count_update);
-            }
-            BarrierOps::CommitCopyAsync { barrier } => visit_read(self, barrier),
-            BarrierOps::ExpectTx {
-                barrier,
-                transaction_count_update,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, transaction_count_update);
-            }
-            BarrierOps::Wait { barrier, token } => {
-                visit_read(self, barrier);
-                visit_read(self, token);
-            }
-            BarrierOps::WaitParity { barrier, phase } => {
-                visit_read(self, barrier);
-                visit_read(self, phase);
-            }
-        }
-    }
-
     fn visit_tma(
         &mut self,
         tma_ops: &mut TmaOps,
@@ -721,31 +335,5 @@ impl<T> Visitor<T> {
                 }
             }
         }
-    }
-
-    fn visit_unop(
-        &mut self,
-        unop: &mut UnaryOperands,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        visit_read(self, &mut unop.input);
-    }
-
-    fn visit_binop(
-        &mut self,
-        binop: &mut BinaryOperands,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        visit_read(self, &mut binop.lhs);
-        visit_read(self, &mut binop.rhs);
-    }
-
-    fn visit_atomic_binop(
-        &mut self,
-        binop: &mut AtomicBinaryOperands,
-        mut visit_read: impl FnMut(&mut T, &mut Variable),
-    ) {
-        visit_read(self, &mut binop.ptr);
-        visit_read(self, &mut binop.value);
     }
 }

--- a/crates/cubecl-core/src/runtime_tests/atomic.rs
+++ b/crates/cubecl-core/src/runtime_tests/atomic.rs
@@ -188,7 +188,7 @@ pub fn test_kernel_atomic_numeric<R: Runtime, F: Numeric + CubeElement>(
     };
     let actual = F::from_bytes(&actual);
 
-    assert_all_eq(&actual, numeric_expected(op));
+    assert_all_eq(actual, numeric_expected(op));
 }
 
 pub fn test_kernel_atomic_numeric_all_sizes<R: Runtime, F: Numeric + CubeElement>(

--- a/crates/cubecl-core/src/runtime_tests/barrier.rs
+++ b/crates/cubecl-core/src/runtime_tests/barrier.rs
@@ -8,7 +8,7 @@ use num_traits::Zero;
 #[cube(launch)]
 pub fn async_copy_test<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut [Vector<F, N>]) {
     let barrier = Barrier::local();
-    let mut smem = SharedMemory::<Vector<F, N>>::new(1usize);
+    let mut smem = Shared::<Vector<F, N>>::new_array(1usize);
 
     let source = &input[2..3];
     let destination = &mut smem[..1];
@@ -50,7 +50,7 @@ pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(client: ComputeClient
 
 #[cube(launch)]
 fn one_load<F: Float, N: Size>(lhs: &Tensor<Vector<F, N>>, output: &mut Tensor<Vector<F, N>>) {
-    let mut lhs_smem = SharedMemory::<Vector<F, N>>::new(4usize);
+    let mut lhs_smem = Shared::<Vector<F, N>>::new_array(4usize);
 
     let barrier = Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     sync_cube();
@@ -74,8 +74,8 @@ fn two_loads<F: Float, N: Size>(
     output: &mut Tensor<Vector<F, N>>,
     #[comptime] num_data: usize, // should be even
 ) {
-    let mut lhs_smem = SharedMemory::<Vector<F, N>>::new(num_data);
-    let mut rhs_smem = SharedMemory::<Vector<F, N>>::new(num_data);
+    let mut lhs_smem = Shared::<Vector<F, N>>::new_array(num_data);
+    let mut rhs_smem = Shared::<Vector<F, N>>::new_array(num_data);
 
     let barrier = Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     sync_cube();
@@ -102,8 +102,8 @@ fn two_independent_loads<F: Float, N: Size>(
     output: &mut Tensor<Vector<F, N>>,
     #[comptime] num_data: usize,
 ) {
-    let mut lhs_smem = SharedMemory::<Vector<F, N>>::new(num_data);
-    let mut rhs_smem = SharedMemory::<Vector<F, N>>::new(num_data);
+    let mut lhs_smem = Shared::<Vector<F, N>>::new_array(num_data);
+    let mut rhs_smem = Shared::<Vector<F, N>>::new_array(num_data);
 
     let barrier_0 = barrier::Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     let barrier_1 = barrier::Barrier::shared(CUBE_DIM, UNIT_POS == 0);

--- a/crates/cubecl-core/src/runtime_tests/barrier.rs
+++ b/crates/cubecl-core/src/runtime_tests/barrier.rs
@@ -102,8 +102,8 @@ fn two_independent_loads<F: Float, N: Size>(
     output: &mut Tensor<Vector<F, N>>,
     #[comptime] num_data: usize,
 ) {
-    let mut lhs_smem: Shared<[Vector<F, N>]> = Shared::new_slice(num_data);
-    let mut rhs_smem: Shared<[Vector<F, N>]> = Shared::new_slice(num_data);
+    let mut lhs_smem = Shared::new_slice(num_data);
+    let mut rhs_smem = Shared::new_slice(num_data);
 
     let barrier_0 = barrier::Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     let barrier_1 = barrier::Barrier::shared(CUBE_DIM, UNIT_POS == 0);

--- a/crates/cubecl-core/src/runtime_tests/barrier.rs
+++ b/crates/cubecl-core/src/runtime_tests/barrier.rs
@@ -8,7 +8,7 @@ use num_traits::Zero;
 #[cube(launch)]
 pub fn async_copy_test<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut [Vector<F, N>]) {
     let barrier = Barrier::local();
-    let mut smem = Shared::<Vector<F, N>>::new_array(1usize);
+    let mut smem = Shared::new_slice(1usize);
 
     let source = &input[2..3];
     let destination = &mut smem[..1];
@@ -50,7 +50,7 @@ pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(client: ComputeClient
 
 #[cube(launch)]
 fn one_load<F: Float, N: Size>(lhs: &Tensor<Vector<F, N>>, output: &mut Tensor<Vector<F, N>>) {
-    let mut lhs_smem = Shared::<Vector<F, N>>::new_array(4usize);
+    let mut lhs_smem = Shared::new_slice(4usize);
 
     let barrier = Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     sync_cube();
@@ -74,8 +74,8 @@ fn two_loads<F: Float, N: Size>(
     output: &mut Tensor<Vector<F, N>>,
     #[comptime] num_data: usize, // should be even
 ) {
-    let mut lhs_smem = Shared::<Vector<F, N>>::new_array(num_data);
-    let mut rhs_smem = Shared::<Vector<F, N>>::new_array(num_data);
+    let mut lhs_smem = Shared::new_slice(num_data);
+    let mut rhs_smem = Shared::new_slice(num_data);
 
     let barrier = Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     sync_cube();
@@ -102,8 +102,8 @@ fn two_independent_loads<F: Float, N: Size>(
     output: &mut Tensor<Vector<F, N>>,
     #[comptime] num_data: usize,
 ) {
-    let mut lhs_smem = Shared::<Vector<F, N>>::new_array(num_data);
-    let mut rhs_smem = Shared::<Vector<F, N>>::new_array(num_data);
+    let mut lhs_smem: Shared<[Vector<F, N>]> = Shared::new_slice(num_data);
+    let mut rhs_smem: Shared<[Vector<F, N>]> = Shared::new_slice(num_data);
 
     let barrier_0 = barrier::Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     let barrier_1 = barrier::Barrier::shared(CUBE_DIM, UNIT_POS == 0);

--- a/crates/cubecl-core/src/runtime_tests/cmma.rs
+++ b/crates/cubecl-core/src/runtime_tests/cmma.rs
@@ -1176,8 +1176,8 @@ pub fn kernel_manual_ldmatrix<AB: Numeric, CD: Numeric, N: Size>(
     let elem_size = AB::type_size();
     let width = comptime![16 / elem_size];
 
-    let mut stage_a = Shared::new_aligned_array(size_m * size_k, 16usize);
-    let mut stage_b = Shared::new_aligned_array(size_k * size_n, 16usize);
+    let mut stage_a = Shared::new_aligned_slice(size_m * size_k, 16usize);
+    let mut stage_b = Shared::new_aligned_slice(size_k * size_n, 16usize);
     bar.memcpy_async_cooperative(a.as_slice(), stage_a.as_mut_slice());
     bar.memcpy_async_cooperative(b.as_slice(), stage_b.as_mut_slice());
     bar.arrive_and_wait();

--- a/crates/cubecl-core/src/runtime_tests/index.rs
+++ b/crates/cubecl-core/src/runtime_tests/index.rs
@@ -5,7 +5,7 @@ use cubecl::prelude::*;
 #[cube(launch)]
 fn shuffle_kernel(orders: &mut [u32]) {
     if UNIT_POS < 2 {
-        let mut order = Array::<u32>::new(2usize);
+        let mut order = Array::new(2usize);
         order[0] = 0;
         order[1] = 1;
 

--- a/crates/cubecl-core/src/runtime_tests/launch.rs
+++ b/crates/cubecl-core/src/runtime_tests/launch.rs
@@ -51,8 +51,8 @@ pub fn kernel_with_max_shared(
     #[comptime] shared_size_1: usize,
     #[comptime] shared_size_2: usize,
 ) {
-    let mut shared_1 = SharedMemory::<u32>::new(shared_size_1);
-    let mut shared_2 = SharedMemory::<u32>::new(shared_size_2);
+    let mut shared_1 = Shared::<u32>::new_array(shared_size_1);
+    let mut shared_2 = Shared::<u32>::new_array(shared_size_2);
     if UNIT_POS < 8 {
         shared_1[shared_size_1 - UNIT_POS as usize - 1] = output[UNIT_POS as usize];
         shared_2[shared_size_2 - UNIT_POS as usize - 1] = output[8 - UNIT_POS as usize];
@@ -67,7 +67,7 @@ pub fn kernel_with_max_shared(
 
 #[cube(launch)]
 pub fn kernel_resource_errors(output: &mut [u32], #[comptime] shared_size: usize) {
-    let mut shared = SharedMemory::<u32>::new(shared_size);
+    let mut shared = Shared::<u32>::new_array(shared_size);
     // Add some dummy code to prevent smem from being optimized out
     shared[0] = 0;
     sync_cube();

--- a/crates/cubecl-core/src/runtime_tests/launch.rs
+++ b/crates/cubecl-core/src/runtime_tests/launch.rs
@@ -51,8 +51,8 @@ pub fn kernel_with_max_shared(
     #[comptime] shared_size_1: usize,
     #[comptime] shared_size_2: usize,
 ) {
-    let mut shared_1: Shared<[u32]> = Shared::new_slice(shared_size_1);
-    let mut shared_2: Shared<[u32]> = Shared::new_slice(shared_size_2);
+    let mut shared_1 = Shared::new_slice(shared_size_1);
+    let mut shared_2 = Shared::new_slice(shared_size_2);
     if UNIT_POS < 8 {
         shared_1[shared_size_1 - UNIT_POS as usize - 1] = output[UNIT_POS as usize];
         shared_2[shared_size_2 - UNIT_POS as usize - 1] = output[8 - UNIT_POS as usize];
@@ -67,7 +67,7 @@ pub fn kernel_with_max_shared(
 
 #[cube(launch)]
 pub fn kernel_resource_errors(output: &mut [u32], #[comptime] shared_size: usize) {
-    let mut shared: Shared<[u32]> = Shared::new_slice(shared_size);
+    let mut shared = Shared::new_slice(shared_size);
     // Add some dummy code to prevent smem from being optimized out
     shared[0] = 0;
     sync_cube();

--- a/crates/cubecl-core/src/runtime_tests/launch.rs
+++ b/crates/cubecl-core/src/runtime_tests/launch.rs
@@ -51,8 +51,8 @@ pub fn kernel_with_max_shared(
     #[comptime] shared_size_1: usize,
     #[comptime] shared_size_2: usize,
 ) {
-    let mut shared_1 = Shared::<u32>::new_array(shared_size_1);
-    let mut shared_2 = Shared::<u32>::new_array(shared_size_2);
+    let mut shared_1: Shared<[u32]> = Shared::new_slice(shared_size_1);
+    let mut shared_2: Shared<[u32]> = Shared::new_slice(shared_size_2);
     if UNIT_POS < 8 {
         shared_1[shared_size_1 - UNIT_POS as usize - 1] = output[UNIT_POS as usize];
         shared_2[shared_size_2 - UNIT_POS as usize - 1] = output[8 - UNIT_POS as usize];
@@ -67,7 +67,7 @@ pub fn kernel_with_max_shared(
 
 #[cube(launch)]
 pub fn kernel_resource_errors(output: &mut [u32], #[comptime] shared_size: usize) {
-    let mut shared = Shared::<u32>::new_array(shared_size);
+    let mut shared: Shared<[u32]> = Shared::new_slice(shared_size);
     // Add some dummy code to prevent smem from being optimized out
     shared[0] = 0;
     sync_cube();

--- a/crates/cubecl-core/src/runtime_tests/short_circuit.rs
+++ b/crates/cubecl-core/src/runtime_tests/short_circuit.rs
@@ -8,7 +8,7 @@ use cubecl_runtime::server::Handle;
 #[cube]
 fn mark_side_channel(side_channel: &mut Array<u32>) -> bool {
     side_channel[0] = 1u32;
-    false.into()
+    false.runtime()
 }
 
 #[cube(launch)]
@@ -116,10 +116,10 @@ pub fn test_pure_or<R: Runtime>(client: ComputeClient<R>) {
             b,
         );
     };
-    assert_eq!(run_pure(&client, &launch, 0, 0), 0, "0 || 0");
-    assert_eq!(run_pure(&client, &launch, 0, 7), 1, "0 || 7");
-    assert_eq!(run_pure(&client, &launch, 5, 0), 1, "5 || 0");
-    assert_eq!(run_pure(&client, &launch, 5, 7), 1, "5 || 7");
+    assert_eq!(run_pure(&client, launch, 0, 0), 0, "0 || 0");
+    assert_eq!(run_pure(&client, launch, 0, 7), 1, "0 || 7");
+    assert_eq!(run_pure(&client, launch, 5, 0), 1, "5 || 0");
+    assert_eq!(run_pure(&client, launch, 5, 7), 1, "5 || 7");
 }
 
 pub fn test_pure_and<R: Runtime>(client: ComputeClient<R>) {
@@ -133,10 +133,10 @@ pub fn test_pure_and<R: Runtime>(client: ComputeClient<R>) {
             b,
         );
     };
-    assert_eq!(run_pure(&client, &launch, 0, 0), 0, "0 && 0");
-    assert_eq!(run_pure(&client, &launch, 0, 7), 0, "0 && 7");
-    assert_eq!(run_pure(&client, &launch, 5, 0), 0, "5 && 0");
-    assert_eq!(run_pure(&client, &launch, 5, 7), 1, "5 && 7");
+    assert_eq!(run_pure(&client, launch, 0, 0), 0, "0 && 0");
+    assert_eq!(run_pure(&client, launch, 0, 7), 0, "0 && 7");
+    assert_eq!(run_pure(&client, launch, 5, 0), 0, "5 && 0");
+    assert_eq!(run_pure(&client, launch, 5, 7), 1, "5 && 7");
 }
 
 #[allow(missing_docs)]

--- a/crates/cubecl-core/src/runtime_tests/synchronization.rs
+++ b/crates/cubecl-core/src/runtime_tests/synchronization.rs
@@ -147,7 +147,7 @@ pub fn test_sync_cube_shared<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load(out: &mut [u32]) {
-    let mut count = Shared::<u32>::new_array(1usize);
+    let mut count: Shared<[u32]> = Shared::new_slice(1usize);
     if UNIT_POS == 0 {
         count[0] = 3u32;
     }
@@ -176,7 +176,7 @@ pub fn test_workgroup_uniform_load<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load_atomic(out: &mut [u32]) {
-    let count = Shared::<Atomic<u32>>::new_array(1usize);
+    let count: Shared<[Atomic<u32>]> = Shared::new_slice(1usize);
     if UNIT_POS == 0 {
         count[0].store(3u32);
     }
@@ -214,7 +214,7 @@ pub fn test_workgroup_uniform_load_atomic<R: Runtime>(client: ComputeClient<R>) 
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load_vec<N: Size>(out: &mut [Vector<f32, N>]) {
-    let mut smem = Shared::<Vector<f32, N>>::new_array(1usize);
+    let mut smem: Shared<[Vector<f32, N>]> = Shared::new_slice(1usize);
     if UNIT_POS == 0 {
         smem[0] = Vector::new(7.0f32);
     }

--- a/crates/cubecl-core/src/runtime_tests/synchronization.rs
+++ b/crates/cubecl-core/src/runtime_tests/synchronization.rs
@@ -147,7 +147,7 @@ pub fn test_sync_cube_shared<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load(out: &mut [u32]) {
-    let mut count: Shared<[u32]> = Shared::new_slice(1usize);
+    let mut count = Shared::new_slice(1usize);
     if UNIT_POS == 0 {
         count[0] = 3u32;
     }
@@ -176,7 +176,7 @@ pub fn test_workgroup_uniform_load<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load_atomic(out: &mut [u32]) {
-    let count: Shared<[Atomic<u32>]> = Shared::new_slice(1usize);
+    let count = Shared::<[Atomic<u32>]>::new_slice(1usize);
     if UNIT_POS == 0 {
         count[0].store(3u32);
     }
@@ -214,7 +214,7 @@ pub fn test_workgroup_uniform_load_atomic<R: Runtime>(client: ComputeClient<R>) 
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load_vec<N: Size>(out: &mut [Vector<f32, N>]) {
-    let mut smem: Shared<[Vector<f32, N>]> = Shared::new_slice(1usize);
+    let mut smem = Shared::new_slice(1usize);
     if UNIT_POS == 0 {
         smem[0] = Vector::new(7.0f32);
     }

--- a/crates/cubecl-core/src/runtime_tests/synchronization.rs
+++ b/crates/cubecl-core/src/runtime_tests/synchronization.rs
@@ -147,7 +147,7 @@ pub fn test_sync_cube_shared<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load(out: &mut [u32]) {
-    let mut count = SharedMemory::<u32>::new(1usize);
+    let mut count = Shared::<u32>::new_array(1usize);
     if UNIT_POS == 0 {
         count[0] = 3u32;
     }
@@ -176,7 +176,7 @@ pub fn test_workgroup_uniform_load<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load_atomic(out: &mut [u32]) {
-    let count = SharedMemory::<Atomic<u32>>::new(1usize);
+    let count = Shared::<Atomic<u32>>::new_array(1usize);
     if UNIT_POS == 0 {
         count[0].store(3u32);
     }
@@ -214,7 +214,7 @@ pub fn test_workgroup_uniform_load_atomic<R: Runtime>(client: ComputeClient<R>) 
 
 #[cube(launch)]
 fn kernel_test_workgroup_uniform_load_vec<N: Size>(out: &mut [Vector<f32, N>]) {
-    let mut smem = SharedMemory::<Vector<f32, N>>::new(1usize);
+    let mut smem = Shared::<Vector<f32, N>>::new_array(1usize);
     if UNIT_POS == 0 {
         smem[0] = Vector::new(7.0f32);
     }

--- a/crates/cubecl-core/src/runtime_tests/tensormap.rs
+++ b/crates/cubecl-core/src/runtime_tests/tensormap.rs
@@ -13,7 +13,7 @@ use std::println;
 fn tensormap_load<F: Float, N: Size>(input: &TensorMap<F, Tiled>, output: &mut [Vector<F, N>]) {
     let barrier = Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     sync_async_proxy_shared();
-    let mut stage = Shared::<Vector<F, N>>::new_aligned_array(32usize * 16, 128usize);
+    let mut stage: Shared<[Vector<F, N>]> = Shared::new_aligned_slice(32usize * 16, 128usize);
 
     let type_size = F::type_size();
     let expected = select(UNIT_POS == 0, comptime![32 * 16 * type_size] as u32, 0);
@@ -29,7 +29,7 @@ fn tensormap_load<F: Float, N: Size>(input: &TensorMap<F, Tiled>, output: &mut [
 
 #[cube(launch)]
 fn tensormap_store<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut TensorMap<F, Tiled>) {
-    let mut shared = Shared::<Vector<F, N>>::new_aligned_array(32usize * 16, 128usize);
+    let mut shared: Shared<[Vector<F, N>]> = Shared::new_aligned_slice(32usize * 16, 128usize);
 
     let in_pos = UNIT_POS_Y * 32 + UNIT_POS_X;
     shared[in_pos as usize] = input[in_pos as usize];
@@ -60,7 +60,8 @@ fn tensormap_im2col_load<F: Float, N: Size>(
 
     let barrier = Barrier::shared(CUBE_DIM, UNIT_POS == 0);
     sync_async_proxy_shared();
-    let mut stage = Shared::<Vector<F, N>>::new_aligned_array(tile_k * tile_width, 128usize);
+    let mut stage: Shared<[Vector<F, N>]> =
+        Shared::new_aligned_slice(tile_k * tile_width, 128usize);
 
     let type_size = F::type_size();
     let expected = select(

--- a/crates/cubecl-core/src/runtime_tests/vector.rs
+++ b/crates/cubecl-core/src/runtime_tests/vector.rs
@@ -164,7 +164,7 @@ pub fn test_vector_conditional<R: Runtime, F: Float + CubeElement>(client: Compu
 
 #[cube(launch_unchecked)]
 pub fn kernel_shared_memory<F: Float, N: Size>(output: &mut [Vector<F, N>]) {
-    let mut smem1 = Shared::<Vector<F, N>>::new_array(8usize);
+    let mut smem1: Shared<[Vector<F, N>]> = Shared::new_slice(8usize);
     smem1[0] = Vector::new(F::new(42f32));
     output[0] = smem1[0];
 }

--- a/crates/cubecl-core/src/runtime_tests/vector.rs
+++ b/crates/cubecl-core/src/runtime_tests/vector.rs
@@ -164,7 +164,7 @@ pub fn test_vector_conditional<R: Runtime, F: Float + CubeElement>(client: Compu
 
 #[cube(launch_unchecked)]
 pub fn kernel_shared_memory<F: Float, N: Size>(output: &mut [Vector<F, N>]) {
-    let mut smem1: Shared<[Vector<F, N>]> = Shared::new_slice(8usize);
+    let mut smem1 = Shared::new_slice(8usize);
     smem1[0] = Vector::new(F::new(42f32));
     output[0] = smem1[0];
 }

--- a/crates/cubecl-core/src/runtime_tests/vector.rs
+++ b/crates/cubecl-core/src/runtime_tests/vector.rs
@@ -164,7 +164,7 @@ pub fn test_vector_conditional<R: Runtime, F: Float + CubeElement>(client: Compu
 
 #[cube(launch_unchecked)]
 pub fn kernel_shared_memory<F: Float, N: Size>(output: &mut [Vector<F, N>]) {
-    let mut smem1 = SharedMemory::<Vector<F, N>>::new(8usize);
+    let mut smem1 = Shared::<Vector<F, N>>::new_array(8usize);
     smem1[0] = Vector::new(F::new(42f32));
     output[0] = smem1[0];
 }

--- a/crates/cubecl-cpp/src/shared/dialect.rs
+++ b/crates/cubecl-cpp/src/shared/dialect.rs
@@ -485,7 +485,7 @@ pub trait DialectInstructions<D: Dialect> {
         input: &Variable<D>,
         out: &Variable<D>,
     ) -> std::fmt::Result {
-        let zero = Variable::Constant(ConstantValue::UInt(0), input.item());
+        let zero = Variable::Constant(ConstantValue::UInt(0), *input.item().value_ty());
         Self::compile_atomic_add(f, input, &zero, out)
     }
 
@@ -539,11 +539,14 @@ pub trait DialectInstructions<D: Dialect> {
         match rhs.elem() {
             Elem::U32 | Elem::I32 => writeln!(f, "{out} = atomicSub({lhs}, {rhs});"),
             Elem::U64 => writeln!(f, "{out} = atomicAdd({lhs}, -{rhs});"),
-            Elem::I64 => writeln!(
-                f,
-                "{out} = atomicAdd(reinterpret_cast<{addr_space}{uint}*>({lhs}), {uint}(-{rhs}));",
-                uint = Elem::<D>::U64
-            ),
+            Elem::I64 => {
+                let rhs = rhs.ensure_lvalue(f)?;
+                writeln!(
+                    f,
+                    "{out} = atomicAdd(reinterpret_cast<{addr_space}{uint}*>({lhs}), {uint}(-{rhs}));",
+                    uint = Elem::<D>::U64
+                )
+            }
             _ => writeln!(f, "{out} = atomicAdd({lhs}, -{rhs});"),
         }
     }

--- a/crates/cubecl-cpp/src/shared/dialect.rs
+++ b/crates/cubecl-cpp/src/shared/dialect.rs
@@ -534,21 +534,9 @@ pub trait DialectInstructions<D: Dialect> {
         rhs: &Variable<D>,
         out: &Variable<D>,
     ) -> std::fmt::Result {
-        let addr_space = D::address_space_for_variable(out);
-        let out = out.fmt_left();
-        match rhs.elem() {
-            Elem::U32 | Elem::I32 => writeln!(f, "{out} = atomicSub({lhs}, {rhs});"),
-            Elem::U64 => writeln!(f, "{out} = atomicAdd({lhs}, -{rhs});"),
-            Elem::I64 => {
-                let rhs = rhs.ensure_lvalue(f)?;
-                writeln!(
-                    f,
-                    "{out} = atomicAdd(reinterpret_cast<{addr_space}{uint}*>({lhs}), {uint}(-{rhs}));",
-                    uint = Elem::<D>::U64
-                )
-            }
-            _ => writeln!(f, "{out} = atomicAdd({lhs}, -{rhs});"),
-        }
+        let neg_rhs = Variable::tmp(rhs.item());
+        writeln!(f, "{} = -{rhs};", neg_rhs.fmt_left())?;
+        Self::compile_atomic_add(f, lhs, &neg_rhs, out)
     }
 
     fn compile_atomic_swap(

--- a/crates/cubecl-cpu/src/compute/affinity/windows.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/windows.rs
@@ -8,9 +8,8 @@ use super::CoreId;
 pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
     let mask = get_affinity_mask();
 
-    (0..64 as u64)
-        .into_iter()
-        .filter(|&i| (mask & 1 << i) == 1 << i)
+    (0..64u64)
+        .filter(move |&i| (mask & 1 << i) == 1 << i)
         .map(|i| CoreId(i as usize))
 }
 
@@ -28,7 +27,7 @@ fn get_affinity_mask() -> u64 {
             GetCurrentProcess(),
             &mut process_mask as PDWORD_PTR,
             &mut system_mask as PDWORD_PTR,
-        )
+        );
     }
 
     process_mask as u64

--- a/crates/cubecl-cpu/src/frontend/unaligned_vector.rs
+++ b/crates/cubecl-cpu/src/frontend/unaligned_vector.rs
@@ -44,12 +44,11 @@ pub trait UnalignedVector<E: Scalar, N: Size>: CubeType {
 }
 
 type ArrayExpand<T> = NativeExpand<Array<T>>;
-type SharedMemoryExpand<T> = NativeExpand<SharedMemory<T>>;
 
 macro_rules! impl_unaligned_vector {
-    ($type:ident) => {
+    ($type: ty) => {
         #[cube]
-        impl<E: Scalar, N: Size> UnalignedVector<E, N> for $type<E> {
+        impl<E: Scalar, N: Size> UnalignedVector<E, N> for $type {
             fn unaligned_vector_read(&self, index: usize) -> Vector<E, N> {
                 unaligned_vector_read::<E, N>(self.as_slice(), index)
             }
@@ -61,9 +60,9 @@ macro_rules! impl_unaligned_vector {
     };
 }
 
-impl_unaligned_vector!(Array);
-impl_unaligned_vector!(Tensor);
-impl_unaligned_vector!(SharedMemory);
+impl_unaligned_vector!(Array<E>);
+impl_unaligned_vector!(Tensor<E>);
+impl_unaligned_vector!(Shared<[E]>);
 
 // TODO: Maybe impl unaligned IO on slices?
 // The last dimension will have to be contiguous for this to make sense,

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_magic(out: &mut [u32]) {
-        let mut mem = SharedMemory::<u32>::new(1usize);
+        let mut mem = Shared::<u32>::new_array(1usize);
         if UNIT_POS == 0 {
             mem[0] = 0xDEADBEEFu32;
         }
@@ -39,7 +39,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_two_phase(out: &mut [u32]) {
-        let mut mem = SharedMemory::<u32>::new(4usize);
+        let mut mem = Shared::<u32>::new_array(4usize);
         let idx = UNIT_POS as usize;
         mem[idx] = (idx as u32) + 1;
         sync_cube();
@@ -58,7 +58,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_all_reduce(out: &mut [u32]) {
-        let mut mem = SharedMemory::<u32>::new(8usize);
+        let mut mem = Shared::<u32>::new_array(8usize);
         let idx = UNIT_POS as usize;
         mem[idx] = idx as u32;
         sync_cube();

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_magic(out: &mut [u32]) {
-        let mut mem: Shared<[u32]> = Shared::new_slice(1usize);
+        let mut mem = Shared::new_slice(1usize);
         if UNIT_POS == 0 {
             mem[0] = 0xDEADBEEFu32;
         }
@@ -39,7 +39,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_two_phase(out: &mut [u32]) {
-        let mut mem: Shared<[u32]> = Shared::new_slice(4usize);
+        let mut mem = Shared::new_slice(4usize);
         let idx = UNIT_POS as usize;
         mem[idx] = (idx as u32) + 1;
         sync_cube();
@@ -58,7 +58,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_all_reduce(out: &mut [u32]) {
-        let mut mem: Shared<[u32]> = Shared::new_slice(8usize);
+        let mut mem = Shared::new_slice(8usize);
         let idx = UNIT_POS as usize;
         mem[idx] = idx as u32;
         sync_cube();

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_magic(out: &mut [u32]) {
-        let mut mem = Shared::<u32>::new_array(1usize);
+        let mut mem: Shared<[u32]> = Shared::new_slice(1usize);
         if UNIT_POS == 0 {
             mem[0] = 0xDEADBEEFu32;
         }
@@ -39,7 +39,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_two_phase(out: &mut [u32]) {
-        let mut mem = Shared::<u32>::new_array(4usize);
+        let mut mem: Shared<[u32]> = Shared::new_slice(4usize);
         let idx = UNIT_POS as usize;
         mem[idx] = (idx as u32) + 1;
         sync_cube();
@@ -58,7 +58,7 @@ mod tests {
 
     #[cube(launch)]
     fn sync_cube_all_reduce(out: &mut [u32]) {
-        let mut mem = Shared::<u32>::new_array(8usize);
+        let mut mem: Shared<[u32]> = Shared::new_slice(8usize);
         let idx = UNIT_POS as usize;
         mem[idx] = idx as u32;
         sync_cube();

--- a/crates/cubecl-ir/Cargo.toml
+++ b/crates/cubecl-ir/Cargo.toml
@@ -35,7 +35,7 @@ cubecl-macros-internal = { path = "../cubecl-macros-internal", version = "=0.11.
 
 bumpalo = { workspace = true }
 derive-new = { workspace = true }
-derive_more = { workspace = true, features = ["from"] }
+derive_more = { workspace = true, features = ["from", "eq"] }
 enumset = { workspace = true }
 float-ord = { workspace = true }
 fnv = { workspace = true }

--- a/crates/cubecl-ir/src/arena.rs
+++ b/crates/cubecl-ir/src/arena.rs
@@ -1,0 +1,75 @@
+use alloc::vec::Vec;
+
+use bumpalo::Bump;
+use cubecl_macros_internal::TypeHash;
+
+/// Bump allocator that runs drop on non-trivially droppable values on reset.
+/// This is useful to prevent memory leaks without drastically affecting performance for the vast
+/// majority of values that do not need custom drops.
+///
+/// # SAFETY
+///
+/// Values inserted *must not* access external borrowed data in a custom `Drop` implementation.
+/// This shouldn't happen for normal types, but should be kept in mind regardless.
+/// Contrived Example:
+///
+/// ```
+/// struct Wrapper<'a>(&'a mut String);
+///
+/// impl<'a> Drop for Wrapper<'a> {
+///     fn drop(&mut self) {
+///         self.0.push_str(" dropped"); // Accesses external borrow
+///     }
+/// }
+///
+/// let mut external = String::from("hello");
+///
+/// let pool = DropBump::new();
+/// let w = pool.alloc(Wrapper(&mut external));
+/// drop(external);
+/// pool.reset(); // Runs `drop_in_place::<Wrapper>`
+/// ```
+///
+/// So don't do that.
+///
+#[derive(Default, Debug, TypeHash)]
+pub struct DropBump {
+    bump: Bump,
+    drop_thunks: Vec<DropThunk>,
+}
+
+#[derive(Debug, TypeHash)]
+struct DropThunk {
+    func: fn(*mut ()),
+    ptr: *mut (),
+}
+
+impl DropBump {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn reset(&mut self) {
+        for drop in self.drop_thunks.drain(..).rev() {
+            (drop.func)(drop.ptr)
+        }
+        self.bump.reset();
+    }
+
+    pub fn alloc<T>(&mut self, val: T) -> &mut T {
+        let ret = self.bump.alloc(val);
+
+        if core::mem::needs_drop::<T>() {
+            self.drop_thunks.push(DropThunk {
+                func: drop_glue::<T>,
+                ptr: ret as *mut T as *mut (),
+            });
+        }
+
+        ret
+    }
+}
+
+fn drop_glue<T>(ptr: *mut ()) {
+    unsafe { core::ptr::drop_in_place::<T>(ptr as *mut T) };
+}

--- a/crates/cubecl-ir/src/arena.rs
+++ b/crates/cubecl-ir/src/arena.rs
@@ -13,7 +13,8 @@ use cubecl_macros_internal::TypeHash;
 /// This shouldn't happen for normal types, but should be kept in mind regardless.
 /// Contrived Example:
 ///
-/// ```
+/// ```no_run
+/// # use cubecl_ir::arena::DropBump;
 /// struct Wrapper<'a>(&'a mut String);
 ///
 /// impl<'a> Drop for Wrapper<'a> {
@@ -24,7 +25,7 @@ use cubecl_macros_internal::TypeHash;
 ///
 /// let mut external = String::from("hello");
 ///
-/// let pool = DropBump::new();
+/// let mut pool = DropBump::new();
 /// let w = pool.alloc(Wrapper(&mut external));
 /// drop(external);
 /// pool.reset(); // Runs `drop_in_place::<Wrapper>`

--- a/crates/cubecl-ir/src/lib.rs
+++ b/crates/cubecl-ir/src/lib.rs
@@ -35,6 +35,8 @@ mod r#type;
 mod type_hash;
 mod variable;
 
+pub mod arena;
+
 pub use address::*;
 pub use allocator::*;
 pub use arithmetic::*;

--- a/crates/cubecl-ir/src/reflect.rs
+++ b/crates/cubecl-ir/src/reflect.rs
@@ -17,6 +17,9 @@ pub trait OperationReflect: Sized {
     fn args(&self) -> Option<Vec<Variable>> {
         None
     }
+    fn args_mut(&mut self) -> Option<Vec<&mut Variable>> {
+        None
+    }
     /// Create typed operation from an opcode and a list of arguments. Returns `None` if not all
     /// arguments are [`Variable`].
     #[allow(unused)]
@@ -65,6 +68,12 @@ pub trait OperationArgs: Sized {
         None
     }
 
+    /// Turns this type into a flat list of arguments. If not all arguments are [`Variable`],
+    /// returns `None`
+    fn as_args_mut(&mut self) -> Option<Vec<&mut Variable>> {
+        None
+    }
+
     fn read_pointers(&self) -> Vec<Variable> {
         Vec::new()
     }
@@ -86,11 +95,21 @@ impl OperationArgs for Variable {
     fn as_args(&self) -> Option<Vec<Variable>> {
         Some(vec![*self])
     }
+
+    fn as_args_mut(&mut self) -> Option<Vec<&mut Variable>> {
+        Some(vec![self])
+    }
 }
 
 impl<T: OperationArgs> OperationArgs for Vec<T> {
     fn sanitize_args_ptr(&mut self, scope: &Scope) {
         self.iter_mut().for_each(|it| it.sanitize_args_ptr(scope));
+    }
+
+    fn as_args_mut(&mut self) -> Option<Vec<&mut Variable>> {
+        let inner = self.iter_mut().map(|it| it.as_args_mut());
+        let inner = inner.collect::<Option<Vec<_>>>()?;
+        Some(inner.into_iter().flatten().collect())
     }
 }
 
@@ -99,6 +118,10 @@ impl<T: OperationArgs> OperationArgs for Option<T> {
         if let Some(it) = self.as_mut() {
             it.sanitize_args_ptr(scope)
         }
+    }
+
+    fn as_args_mut(&mut self) -> Option<Vec<&mut Variable>> {
+        self.as_mut().and_then(|inner| inner.as_args_mut())
     }
 }
 
@@ -119,6 +142,7 @@ pub trait FromArgList: Sized {
     fn from_arg_list(args: &mut VecDeque<Variable>) -> Self;
     /// Turns this type into a list of [`Variable`]s.
     fn as_arg_list(&self) -> impl IntoIterator<Item = Variable>;
+    fn as_arg_list_mut(&mut self) -> impl IntoIterator<Item = &mut Variable>;
 }
 
 impl FromArgList for Variable {
@@ -129,6 +153,10 @@ impl FromArgList for Variable {
     fn as_arg_list(&self) -> impl IntoIterator<Item = Variable> {
         [*self]
     }
+
+    fn as_arg_list_mut(&mut self) -> impl IntoIterator<Item = &mut Variable> {
+        [self]
+    }
 }
 
 impl FromArgList for Vec<Variable> {
@@ -138,6 +166,10 @@ impl FromArgList for Vec<Variable> {
 
     fn as_arg_list(&self) -> impl IntoIterator<Item = Variable> {
         self.iter().cloned()
+    }
+
+    fn as_arg_list_mut(&mut self) -> impl IntoIterator<Item = &mut Variable> {
+        self.iter_mut()
     }
 }
 
@@ -153,6 +185,10 @@ impl FromArgList for bool {
     fn as_arg_list(&self) -> impl IntoIterator<Item = Variable> {
         [(*self).into()]
     }
+
+    fn as_arg_list_mut(&mut self) -> impl IntoIterator<Item = &mut Variable> {
+        []
+    }
 }
 
 impl FromArgList for u32 {
@@ -167,6 +203,10 @@ impl FromArgList for u32 {
     fn as_arg_list(&self) -> impl IntoIterator<Item = Variable> {
         [(*self).into()]
     }
+
+    fn as_arg_list_mut(&mut self) -> impl IntoIterator<Item = &mut Variable> {
+        []
+    }
 }
 
 impl FromArgList for usize {
@@ -180,6 +220,10 @@ impl FromArgList for usize {
 
     fn as_arg_list(&self) -> impl IntoIterator<Item = Variable> {
         [(*self).into()]
+    }
+
+    fn as_arg_list_mut(&mut self) -> impl IntoIterator<Item = &mut Variable> {
+        []
     }
 }
 

--- a/crates/cubecl-ir/src/scope.rs
+++ b/crates/cubecl-ir/src/scope.rs
@@ -240,9 +240,9 @@ impl Scope {
     }
 
     /// Add a value to the global arena so we can create a kernel-wide reference to it.
-    /// The reference is `'static` for simplicity, but is only valid for the duration of the root scope.
-    /// Ensure the reference lifetime is shortened to the lifetime of the underlying variable being
-    /// referenced.
+    /// The reference is the same as the type for simplicity, but is only valid for the duration of
+    /// the root scope. Ensure the reference lifetime is shortened to the lifetime of the underlying
+    /// variable being referenced.
     pub fn create_kernel_ref<'a, T>(&self, var: T) -> &'a mut T
     where
         T: 'a,

--- a/crates/cubecl-ir/src/scope.rs
+++ b/crates/cubecl-ir/src/scope.rs
@@ -1,6 +1,5 @@
 use alloc::collections::BTreeMap;
 use alloc::{borrow::Cow, rc::Rc, string::String, string::ToString, vec::Vec};
-use bumpalo::Bump;
 use core::{
     any::TypeId,
     cell::{Ref, RefCell, RefMut},
@@ -14,7 +13,7 @@ use itertools::Itertools;
 use crate::{
     AggregateExtractOperands, AggregateKind, BarrierLevel, CubeFnSource, DeviceProperties,
     FastMath, Function, Matrix, Operation, OperationReflect, Processor, SemanticType, SourceLoc,
-    StorageType, TargetProperties, TypeHash,
+    StorageType, TargetProperties, TypeHash, arena::DropBump,
 };
 
 use super::{
@@ -53,7 +52,7 @@ pub type GlobalState = Rc<RefCell<GlobalStateInner>>;
 pub struct GlobalStateInner {
     #[partial_eq(skip)]
     #[eq(skip)]
-    pub reference_arena: Bump,
+    pub reference_arena: DropBump,
     pub allocator: Allocator,
 
     pub functions: BTreeMap<Id, Function>,
@@ -67,7 +66,7 @@ pub struct GlobalStateInner {
 impl GlobalStateInner {
     pub fn clone_deep(&self) -> Self {
         Self {
-            reference_arena: Bump::new(),
+            reference_arena: DropBump::new(),
             allocator: self.allocator.clone_deep(),
             functions: self.functions.clone(),
             typemap: self.typemap.clone(),
@@ -244,8 +243,11 @@ impl Scope {
     /// The reference is `'static` for simplicity, but is only valid for the duration of the root scope.
     /// Ensure the reference lifetime is shortened to the lifetime of the underlying variable being
     /// referenced.
-    pub fn create_kernel_ref<T: 'static>(&self, var: T) -> &'static mut T {
-        let state = self.global_state.borrow();
+    pub fn create_kernel_ref<'a, T>(&self, var: T) -> &'a mut T
+    where
+        T: 'a,
+    {
+        let mut state = self.state_mut();
         let reference = state.reference_arena.alloc(var);
         unsafe { core::mem::transmute(reference) }
     }

--- a/crates/cubecl-ir/src/type_hash.rs
+++ b/crates/cubecl-ir/src/type_hash.rs
@@ -184,3 +184,12 @@ impl<T: TypeHash + ?Sized> TypeHash for &mut T {
         T::write_hash(hasher);
     }
 }
+
+impl<T: TypeHash + ?Sized, U: TypeHash + ?Sized> TypeHash for fn(T) -> U {
+    fn write_hash(hasher: &mut impl Hasher) {
+        hasher.write(b"fn(");
+        T::write_hash(hasher);
+        hasher.write(b") -> ");
+        U::write_hash(hasher);
+    }
+}

--- a/crates/cubecl-macros-internal/src/generate/op_args.rs
+++ b/crates/cubecl-macros-internal/src/generate/op_args.rs
@@ -18,6 +18,20 @@ impl OpArgs {
         }
     }
 
+    fn generate_into_mut(&self) -> TokenStream {
+        let mut tokens = quote![let mut args = alloc::vec::Vec::new();];
+        for field in self.data.as_ref().take_struct().unwrap().fields {
+            let ident = field.ident.as_ref().unwrap();
+            tokens.extend(
+                quote![args.extend(crate::FromArgList::as_arg_list_mut(&mut self.#ident));],
+            );
+        }
+        quote! {
+            #tokens
+            args
+        }
+    }
+
     fn generate_from(&self) -> TokenStream {
         let mut tokens = quote![];
         for field in self.data.as_ref().take_struct().unwrap().fields {
@@ -72,6 +86,7 @@ impl OpArgs {
         let (generics, generic_names, where_clause) = self.generics.split_for_impl();
 
         let into = self.generate_into();
+        let into_mut = self.generate_into_mut();
         let from = self.generate_from();
         let sanitize_ptr = self.generate_sanitize_ptr();
 
@@ -85,6 +100,10 @@ impl OpArgs {
 
             fn as_args(&self) -> Option<alloc::vec::Vec<crate::Variable>> {
                 Some({#into})
+            }
+
+            fn as_args_mut(&mut self) -> Option<alloc::vec::Vec<&mut crate::Variable>> {
+                Some({#into_mut})
             }
 
             fn sanitize_args_ptr(&mut self, scope: &crate::Scope) {

--- a/crates/cubecl-macros-internal/src/generate/operation.rs
+++ b/crates/cubecl-macros-internal/src/generate/operation.rs
@@ -71,6 +71,44 @@ impl Operation {
         }
     }
 
+    fn generate_args_mut_impl(&self) -> TokenStream {
+        let variants = self.variants();
+        let match_variants = variants.iter().map(|variant| {
+            let ident = &variant.ident;
+            if variant.nested.is_present() {
+                quote![Self::#ident(child) => crate::OperationReflect::args_mut(child)]
+            } else if variant.fields.is_empty() {
+                quote![Self::#ident => Some(alloc::vec::Vec::new())]
+            } else if variant.fields.fields[0].ident.is_some() {
+                if variant.fields.fields.iter().any(|it| it.skip.is_present()) {
+                    quote![Self::#ident { .. } => None]
+                } else {
+                    let names = variant
+                        .fields
+                        .fields
+                        .iter()
+                        .map(|it| it.ident.clone().unwrap())
+                        .collect::<Vec<_>>();
+                    let body = quote![{
+                        let mut args = alloc::vec::Vec::new();
+                        #(args.extend(crate::FromArgList::as_arg_list_mut(#names));)*
+                        Some(args)
+                    }];
+                    quote![Self::#ident { #(#names),* } => #body]
+                }
+            } else if variant.fields.fields[0].skip.is_present() {
+                quote![Self::#ident(args) => None]
+            } else {
+                quote![Self::#ident(args) => crate::OperationArgs::as_args_mut(args)]
+            }
+        });
+        quote! {
+            match self {
+                #(#match_variants),*
+            }
+        }
+    }
+
     fn generate_from_args_impl(&self) -> TokenStream {
         let opcode = &self.opcode_name;
         let variants = self.variants();
@@ -247,6 +285,7 @@ impl Operation {
 
         let opcode_impl = self.generate_opcode_impl();
         let args_impl = self.generate_args_impl();
+        let args_mut_impl = self.generate_args_mut_impl();
         let from_args_impl = self.generate_from_args_impl();
         let commutative =
             self.generate_bool_property(|x| x.commutative, |x| x.commutative, "is_commutative");
@@ -264,6 +303,9 @@ impl Operation {
             }
             fn args(&self) -> Option<alloc::vec::Vec<crate::Variable>> {
                 #args_impl
+            }
+            fn args_mut(&mut self) -> Option<alloc::vec::Vec<&mut crate::Variable>> {
+                #args_mut_impl
             }
             fn from_code_and_args(op_code: Self::OpCode, args: &[crate::Variable]) -> Option<Self> {
                 #from_args_impl

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -294,6 +294,22 @@ impl Expression {
     }
 }
 
+pub fn is_intrinsic(path: &Path) -> bool {
+    // Add both possible import paths
+    let intrinsic_paths = [
+        "::cubecl::prelude::vectorization_of",
+        "::cubecl::frontend::vectorization_of",
+    ];
+
+    let mut path = path.clone();
+    // Strip function generics
+    path.segments.last_mut().unwrap().arguments = PathArguments::None;
+    let func_path = path.to_token_stream().to_string();
+    intrinsic_paths
+        .iter()
+        .any(|path| path.ends_with(&func_path))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -434,20 +450,4 @@ mod tests {
             .is_always_pure()
         );
     }
-}
-
-pub fn is_intrinsic(path: &Path) -> bool {
-    // Add both possible import paths
-    let intrinsic_paths = [
-        "::cubecl::prelude::vectorization_of",
-        "::cubecl::frontend::vectorization_of",
-    ];
-
-    let mut path = path.clone();
-    // Strip function generics
-    path.segments.last_mut().unwrap().arguments = PathArguments::None;
-    let func_path = path.to_token_stream().to_string();
-    intrinsic_paths
-        .iter()
-        .any(|path| path.ends_with(&func_path))
 }

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -18,6 +18,11 @@ macro_rules! error {
     };
 }
 
+fn into_expand(tokens: TokenStream) -> TokenStream {
+    let into_expand = prelude_type("IntoExpand");
+    quote![#into_expand::into_expand(#tokens, scope)]
+}
+
 impl Expression {
     pub fn to_tokens(&self, context: &mut Context) -> TokenStream {
         match self {
@@ -32,23 +37,17 @@ impl Expression {
             } if !left.is_always_pure() || !right.is_always_pure() => {
                 let path = frontend_path();
                 let native = frontend_type("NativeExpand");
-                let left = left.to_tokens(context);
-                let right = right.to_tokens(context);
+                let left = into_expand(left.to_tokens(context));
+                let right = into_expand(right.to_tokens(context));
                 let (then_block, else_block) = match op {
                     // `a || b`  =>  if a { true } else { b }
-                    Operator::Or => (
-                        quote![#native::from_lit(scope, true)],
-                        quote![#right.into_expand(scope)],
-                    ),
+                    Operator::Or => (quote![#native::from_lit(scope, true)], right),
                     // `a && b`  =>  if a { b } else { false }
-                    Operator::And => (
-                        quote![#right.into_expand(scope)],
-                        quote![#native::from_lit(scope, false)],
-                    ),
+                    Operator::And => (right, quote![#native::from_lit(scope, false)]),
                     _ => unreachable!(),
                 };
                 let body = quote! {
-                    #path::branch::if_else_expr_expand(scope, #left.into_expand(scope), |scope| #then_block)
+                    #path::branch::if_else_expr_expand(scope, #left, |scope| #then_block)
                         .or_else(scope, |scope| #else_block)
                 };
                 let expand = with_span(context, *span, body);
@@ -62,11 +61,11 @@ impl Expression {
                 ..
             } => {
                 let op = format_ident!("__expand_{}_method", operator.op_name());
-                let left = left.to_tokens(context);
-                let right = right.to_tokens(context);
+                let left = into_expand(left.to_tokens(context));
+                let right = into_expand(right.to_tokens(context));
                 let rhs = match operator.is_cmp() {
-                    true => quote![&#right.into_expand(scope)],
-                    false => quote![#right.into_expand(scope)],
+                    true => quote![&#right],
+                    false => quote![#right],
                 };
                 let expand = with_span(
                     context,
@@ -82,10 +81,18 @@ impl Expression {
                 operator: Operator::Deref,
                 ..
             } => {
-                let input = input.to_tokens(context);
-                quote! {{
-                    #input.__expand_deref_method(scope)
-                }}
+                if matches!(**input, Expression::Index { .. }) {
+                    let deref = prelude_type("__expand_deref");
+                    let input = input.to_tokens(context);
+                    quote! {{
+                        #deref(scope, #input)
+                    }}
+                } else {
+                    let input = input.to_tokens(context);
+                    quote! {{
+                        #input.__expand_deref_method(scope)
+                    }}
+                }
             }
             Expression::Unary {
                 input,
@@ -126,30 +133,40 @@ impl Expression {
                 quote![#expand_elem::from_lit(scope, #value)]
             }
             Expression::Assignment { left, right, .. } => {
-                let right = right.to_tokens(context);
-                let left = left.to_tokens(context);
-                quote! {{
-                    let _value = #right.into_expand(scope);
-                    #left.__expand_assign_method(scope, _value)
-                }}
+                let right = into_expand(right.to_tokens(context));
+
+                if matches!(**left, Expression::IndexMut { .. }) {
+                    let assign = prelude_type("__expand_assign");
+                    let left = left.to_tokens(context);
+                    quote! {{
+                        let _value = #right;
+                        #assign(scope, #left, _value)
+                    }}
+                } else {
+                    let left = left.to_tokens(context);
+                    quote! {{
+                        let _value = #right;
+                        #left.__expand_assign_method(scope, _value)
+                    }}
+                }
             }
             Expression::Index { expr, index, span } => {
                 let expr = expr.to_tokens(context);
-                let index = index.to_tokens(context);
+                let index = into_expand(index.to_tokens(context));
                 let expand = with_span(
                     context,
                     *span,
-                    quote![#expr.__expand_index_method(scope, #index.into_expand(scope))],
+                    quote![#expr.__expand_index_method(scope, #index)],
                 );
                 quote! {{#expand}}
             }
             Expression::IndexMut { expr, index, span } => {
                 let expr = expr.to_tokens(context);
-                let index = index.to_tokens(context);
+                let index = into_expand(index.to_tokens(context));
                 let expand = with_span(
                     context,
                     *span,
-                    quote![#expr.__expand_index_mut_method(scope,  #index.into_expand(scope))],
+                    quote![#expr.__expand_index_mut_method(scope, #index)],
                 );
                 quote! {{#expand}}
             }
@@ -233,10 +250,10 @@ impl Expression {
             ),
             Expression::Cast { from, to } => {
                 let cast = prelude_type("Cast");
-                let from = from.to_tokens(context);
+                let from = into_expand(from.to_tokens(context));
                 let to = quote_spanned![to.span()=> <#to as #cast>];
                 quote! {{
-                    #to::__expand_cast_from(scope, #from.into_expand(scope))
+                    #to::__expand_cast_from(scope, #from)
                 }}
             }
             Expression::ForLoop {
@@ -286,11 +303,11 @@ impl Expression {
                 else_branch: Some(else_branch),
             } if then_block.ret.is_some() && else_branch.needs_terminator() => {
                 let path = frontend_path();
-                let condition = condition.to_tokens(context);
+                let condition = into_expand(condition.to_tokens(context));
                 let then_block = then_block.to_tokens(context);
                 let else_branch = else_branch.to_tokens(context);
                 quote! {{
-                    #path::branch::if_else_expr_expand(scope, #condition.into_expand(scope), |scope| #then_block)
+                    #path::branch::if_else_expr_expand(scope, #condition, |scope| #then_block)
                         .or_else(scope, |scope| #else_branch)
                 }}
             }
@@ -300,11 +317,11 @@ impl Expression {
                 else_branch: Some(else_branch),
             } => {
                 let path = frontend_path();
-                let condition = condition.to_tokens(context);
+                let condition = into_expand(condition.to_tokens(context));
                 let then_block = then_block.to_tokens(context);
                 let else_branch = else_branch.to_tokens(context);
                 quote! {{
-                    #path::branch::if_else_expand(scope, #condition.into_expand(scope), |scope| #then_block)
+                    #path::branch::if_else_expand(scope, #condition, |scope| #then_block)
                         .or_else(scope, |scope| #else_branch);
                 }}
             }
@@ -314,10 +331,10 @@ impl Expression {
                 ..
             } => {
                 let path = frontend_path();
-                let condition = condition.to_tokens(context);
+                let condition = into_expand(condition.to_tokens(context));
                 let then_block = then_block.to_tokens(context);
                 quote! {{
-                    #path::branch::if_expand(scope, #condition.into_expand(scope), |scope| #then_block);
+                    #path::branch::if_expand(scope, #condition, |scope| #then_block);
                 }}
             }
             Expression::Switch {
@@ -330,7 +347,7 @@ impl Expression {
                     true => quote![switch_expand_expr],
                     false => quote![switch_expand],
                 };
-                let value = value.to_tokens(context);
+                let value = into_expand(value.to_tokens(context));
                 let default = default.to_tokens(context);
                 let blocks = cases
                     .iter()
@@ -343,7 +360,7 @@ impl Expression {
                     })
                     .collect::<Vec<_>>();
                 quote! {{
-                    #branch::#switch(scope, #value.into_expand(scope), |scope| #default)
+                    #branch::#switch(scope, #value, |scope| #default)
                         #(#blocks)*
                         .finish(scope)
                 }}

--- a/crates/cubecl-opt/src/instructions.rs
+++ b/crates/cubecl-opt/src/instructions.rs
@@ -1,7 +1,6 @@
 use cubecl_ir::{
-    Arithmetic, AtomicBinaryOperands, AtomicOp, BarrierOps, BinaryOperands, Bitwise, Comparison,
-    CoopMma, Instruction, Memory, Metadata, NonSemantic, Operation, OperationReflect, Operator,
-    Plane, TensorIndexingOps, TmaOps, UnaryOperands, Variable,
+    CoopMma, Instruction, Marker, Metadata, NonSemantic, Operation, OperationReflect, Operator,
+    TensorIndexingOps, TmaOps, Variable,
 };
 
 use crate::{ControlFlow, Function, GlobalState, analyses::pointer_source::PointerSource};
@@ -70,29 +69,23 @@ impl Function {
         }
 
         match op {
-            Operation::Copy(variable) => visit_read(self, variable),
-            Operation::Memory(memory) => self.visit_memory(memory, visit_read),
-            Operation::Arithmetic(arithmetic) => self.visit_arithmetic(arithmetic, visit_read),
-            Operation::Comparison(comparison) => self.visit_compare(comparison, visit_read),
-            Operation::Bitwise(bitwise) => self.visit_bitwise(bitwise, visit_read),
-            Operation::Operator(operator) => self.visit_operator(operator, visit_read),
-            Operation::Atomic(atomic) => self.visit_atomic(atomic, visit_read),
+            Operation::Marker(Marker::Free(_)) => {}
             Operation::Metadata(meta) => self.visit_meta(meta, visit_read),
-            // Sync has no outputs
-            Operation::Synchronization(_) => {}
-            Operation::WorkgroupUniformLoad(variable) => visit_read(self, variable),
-            Operation::Plane(plane) => self.visit_plane(plane, visit_read),
             Operation::CoopMma(coop_mma) => self.visit_cmma(state, coop_mma, visit_read),
             Operation::Branch(_) => unreachable!(),
-            Operation::Barrier(barrier_ops) => self.visit_barrier(barrier_ops, visit_read),
             Operation::Tma(tma_ops) => self.visit_tma(tma_ops, visit_read),
             Operation::TensorIndexing(tensor_ops) => self.visit_tensor_ops(tensor_ops, visit_read),
             Operation::NonSemantic(non_semantic) => {
                 self.visit_nonsemantic(non_semantic, visit_read)
             }
-            Operation::Marker(_) => {}
-            Operation::ConstructAggregate(..) | Operation::ExtractAggregateField(..) => {
-                unreachable!("Should be disaggregated at this point")
+            op => {
+                if let Some(args) = op.args_mut() {
+                    for arg in args {
+                        visit_read(self, arg);
+                    }
+                } else {
+                    panic!("Found op {op} which doesn't reflect. Needs special handling.");
+                }
             }
         }
     }
@@ -118,208 +111,6 @@ impl Function {
         }
     }
 
-    /// Visit an operator with a set of read and write visitors. Each visitor will be called with
-    /// each read or written to variable.
-    pub fn visit_arithmetic(
-        &mut self,
-        op: &mut Arithmetic,
-        mut visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        match op {
-            Arithmetic::Fma(fma_operator) => {
-                visit_read(self, &mut fma_operator.a);
-                visit_read(self, &mut fma_operator.b);
-                visit_read(self, &mut fma_operator.c);
-            }
-            Arithmetic::Add(binary_operator)
-            | Arithmetic::SaturatingAdd(binary_operator)
-            | Arithmetic::Sub(binary_operator)
-            | Arithmetic::SaturatingSub(binary_operator)
-            | Arithmetic::Mul(binary_operator)
-            | Arithmetic::Div(binary_operator)
-            | Arithmetic::Powf(binary_operator)
-            | Arithmetic::Powi(binary_operator)
-            | Arithmetic::Hypot(binary_operator)
-            | Arithmetic::Rhypot(binary_operator)
-            | Arithmetic::ModFloor(binary_operator)
-            | Arithmetic::Max(binary_operator)
-            | Arithmetic::Min(binary_operator)
-            | Arithmetic::Rem(binary_operator)
-            | Arithmetic::Dot(binary_operator)
-            | Arithmetic::MulHi(binary_operator)
-            | Arithmetic::ArcTan2(binary_operator) => self.visit_binop(binary_operator, visit_read),
-
-            Arithmetic::Abs(unary_operator)
-            | Arithmetic::Exp(unary_operator)
-            | Arithmetic::Log(unary_operator)
-            | Arithmetic::Log1p(unary_operator)
-            | Arithmetic::Cos(unary_operator)
-            | Arithmetic::Sin(unary_operator)
-            | Arithmetic::Tan(unary_operator)
-            | Arithmetic::Tanh(unary_operator)
-            | Arithmetic::Sinh(unary_operator)
-            | Arithmetic::Cosh(unary_operator)
-            | Arithmetic::ArcCos(unary_operator)
-            | Arithmetic::ArcSin(unary_operator)
-            | Arithmetic::ArcTan(unary_operator)
-            | Arithmetic::ArcSinh(unary_operator)
-            | Arithmetic::ArcCosh(unary_operator)
-            | Arithmetic::ArcTanh(unary_operator)
-            | Arithmetic::Degrees(unary_operator)
-            | Arithmetic::Radians(unary_operator)
-            | Arithmetic::Sqrt(unary_operator)
-            | Arithmetic::InverseSqrt(unary_operator)
-            | Arithmetic::Round(unary_operator)
-            | Arithmetic::Floor(unary_operator)
-            | Arithmetic::Ceil(unary_operator)
-            | Arithmetic::Trunc(unary_operator)
-            | Arithmetic::Erf(unary_operator)
-            | Arithmetic::Recip(unary_operator)
-            | Arithmetic::Neg(unary_operator)
-            | Arithmetic::Magnitude(unary_operator)
-            | Arithmetic::Normalize(unary_operator)
-            | Arithmetic::VectorSum(unary_operator) => self.visit_unop(unary_operator, visit_read),
-
-            Arithmetic::Clamp(clamp_operator) => {
-                visit_read(self, &mut clamp_operator.input);
-                visit_read(self, &mut clamp_operator.min_value);
-                visit_read(self, &mut clamp_operator.max_value);
-            }
-        }
-    }
-
-    /// Visit an operator with a set of read and write visitors. Each visitor will be called with
-    /// each read or written to variable.
-    pub fn visit_compare(
-        &mut self,
-        op: &mut Comparison,
-        visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        match op {
-            Comparison::Equal(binary_operator)
-            | Comparison::NotEqual(binary_operator)
-            | Comparison::LowerEqual(binary_operator)
-            | Comparison::Greater(binary_operator)
-            | Comparison::Lower(binary_operator)
-            | Comparison::GreaterEqual(binary_operator) => {
-                self.visit_binop(binary_operator, visit_read)
-            }
-            Comparison::IsNan(unary_operator) | Comparison::IsInf(unary_operator) => {
-                self.visit_unop(unary_operator, visit_read)
-            }
-        }
-    }
-
-    /// Visit an operator with a set of read and write visitors. Each visitor will be called with
-    /// each read or written to variable.
-    pub fn visit_bitwise(
-        &mut self,
-        op: &mut Bitwise,
-        visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        match op {
-            Bitwise::BitwiseAnd(binary_operator)
-            | Bitwise::BitwiseOr(binary_operator)
-            | Bitwise::BitwiseXor(binary_operator)
-            | Bitwise::ShiftLeft(binary_operator)
-            | Bitwise::ShiftRight(binary_operator) => self.visit_binop(binary_operator, visit_read),
-
-            Bitwise::CountOnes(unary_operator)
-            | Bitwise::BitwiseNot(unary_operator)
-            | Bitwise::ReverseBits(unary_operator)
-            | Bitwise::LeadingZeros(unary_operator)
-            | Bitwise::TrailingZeros(unary_operator)
-            | Bitwise::FindFirstSet(unary_operator) => self.visit_unop(unary_operator, visit_read),
-        }
-    }
-
-    pub fn visit_memory(
-        &mut self,
-        memory: &mut Memory,
-        mut visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        match memory {
-            Memory::Reference(variable) => visit_read(self, variable),
-            Memory::Index(index_operator) => {
-                visit_read(self, &mut index_operator.list);
-                visit_read(self, &mut index_operator.index);
-            }
-            Memory::Load(variable) => {
-                visit_read(self, variable);
-            }
-            Memory::Store(op) => {
-                visit_read(self, &mut op.ptr);
-                visit_read(self, &mut op.value);
-            }
-            Memory::CopyMemory(op) => {
-                visit_read(self, &mut op.source);
-                visit_read(self, &mut op.target);
-            }
-        }
-    }
-
-    /// Visit an operator with a set of read and write visitors. Each visitor will be called with
-    /// each read or written to variable.
-    pub fn visit_operator(
-        &mut self,
-        op: &mut Operator,
-        mut visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        match op {
-            Operator::And(binary_operator)
-            | Operator::Or(binary_operator)
-            | Operator::ExtractComponent(binary_operator) => {
-                self.visit_binop(binary_operator, visit_read)
-            }
-            Operator::Not(unary_operator)
-            | Operator::Cast(unary_operator)
-            | Operator::Reinterpret(unary_operator) => self.visit_unop(unary_operator, visit_read),
-            Operator::InitVector(vector_init_operator) => {
-                for input in &mut vector_init_operator.inputs {
-                    visit_read(self, input)
-                }
-            }
-            Operator::InsertComponent(vector_insert_operator) => {
-                visit_read(self, &mut vector_insert_operator.vector);
-                visit_read(self, &mut vector_insert_operator.index);
-                visit_read(self, &mut vector_insert_operator.value);
-            }
-            Operator::Select(select) => {
-                visit_read(self, &mut select.cond);
-                visit_read(self, &mut select.then);
-                visit_read(self, &mut select.or_else);
-            }
-        }
-    }
-
-    fn visit_atomic(
-        &mut self,
-        atomic: &mut AtomicOp,
-        mut visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        match atomic {
-            AtomicOp::Add(binary_operator)
-            | AtomicOp::Sub(binary_operator)
-            | AtomicOp::Max(binary_operator)
-            | AtomicOp::Min(binary_operator)
-            | AtomicOp::And(binary_operator)
-            | AtomicOp::Or(binary_operator)
-            | AtomicOp::Xor(binary_operator)
-            | AtomicOp::Swap(binary_operator) => {
-                self.visit_atomic_binop(binary_operator, visit_read);
-            }
-            AtomicOp::Load(ptr) => visit_read(self, ptr),
-            AtomicOp::Store(store) => {
-                visit_read(self, &mut store.ptr);
-                visit_read(self, &mut store.value);
-            }
-            AtomicOp::CompareAndSwap(op) => {
-                visit_read(self, &mut op.ptr);
-                visit_read(self, &mut op.cmp);
-                visit_read(self, &mut op.val);
-            }
-        }
-    }
     fn visit_meta(
         &mut self,
         metadata: &mut Metadata,
@@ -334,28 +125,6 @@ impl Function {
             Metadata::Shape { dim, .. } => {
                 visit_read(self, dim);
             }
-        }
-    }
-
-    fn visit_plane(&mut self, plane: &mut Plane, visit_read: impl FnMut(&mut Self, &mut Variable)) {
-        match plane {
-            Plane::Elect => {}
-            Plane::Broadcast(binary_operator)
-            | Plane::Shuffle(binary_operator)
-            | Plane::ShuffleXor(binary_operator)
-            | Plane::ShuffleUp(binary_operator)
-            | Plane::ShuffleDown(binary_operator) => self.visit_binop(binary_operator, visit_read),
-            Plane::All(unary_operator)
-            | Plane::Any(unary_operator)
-            | Plane::Sum(unary_operator)
-            | Plane::InclusiveSum(unary_operator)
-            | Plane::ExclusiveSum(unary_operator)
-            | Plane::Prod(unary_operator)
-            | Plane::InclusiveProd(unary_operator)
-            | Plane::ExclusiveProd(unary_operator)
-            | Plane::Min(unary_operator)
-            | Plane::Max(unary_operator)
-            | Plane::Ballot(unary_operator) => self.visit_unop(unary_operator, visit_read),
         }
     }
 
@@ -465,131 +234,6 @@ impl Function {
         }
     }
 
-    fn visit_barrier(
-        &mut self,
-        barrier_ops: &mut BarrierOps,
-        mut visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        match barrier_ops {
-            BarrierOps::Declare { barrier } => visit_read(self, barrier),
-            BarrierOps::Init {
-                barrier,
-                is_elected,
-                arrival_count,
-                ..
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, is_elected);
-                visit_read(self, arrival_count);
-            }
-            BarrierOps::InitManual {
-                barrier,
-                arrival_count,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, arrival_count);
-            }
-            BarrierOps::MemCopyAsync {
-                barrier,
-                source,
-                destination,
-                source_length,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, source_length);
-                visit_read(self, source);
-                visit_read(self, destination);
-            }
-            BarrierOps::MemCopyAsyncCooperative {
-                barrier,
-                source,
-                destination,
-                source_length,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, source_length);
-                visit_read(self, source);
-                visit_read(self, destination);
-            }
-            BarrierOps::CopyAsync {
-                source,
-                source_length,
-                ..
-            } => {
-                visit_read(self, source_length);
-                visit_read(self, source);
-            }
-            BarrierOps::MemCopyAsyncTx {
-                barrier,
-                source,
-                destination,
-                source_length,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, source_length);
-                visit_read(self, source);
-                visit_read(self, destination);
-            }
-            BarrierOps::TmaLoad {
-                barrier,
-                tensor_map,
-                destination,
-                indices,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, tensor_map);
-                visit_read(self, destination);
-                for index in indices {
-                    visit_read(self, index);
-                }
-            }
-            BarrierOps::TmaLoadIm2col {
-                barrier,
-                tensor_map,
-                destination,
-                indices,
-                offsets,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, tensor_map);
-                visit_read(self, destination);
-                for index in indices {
-                    visit_read(self, index);
-                }
-                for offset in offsets {
-                    visit_read(self, offset);
-                }
-            }
-            BarrierOps::ArriveAndWait { barrier } => visit_read(self, barrier),
-            BarrierOps::Arrive { barrier } => visit_read(self, barrier),
-            BarrierOps::ArriveTx {
-                barrier,
-                arrive_count_update,
-                transaction_count_update,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, arrive_count_update);
-                visit_read(self, transaction_count_update);
-            }
-            BarrierOps::CommitCopyAsync { barrier } => visit_read(self, barrier),
-            BarrierOps::ExpectTx {
-                barrier,
-                transaction_count_update,
-            } => {
-                visit_read(self, barrier);
-                visit_read(self, transaction_count_update);
-            }
-            BarrierOps::Wait { barrier, token } => {
-                visit_read(self, barrier);
-                visit_read(self, token);
-            }
-            BarrierOps::WaitParity { barrier, phase } => {
-                visit_read(self, barrier);
-                visit_read(self, phase);
-            }
-        }
-    }
-
     fn visit_tma(
         &mut self,
         tma_ops: &mut TmaOps,
@@ -659,31 +303,5 @@ impl Function {
                 }
             }
         }
-    }
-
-    fn visit_unop(
-        &mut self,
-        unop: &mut UnaryOperands,
-        mut visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        visit_read(self, &mut unop.input);
-    }
-
-    fn visit_binop(
-        &mut self,
-        binop: &mut BinaryOperands,
-        mut visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        visit_read(self, &mut binop.lhs);
-        visit_read(self, &mut binop.rhs);
-    }
-
-    fn visit_atomic_binop(
-        &mut self,
-        binop: &mut AtomicBinaryOperands,
-        mut visit_read: impl FnMut(&mut Self, &mut Variable),
-    ) {
-        visit_read(self, &mut binop.ptr);
-        visit_read(self, &mut binop.value);
     }
 }

--- a/crates/cubecl-std/src/quant/view.rs
+++ b/crates/cubecl-std/src/quant/view.rs
@@ -30,6 +30,7 @@ use half::{bf16, f16};
 #[expect(dead_code, reason = "only used in expand")]
 #[derive(CubeType, CubeLaunch, Clone)]
 pub struct QuantizedView<
+    'a,
     Q: Scalar,
     NQ: Size,
     S: Scalar,
@@ -37,8 +38,8 @@ pub struct QuantizedView<
     NF: Size,
     C: Coordinates + 'static,
 > {
-    values: View<Vector<Q, NQ>, C>,
-    scales: View<S, C>,
+    values: View<'a, Vector<Q, NQ>, C>,
+    scales: View<'a, S, C>,
     #[cube(comptime)]
     scheme: QuantScheme,
     #[cube(comptime)]
@@ -46,15 +47,15 @@ pub struct QuantizedView<
 }
 
 #[cube]
-impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
-    QuantizedView<Q, NQ, S, F, NF, C>
+impl<'a, Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
+    QuantizedView<'a, Q, NQ, S, F, NF, C>
 {
     pub fn new(
-        values: View<Vector<Q, NQ>, C>,
-        scales: View<S, C>,
+        values: View<'a, Vector<Q, NQ>, C>,
+        scales: View<'a, S, C>,
         #[comptime] scheme: QuantScheme,
     ) -> Self {
-        QuantizedView::<Q, NQ, S, F, NF, C> {
+        QuantizedView::<'a, Q, NQ, S, F, NF, C> {
             values,
             scales,
             scheme,
@@ -63,30 +64,30 @@ impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'sta
     }
 }
 
-impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
-    QuantizedView<Q, NQ, S, F, NF, C>
+impl<'a, Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
+    QuantizedView<'a, Q, NQ, S, F, NF, C>
 {
-    pub fn view(self) -> View<Vector<F, NF>, C> {
+    pub fn view(self) -> View<'a, Vector<F, NF>, C> {
         unexpanded!()
     }
 
     pub fn __expand_view(
         scope: &Scope,
-        this: QuantizedViewExpand<Q, NQ, S, F, NF, C>,
-    ) -> ViewExpand<Vector<F, NF>, C, ReadOnly> {
+        this: QuantizedViewExpand<'a, Q, NQ, S, F, NF, C>,
+    ) -> ViewExpand<'a, Vector<F, NF>, C> {
         this.__expand_view_method(scope)
     }
 }
 
-impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
-    QuantizedViewExpand<Q, NQ, S, F, NF, C>
+impl<'a, Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
+    QuantizedViewExpand<'a, Q, NQ, S, F, NF, C>
 {
     pub fn new(
-        values: ViewExpand<Vector<Q, NQ>, C>,
-        scales: ViewExpand<S, C>,
+        values: ViewExpand<'a, Vector<Q, NQ>, C>,
+        scales: ViewExpand<'a, S, C>,
         scheme: QuantScheme,
     ) -> Self {
-        QuantizedViewExpand::<Q, NQ, S, F, NF, C> {
+        QuantizedViewExpand::<'a, Q, NQ, S, F, NF, C> {
             values,
             scales,
             scheme,
@@ -94,30 +95,30 @@ impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'sta
         }
     }
 
-    pub fn __expand_view_method(self, _scope: &Scope) -> ViewExpand<Vector<F, NF>, C, ReadOnly> {
-        ViewExpand::new(self)
+    pub fn __expand_view_method(self, scope: &Scope) -> ViewExpand<'a, Vector<F, NF>, C> {
+        ViewExpand::new(scope, self)
     }
 }
 
-impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static> Vectorized
-    for QuantizedView<Q, NQ, S, F, NF, C>
+impl<'a, Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static> Vectorized
+    for QuantizedView<'a, Q, NQ, S, F, NF, C>
 {
 }
-impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
-    VectorizedExpand for QuantizedViewExpand<Q, NQ, S, F, NF, C>
+impl<'a, Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
+    VectorizedExpand for QuantizedViewExpand<'a, Q, NQ, S, F, NF, C>
 {
     fn vector_size(&self) -> VectorSize {
         self.values.vector_size() * self.scheme.num_quants()
     }
 }
 
-impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
-    ViewOperations<Vector<F, NF>, C> for QuantizedView<Q, NQ, S, F, NF, C>
+impl<'a, Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
+    ViewOperations<Vector<F, NF>, C> for QuantizedView<'a, Q, NQ, S, F, NF, C>
 {
 }
 
-impl<Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
-    ViewOperationsExpand<Vector<F, NF>, C> for QuantizedViewExpand<Q, NQ, S, F, NF, C>
+impl<'a, Q: Scalar, NQ: Size, S: Scalar, F: Numeric, NF: Size, C: Coordinates + 'static>
+    ViewOperationsExpand<Vector<F, NF>, C> for QuantizedViewExpand<'a, Q, NQ, S, F, NF, C>
 {
     fn __expand_read_method(
         &self,
@@ -227,7 +228,7 @@ struct ExpandDynamic<'a, E: Numeric, N: Size, C: Coordinates + 'static> {
 impl<'a, E: Numeric, N: Size, C: Coordinates + 'static> RunWithQuantType
     for ExpandDynamic<'a, E, N, C>
 {
-    type Output = ViewExpand<Vector<E, N>, C>;
+    type Output = ViewExpand<'static, Vector<E, N>, C>;
 
     fn execute<Q: Scalar, S: Scalar>(self) -> Self::Output {
         define_size!(NQ);
@@ -239,7 +240,7 @@ impl<'a, E: Numeric, N: Size, C: Coordinates + 'static> RunWithQuantType
         let values = View::<Vector<Q, NQ>, C>::expand(self.values, self.builder);
         let scales = View::<S, C>::expand(self.scales, self.builder);
         let view = QuantizedViewExpand::new(values, scales, self.scheme);
-        ViewExpand::new(view)
+        ViewExpand::new(&self.builder.scope, view)
     }
 }
 
@@ -309,12 +310,12 @@ pub fn run_with_quant_type<F: RunWithQuantType>(func: F, scheme: QuantScheme) ->
 
 /// Dynamically expand based on the quantization scheme. Ugly, but the only way to fully hide the
 /// quantization from the kernel using the view.
-pub(crate) fn expand_dynamic<E: CubePrimitive, C: Coordinates + 'static, IO: SliceVisibility>(
+pub(crate) fn expand_dynamic<E: CubePrimitive, C: Coordinates + 'static>(
     values: &ViewCompilationArg<C>,
     scales: &ViewCompilationArg<C>,
     scheme: QuantScheme,
     builder: &mut KernelBuilder,
-) -> ViewExpand<E, C, IO> {
+) -> ViewExpand<'static, E, C> {
     use core::mem::transmute as t;
 
     // To specify tighter trait bounds
@@ -323,7 +324,7 @@ pub(crate) fn expand_dynamic<E: CubePrimitive, C: Coordinates + 'static, IO: Sli
         scales: &ViewCompilationArg<C>,
         scheme: QuantScheme,
         builder: &mut KernelBuilder,
-    ) -> ViewExpand<Vector<F, NF>, C> {
+    ) -> ViewExpand<'static, Vector<F, NF>, C> {
         let func = ExpandDynamic {
             values,
             scales,

--- a/crates/cubecl-std/src/tensor/contiguous/base.rs
+++ b/crates/cubecl-std/src/tensor/contiguous/base.rs
@@ -94,7 +94,7 @@ pub fn index_offset_contiguous_fastdivmod(
 
 #[cube(launch, address_type = "dynamic")]
 fn copy_kernel<T: Numeric, N: Size>(
-    input: &LinearView<Vector<T, N>>,
+    input: LinearView<'_, Vector<T, N>>,
     output: &mut [Vector<T, N>],
     out_layout: LinearLayout,
     #[comptime] elems_per_thread: usize,
@@ -119,7 +119,7 @@ fn copy_kernel<T: Numeric, N: Size>(
 
 #[cube(launch, address_type = "dynamic")]
 fn copy_kernel_pack<T: Numeric, N: Size>(
-    input: &LinearView<T>,
+    input: LinearView<'_, T>,
     output: &mut [Vector<T, N>],
     out_layout: LinearLayout,
     #[comptime] elems_per_thread: usize,

--- a/crates/cubecl-std/src/tensor/contiguous/base.rs
+++ b/crates/cubecl-std/src/tensor/contiguous/base.rs
@@ -102,7 +102,7 @@ fn copy_kernel<T: Numeric, N: Size>(
 ) {
     let offset_linear = ABSOLUTE_POS * elems_per_thread;
 
-    let mut registers = Array::<Vector<T, N>>::new(elems_per_thread);
+    let mut registers = Array::new(elems_per_thread);
 
     #[unroll]
     for i in 0..elems_per_thread {
@@ -131,7 +131,7 @@ fn copy_kernel_pack<T: Numeric, N: Size>(
     let offset_output = ABSOLUTE_POS * vectors_per_thread;
     let offset_input = offset_output * vector_size;
 
-    let mut registers = Array::<Vector<T, N>>::new(vectors_per_thread);
+    let mut registers = Array::new(vectors_per_thread);
 
     #[unroll]
     for i in 0..vectors_per_thread {
@@ -220,7 +220,7 @@ fn copy_kernel_packed<T: Int, N: Size>(
         terminate!()
     }
 
-    let mut registers = Array::<Vector<T, N>>::new(vectors_per_thread);
+    let mut registers = Array::new(vectors_per_thread);
 
     #[unroll]
     for i in 0..vectors_per_thread {

--- a/crates/cubecl-std/src/tensor/layout/linear.rs
+++ b/crates/cubecl-std/src/tensor/layout/linear.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, ir::UIntKind, zspace::Shape};
 
 use crate::tensor::{
-    View, is_contiguous, is_contiguous_pitched,
+    View, ViewMut, is_contiguous, is_contiguous_pitched,
     launch::{ConcreteLayout, ConcreteLayoutLaunch, MemoryArg, ViewArg, ViewLayoutLaunchArg},
     layout::{
         Coords1d, Layout, LayoutExpand, VirtualLayoutOperationsExpand,
@@ -164,7 +164,8 @@ pub type LinearLayoutLaunch<R> = ConcreteLayoutLaunch<LinearViewLayout, R>;
 
 /// [`View`] with a linear layout inferred from the shape/strides at launch.
 /// Useful for elementwise kernels.
-pub type LinearView<E, IO = ReadOnly> = View<E, Coords1d, IO>;
+pub type LinearView<'a, E> = View<'a, E, Coords1d>;
+pub type LinearViewMut<'a, E> = ViewMut<'a, E, Coords1d>;
 /// Launch type for [`LinearView`].
 pub type LinearViewLaunch<R> = ViewArg<Coords1d, R>;
 

--- a/crates/cubecl-std/src/tensor/view/as_view.rs
+++ b/crates/cubecl-std/src/tensor/view/as_view.rs
@@ -1,6 +1,6 @@
 use cubecl_core::{prelude::*, unexpanded};
 
-use crate::tensor::{View, ViewExpand, layout::*};
+use crate::tensor::{View, ViewExpand, ViewMut, ViewMutExpand, layout::*};
 
 type ArrayExpand<T> = NativeExpand<Array<T>>;
 
@@ -13,15 +13,15 @@ pub trait AsView<E: CubePrimitive>:
     fn view<C: Coordinates + 'static>(
         &self,
         layout: impl Into<VirtualLayout<C, Self::SourceCoords>>,
-    ) -> View<E, C, ReadOnly> {
+    ) -> View<'_, E, C> {
         unexpanded!()
     }
 
-    fn __expand_view<C: Coordinates + 'static>(
+    fn __expand_view<'a, C: Coordinates + 'static>(
         scope: &Scope,
-        this: Self::ExpandType,
+        this: &'a Self::ExpandType,
         layout: VirtualLayoutExpand<C, Self::SourceCoords>,
-    ) -> ViewExpand<E, C, ReadOnly> {
+    ) -> ViewExpand<'a, E, C> {
         this.__expand_view_method(scope, layout)
     }
 }
@@ -34,7 +34,7 @@ pub trait AsViewExpand<E: CubePrimitive> {
         &self,
         scope: &Scope,
         layout: VirtualLayoutExpand<C, Self::SourceCoords>,
-    ) -> ViewExpand<E, C, ReadOnly>;
+    ) -> ViewExpand<'_, E, C>;
 }
 
 pub trait AsViewMut<E: CubePrimitive>: AsView<E> {
@@ -42,7 +42,7 @@ pub trait AsViewMut<E: CubePrimitive>: AsView<E> {
     fn view_mut<C: Coordinates + 'static>(
         &mut self,
         layout: impl Into<VirtualLayout<C, Self::SourceCoords>>,
-    ) -> View<E, C, ReadWrite> {
+    ) -> ViewMut<'_, E, C> {
         unexpanded!()
     }
 }
@@ -53,7 +53,7 @@ pub trait AsViewMutExpand<E: CubePrimitive>: AsViewExpand<E> {
         &mut self,
         scope: &Scope,
         layout: VirtualLayoutExpand<C, Self::SourceCoords>,
-    ) -> ViewExpand<E, C, ReadWrite>;
+    ) -> ViewMutExpand<'_, E, C>;
 }
 
 macro_rules! impl_as_view {
@@ -67,10 +67,10 @@ macro_rules! impl_as_view {
                 &self,
                 scope: &Scope,
                 layout: VirtualLayoutExpand<C, $coords>,
-            ) -> super::ViewExpand<E, C, ReadOnly> {
-                View::__expand_new::<Box<[E]>, $coords>(
+            ) -> super::ViewExpand<'_, E, C> {
+                View::__expand_new::<&[E], $coords>(
                     scope,
-                    unsafe { self.__expand_as_boxed_unchecked_method(scope) },
+                    self.__expand_as_slice_method(scope),
                     layout,
                 )
             }
@@ -82,13 +82,10 @@ macro_rules! impl_as_view {
                 &mut self,
                 scope: &Scope,
                 layout: VirtualLayoutExpand<C, $coords>,
-            ) -> super::ViewExpand<E, C, ReadWrite> {
-                View::__expand_new_mut::<Box<[E]>, $coords>(
+            ) -> super::ViewMutExpand<'_, E, C> {
+                ViewMut::__expand_new::<&mut [E], $coords>(
                     scope,
-                    unsafe {
-                        self.__expand_as_mut_slice_method(scope)
-                            .__expand_as_boxed_unchecked_method(scope)
-                    },
+                    self.__expand_as_mut_slice_method(scope),
                     layout,
                 )
             }
@@ -105,8 +102,8 @@ impl<E: CubePrimitive> AsView<E> for [E] {
     fn view<C: Coordinates + 'static>(
         &self,
         layout: impl Into<VirtualLayout<C, Coords1d>>,
-    ) -> View<E, C, ReadOnly> {
-        View::new::<Box<[E]>, Coords1d>(unsafe { self.as_boxed_unchecked() }, layout)
+    ) -> View<'_, E, C> {
+        View::new::<&[E], Coords1d>(self, layout)
     }
 }
 
@@ -116,12 +113,8 @@ impl<E: CubePrimitive> AsViewExpand<E> for SliceExpand<E> {
         &self,
         scope: &Scope,
         layout: VirtualLayoutExpand<C, Self::SourceCoords>,
-    ) -> ViewExpand<E, C, ReadOnly> {
-        View::__expand_new::<Box<[E]>, Self::SourceCoords>(
-            scope,
-            unsafe { self.__expand_as_boxed_unchecked_method(scope) },
-            layout,
-        )
+    ) -> ViewExpand<'_, E, C> {
+        View::__expand_new::<&[E], Self::SourceCoords>(scope, self, layout)
     }
 }
 
@@ -129,8 +122,8 @@ impl<E: CubePrimitive> AsViewMut<E> for [E] {
     fn view_mut<C: Coordinates + 'static>(
         &mut self,
         layout: impl Into<VirtualLayout<C, Coords1d>>,
-    ) -> View<E, C, ReadWrite> {
-        View::new_mut::<Box<[E]>, Coords1d>(unsafe { self.as_boxed_unchecked() }, layout)
+    ) -> ViewMut<'_, E, C> {
+        ViewMut::new::<&mut [E], Coords1d>(self, layout)
     }
 }
 impl<E: CubePrimitive> AsViewMutExpand<E> for SliceExpand<E> {
@@ -138,12 +131,8 @@ impl<E: CubePrimitive> AsViewMutExpand<E> for SliceExpand<E> {
         &mut self,
         scope: &Scope,
         layout: VirtualLayoutExpand<C, Self::SourceCoords>,
-    ) -> ViewExpand<E, C, ReadWrite> {
-        View::__expand_new_mut::<Box<[E]>, Coords1d>(
-            scope,
-            unsafe { self.__expand_as_boxed_unchecked_method(scope) },
-            layout,
-        )
+    ) -> ViewMutExpand<'_, E, C> {
+        ViewMut::__expand_new::<&mut [E], Coords1d>(scope, self, layout)
     }
 }
 
@@ -158,7 +147,7 @@ macro_rules! as_view_tensor_map {
                     fn [<view_ $dim>]<C: Coordinates + 'static>(
                         &self,
                         layout: impl Into<VirtualLayout<C, [<Coords $dim>]>>,
-                    ) -> View<E, C, ReadOnly> {
+                    ) -> View<'_, E, C> {
                         unexpanded!()
                     }
 
@@ -166,7 +155,7 @@ macro_rules! as_view_tensor_map {
                         scope: &Scope,
                         this: Self::ExpandType,
                         layout: VirtualLayoutExpand<C, [<Coords $dim>]>,
-                    ) -> ViewExpand<E, C, ReadOnly> {
+                    ) -> ViewExpand<'_, E, C> {
                         this.[<__expand_view_ $dim _method>](scope, layout)
                     }
                 )*
@@ -179,7 +168,7 @@ macro_rules! as_view_tensor_map {
                         self,
                         scope: &Scope,
                         layout: VirtualLayoutExpand<C, [<Coords $dim>]>,
-                    ) -> ViewExpand<E, C, ReadOnly>;
+                    ) -> ViewExpand<'_, E, C>;
                 )*
             }
 
@@ -189,7 +178,7 @@ macro_rules! as_view_tensor_map {
                     fn [<view_mut_ $dim>]<C: Coordinates + 'static>(
                         &mut self,
                         layout: impl Into<VirtualLayout<C, [<Coords $dim>]>>,
-                    ) -> View<E, C, ReadWrite> {
+                    ) -> ViewMut<'_, E, C> {
                         unexpanded!()
                     }
                 )*
@@ -202,7 +191,7 @@ macro_rules! as_view_tensor_map {
                         self,
                         scope: &Scope,
                         layout: VirtualLayoutExpand<C, [<Coords $dim>]>,
-                    ) -> ViewExpand<E, C, ReadWrite>;
+                    ) -> ViewMutExpand<'_, E, C>;
                 )*
             }
 
@@ -213,7 +202,7 @@ macro_rules! as_view_tensor_map {
                         self,
                         scope: &Scope,
                         layout: VirtualLayoutExpand<C, [<Coords $dim>]>,
-                    ) -> super::ViewExpand<E, C, ReadOnly> {
+                    ) -> super::ViewExpand<'_, E, C> {
                         View::__expand_new::<TensorMap<E, Tiled>, [<Coords $dim>]>(scope, self, layout)
                     }
                 )*
@@ -226,8 +215,8 @@ macro_rules! as_view_tensor_map {
                         self,
                         scope: &Scope,
                         layout: VirtualLayoutExpand<C, [<Coords $dim>]>,
-                    ) -> super::ViewExpand<E, C, ReadWrite> {
-                        View::__expand_new_mut::<TensorMap<E, Tiled>, [<Coords $dim>]>(scope, self, layout)
+                    ) -> super::ViewMutExpand<'_, E, C> {
+                        ViewMut::__expand_new::<TensorMap<E, Tiled>, [<Coords $dim>]>(scope, self, layout)
                     }
                 )*
             }

--- a/crates/cubecl-std/src/tensor/view/as_view.rs
+++ b/crates/cubecl-std/src/tensor/view/as_view.rs
@@ -3,7 +3,6 @@ use cubecl_core::{prelude::*, unexpanded};
 use crate::tensor::{View, ViewExpand, layout::*};
 
 type ArrayExpand<T> = NativeExpand<Array<T>>;
-type SharedMemoryExpand<T> = NativeExpand<SharedMemory<T>>;
 
 pub trait AsView<E: CubePrimitive>:
     CubeType<ExpandType: AsViewExpand<E, SourceCoords = Self::SourceCoords>>
@@ -58,11 +57,11 @@ pub trait AsViewMutExpand<E: CubePrimitive>: AsViewExpand<E> {
 }
 
 macro_rules! impl_as_view {
-    ($ty: ident, $expand: ident, $coords: ty) => {
-        impl<E: CubePrimitive> AsView<E> for $ty<E> {
+    ($ty: ty, $expand: ty, $coords: ty) => {
+        impl<E: CubePrimitive> AsView<E> for $ty {
             type SourceCoords = $coords;
         }
-        impl<E: CubePrimitive> AsViewExpand<E> for $expand<E> {
+        impl<E: CubePrimitive> AsViewExpand<E> for $expand {
             type SourceCoords = $coords;
             fn __expand_view_method<C: Coordinates + 'static>(
                 &self,
@@ -77,8 +76,8 @@ macro_rules! impl_as_view {
             }
         }
 
-        impl<E: CubePrimitive> AsViewMut<E> for $ty<E> {}
-        impl<E: CubePrimitive> AsViewMutExpand<E> for $expand<E> {
+        impl<E: CubePrimitive> AsViewMut<E> for $ty {}
+        impl<E: CubePrimitive> AsViewMutExpand<E> for $expand {
             fn __expand_view_mut_method<C: Coordinates + 'static>(
                 &mut self,
                 scope: &Scope,
@@ -97,9 +96,9 @@ macro_rules! impl_as_view {
     };
 }
 
-impl_as_view!(Array, ArrayExpand, Coords1d);
-impl_as_view!(Tensor, TensorExpand, Coords1d);
-impl_as_view!(SharedMemory, SharedMemoryExpand, Coords1d);
+impl_as_view!(Array<E>, ArrayExpand<E>, Coords1d);
+impl_as_view!(Tensor<E>, TensorExpand<E>, Coords1d);
+impl_as_view!(Shared<[E]>, SharedExpand<[E]>, Coords1d);
 
 impl<E: CubePrimitive> AsView<E> for [E] {
     type SourceCoords = Coords1d;

--- a/crates/cubecl-std/src/tensor/view/base.rs
+++ b/crates/cubecl-std/src/tensor/view/base.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, sync::Arc};
+use std::marker::PhantomData;
 
 use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, ir::VectorSize, prelude::barrier::Barrier, unexpanded};
@@ -13,435 +13,469 @@ use crate::tensor::{
 /// Allows abstract indexing in multiple dimensions, without having to know the data layout or
 /// location.
 #[derive(Clone, Copy)]
-pub struct View<E: CubePrimitive, C: Coordinates, IO: Clone = ReadOnly> {
+pub struct View<'a, E: CubePrimitive, C: Coordinates> {
     _layout: PhantomData<C>,
-    _ty: PhantomData<(E, IO)>,
-}
-
-// `View` is a dummy type so it's always send/sync
-unsafe impl<E: CubePrimitive, C: Coordinates, IO: Clone> Send for View<E, C, IO> {}
-unsafe impl<E: CubePrimitive, C: Coordinates, IO: Clone> Sync for View<E, C, IO> {}
-
-#[derive(Clone)]
-pub(super) enum ViewType<E: CubePrimitive, C: Coordinates> {
-    Read(Arc<dyn ViewOperationsExpand<E, C>>),
-    ReadWrite(Arc<dyn ViewOperationsMutExpand<E, C>>),
-}
-
-impl<E: CubePrimitive, C: Coordinates> ViewType<E, C> {
-    /// Dereference in read mode
-    pub fn read(&self) -> &dyn ViewOperationsExpand<E, C> {
-        match self {
-            ViewType::Read(list) => &**list,
-            ViewType::ReadWrite(list) => &**list,
-        }
-    }
-
-    /// Dereference in write mode
-    pub fn write(&self) -> &dyn ViewOperationsMutExpand<E, C> {
-        match self {
-            ViewType::Read(_) => panic!("Can't write to readonly list"),
-            ViewType::ReadWrite(list) => &**list,
-        }
-    }
+    _ty: PhantomData<E>,
+    _lifetime: PhantomData<&'a ()>,
 }
 
 /// Expand type of [`View`]
-#[derive(Clone)]
-pub struct ViewExpand<E: CubePrimitive, C: Coordinates, IO: Clone = ReadOnly> {
-    pub(super) inner: ViewType<E, C>,
-    pub(super) _io: PhantomData<IO>,
+#[derive(Clone, Copy)]
+pub struct ViewExpand<'a, E: CubePrimitive, C: Coordinates> {
+    pub(super) inner: &'a (dyn ViewOperationsExpand<E, C> + 'a),
 }
 
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> CubeType for View<E, C, IO> {
-    type ExpandType = ViewExpand<E, C, IO>;
+/// Mutable view
+/// Note: `Clone` and `Copy` should ideally not be there, but are required for good ergonomics until
+/// `Reborrow` and `CoerceShared` are implemented and stabilized.
+#[derive(Clone, Copy)]
+pub struct ViewMut<'a, E: CubePrimitive, C: Coordinates> {
+    _layout: PhantomData<C>,
+    _ty: PhantomData<E>,
+    _lifetime: PhantomData<&'a mut ()>,
 }
 
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> IntoExpand for ViewExpand<E, C, IO> {
-    type Expand = ViewExpand<E, C, IO>;
-
-    fn into_expand(self, _: &Scope) -> Self::Expand {
-        self
-    }
+/// Expand type of [`ViewMutExpand`]
+#[derive(Clone, Copy)]
+pub struct ViewMutExpand<'a, E: CubePrimitive, C: Coordinates> {
+    pub(super) inner: &'a (dyn ViewOperationsMutExpand<E, C> + 'a),
 }
 
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> ExpandTypeClone for ViewExpand<E, C, IO> {
-    fn clone_unchecked(&self) -> Self {
-        self.clone()
-    }
+macro_rules! impl_cube_type {
+    ($ty: ident, $expand: ident) => {
+        impl<'a, E: CubePrimitive, C: Coordinates + 'a> CubeType for $ty<'a, E, C> {
+            type ExpandType = $expand<'a, E, C>;
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates> IntoExpand for $expand<'a, E, C> {
+            type Expand = $expand<'a, E, C>;
+
+            fn into_expand(self, _: &Scope) -> Self::Expand {
+                self
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates> ExpandTypeClone for $expand<'a, E, C> {
+            fn clone_unchecked(&self) -> Self {
+                self.clone()
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates> IntoMut for $expand<'a, E, C> {
+            fn into_mut(self, _scope: &Scope) -> Self {
+                self
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates> CubeDebug for $expand<'a, E, C> {}
+
+        impl<'a, E: CubePrimitive, C: Coordinates> AsRefExpand for $expand<'a, E, C> {
+            fn __expand_ref_method(&self, _: &Scope) -> &Self {
+                self
+            }
+        }
+        impl<'a, E: CubePrimitive, C: Coordinates> AsMutExpand for $expand<'a, E, C> {
+            fn __expand_ref_mut_method(&mut self, _: &Scope) -> &mut Self {
+                self
+            }
+        }
+        impl<'a, E: CubePrimitive, C: Coordinates> DerefExpand for $expand<'a, E, C> {
+            type Target = Self;
+
+            fn __expand_deref_method(&self, _: &Scope) -> Self::Target {
+                self.clone()
+            }
+        }
+    };
 }
 
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> IntoMut for ViewExpand<E, C, IO> {
-    fn into_mut(self, _scope: &Scope) -> Self {
-        self
-    }
-}
+impl_cube_type!(View, ViewExpand);
+impl_cube_type!(ViewMut, ViewMutExpand);
 
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> CubeDebug for ViewExpand<E, C, IO> {}
-
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> AsRefExpand for ViewExpand<E, C, IO> {
-    fn __expand_ref_method(&self, _: &Scope) -> &Self {
-        self
-    }
-}
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> AsMutExpand for ViewExpand<E, C, IO> {
-    fn __expand_ref_mut_method(&mut self, _: &Scope) -> &mut Self {
-        self
-    }
-}
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> DerefExpand for ViewExpand<E, C, IO> {
-    type Target = Self;
-
-    fn __expand_deref_method(&self, _: &Scope) -> Self::Target {
-        self.clone()
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates + 'static> View<E, C, ReadOnly> {
+impl<'a, E: CubePrimitive, C: Coordinates + 'a> View<'a, E, C> {
     /// Create a new tensor view from an underlying concrete storage and a layout to map it into
     /// the target coordinate space
     #[allow(unused_variables)]
-    pub fn new<V: ViewOperations<E, S>, S: Coordinates>(
+    pub fn new<V: ViewOperations<E, S> + 'a, S: Coordinates>(
         view: V,
         layout: impl Into<VirtualLayout<C, S>>,
     ) -> Self {
         View {
             _layout: PhantomData,
             _ty: PhantomData,
+            _lifetime: PhantomData,
         }
     }
 
     /// Expand function for [`View::new`]
-    pub fn __expand_new<V: ViewOperations<E, S> + 'static, S: Coordinates + 'static>(
+    pub fn __expand_new<V: ViewOperations<E, S> + 'a, S: Coordinates + 'a>(
         scope: &Scope,
         view: V::ExpandType,
         layout: VirtualLayoutExpand<C, S>,
-    ) -> ViewExpand<E, C, ReadOnly> {
-        ViewExpand::new(VirtualView::<E, C, S, V>::__expand_new(scope, view, layout))
+    ) -> ViewExpand<'a, E, C> {
+        ViewExpand::new(
+            scope,
+            VirtualView::<E, C, S, V>::__expand_new(scope, view, layout),
+        )
     }
 }
 
-impl<E: CubePrimitive, C: Coordinates + 'static, IO: Clone + 'static> View<E, C, IO> {
-    pub fn view<T: Coordinates>(
-        &self,
-        _layout: impl Into<VirtualLayout<T, C>>,
-    ) -> View<E, T, ReadOnly> {
-        unexpanded!()
-    }
-
-    pub fn __expand_view<T: Coordinates + 'static>(
-        scope: &Scope,
-        this: ViewExpand<E, C, IO>,
-        layout: VirtualLayoutExpand<T, C>,
-    ) -> ViewExpand<E, T, ReadOnly> {
-        this.__expand_view_method(scope, layout)
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates + 'static, IO: Clone + 'static> ViewExpand<E, C, IO> {
-    pub fn __expand_view_method<T: Coordinates + 'static>(
-        &self,
-        scope: &Scope,
-        layout: VirtualLayoutExpand<T, C>,
-    ) -> ViewExpand<E, T, ReadOnly> {
-        View::__expand_new::<View<E, C, IO>, C>(scope, self.clone(), layout)
-    }
-
-    pub fn new<V: ViewOperationsExpand<E, C> + 'static>(view: V) -> Self {
-        ViewExpand {
-            inner: ViewType::Read(Arc::new(view)),
-            _io: PhantomData,
+impl<'a, E: CubePrimitive, C: Coordinates + 'a> ViewMut<'a, E, C> {
+    /// Create a new tensor view from an underlying concrete storage and a layout to map it into
+    /// the target coordinate space
+    #[allow(unused_variables)]
+    pub fn new<V: ViewOperationsMut<E, S> + 'a, S: Coordinates>(
+        view: V,
+        layout: impl Into<VirtualLayout<C, S>>,
+    ) -> Self {
+        ViewMut {
+            _layout: PhantomData,
+            _ty: PhantomData,
+            _lifetime: PhantomData,
         }
     }
 
-    pub fn new_mut<V: ViewOperationsMutExpand<E, C> + 'static>(view: V) -> Self {
-        ViewExpand {
-            inner: ViewType::ReadWrite(Arc::new(view)),
-            _io: PhantomData,
-        }
+    /// Expand function for [`View::new`]
+    pub fn __expand_new<V: ViewOperationsMut<E, S> + 'a, S: Coordinates + 'a>(
+        scope: &Scope,
+        view: V::ExpandType,
+        layout: VirtualLayoutExpand<C, S>,
+    ) -> ViewMutExpand<'a, E, C> {
+        ViewMutExpand::new(
+            scope,
+            VirtualViewMut::<E, C, S, V>::__expand_new(scope, view, layout),
+        )
     }
 }
 
-impl<E: CubePrimitive, C: Coordinates + 'static> View<E, C, ReadWrite> {
-    pub fn view_mut<T: Coordinates>(
-        &self,
+macro_rules! impl_read {
+    ($ty: ident, $expand: ident) => {
+        impl<'a, E: CubePrimitive, C: Coordinates + 'a> $ty<'a, E, C> {
+            pub fn view<T: Coordinates + 'a>(
+                self,
+                _layout: impl Into<VirtualLayout<T, C>>,
+            ) -> $ty<'a, E, T> {
+                unexpanded!()
+            }
+
+            pub fn __expand_view<T: Coordinates + 'a>(
+                scope: &Scope,
+                this: $expand<'a, E, C>,
+                layout: VirtualLayoutExpand<T, C>,
+            ) -> $expand<'a, E, T> {
+                this.__expand_view_method(scope, layout)
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates + 'a> $expand<'a, E, C> {
+            pub fn __expand_view_method<T: Coordinates + 'a>(
+                self,
+                scope: &Scope,
+                layout: VirtualLayoutExpand<T, C>,
+            ) -> $expand<'a, E, T> {
+                $ty::__expand_new::<$ty<'a, E, C>, C>(scope, self, layout)
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates> $ty<'a, E, C> {
+            /// Calls [`Layout::shape`] on the view's layout
+            pub fn shape(&self) -> C {
+                unexpanded!()
+            }
+
+            /// Calls [`Layout::is_in_bounds`] on the view's layout
+            pub fn is_in_bounds(&self, _pos: C) -> bool {
+                unexpanded!()
+            }
+
+            pub fn __expand_shape(scope: &Scope, this: $expand<'a, E, C>) -> C::ExpandType {
+                this.__expand_shape_method(scope)
+            }
+
+            pub fn __expand_is_in_bounds(
+                scope: &Scope,
+                this: $expand<'a, E, C>,
+                pos: C::ExpandType,
+            ) -> NativeExpand<bool> {
+                this.__expand_is_in_bounds_method(scope, pos)
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates> $expand<'a, E, C> {
+            pub fn __expand_shape_method(&self, scope: &Scope) -> C::ExpandType {
+                self.inner.__expand_shape_method(scope)
+            }
+
+            pub fn __expand_is_in_bounds_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+            ) -> NativeExpand<bool> {
+                self.inner.__expand_is_in_bounds_method(scope, pos)
+            }
+        }
+
+        #[allow(unused_variables)]
+        impl<'a, E: CubePrimitive, C: Coordinates> $ty<'a, E, C> {
+            /// Read a value at `pos`. The layout handles translation into a concrete index.
+            pub fn read(&self, pos: C) -> E {
+                unexpanded!()
+            }
+
+            /// Read a value at `pos`. The layout handles translation into a concrete index.
+            /// Reading is done unchecked
+            pub fn read_unchecked(&self, pos: C) -> E {
+                unexpanded!()
+            }
+
+            /// Read a value at `pos` if it's in bounds. The layout handles translation into a concrete index.
+            pub fn read_checked(&self, pos: C) -> E {
+                unexpanded!()
+            }
+
+            /// Read a value at `pos` if it's in bounds, returning `mask_value` otherwise. The layout handles translation into a concrete index.
+            pub fn read_masked(&self, pos: C, mask_value: E) -> E {
+                unexpanded!()
+            }
+
+            /// Interpret this view as a linear slice encompassing the entire view.
+            ///
+            /// # Safety
+            ///
+            /// No checking is done on whether the slice is contiguous in memory.
+            pub fn as_linear_slice(&self) -> &'a [E] {
+                unexpanded!()
+            }
+
+            pub fn vector_size(&self) -> VectorSize {
+                unexpanded!()
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates> $expand<'a, E, C> {
+            /// Expand method for [`View::read`]
+            pub fn __expand_read_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+            ) -> NativeExpand<E> {
+                self.inner.__expand_read_method(scope, pos)
+            }
+
+            /// Expand method for [`View::read_unchecked`]
+            pub fn __expand_read_unchecked_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+            ) -> NativeExpand<E> {
+                self.inner.__expand_read_unchecked_method(scope, pos)
+            }
+
+            /// Expand method for [`View::read_checked`]
+            pub fn __expand_read_checked_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+            ) -> NativeExpand<E> {
+                self.inner.__expand_read_checked_method(scope, pos)
+            }
+
+            /// Expand method for [`View::read_masked`]
+            pub fn __expand_read_masked_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+                mask_value: E::ExpandType,
+            ) -> NativeExpand<E> {
+                self.inner
+                    .__expand_read_masked_method(scope, pos, mask_value)
+            }
+
+            /// Expand method for [`View::vector_size`]
+            pub fn __expand_vector_size_method(&self, _scope: &Scope) -> VectorSize {
+                self.inner.vector_size()
+            }
+
+            pub fn vector_size(&self) -> VectorSize {
+                self.inner.vector_size()
+            }
+
+            pub fn __expand_as_linear_slice_method(&self, scope: &Scope) -> &'a SliceExpand<E> {
+                let shape = self.inner.__expand_shape_method(scope);
+                let origin = C::__expand_from_int(scope, shape.clone_unchecked(), 0);
+                // Inclusive end so clamping works correctly
+                let one = C::__expand_from_int(scope, shape.clone_unchecked(), 1);
+                let shape = C::__expand_max(scope, shape, one.clone_unchecked());
+                let end = C::__expand_sub(scope, shape, one);
+                let slice = self
+                    .inner
+                    .__expand_as_linear_slice_method(scope, origin, end);
+                scope.create_kernel_ref(slice.expand.into())
+            }
+
+            pub(super) fn __expand_as_linear_slice_inner_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+                end: C::ExpandType,
+            ) -> &SliceExpand<E> {
+                self.inner.__expand_as_linear_slice_method(scope, pos, end)
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates + 'static> $ty<'a, E, C> {
+            /// Create a slice starting from `pos`, with `size`.
+            /// The layout handles translation into concrete indices.
+            /// Size will be clamped to the current layout size.
+            pub fn slice(self, _pos: C, _size: C) -> $ty<'a, E, C> {
+                unexpanded!()
+            }
+
+            /// Create a slice starting from `pos`, with `size`.
+            /// The layout handles translation into concrete indices.
+            /// Size and pos will be clamped to the current layout size.
+            /// #Safety
+            /// Access is always unchecked
+            pub fn slice_unchecked(self, _pos: C, _size: C) -> $ty<'a, E, C> {
+                unexpanded!()
+            }
+
+            pub fn __expand_slice(
+                scope: &Scope,
+                this: $expand<'a, E, C>,
+                pos: C::ExpandType,
+                size: C::ExpandType,
+            ) -> $expand<'a, E, C> {
+                this.__expand_slice_method(scope, pos, size)
+            }
+
+            pub fn __expand_slice_unchecked(
+                scope: &Scope,
+                this: $expand<'a, E, C>,
+                pos: C::ExpandType,
+                size: C::ExpandType,
+            ) -> $expand<'a, E, C> {
+                this.__expand_slice_unchecked_method(scope, pos, size)
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates + 'static> $expand<'a, E, C> {
+            pub fn __expand_slice_method(
+                self,
+                scope: &Scope,
+                pos: C::ExpandType,
+                size: C::ExpandType,
+            ) -> $expand<'a, E, C> {
+                self.slice(scope, pos, size, true)
+            }
+
+            pub fn __expand_slice_unchecked_method(
+                self,
+                scope: &Scope,
+                pos: C::ExpandType,
+                size: C::ExpandType,
+            ) -> $expand<'a, E, C> {
+                self.slice(scope, pos, size, false)
+            }
+
+            fn slice(
+                self,
+                scope: &Scope,
+                pos: C::ExpandType,
+                size: C::ExpandType,
+                checked: bool,
+            ) -> $expand<'a, E, C> {
+                let shape = self.__expand_shape_method(scope);
+                let pos = C::__expand_min(scope, pos, shape.clone_unchecked());
+                let max_size = C::__expand_sub(scope, shape, pos.clone_unchecked());
+                let size = C::__expand_min(scope, size, max_size);
+                let layout = SliceLayout::__expand_new(scope, pos, size, checked);
+                $ty::__expand_new::<$ty<'a, E, C>, _>(scope, self, layout.into())
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates + 'static> $ty<'a, E, C> {
+            ///.Execute a TMA load into shared memory, if the underlying storage supports it.
+            /// Panics if it's unsupported.
+            pub fn tensor_map_load(&self, _barrier: &Barrier, _shared_memory: &mut [E], _pos: C) {
+                unexpanded!()
+            }
+        }
+
+        impl<'a, E: CubePrimitive, C: Coordinates> $expand<'a, E, C> {
+            pub fn __expand_tensor_map_load_method(
+                &self,
+                scope: &Scope,
+                barrier: &NativeExpand<Barrier>,
+                shared_memory: &mut SliceExpand<E>,
+                pos: C::ExpandType,
+            ) {
+                self.inner
+                    .__expand_tensor_map_load_method(scope, barrier, shared_memory, pos)
+            }
+        }
+    };
+}
+
+impl_read!(View, ViewExpand);
+impl_read!(ViewMut, ViewMutExpand);
+
+impl<'a, E: CubePrimitive, C: Coordinates> ViewExpand<'a, E, C> {
+    pub fn new<V: ViewOperationsExpand<E, C> + 'a>(scope: &Scope, view: V) -> Self {
+        let inner: &dyn ViewOperationsExpand<E, C> = scope.create_kernel_ref(view);
+        ViewExpand { inner }
+    }
+}
+
+impl<'a, E: CubePrimitive, C: Coordinates> ViewMutExpand<'a, E, C> {
+    pub fn new<V: ViewOperationsMutExpand<E, C> + 'a>(scope: &Scope, view: V) -> Self {
+        let inner: &mut dyn ViewOperationsMutExpand<E, C> = scope.create_kernel_ref(view);
+        ViewMutExpand { inner }
+    }
+}
+
+impl<'a, E: CubePrimitive, C: Coordinates + 'a> ViewMut<'a, E, C> {
+    pub fn view_mut<'b, T: Coordinates + 'a>(
+        self,
         _layout: impl Layout<Coordinates = T, SourceCoordinates = C>,
-    ) -> View<E, T, ReadWrite> {
+    ) -> ViewMut<'b, E, T>
+    where
+        'a: 'b,
+    {
         unexpanded!()
     }
 
-    pub fn __expand_view_mut<T: Coordinates + 'static>(
+    pub fn __expand_view_mut<T: Coordinates + 'a>(
         scope: &Scope,
-        this: ViewExpand<E, C, ReadWrite>,
+        this: ViewMutExpand<'a, E, C>,
         layout: VirtualLayoutExpand<T, C>,
-    ) -> ViewExpand<E, T, ReadWrite> {
+    ) -> ViewMutExpand<'a, E, T> {
         this.__expand_view_mut_method(scope, layout)
     }
 }
 
-impl<E: CubePrimitive, C: Coordinates + 'static> ViewExpand<E, C, ReadWrite> {
-    pub fn __expand_view_mut_method<T: Coordinates + 'static>(
-        &self,
+impl<'a, E: CubePrimitive, C: Coordinates + 'a> ViewMutExpand<'a, E, C> {
+    pub fn __expand_view_mut_method<'b, T: Coordinates + 'a>(
+        self,
         scope: &Scope,
         layout: VirtualLayoutExpand<T, C>,
-    ) -> ViewExpand<E, T, ReadWrite> {
-        View::__expand_new_mut::<View<E, C, ReadWrite>, C>(scope, self.clone(), layout)
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates + 'static> View<E, C, ReadWrite> {
-    /// Create a new mutable tensor view from an underlying concrete storage and a layout to map it
-    /// into the target coordinate space
-    pub fn new_mut<V: ViewOperationsMut<E, S>, S: Coordinates>(
-        _view: V,
-        _layout: impl Into<VirtualLayout<C, S>>,
-    ) -> View<E, C, ReadWrite> {
-        View {
-            _ty: PhantomData,
-            _layout: PhantomData,
-        }
-    }
-
-    /// Expand function for [`View::new_mut`]
-    pub fn __expand_new_mut<V: ViewOperationsMut<E, S> + 'static, S: Coordinates + 'static>(
-        scope: &Scope,
-        view: V::ExpandType,
-        layout: VirtualLayoutExpand<C, S>,
-    ) -> ViewExpand<E, C, ReadWrite> {
-        ViewExpand::new_mut(VirtualViewMut::<E, C, S, V>::__expand_new(
-            scope, view, layout,
-        ))
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> View<E, C, IO> {
-    /// Calls [`Layout::shape`] on the view's layout
-    pub fn shape(&self) -> C {
-        unexpanded!()
-    }
-
-    /// Calls [`Layout::is_in_bounds`] on the view's layout
-    pub fn is_in_bounds(&self, _pos: C) -> bool {
-        unexpanded!()
-    }
-
-    pub fn __expand_shape(scope: &Scope, this: ViewExpand<E, C, IO>) -> C::ExpandType {
-        this.__expand_shape_method(scope)
-    }
-
-    pub fn __expand_is_in_bounds(
-        scope: &Scope,
-        this: ViewExpand<E, C, IO>,
-        pos: C::ExpandType,
-    ) -> NativeExpand<bool> {
-        this.__expand_is_in_bounds_method(scope, pos)
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> ViewExpand<E, C, IO> {
-    pub fn __expand_shape_method(&self, scope: &Scope) -> C::ExpandType {
-        self.inner.read().__expand_shape_method(scope)
-    }
-
-    pub fn __expand_is_in_bounds_method(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-    ) -> NativeExpand<bool> {
-        self.inner.read().__expand_is_in_bounds_method(scope, pos)
+    ) -> ViewMutExpand<'b, E, T>
+    where
+        'a: 'b,
+    {
+        ViewMut::__expand_new::<ViewMut<'a, E, C>, C>(scope, self, layout)
     }
 }
 
 #[allow(unused_variables)]
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> View<E, C, IO> {
-    /// Read a value at `pos`. The layout handles translation into a concrete index.
-    pub fn read(&self, pos: C) -> E {
-        unexpanded!()
-    }
-
-    /// Read a value at `pos`. The layout handles translation into a concrete index.
-    /// Reading is done unchecked
-    pub fn read_unchecked(&self, pos: C) -> E {
-        unexpanded!()
-    }
-
-    /// Read a value at `pos` if it's in bounds. The layout handles translation into a concrete index.
-    pub fn read_checked(&self, pos: C) -> E {
-        unexpanded!()
-    }
-
-    /// Read a value at `pos` if it's in bounds, returning `mask_value` otherwise. The layout handles translation into a concrete index.
-    pub fn read_masked(&self, pos: C, mask_value: E) -> E {
-        unexpanded!()
-    }
-
-    /// Interpret this view as a linear slice encompassing the entire view.
-    ///
-    /// # Safety
-    ///
-    /// No checking is done on whether the slice is contiguous in memory.
-    pub fn as_linear_slice(&self) -> &[E] {
-        unexpanded!()
-    }
-
-    pub fn vector_size(&self) -> VectorSize {
-        unexpanded!()
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> ViewExpand<E, C, IO> {
-    /// Expand method for [`View::read`]
-    pub fn __expand_read_method(&self, scope: &Scope, pos: C::ExpandType) -> NativeExpand<E> {
-        self.inner.read().__expand_read_method(scope, pos)
-    }
-
-    /// Expand method for [`View::read_unchecked`]
-    pub fn __expand_read_unchecked_method(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-    ) -> NativeExpand<E> {
-        self.inner.read().__expand_read_unchecked_method(scope, pos)
-    }
-
-    /// Expand method for [`View::read_checked`]
-    pub fn __expand_read_checked_method(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-    ) -> NativeExpand<E> {
-        self.inner.read().__expand_read_checked_method(scope, pos)
-    }
-
-    /// Expand method for [`View::read_masked`]
-    pub fn __expand_read_masked_method(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        mask_value: E::ExpandType,
-    ) -> NativeExpand<E> {
-        self.inner
-            .read()
-            .__expand_read_masked_method(scope, pos, mask_value)
-    }
-
-    /// Expand method for [`View::vector_size`]
-    pub fn __expand_vector_size_method(&self, _scope: &Scope) -> VectorSize {
-        self.inner.read().vector_size()
-    }
-
-    pub fn vector_size(&self) -> VectorSize {
-        self.inner.read().vector_size()
-    }
-
-    pub fn __expand_as_linear_slice_method(&self, scope: &Scope) -> &SliceExpand<E> {
-        let shape = self.inner.read().__expand_shape_method(scope);
-        let origin = C::__expand_from_int(scope, shape.clone_unchecked(), 0);
-        // Inclusive end so clamping works correctly
-        let one = C::__expand_from_int(scope, shape.clone_unchecked(), 1);
-        let shape = C::__expand_max(scope, shape, one.clone_unchecked());
-        let end = C::__expand_sub(scope, shape, one);
-        self.inner
-            .read()
-            .__expand_as_linear_slice_method(scope, origin, end)
-    }
-
-    pub(super) fn __expand_as_linear_slice_inner_method(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        end: C::ExpandType,
-    ) -> &SliceExpand<E> {
-        self.inner
-            .read()
-            .__expand_as_linear_slice_method(scope, pos, end)
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates + 'static, IO: Clone + 'static> View<E, C, IO> {
-    /// Create a slice starting from `pos`, with `size`.
-    /// The layout handles translation into concrete indices.
-    /// Size will be clamped to the current layout size.
-    pub fn slice(&self, _pos: C, _size: C) -> &View<E, C, ReadOnly> {
-        unexpanded!()
-    }
-
-    /// Create a slice starting from `pos`, with `size`.
-    /// The layout handles translation into concrete indices.
-    /// Size and pos will be clamped to the current layout size.
-    /// #Safety
-    /// Access is always unchecked
-    pub fn slice_unchecked(&self, _pos: C, _size: C) -> &View<E, C, ReadOnly> {
-        unexpanded!()
-    }
-
-    pub fn __expand_slice<'this>(
-        scope: &Scope,
-        this: &'this ViewExpand<E, C, IO>,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-    ) -> &'this ViewExpand<E, C, ReadOnly> {
-        this.__expand_slice_method(scope, pos, size)
-    }
-
-    pub fn __expand_slice_unchecked<'this>(
-        scope: &Scope,
-        this: &'this ViewExpand<E, C, IO>,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-    ) -> &'this ViewExpand<E, C, ReadOnly> {
-        this.__expand_slice_unchecked_method(scope, pos, size)
-    }
-}
-
-#[cube]
-impl<E: CubePrimitive, C: Coordinates + 'static, IO: Clone + 'static> View<E, C, IO> {}
-
-impl<E: CubePrimitive, C: Coordinates + 'static, IO: Clone + 'static> ViewExpand<E, C, IO> {
-    pub fn __expand_slice_method(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-    ) -> &ViewExpand<E, C, ReadOnly> {
-        self.slice(scope, pos, size, true)
-    }
-
-    pub fn __expand_slice_unchecked_method(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-    ) -> &ViewExpand<E, C, ReadOnly> {
-        self.slice(scope, pos, size, false)
-    }
-
-    fn slice(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-        checked: bool,
-    ) -> &ViewExpand<E, C, ReadOnly> {
-        let shape = self.__expand_shape_method(scope);
-        let pos = C::__expand_min(scope, pos, shape.clone_unchecked());
-        let max_size = C::__expand_sub(scope, shape, pos.clone_unchecked());
-        let size = C::__expand_min(scope, size, max_size);
-        let layout = SliceLayout::__expand_new(scope, pos, size, checked);
-        let view = self.__expand_view_method(scope, layout.into());
-        scope.create_kernel_ref(view)
-    }
-}
-
-#[allow(unused_variables)]
-impl<E: CubePrimitive, C: Coordinates> View<E, C, ReadWrite> {
+impl<'a, E: CubePrimitive, C: Coordinates> ViewMut<'a, E, C> {
     /// Write a value to `pos`. The layout handles translation into a concrete index.
-    pub fn write(&self, pos: C, value: E) {
+    pub fn write(&mut self, pos: C, value: E) {
         unexpanded!()
     }
 
     /// Write a value to `pos` if it's in bounds. The layout handles translation into a concrete index.
-    pub fn write_checked(&self, pos: C, value: E) {
+    pub fn write_checked(&mut self, pos: C, value: E) {
         unexpanded!()
     }
 
@@ -450,58 +484,61 @@ impl<E: CubePrimitive, C: Coordinates> View<E, C, ReadWrite> {
     /// # Safety
     ///
     /// No checking is done on whether the slice is contiguous in memory.
-    pub fn to_linear_slice_mut(&self) -> &mut [E] {
+    pub fn to_linear_slice_mut(&mut self) -> &'a mut [E] {
         unexpanded!()
     }
 }
 
-impl<E: CubePrimitive, C: Coordinates> ViewExpand<E, C, ReadWrite> {
+impl<'a, E: CubePrimitive, C: Coordinates> ViewMutExpand<'a, E, C> {
     /// Expand method for [`View::write`]
-    pub fn __expand_write_method(&self, scope: &Scope, pos: C::ExpandType, value: NativeExpand<E>) {
-        self.inner.write().__expand_write_method(scope, pos, value)
-    }
-
-    /// Expand method for [`View::write_checked`]
-    pub fn __expand_write_checked_method(
-        &self,
+    pub fn __expand_write_method(
+        &mut self,
         scope: &Scope,
         pos: C::ExpandType,
         value: NativeExpand<E>,
     ) {
-        self.inner
-            .write()
-            .__expand_write_checked_method(scope, pos, value);
+        self.inner.__expand_write_method(scope, pos, value)
     }
 
-    pub fn __expand_as_linear_slice_mut_method(&mut self, scope: &Scope) -> &mut SliceExpand<E> {
-        let shape = self.inner.read().__expand_shape_method(scope);
+    /// Expand method for [`View::write_checked`]
+    pub fn __expand_write_checked_method(
+        &mut self,
+        scope: &Scope,
+        pos: C::ExpandType,
+        value: NativeExpand<E>,
+    ) {
+        self.inner.__expand_write_checked_method(scope, pos, value);
+    }
+
+    pub fn __expand_as_linear_slice_mut_method(&mut self, scope: &Scope) -> &'a mut SliceExpand<E> {
+        let shape = self.inner.__expand_shape_method(scope);
         let origin = C::__expand_from_int(scope, shape.clone_unchecked(), 0);
         // Inclusive end so clamping works correctly
         let one = C::__expand_from_int(scope, shape.clone_unchecked(), 1);
         let shape = C::__expand_max(scope, shape, one.clone_unchecked());
         let end = C::__expand_sub(scope, shape, one);
-        self.inner
-            .write()
-            .__expand_as_linear_slice_mut_method(scope, origin, end)
+        let slice = self
+            .inner
+            .__expand_as_linear_slice_mut_method(scope, origin, end);
+        scope.create_kernel_ref(slice.expand.into())
     }
 
     pub(super) fn __expand_to_linear_slice_mut_inner_method(
-        &self,
+        &mut self,
         scope: &Scope,
         pos: C::ExpandType,
         end: C::ExpandType,
     ) -> &mut SliceExpand<E> {
         self.inner
-            .write()
             .__expand_as_linear_slice_mut_method(scope, pos, end)
     }
 }
 
-impl<E: CubePrimitive, C: Coordinates + 'static> View<E, C, ReadWrite> {
+impl<'a, E: CubePrimitive, C: Coordinates + 'static> ViewMut<'a, E, C> {
     /// Create a mutable slice starting from `pos`, with `size`.
     /// The layout handles translation into concrete indices.
     /// Size and pos will be clamped to the current layout size.
-    pub fn slice_mut(&self, _pos: C, _size: C) -> View<E, C, ReadWrite> {
+    pub fn slice_mut(self, _pos: C, _size: C) -> ViewMut<'a, E, C> {
         unexpanded!()
     }
 
@@ -511,39 +548,36 @@ impl<E: CubePrimitive, C: Coordinates + 'static> View<E, C, ReadWrite> {
     ///
     /// # Safety
     /// Access is always unchecked.
-    pub fn slice_mut_unchecked(&self, _pos: C, _size: C) -> View<E, C, ReadWrite> {
+    pub fn slice_mut_unchecked(self, _pos: C, _size: C) -> ViewMut<'a, E, C> {
         unexpanded!()
     }
 
     pub fn __expand_slice_mut(
         scope: &Scope,
-        this: ViewExpand<E, C, ReadWrite>,
+        this: ViewMutExpand<'a, E, C>,
         pos: C::ExpandType,
         size: C::ExpandType,
-    ) -> ViewExpand<E, C, ReadWrite> {
+    ) -> ViewMutExpand<'a, E, C> {
         this.__expand_slice_mut_method(scope, pos, size)
     }
 
     pub fn __expand_slice_mut_unchecked(
         scope: &Scope,
-        this: ViewExpand<E, C, ReadWrite>,
+        this: ViewMutExpand<'a, E, C>,
         pos: C::ExpandType,
         size: C::ExpandType,
-    ) -> ViewExpand<E, C, ReadWrite> {
+    ) -> ViewMutExpand<'a, E, C> {
         this.__expand_slice_mut_unchecked_method(scope, pos, size)
     }
 }
 
-#[cube]
-impl<E: CubePrimitive, C: Coordinates + 'static> View<E, C, ReadWrite> {}
-
-impl<E: CubePrimitive, C: Coordinates + 'static> ViewExpand<E, C, ReadWrite> {
+impl<'a, E: CubePrimitive, C: Coordinates + 'static> ViewMutExpand<'a, E, C> {
     pub fn __expand_slice_mut_method(
-        &self,
+        self,
         scope: &Scope,
         pos: C::ExpandType,
         size: C::ExpandType,
-    ) -> ViewExpand<E, C, ReadWrite> {
+    ) -> ViewMutExpand<'a, E, C> {
         self.slice_mut(scope, pos, size, true)
     }
 
@@ -552,7 +586,7 @@ impl<E: CubePrimitive, C: Coordinates + 'static> ViewExpand<E, C, ReadWrite> {
         scope: &Scope,
         pos: C::ExpandType,
         size: C::ExpandType,
-    ) -> ViewExpand<E, C, ReadWrite> {
+    ) -> ViewMutExpand<'a, E, C> {
         self.slice_mut(scope, pos, size, false)
     }
 
@@ -562,7 +596,7 @@ impl<E: CubePrimitive, C: Coordinates + 'static> ViewExpand<E, C, ReadWrite> {
         pos: C::ExpandType,
         size: C::ExpandType,
         checked: bool,
-    ) -> ViewExpand<E, C, ReadWrite> {
+    ) -> ViewMutExpand<'a, E, C> {
         let shape = self.__expand_shape_method(scope);
         let pos = C::__expand_min(scope, pos, shape.clone_unchecked());
         let max_size = C::__expand_sub(scope, shape, pos.clone_unchecked());
@@ -572,50 +606,22 @@ impl<E: CubePrimitive, C: Coordinates + 'static> ViewExpand<E, C, ReadWrite> {
     }
 }
 
-impl<E: CubePrimitive, C: Coordinates + 'static, IO: SliceVisibility> View<E, C, IO> {
-    ///.Execute a TMA load into shared memory, if the underlying storage supports it.
-    /// Panics if it's unsupported.
-    pub fn tensor_map_load(
-        &self,
-        _barrier: &Barrier,
-        _shared_memory: &mut [E],
-        _pos: C,
-    ) -> View<E, C, ReadWrite> {
-        unexpanded!()
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates, IO: Clone> ViewExpand<E, C, IO> {
-    pub fn __expand_tensor_map_load_method(
-        &self,
-        scope: &Scope,
-        barrier: &NativeExpand<Barrier>,
-        shared_memory: &mut SliceExpand<E>,
-        pos: C::ExpandType,
-    ) {
-        self.inner
-            .read()
-            .__expand_tensor_map_load_method(scope, barrier, shared_memory, pos)
-    }
-}
-
-impl<E: CubePrimitive, C: Coordinates> View<E, C, ReadWrite> {
+impl<'a, E: CubePrimitive, C: Coordinates> ViewMut<'a, E, C> {
     ///.Execute a TMA store into global memory, if the underlying storage supports it.
     /// Panics if it's unsupported.
-    pub fn tensor_map_store(&self, _shared_memory: &[E], _pos: C) -> View<E, C, ReadWrite> {
+    pub fn tensor_map_store(&self, _shared_memory: &[E], _pos: C) {
         unexpanded!()
     }
 }
 
-impl<E: CubePrimitive, C: Coordinates> ViewExpand<E, C, ReadWrite> {
+impl<'a, E: CubePrimitive, C: Coordinates> ViewMutExpand<'a, E, C> {
     pub fn __expand_tensor_map_store_method(
-        &self,
+        &mut self,
         scope: &Scope,
         shared_memory: &SliceExpand<E>,
         pos: C::ExpandType,
     ) {
         self.inner
-            .write()
             .__expand_tensor_map_store_method(scope, shared_memory, pos)
     }
 }

--- a/crates/cubecl-std/src/tensor/view/base.rs
+++ b/crates/cubecl-std/src/tensor/view/base.rs
@@ -177,65 +177,47 @@ macro_rules! impl_read {
             }
         }
 
+        #[cube]
         impl<'a, E: CubePrimitive, C: Coordinates> $ty<'a, E, C> {
             /// Calls [`Layout::shape`] on the view's layout
             pub fn shape(&self) -> C {
-                unexpanded!()
+                intrinsic!(|scope| self.inner.__expand_shape_method(scope))
             }
 
             /// Calls [`Layout::is_in_bounds`] on the view's layout
-            pub fn is_in_bounds(&self, _pos: C) -> bool {
-                unexpanded!()
-            }
-
-            pub fn __expand_shape(scope: &Scope, this: $expand<'a, E, C>) -> C::ExpandType {
-                this.__expand_shape_method(scope)
-            }
-
-            pub fn __expand_is_in_bounds(
-                scope: &Scope,
-                this: $expand<'a, E, C>,
-                pos: C::ExpandType,
-            ) -> NativeExpand<bool> {
-                this.__expand_is_in_bounds_method(scope, pos)
+            #[allow(unused_variables)]
+            pub fn is_in_bounds(&self, pos: C) -> bool {
+                intrinsic!(|scope| self.inner.__expand_is_in_bounds_method(scope, pos))
             }
         }
 
-        impl<'a, E: CubePrimitive, C: Coordinates> $expand<'a, E, C> {
-            pub fn __expand_shape_method(&self, scope: &Scope) -> C::ExpandType {
-                self.inner.__expand_shape_method(scope)
-            }
-
-            pub fn __expand_is_in_bounds_method(
-                &self,
-                scope: &Scope,
-                pos: C::ExpandType,
-            ) -> NativeExpand<bool> {
-                self.inner.__expand_is_in_bounds_method(scope, pos)
-            }
-        }
-
-        #[allow(unused_variables)]
+        #[cube]
         impl<'a, E: CubePrimitive, C: Coordinates> $ty<'a, E, C> {
             /// Read a value at `pos`. The layout handles translation into a concrete index.
+            #[allow(unused_variables)]
             pub fn read(&self, pos: C) -> E {
-                unexpanded!()
+                intrinsic!(|scope| self.inner.__expand_read_method(scope, pos))
             }
 
             /// Read a value at `pos`. The layout handles translation into a concrete index.
             /// Reading is done unchecked
+            #[allow(unused_variables)]
             pub fn read_unchecked(&self, pos: C) -> E {
-                unexpanded!()
+                intrinsic!(|scope| self.inner.__expand_read_unchecked_method(scope, pos))
             }
 
             /// Read a value at `pos` if it's in bounds. The layout handles translation into a concrete index.
+            #[allow(unused_variables)]
             pub fn read_checked(&self, pos: C) -> E {
-                unexpanded!()
+                intrinsic!(|scope| self.inner.__expand_read_checked_method(scope, pos))
             }
 
             /// Read a value at `pos` if it's in bounds, returning `mask_value` otherwise. The layout handles translation into a concrete index.
+            #[allow(unused_variables)]
             pub fn read_masked(&self, pos: C, mask_value: E) -> E {
-                unexpanded!()
+                intrinsic!(|scope| self
+                    .inner
+                    .__expand_read_masked_method(scope, pos, mask_value))
             }
 
             /// Interpret this view as a linear slice encompassing the entire view.
@@ -244,75 +226,26 @@ macro_rules! impl_read {
             ///
             /// No checking is done on whether the slice is contiguous in memory.
             pub fn as_linear_slice(&self) -> &'a [E] {
-                unexpanded!()
+                intrinsic!(|scope| {
+                    let shape = self.inner.__expand_shape_method(scope);
+                    let origin = C::__expand_from_int(scope, shape.clone_unchecked(), 0);
+                    // Inclusive end so clamping works correctly
+                    let one = C::__expand_from_int(scope, shape.clone_unchecked(), 1);
+                    let shape = C::__expand_max(scope, shape, one.clone_unchecked());
+                    let end = C::__expand_sub(scope, shape, one);
+                    let slice = self
+                        .inner
+                        .__expand_as_linear_slice_method(scope, origin, end);
+                    scope.create_kernel_ref(slice.expand.into())
+                })
             }
 
-            pub fn vector_size(&self) -> VectorSize {
-                unexpanded!()
+            pub fn vector_size(&self) -> comptime_type!(VectorSize) {
+                intrinsic!(|scope| self.inner.vector_size())
             }
         }
 
         impl<'a, E: CubePrimitive, C: Coordinates> $expand<'a, E, C> {
-            /// Expand method for [`View::read`]
-            pub fn __expand_read_method(
-                &self,
-                scope: &Scope,
-                pos: C::ExpandType,
-            ) -> NativeExpand<E> {
-                self.inner.__expand_read_method(scope, pos)
-            }
-
-            /// Expand method for [`View::read_unchecked`]
-            pub fn __expand_read_unchecked_method(
-                &self,
-                scope: &Scope,
-                pos: C::ExpandType,
-            ) -> NativeExpand<E> {
-                self.inner.__expand_read_unchecked_method(scope, pos)
-            }
-
-            /// Expand method for [`View::read_checked`]
-            pub fn __expand_read_checked_method(
-                &self,
-                scope: &Scope,
-                pos: C::ExpandType,
-            ) -> NativeExpand<E> {
-                self.inner.__expand_read_checked_method(scope, pos)
-            }
-
-            /// Expand method for [`View::read_masked`]
-            pub fn __expand_read_masked_method(
-                &self,
-                scope: &Scope,
-                pos: C::ExpandType,
-                mask_value: E::ExpandType,
-            ) -> NativeExpand<E> {
-                self.inner
-                    .__expand_read_masked_method(scope, pos, mask_value)
-            }
-
-            /// Expand method for [`View::vector_size`]
-            pub fn __expand_vector_size_method(&self, _scope: &Scope) -> VectorSize {
-                self.inner.vector_size()
-            }
-
-            pub fn vector_size(&self) -> VectorSize {
-                self.inner.vector_size()
-            }
-
-            pub fn __expand_as_linear_slice_method(&self, scope: &Scope) -> &'a SliceExpand<E> {
-                let shape = self.inner.__expand_shape_method(scope);
-                let origin = C::__expand_from_int(scope, shape.clone_unchecked(), 0);
-                // Inclusive end so clamping works correctly
-                let one = C::__expand_from_int(scope, shape.clone_unchecked(), 1);
-                let shape = C::__expand_max(scope, shape, one.clone_unchecked());
-                let end = C::__expand_sub(scope, shape, one);
-                let slice = self
-                    .inner
-                    .__expand_as_linear_slice_method(scope, origin, end);
-                scope.create_kernel_ref(slice.expand.into())
-            }
-
             pub(super) fn __expand_as_linear_slice_inner_method(
                 &self,
                 scope: &Scope,
@@ -323,12 +256,14 @@ macro_rules! impl_read {
             }
         }
 
+        #[cube]
         impl<'a, E: CubePrimitive, C: Coordinates + 'static> $ty<'a, E, C> {
             /// Create a slice starting from `pos`, with `size`.
             /// The layout handles translation into concrete indices.
             /// Size will be clamped to the current layout size.
-            pub fn slice(self, _pos: C, _size: C) -> $ty<'a, E, C> {
-                unexpanded!()
+            #[allow(unused_variables)]
+            pub fn slice(self, pos: C, size: C) -> $ty<'a, E, C> {
+                intrinsic!(|scope| self.slice(scope, pos, size, true))
             }
 
             /// Create a slice starting from `pos`, with `size`.
@@ -336,48 +271,13 @@ macro_rules! impl_read {
             /// Size and pos will be clamped to the current layout size.
             /// #Safety
             /// Access is always unchecked
-            pub fn slice_unchecked(self, _pos: C, _size: C) -> $ty<'a, E, C> {
-                unexpanded!()
-            }
-
-            pub fn __expand_slice(
-                scope: &Scope,
-                this: $expand<'a, E, C>,
-                pos: C::ExpandType,
-                size: C::ExpandType,
-            ) -> $expand<'a, E, C> {
-                this.__expand_slice_method(scope, pos, size)
-            }
-
-            pub fn __expand_slice_unchecked(
-                scope: &Scope,
-                this: $expand<'a, E, C>,
-                pos: C::ExpandType,
-                size: C::ExpandType,
-            ) -> $expand<'a, E, C> {
-                this.__expand_slice_unchecked_method(scope, pos, size)
+            #[allow(unused_variables)]
+            pub fn slice_unchecked(self, pos: C, size: C) -> $ty<'a, E, C> {
+                intrinsic!(|scope| self.slice(scope, pos, size, false))
             }
         }
 
         impl<'a, E: CubePrimitive, C: Coordinates + 'static> $expand<'a, E, C> {
-            pub fn __expand_slice_method(
-                self,
-                scope: &Scope,
-                pos: C::ExpandType,
-                size: C::ExpandType,
-            ) -> $expand<'a, E, C> {
-                self.slice(scope, pos, size, true)
-            }
-
-            pub fn __expand_slice_unchecked_method(
-                self,
-                scope: &Scope,
-                pos: C::ExpandType,
-                size: C::ExpandType,
-            ) -> $expand<'a, E, C> {
-                self.slice(scope, pos, size, false)
-            }
-
             fn slice(
                 self,
                 scope: &Scope,
@@ -394,24 +294,16 @@ macro_rules! impl_read {
             }
         }
 
-        impl<'a, E: CubePrimitive, C: Coordinates + 'static> $ty<'a, E, C> {
-            ///.Execute a TMA load into shared memory, if the underlying storage supports it.
+        #[cube]
+        impl<'a, E: CubePrimitive, C: Coordinates + 'a> $ty<'a, E, C> {
+            /// Execute a TMA load into shared memory, if the underlying storage supports it.
             /// Panics if it's unsupported.
-            pub fn tensor_map_load(&self, _barrier: &Barrier, _shared_memory: &mut [E], _pos: C) {
-                unexpanded!()
-            }
-        }
-
-        impl<'a, E: CubePrimitive, C: Coordinates> $expand<'a, E, C> {
-            pub fn __expand_tensor_map_load_method(
-                &self,
-                scope: &Scope,
-                barrier: &NativeExpand<Barrier>,
-                shared_memory: &mut SliceExpand<E>,
-                pos: C::ExpandType,
-            ) {
-                self.inner
-                    .__expand_tensor_map_load_method(scope, barrier, shared_memory, pos)
+            #[allow(unused_variables)]
+            pub fn tensor_map_load(&self, barrier: &Barrier, shared_memory: &mut [E], pos: C) {
+                intrinsic!(|scope| {
+                    self.inner
+                        .__expand_tensor_map_load_method(scope, barrier, shared_memory, pos)
+                })
             }
         }
     };
@@ -467,16 +359,18 @@ impl<'a, E: CubePrimitive, C: Coordinates + 'a> ViewMutExpand<'a, E, C> {
     }
 }
 
-#[allow(unused_variables)]
+#[cube]
 impl<'a, E: CubePrimitive, C: Coordinates> ViewMut<'a, E, C> {
     /// Write a value to `pos`. The layout handles translation into a concrete index.
+    #[allow(unused_variables)]
     pub fn write(&mut self, pos: C, value: E) {
-        unexpanded!()
+        intrinsic!(|scope| self.inner.__expand_write_method(scope, pos, value));
     }
 
     /// Write a value to `pos` if it's in bounds. The layout handles translation into a concrete index.
+    #[allow(unused_variables)]
     pub fn write_checked(&mut self, pos: C, value: E) {
-        unexpanded!()
+        intrinsic!(|scope| self.inner.__expand_write_checked_method(scope, pos, value));
     }
 
     /// Interpret this view as a mutable linear slice encompassing the entire view.
@@ -484,45 +378,23 @@ impl<'a, E: CubePrimitive, C: Coordinates> ViewMut<'a, E, C> {
     /// # Safety
     ///
     /// No checking is done on whether the slice is contiguous in memory.
-    pub fn to_linear_slice_mut(&mut self) -> &'a mut [E] {
-        unexpanded!()
+    pub fn as_linear_slice_mut(&mut self) -> &'a mut [E] {
+        intrinsic!(|scope| {
+            let shape = self.inner.__expand_shape_method(scope);
+            let origin = C::__expand_from_int(scope, shape.clone_unchecked(), 0);
+            // Inclusive end so clamping works correctly
+            let one = C::__expand_from_int(scope, shape.clone_unchecked(), 1);
+            let shape = C::__expand_max(scope, shape, one.clone_unchecked());
+            let end = C::__expand_sub(scope, shape, one);
+            let slice = self
+                .inner
+                .__expand_as_linear_slice_mut_method(scope, origin, end);
+            scope.create_kernel_ref(slice.expand.into())
+        })
     }
 }
 
 impl<'a, E: CubePrimitive, C: Coordinates> ViewMutExpand<'a, E, C> {
-    /// Expand method for [`View::write`]
-    pub fn __expand_write_method(
-        &mut self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        value: NativeExpand<E>,
-    ) {
-        self.inner.__expand_write_method(scope, pos, value)
-    }
-
-    /// Expand method for [`View::write_checked`]
-    pub fn __expand_write_checked_method(
-        &mut self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        value: NativeExpand<E>,
-    ) {
-        self.inner.__expand_write_checked_method(scope, pos, value);
-    }
-
-    pub fn __expand_as_linear_slice_mut_method(&mut self, scope: &Scope) -> &'a mut SliceExpand<E> {
-        let shape = self.inner.__expand_shape_method(scope);
-        let origin = C::__expand_from_int(scope, shape.clone_unchecked(), 0);
-        // Inclusive end so clamping works correctly
-        let one = C::__expand_from_int(scope, shape.clone_unchecked(), 1);
-        let shape = C::__expand_max(scope, shape, one.clone_unchecked());
-        let end = C::__expand_sub(scope, shape, one);
-        let slice = self
-            .inner
-            .__expand_as_linear_slice_mut_method(scope, origin, end);
-        scope.create_kernel_ref(slice.expand.into())
-    }
-
     pub(super) fn __expand_to_linear_slice_mut_inner_method(
         &mut self,
         scope: &Scope,
@@ -534,12 +406,14 @@ impl<'a, E: CubePrimitive, C: Coordinates> ViewMutExpand<'a, E, C> {
     }
 }
 
+#[cube]
 impl<'a, E: CubePrimitive, C: Coordinates + 'static> ViewMut<'a, E, C> {
     /// Create a mutable slice starting from `pos`, with `size`.
     /// The layout handles translation into concrete indices.
     /// Size and pos will be clamped to the current layout size.
-    pub fn slice_mut(self, _pos: C, _size: C) -> ViewMut<'a, E, C> {
-        unexpanded!()
+    #[allow(unused_variables)]
+    pub fn slice_mut(self, pos: C, size: C) -> ViewMut<'a, E, C> {
+        intrinsic!(|scope| self.slice_mut(scope, pos, size, true))
     }
 
     /// Create a mutable slice starting from `pos`, with `size`.
@@ -548,48 +422,13 @@ impl<'a, E: CubePrimitive, C: Coordinates + 'static> ViewMut<'a, E, C> {
     ///
     /// # Safety
     /// Access is always unchecked.
-    pub fn slice_mut_unchecked(self, _pos: C, _size: C) -> ViewMut<'a, E, C> {
-        unexpanded!()
-    }
-
-    pub fn __expand_slice_mut(
-        scope: &Scope,
-        this: ViewMutExpand<'a, E, C>,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-    ) -> ViewMutExpand<'a, E, C> {
-        this.__expand_slice_mut_method(scope, pos, size)
-    }
-
-    pub fn __expand_slice_mut_unchecked(
-        scope: &Scope,
-        this: ViewMutExpand<'a, E, C>,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-    ) -> ViewMutExpand<'a, E, C> {
-        this.__expand_slice_mut_unchecked_method(scope, pos, size)
+    #[allow(unused_variables)]
+    pub fn slice_mut_unchecked(self, pos: C, size: C) -> ViewMut<'a, E, C> {
+        intrinsic!(|scope| self.slice_mut(scope, pos, size, false))
     }
 }
 
 impl<'a, E: CubePrimitive, C: Coordinates + 'static> ViewMutExpand<'a, E, C> {
-    pub fn __expand_slice_mut_method(
-        self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-    ) -> ViewMutExpand<'a, E, C> {
-        self.slice_mut(scope, pos, size, true)
-    }
-
-    pub fn __expand_slice_mut_unchecked_method(
-        &self,
-        scope: &Scope,
-        pos: C::ExpandType,
-        size: C::ExpandType,
-    ) -> ViewMutExpand<'a, E, C> {
-        self.slice_mut(scope, pos, size, false)
-    }
-
     fn slice_mut(
         &self,
         scope: &Scope,
@@ -606,22 +445,15 @@ impl<'a, E: CubePrimitive, C: Coordinates + 'static> ViewMutExpand<'a, E, C> {
     }
 }
 
+#[cube]
 impl<'a, E: CubePrimitive, C: Coordinates> ViewMut<'a, E, C> {
-    ///.Execute a TMA store into global memory, if the underlying storage supports it.
+    /// Execute a TMA store into global memory, if the underlying storage supports it.
     /// Panics if it's unsupported.
-    pub fn tensor_map_store(&self, _shared_memory: &[E], _pos: C) {
-        unexpanded!()
-    }
-}
-
-impl<'a, E: CubePrimitive, C: Coordinates> ViewMutExpand<'a, E, C> {
-    pub fn __expand_tensor_map_store_method(
-        &mut self,
-        scope: &Scope,
-        shared_memory: &SliceExpand<E>,
-        pos: C::ExpandType,
-    ) {
-        self.inner
-            .__expand_tensor_map_store_method(scope, shared_memory, pos)
+    #[allow(unused_variables)]
+    pub fn tensor_map_store(&self, shared_memory: &[E], pos: C) {
+        intrinsic!(|scope| {
+            self.inner
+                .__expand_tensor_map_store_method(scope, shared_memory, pos)
+        })
     }
 }

--- a/crates/cubecl-std/src/tensor/view/launch.rs
+++ b/crates/cubecl-std/src/tensor/view/launch.rs
@@ -1,10 +1,9 @@
 use cubecl_core::prelude::*;
-use std::{marker::PhantomData, ops::Deref, sync::Arc};
+use std::{marker::PhantomData, ops::Deref};
 
 use crate::tensor::{
     View, ViewExpand, VirtualViewMutExpand,
     layout::{Coordinates, Coords1d, Layout, VirtualLayoutExpand},
-    view::ViewType,
 };
 
 mod layout {
@@ -405,7 +404,7 @@ mod dynamic {
             view::{RegisterDynamic, run_with_quant_type},
         },
         tensor::{
-            VirtualViewExpand,
+            ViewMut, ViewMutExpand, VirtualViewExpand,
             launch::layout::{ViewLayoutLaunchArg, VirtualViewLayoutLaunch},
             layout::as_dyn::{IntoDyn, IntoDyn2Layout, IntoDynLayout},
         },
@@ -612,7 +611,7 @@ mod dynamic {
         }
     }
 
-    impl<E: CubePrimitive, C: Coordinates + 'static, IO: SliceVisibility> LaunchArg for View<E, C, IO> {
+    impl<E: CubePrimitive, C: Coordinates + 'static> LaunchArg for View<'static, E, C> {
         type RuntimeArg<R: Runtime> = ViewArg<C, R>;
         type CompilationArg = ViewCompilationArg<C>;
 
@@ -665,10 +664,7 @@ mod dynamic {
                     let buffer = <Box<[E]> as LaunchArg>::expand(buffer, builder);
                     let view =
                         VirtualViewMutExpand::<E, C, Coords1d, Box<[E]>>::new(buffer, layout);
-                    ViewExpand::<E, C, IO> {
-                        inner: ViewType::ReadWrite(Arc::new(view)),
-                        _io: PhantomData,
-                    }
+                    ViewExpand::new(&builder.scope, view)
                 }
                 ViewCompilationArg::TensorMapTiled { buffer, layout } => {
                     let layout = layout.expand(ty, builder);
@@ -677,10 +673,7 @@ mod dynamic {
                         VirtualViewMutExpand::<E, C, Sequence<i32>, TensorMap<E, Tiled>>::new(
                             buffer, layout,
                         );
-                    ViewExpand::<E, C, IO> {
-                        inner: ViewType::ReadWrite(Arc::new(view)),
-                        _io: PhantomData,
-                    }
+                    ViewExpand::new(&builder.scope, view)
                 }
                 ViewCompilationArg::TensorMapIm2col { buffer, layout } => {
                     let layout = layout.expand(ty, builder);
@@ -691,16 +684,56 @@ mod dynamic {
                         (Sequence<i32>, Sequence<i32>),
                         TensorMap<E, Im2col>,
                     >::new(buffer, layout);
-                    ViewExpand::<E, C, IO> {
-                        inner: ViewType::Read(Arc::new(view)),
-                        _io: PhantomData,
-                    }
+                    ViewExpand::new(&builder.scope, view)
                 }
                 ViewCompilationArg::Quantized {
                     values,
                     scales,
                     scheme,
                 } => quant::view::expand_dynamic(values, scales, *scheme, builder),
+            }
+        }
+    }
+
+    impl<E: CubePrimitive, C: Coordinates + 'static> LaunchArg for ViewMut<'static, E, C> {
+        type RuntimeArg<R: Runtime> = ViewArg<C, R>;
+        type CompilationArg = ViewCompilationArg<C>;
+
+        fn register<R: Runtime>(
+            arg: Self::RuntimeArg<R>,
+            launcher: &mut KernelLauncher<R>,
+        ) -> Self::CompilationArg {
+            <View<'static, E, C> as LaunchArg>::register(arg, launcher)
+        }
+
+        fn expand(
+            arg: &Self::CompilationArg,
+            builder: &mut KernelBuilder,
+        ) -> <Self as CubeType>::ExpandType {
+            let ty = E::__expand_as_type(&builder.scope);
+            match arg {
+                ViewCompilationArg::Array { buffer, layout } => {
+                    let layout = layout.expand(ty, builder);
+                    let buffer = <Box<[E]> as LaunchArg>::expand(buffer, builder);
+                    let view =
+                        VirtualViewMutExpand::<E, C, Coords1d, Box<[E]>>::new(buffer, layout);
+                    ViewMutExpand::new(&builder.scope, view)
+                }
+                ViewCompilationArg::TensorMapTiled { buffer, layout } => {
+                    let layout = layout.expand(ty, builder);
+                    let buffer = <TensorMap<E, Tiled> as LaunchArg>::expand(buffer, builder);
+                    let view =
+                        VirtualViewMutExpand::<E, C, Sequence<i32>, TensorMap<E, Tiled>>::new(
+                            buffer, layout,
+                        );
+                    ViewMutExpand::new(&builder.scope, view)
+                }
+                ViewCompilationArg::TensorMapIm2col { .. } => {
+                    unimplemented!("im2col not supported for writing")
+                }
+                ViewCompilationArg::Quantized { .. } => {
+                    unimplemented!("quantized views not supported for writing")
+                }
             }
         }
     }

--- a/crates/cubecl-std/src/tensor/view/operations/base.rs
+++ b/crates/cubecl-std/src/tensor/view/operations/base.rs
@@ -1,8 +1,12 @@
 #![allow(clippy::mut_from_ref)]
 
 use crate::tensor::layout::Coordinates;
-use cubecl::prelude::*;
-use cubecl_core::{self as cubecl, prelude::barrier::Barrier, unexpanded};
+use cubecl_core::{
+    self as cubecl,
+    frontend::{NativeExpand, barrier::Barrier},
+    prelude::*,
+    unexpanded,
+};
 
 /// Type from which we can read values in cube functions.
 /// For a mutable version, see [`ListMut`].
@@ -70,7 +74,7 @@ pub trait ViewOperationsMut<T: CubePrimitive, C: Coordinates>: ViewOperations<T,
 
     /// Create a mutable slice starting from `pos`, with `size`.
     /// The layout handles translation into concrete indices.
-    #[allow(unused, clippy::wrong_self_convention)]
+    #[allow(unused)]
     fn as_linear_slice_mut(&self, pos: C, size: C) -> &mut [T] {
         unexpanded!()
     }
@@ -80,5 +84,131 @@ pub trait ViewOperationsMut<T: CubePrimitive, C: Coordinates>: ViewOperations<T,
     #[allow(unused)]
     fn tensor_map_store(&self, shared_memory: &[T], pos: C) {
         unexpanded!()
+    }
+}
+
+macro_rules! view_ops_read_ref {
+    ($ty: ty) => {
+        impl<T: CubePrimitive, C: Coordinates, V: ViewOperations<T, C> + ?Sized>
+            ViewOperations<T, C> for $ty
+        {
+        }
+        impl<T: CubePrimitive, C: Coordinates, V: ViewOperationsExpand<T, C> + ?Sized>
+            ViewOperationsExpand<T, C> for $ty
+        {
+            #[allow(clippy::too_many_arguments)]
+            fn __expand_read_method(&self, scope: &Scope, pos: C::ExpandType) -> T::ExpandType {
+                (**self).__expand_read_method(scope, pos)
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn __expand_read_checked_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+            ) -> T::ExpandType {
+                (**self).__expand_read_checked_method(scope, pos)
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn __expand_read_masked_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+                value: T::ExpandType,
+            ) -> T::ExpandType {
+                (**self).__expand_read_masked_method(scope, pos, value)
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn __expand_read_unchecked_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+            ) -> T::ExpandType {
+                (**self).__expand_read_unchecked_method(scope, pos)
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn __expand_as_linear_slice_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+                size: C::ExpandType,
+            ) -> &SliceExpand<T> {
+                (**self).__expand_as_linear_slice_method(scope, pos, size)
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn __expand_tensor_map_load_method(
+                &self,
+                scope: &Scope,
+                barrier: &NativeExpand<Barrier>,
+                shared_memory: &mut SliceExpand<T>,
+                pos: C::ExpandType,
+            ) -> () {
+                (**self).__expand_tensor_map_load_method(scope, barrier, shared_memory, pos);
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn __expand_shape_method(&self, scope: &Scope) -> C::ExpandType {
+                (**self).__expand_shape_method(scope)
+            }
+
+            #[allow(clippy::too_many_arguments)]
+            fn __expand_is_in_bounds_method(
+                &self,
+                scope: &Scope,
+                pos: C::ExpandType,
+            ) -> NativeExpand<bool> {
+                (**self).__expand_is_in_bounds_method(scope, pos)
+            }
+        }
+    };
+}
+
+view_ops_read_ref!(&V);
+view_ops_read_ref!(&mut V);
+
+impl<T: CubePrimitive, C: Coordinates, V: ViewOperationsMut<T, C> + ?Sized> ViewOperationsMut<T, C>
+    for &mut V
+{
+}
+impl<T: CubePrimitive, C: Coordinates, V: ViewOperationsMutExpand<T, C> + ?Sized>
+    ViewOperationsMutExpand<T, C> for &mut V
+{
+    #[allow(clippy::too_many_arguments)]
+    fn __expand_write_method(&self, scope: &Scope, pos: C::ExpandType, value: T::ExpandType) {
+        (**self).__expand_write_method(scope, pos, value);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn __expand_write_checked_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+        value: T::ExpandType,
+    ) {
+        (**self).__expand_write_checked_method(scope, pos, value);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn __expand_as_linear_slice_mut_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+        size: C::ExpandType,
+    ) -> &mut SliceExpand<T> {
+        (**self).__expand_as_linear_slice_mut_method(scope, pos, size)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn __expand_tensor_map_store_method(
+        &self,
+        scope: &Scope,
+        shared_memory: &SliceExpand<T>,
+        pos: C::ExpandType,
+    ) {
+        (**self).__expand_tensor_map_store_method(scope, shared_memory, pos);
     }
 }

--- a/crates/cubecl-std/src/tensor/view/operations/slice.rs
+++ b/crates/cubecl-std/src/tensor/view/operations/slice.rs
@@ -157,8 +157,8 @@ impl<T: CubePrimitive> ViewOperationsMutExpand<T, Coords1d> for SliceExpand<T> {
         pos: NativeExpand<usize>,
         value: <T>::ExpandType,
     ) {
-        let mut this = self.clone_unchecked();
-        this.__expand_index_mut_method(scope, pos)
+        self.__expand_as_mut_unchecked_method(scope)
+            .__expand_index_mut_method(scope, pos)
             .__expand_assign_method(scope, value);
     }
 
@@ -168,11 +168,11 @@ impl<T: CubePrimitive> ViewOperationsMutExpand<T, Coords1d> for SliceExpand<T> {
         pos: NativeExpand<usize>,
         value: <T>::ExpandType,
     ) {
-        let mut this = self.clone_unchecked();
         let len = <Self as ListExpand<T>>::__expand_len_method(self, scope);
         let in_bounds = pos.__expand_lt_method(scope, &len);
         if_expand(scope, in_bounds, |scope| {
-            this.__expand_index_mut_method(scope, pos)
+            self.__expand_as_mut_unchecked_method(scope)
+                .__expand_index_mut_method(scope, pos)
                 .__expand_assign_method(scope, value)
         })
     }
@@ -188,12 +188,12 @@ impl<T: CubePrimitive> ViewOperationsMutExpand<T, Coords1d> for SliceExpand<T> {
         // Handling for shapes that are 0 in at least one dim, ensures the slice is not
         // negative length.
         let start = clamp_max::expand(scope, pos, end);
-        let mut this = self.clone_unchecked();
-        let slice = <Self as SliceOperatorExpand<T>>::__expand_slice_mut_method(
-            &mut this, scope, start, end,
-        );
-        // Slices are internally references, so this is actually 'a
-        unsafe { core::mem::transmute(slice) }
+        <Self as SliceOperatorExpand<T>>::__expand_slice_mut_method(
+            self.__expand_as_mut_unchecked_method(scope),
+            scope,
+            start,
+            end,
+        )
     }
 
     fn __expand_tensor_map_store_method(

--- a/crates/cubecl-std/src/tensor/view/operations/view.rs
+++ b/crates/cubecl-std/src/tensor/view/operations/view.rs
@@ -1,83 +1,94 @@
 use super::*;
-use crate::tensor::layout::Coordinates;
 use crate::tensor::{View, ViewExpand};
+use crate::tensor::{ViewMut, ViewMutExpand, layout::Coordinates};
 use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, prelude::barrier::Barrier};
 
-impl<T: CubePrimitive, C: Coordinates, IO: Clone> Vectorized for View<T, C, IO> {}
-impl<T: CubePrimitive, C: Coordinates, IO: Clone> VectorizedExpand for ViewExpand<T, C, IO> {
-    fn vector_size(&self) -> VectorSize {
-        ViewExpand::vector_size(self)
-    }
+macro_rules! impl_base {
+    ($ty: ident, $expand: ident) => {
+        impl<'a, T: CubePrimitive, C: Coordinates + 'a> Vectorized for $ty<'a, T, C> {}
+        impl<'a, T: CubePrimitive, C: Coordinates + 'a> VectorizedExpand for $expand<'a, T, C> {
+            fn vector_size(&self) -> VectorSize {
+                $expand::vector_size(self)
+            }
+        }
+
+        impl<'a, T: CubePrimitive, C: Coordinates + 'a> ViewOperations<T, C> for $ty<'a, T, C> {}
+        impl<'a, T: CubePrimitive, C: Coordinates + 'a> ViewOperationsExpand<T, C>
+            for $expand<'a, T, C>
+        {
+            fn __expand_read_method(&self, scope: &Scope, pos: <C>::ExpandType) -> <T>::ExpandType {
+                $expand::__expand_read_method(self, scope, pos)
+            }
+
+            fn __expand_read_checked_method(
+                &self,
+                scope: &Scope,
+                pos: <C>::ExpandType,
+            ) -> <T>::ExpandType {
+                $expand::__expand_read_checked_method(self, scope, pos)
+            }
+
+            fn __expand_read_masked_method(
+                &self,
+                scope: &Scope,
+                pos: <C>::ExpandType,
+                mask_value: <T>::ExpandType,
+            ) -> <T>::ExpandType {
+                $expand::__expand_read_masked_method(self, scope, pos, mask_value)
+            }
+
+            fn __expand_read_unchecked_method(
+                &self,
+                scope: &Scope,
+                pos: <C>::ExpandType,
+            ) -> <T>::ExpandType {
+                $expand::__expand_read_unchecked_method(self, scope, pos)
+            }
+
+            fn __expand_as_linear_slice_method(
+                &self,
+                scope: &Scope,
+                pos: <C>::ExpandType,
+                end: <C>::ExpandType,
+            ) -> &SliceExpand<T> {
+                $expand::__expand_as_linear_slice_inner_method(self, scope, pos, end)
+            }
+
+            fn __expand_shape_method(&self, scope: &Scope) -> <C>::ExpandType {
+                $expand::__expand_shape_method(self, scope)
+            }
+
+            fn __expand_is_in_bounds_method(
+                &self,
+                scope: &Scope,
+                pos: <C>::ExpandType,
+            ) -> NativeExpand<bool> {
+                $expand::__expand_is_in_bounds_method(self, scope, pos)
+            }
+
+            fn __expand_tensor_map_load_method(
+                &self,
+                scope: &Scope,
+                barrier: &NativeExpand<Barrier>,
+                shared_memory: &mut SliceExpand<T>,
+                pos: C::ExpandType,
+            ) {
+                $expand::__expand_tensor_map_load_method(self, scope, barrier, shared_memory, pos)
+            }
+        }
+    };
 }
 
-impl<T: CubePrimitive, C: Coordinates, IO: Clone> ViewOperations<T, C> for View<T, C, IO> {}
-impl<T: CubePrimitive, C: Coordinates, IO: Clone> ViewOperationsExpand<T, C>
-    for ViewExpand<T, C, IO>
-{
-    fn __expand_read_method(&self, scope: &Scope, pos: <C>::ExpandType) -> <T>::ExpandType {
-        ViewExpand::__expand_read_method(self, scope, pos)
-    }
+impl_base!(View, ViewExpand);
+impl_base!(ViewMut, ViewMutExpand);
 
-    fn __expand_read_checked_method(&self, scope: &Scope, pos: <C>::ExpandType) -> <T>::ExpandType {
-        ViewExpand::__expand_read_checked_method(self, scope, pos)
-    }
-
-    fn __expand_read_masked_method(
-        &self,
-        scope: &Scope,
-        pos: <C>::ExpandType,
-        mask_value: <T>::ExpandType,
-    ) -> <T>::ExpandType {
-        ViewExpand::__expand_read_masked_method(self, scope, pos, mask_value)
-    }
-
-    fn __expand_read_unchecked_method(
-        &self,
-        scope: &Scope,
-        pos: <C>::ExpandType,
-    ) -> <T>::ExpandType {
-        ViewExpand::__expand_read_unchecked_method(self, scope, pos)
-    }
-
-    fn __expand_as_linear_slice_method(
-        &self,
-        scope: &Scope,
-        pos: <C>::ExpandType,
-        end: <C>::ExpandType,
-    ) -> &SliceExpand<T> {
-        ViewExpand::__expand_as_linear_slice_inner_method(self, scope, pos, end)
-    }
-
-    fn __expand_shape_method(&self, scope: &Scope) -> <C>::ExpandType {
-        ViewExpand::__expand_shape_method(self, scope)
-    }
-
-    fn __expand_is_in_bounds_method(
-        &self,
-        scope: &Scope,
-        pos: <C>::ExpandType,
-    ) -> NativeExpand<bool> {
-        ViewExpand::__expand_is_in_bounds_method(self, scope, pos)
-    }
-
-    fn __expand_tensor_map_load_method(
-        &self,
-        scope: &Scope,
-        barrier: &NativeExpand<Barrier>,
-        shared_memory: &mut SliceExpand<T>,
-        pos: C::ExpandType,
-    ) {
-        ViewExpand::__expand_tensor_map_load_method(self, scope, barrier, shared_memory, pos)
-    }
-}
-
-impl<T: CubePrimitive, C: Coordinates> ViewOperationsMut<T, C> for View<T, C, ReadWrite> {}
-impl<T: CubePrimitive, C: Coordinates> ViewOperationsMutExpand<T, C>
-    for ViewExpand<T, C, ReadWrite>
+impl<'a, T: CubePrimitive, C: Coordinates + 'a> ViewOperationsMut<T, C> for ViewMut<'a, T, C> {}
+impl<'a, T: CubePrimitive, C: Coordinates + 'a> ViewOperationsMutExpand<T, C>
+    for ViewMutExpand<'a, T, C>
 {
     fn __expand_write_method(&self, scope: &Scope, pos: <C>::ExpandType, value: <T>::ExpandType) {
-        ViewExpand::__expand_write_method(self, scope, pos, value);
+        self.inner.__expand_write_method(scope, pos, value);
     }
 
     fn __expand_write_checked_method(
@@ -86,7 +97,7 @@ impl<T: CubePrimitive, C: Coordinates> ViewOperationsMutExpand<T, C>
         pos: <C>::ExpandType,
         value: <T>::ExpandType,
     ) {
-        ViewExpand::__expand_write_checked_method(self, scope, pos, value);
+        self.inner.__expand_write_checked_method(scope, pos, value);
     }
 
     fn __expand_as_linear_slice_mut_method(
@@ -95,7 +106,8 @@ impl<T: CubePrimitive, C: Coordinates> ViewOperationsMutExpand<T, C>
         pos: <C>::ExpandType,
         end: <C>::ExpandType,
     ) -> &mut SliceExpand<T> {
-        ViewExpand::__expand_to_linear_slice_mut_inner_method(self, scope, pos, end)
+        self.inner
+            .__expand_as_linear_slice_mut_method(scope, pos, end)
     }
 
     fn __expand_tensor_map_store_method(
@@ -104,6 +116,7 @@ impl<T: CubePrimitive, C: Coordinates> ViewOperationsMutExpand<T, C>
         shared_memory: &SliceExpand<T>,
         pos: C::ExpandType,
     ) {
-        ViewExpand::__expand_tensor_map_store_method(self, scope, shared_memory, pos)
+        self.inner
+            .__expand_tensor_map_store_method(scope, shared_memory, pos)
     }
 }

--- a/crates/cubecl-std/src/tensor/view/operations/view.rs
+++ b/crates/cubecl-std/src/tensor/view/operations/view.rs
@@ -9,7 +9,7 @@ macro_rules! impl_base {
         impl<'a, T: CubePrimitive, C: Coordinates + 'a> Vectorized for $ty<'a, T, C> {}
         impl<'a, T: CubePrimitive, C: Coordinates + 'a> VectorizedExpand for $expand<'a, T, C> {
             fn vector_size(&self) -> VectorSize {
-                $expand::vector_size(self)
+                self.inner.vector_size()
             }
         }
 

--- a/crates/cubecl-std/src/tensor/view/operations/virtual_tensor.rs
+++ b/crates/cubecl-std/src/tensor/view/operations/virtual_tensor.rs
@@ -100,7 +100,7 @@ impl<T: Numeric, N: Size> ViewOperationsMutExpand<Vector<T, N>, Coords1d>
         pos: NativeExpand<usize>,
         value: <Vector<T, N> as CubeType>::ExpandType,
     ) {
-        self.__expand_write_method(scope, pos, value)
+        self.state_write().__expand_write_method(scope, pos, value)
     }
 
     fn __expand_write_checked_method(
@@ -118,21 +118,11 @@ impl<T: Numeric, N: Size> ViewOperationsMutExpand<Vector<T, N>, Coords1d>
 
     fn __expand_as_linear_slice_mut_method(
         &self,
-        scope: &Scope,
-        pos: NativeExpand<usize>,
-        end: NativeExpand<usize>,
+        _scope: &Scope,
+        _pos: NativeExpand<usize>,
+        _end: NativeExpand<usize>,
     ) -> &mut SliceExpand<Vector<T, N>> {
-        // Convert to exclusive end
-        let end = end.__expand_add_method(scope, 1usize.into_expand(scope));
-        // Handling for shapes that are 0 in at least one dim, ensures the slice is not
-        // negative length.
-        let start = clamp_max::expand(scope, pos, end);
-        let mut this = self.clone();
-        let slice = <Self as SliceOperatorExpand<Vector<T, N>>>::__expand_slice_mut_method(
-            &mut this, scope, start, end,
-        );
-        // Arrays are internally references, so this is actually 'a
-        unsafe { core::mem::transmute(slice) }
+        todo!("VirtualTensor don't support slice mut yet");
     }
 
     fn __expand_tensor_map_store_method(

--- a/crates/cubecl-std/src/tensor/virtual.rs
+++ b/crates/cubecl-std/src/tensor/virtual.rs
@@ -1,11 +1,11 @@
 use alloc::sync::Arc;
-use core::marker::PhantomData;
+use core::{cell::UnsafeCell, marker::PhantomData};
 use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, unexpanded};
 use std::ops::{Deref, DerefMut};
 
 use crate::tensor::{
-    ViewExpand,
+    ViewExpand, ViewMut, ViewMutExpand,
     layout::{
         Coordinates, Coords1d, Layout, VirtualLayout, VirtualLayoutExpand, simple::SimpleLayout,
     },
@@ -24,20 +24,34 @@ pub struct VirtualTensor<E: Numeric, N: Size, IO = ReadOnly> {
 /// Expand type for [`VirtualTensor`].
 #[derive(Clone)]
 pub struct VirtualTensorExpand<E: Numeric, N: Size, IO> {
-    state: Arc<dyn VirtualTensorOperationsExpand<E, N>>,
+    state: Arc<UnsafeCell<dyn VirtualTensorOperationsExpand<E, N>>>,
     _p: PhantomData<IO>,
+}
+
+impl<E: Numeric, N: Size, IO> VirtualTensorExpand<E, N, IO> {
+    fn state_read(&self) -> &dyn VirtualTensorOperationsExpand<E, N> {
+        // SAFETY: State is valid for the entire lifetime of `self`
+        unsafe { &mut *self.state.get() }
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    pub(crate) fn state_write(&self) -> &mut dyn VirtualTensorOperationsExpand<E, N> {
+        // SAFETY: State is a handle into memory and only the memory is written. The state itself
+        // is never mutated, so this is safe.
+        unsafe { &mut *self.state.get() }
+    }
 }
 
 #[cube]
 impl<E: Numeric, N: Size, IO: Clone> VirtualTensor<E, N, IO> {
     #[allow(unused)]
     pub fn read(&self, index: usize) -> Vector<E, N> {
-        intrinsic!(|scope| { self.state.__expand_read_method(scope, index) })
+        intrinsic!(|scope| { self.state_read().__expand_read_method(scope, index) })
     }
 
     #[allow(unused, clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
-        intrinsic!(|scope| { self.state.__expand_len_method(scope) })
+        intrinsic!(|scope| { self.state_read().__expand_len_method(scope) })
     }
 }
 
@@ -58,7 +72,7 @@ impl<T: Numeric, N: Size> DerefMut for VirtualTensor<T, N, ReadWrite> {
 impl<E: Numeric, N: Size, IO: Clone> Vectorized for VirtualTensor<E, N, IO> {}
 impl<E: Numeric, N: Size, IO: Clone> VectorizedExpand for VirtualTensorExpand<E, N, IO> {
     fn vector_size(&self) -> VectorSize {
-        self.state.clone().vector_size()
+        self.state_read().vector_size()
     }
 }
 
@@ -72,7 +86,8 @@ impl<E: Numeric, N: Size, IO: Clone> SliceOperatorExpand<Vector<E, N>>
         start: NativeExpand<usize>,
         end: NativeExpand<usize>,
     ) -> &SliceExpand<Vector<E, N>> {
-        self.state.__expand_read_window_method(scope, start, end)
+        self.state_read()
+            .__expand_read_window_method(scope, start, end)
     }
 
     fn __expand_slice_mut_method(
@@ -96,29 +111,31 @@ impl<E: Numeric, N: Size, IO: Clone> VirtualTensor<E, N, IO> {
     }
 
     pub fn as_tensor_map(&self) -> ComptimeOption<TensorMap<E, Tiled>> {
-        intrinsic!(|scope| self.state.__expand_as_tensor_map_method(scope))
+        intrinsic!(|scope| self.state_read().__expand_as_tensor_map_method(scope))
     }
     #[allow(unused)]
     pub fn slice(&self, start: usize, end: usize) -> &[Vector<E, N>] {
-        intrinsic!(|scope| self.state.__expand_read_window_method(scope, start, end))
+        intrinsic!(|scope| self
+            .state_read()
+            .__expand_read_window_method(scope, start, end))
     }
     /// Get the shape of the tensor at the given axis.
     #[allow(unused)]
     pub fn shape(&self, axis: usize) -> usize {
-        intrinsic!(|scope| { self.state.__expand_shape_method(scope, axis) })
+        intrinsic!(|scope| { self.state_read().__expand_shape_method(scope, axis) })
     }
     /// Get the stride of the tensor at the given axis.
     #[allow(unused)]
     pub fn stride(&self, axis: usize) -> usize {
-        intrinsic!(|scope| self.state.__expand_stride_method(scope, axis))
+        intrinsic!(|scope| self.state_read().__expand_stride_method(scope, axis))
     }
     /// Get the rank of the tensor.
     pub fn rank(&self) -> usize {
-        intrinsic!(|scope| self.state.__expand_rank_method(scope))
+        intrinsic!(|scope| self.state_read().__expand_rank_method(scope))
     }
 
     pub fn buffer_len(&self) -> usize {
-        intrinsic!(|scope| self.state.__expand_buffer_len_method(scope))
+        intrinsic!(|scope| self.state_read().__expand_buffer_len_method(scope))
     }
 }
 
@@ -128,18 +145,27 @@ impl<E: Numeric, N: Size, IO: Clone + 'static> VirtualTensor<E, N, IO> {
     pub fn view<C: Coordinates + 'static>(
         &self,
         layout: impl Into<VirtualLayout<C, Coords1d>>,
-    ) -> View<Vector<E, N>, C, ReadOnly> {
-        View::new::<VirtualTensor<E, N, IO>, Coords1d>(self.clone(), layout)
+    ) -> View<'_, Vector<E, N>, C> {
+        View::new::<&VirtualTensor<E, N, IO>, Coords1d>(self, layout)
+    }
+
+    /// Create a conceptual view over this tensor, allowing for multi-dimensional indexing with custom
+    /// layouts
+    pub fn into_view<C: Coordinates + 'static>(
+        self,
+        layout: impl Into<VirtualLayout<C, Coords1d>>,
+    ) -> View<'static, Vector<E, N>, C> {
+        View::new::<VirtualTensor<E, N, IO>, Coords1d>(self, layout)
     }
 }
 
 #[cube]
 impl<E: Numeric, N: Size, IO: Clone + 'static> VirtualTensor<E, N, IO> {
     /// Create a conceptual view over this tensor, with a simple linear layout
-    pub fn as_view(&self) -> View<Vector<E, N>, usize, ReadOnly> {
+    pub fn as_view(&self) -> View<'_, Vector<E, N>, usize> {
         let vector_size = self.vector_size();
-        View::new::<VirtualTensor<E, N, IO>, usize>(
-            self.clone(),
+        View::new::<&VirtualTensor<E, N, IO>, usize>(
+            self,
             SimpleLayout::new(self.len() * vector_size, vector_size),
         )
     }
@@ -152,52 +178,69 @@ impl<E: Numeric, N: Size, IO: Clone + 'static> VirtualTensorExpand<E, N, IO> {
         &self,
         scope: &Scope,
         layout: VirtualLayoutExpand<C, Coords1d>,
-    ) -> ViewExpand<Vector<E, N>, C, ReadOnly> {
-        View::__expand_new::<VirtualTensor<E, N, IO>, Coords1d>(scope, self.clone(), layout)
+    ) -> ViewExpand<'_, Vector<E, N>, C> {
+        View::__expand_new::<&VirtualTensor<E, N, IO>, Coords1d>(scope, self, layout)
+    }
+
+    pub fn __expand_into_view_method<C: Coordinates + 'static>(
+        self,
+        scope: &Scope,
+        layout: VirtualLayoutExpand<C, Coords1d>,
+    ) -> ViewExpand<'static, Vector<E, N>, C> {
+        View::__expand_new::<VirtualTensor<E, N, IO>, Coords1d>(scope, self, layout)
     }
 }
 
 impl<E: Numeric, N: Size> VirtualTensor<E, N, ReadWrite> {
-    #[doc = " Create a mutable conceptual view over this tensor, allowing for multi-dimensional indexing"]
-    #[doc = " with custom layouts"]
+    /// Create a mutable conceptual view over this tensor, allowing for multi-dimensional indexing
+    /// with custom layouts
     pub fn view_mut<C: Coordinates + 'static>(
-        &self,
+        &mut self,
         layout: impl Layout<Coordinates = C, SourceCoordinates = Coords1d> + 'static,
-    ) -> View<Vector<E, N>, C, ReadWrite> {
-        let this: VirtualTensor<E, N, ReadWrite> = self.clone();
-        View::new_mut::<VirtualTensor<E, N, ReadWrite>, Coords1d>(this, layout)
+    ) -> ViewMut<'_, Vector<E, N>, C> {
+        ViewMut::new::<&mut VirtualTensor<E, N, ReadWrite>, Coords1d>(self, layout)
     }
-    pub fn __expand_view_mut<C: Coordinates + 'static>(
+    pub fn __expand_view_mut<'a, C: Coordinates + 'static>(
         scope: &Scope,
-        this: VirtualTensorExpand<E, N, ReadWrite>,
+        this: &'a mut VirtualTensorExpand<E, N, ReadWrite>,
         layout: VirtualLayoutExpand<C, Coords1d>,
-    ) -> ViewExpand<Vector<E, N>, C, ReadWrite> {
+    ) -> ViewMutExpand<'a, Vector<E, N>, C> {
         this.__expand_view_mut_method::<C>(scope, layout)
     }
+
+    pub fn into_view_mut<C: Coordinates + 'static>(
+        self,
+        layout: impl Layout<Coordinates = C, SourceCoordinates = Coords1d> + 'static,
+    ) -> ViewMut<'static, Vector<E, N>, C> {
+        ViewMut::new::<VirtualTensor<E, N, ReadWrite>, Coords1d>(self, layout)
+    }
 }
+
 impl<E: Numeric, N: Size> VirtualTensorExpand<E, N, ReadWrite> {
     pub fn __expand_view_mut_method<C: Coordinates + 'static>(
-        &self,
+        &mut self,
         scope: &Scope,
         layout: VirtualLayoutExpand<C, Coords1d>,
-    ) -> ViewExpand<Vector<E, N>, C, ReadWrite> {
-        View::__expand_new_mut::<VirtualTensor<E, N, ReadWrite>, Coords1d>(
-            scope,
-            self.clone(),
-            layout,
-        )
+    ) -> ViewMutExpand<'_, Vector<E, N>, C> {
+        ViewMut::__expand_new::<&mut VirtualTensor<E, N, ReadWrite>, Coords1d>(scope, self, layout)
+    }
+
+    pub fn __expand_into_view_mut_method<C: Coordinates + 'static>(
+        self,
+        scope: &Scope,
+        layout: VirtualLayoutExpand<C, Coords1d>,
+    ) -> ViewMutExpand<'static, Vector<E, N>, C> {
+        ViewMut::__expand_new::<VirtualTensor<E, N, ReadWrite>, Coords1d>(scope, self, layout)
     }
 }
 
 #[cube]
 impl<E: Numeric, N: Size> VirtualTensor<E, N, ReadWrite> {
     /// Create a conceptual mutable view over this tensor, with a simple linear layout
-    pub fn as_view_mut(&mut self) -> View<Vector<E, N>, usize, ReadWrite> {
+    pub fn as_view_mut(&mut self) -> ViewMut<'_, Vector<E, N>, usize> {
         let vector_size = self.vector_size();
-        View::new_mut::<VirtualTensor<E, N, ReadWrite>, usize>(
-            self.clone(),
-            SimpleLayout::new(self.len() * vector_size, vector_size),
-        )
+        let layout = SimpleLayout::new(self.len() * vector_size, vector_size);
+        ViewMut::new::<&mut VirtualTensor<E, N, ReadWrite>, usize>(self, layout)
     }
 }
 
@@ -212,8 +255,10 @@ impl<E: Numeric, N: Size, IO: Clone + 'static> VirtualTensor<E, N, IO> {
 #[cube]
 impl<E: Numeric, N: Size> VirtualTensor<E, N, ReadWrite> {
     #[allow(unused)]
-    pub fn write(&self, index: usize, value: Vector<E, N>) {
-        intrinsic!(|scope| self.state.__expand_write_method(scope, index, value))
+    pub fn write(&mut self, index: usize, value: Vector<E, N>) {
+        intrinsic!(|scope| self
+            .state_write()
+            .__expand_write_method(scope, index, value))
     }
 }
 
@@ -229,7 +274,7 @@ impl<E: Numeric, N: Size> VirtualTensor<E, N, ReadOnly> {
         v: V::ExpandType,
     ) -> VirtualTensorExpand<E, N, ReadOnly> {
         VirtualTensorExpand {
-            state: Arc::new(v),
+            state: Arc::new(UnsafeCell::new(v)),
             _p: PhantomData,
         }
     }
@@ -247,7 +292,7 @@ impl<E: Numeric, N: Size> VirtualTensor<E, N, ReadWrite> {
         v: V::ExpandType,
     ) -> VirtualTensorExpand<E, N, ReadWrite> {
         VirtualTensorExpand {
-            state: Arc::new(v),
+            state: Arc::new(UnsafeCell::new(v)),
             _p: PhantomData,
         }
     }
@@ -276,7 +321,7 @@ pub trait VirtualTensorOperations<E: Numeric, N: Size>: Vectorized {
     }
     /// Write the tensor at the given index.
     #[allow(unused)]
-    fn write(&self, _index: usize, value: Vector<E, N>) {
+    fn write(&mut self, _index: usize, value: Vector<E, N>) {
         unexpanded!()
     }
     /// Get the shape of the tensor at the given axis.
@@ -368,14 +413,13 @@ mod __tensor {
         }
 
         fn __expand_write_method(
-            &self,
+            &mut self,
             scope: &Scope,
             index: NativeExpand<usize>,
             value: NativeExpand<Vector<E, N>>,
         ) {
-            let mut this = self.clone_unchecked();
             unsafe {
-                this.__expand_get_unchecked_mut_method(scope, index)
+                self.__expand_get_unchecked_mut_method(scope, index)
                     .__expand_assign_method(scope, value)
             };
         }
@@ -440,7 +484,7 @@ mod __tensor_map {
         }
 
         fn __expand_write_method(
-            &self,
+            &mut self,
             _scope: &Scope,
             _index: NativeExpand<usize>,
             _value: NativeExpand<Vector<E, N>>,

--- a/crates/cubecl-std/src/tests/reinterpret_slice.rs
+++ b/crates/cubecl-std/src/tests/reinterpret_slice.rs
@@ -72,7 +72,7 @@ pub fn run_test_write_global<R: Runtime>(client: ComputeClient<R>, vector_size: 
 
 #[cube(launch_unchecked)]
 fn kernel_read_shared_memory(output: &mut [f16]) {
-    let mut mem: Shared<[Vector<i8, Const<4>>]> = Shared::new_slice(1usize);
+    let mut mem = Shared::<[Vector<i8, Const<4>>]>::new_slice(1usize);
     if UNIT_POS == 0 {
         let mut vector = Vector::empty();
         vector.insert(0, 0_i8);
@@ -112,7 +112,7 @@ pub fn run_test_read_shared_memory<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch_unchecked)]
 fn kernel_write_shared_memory<N: Size>(output: &mut [Vector<i8, N>], input: &[f16]) {
-    let mut mem: Shared<[Vector<i8, N>]> = Shared::new_slice(1usize);
+    let mut mem = Shared::new_slice(1usize);
     let mut list = ReinterpretSliceMut::<_, f16>::new(mem.as_mut_slice());
     let unit_pos = UNIT_POS as usize;
     list.write(unit_pos, input[unit_pos]);

--- a/crates/cubecl-std/src/tests/reinterpret_slice.rs
+++ b/crates/cubecl-std/src/tests/reinterpret_slice.rs
@@ -72,7 +72,7 @@ pub fn run_test_write_global<R: Runtime>(client: ComputeClient<R>, vector_size: 
 
 #[cube(launch_unchecked)]
 fn kernel_read_shared_memory(output: &mut [f16]) {
-    let mut mem = SharedMemory::<Vector<i8, Const<4>>>::new(1usize);
+    let mut mem = Shared::<Vector<i8, Const<4>>>::new_array(1usize);
     if UNIT_POS == 0 {
         let mut vector = Vector::empty();
         vector.insert(0, 0_i8);
@@ -112,7 +112,7 @@ pub fn run_test_read_shared_memory<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch_unchecked)]
 fn kernel_write_shared_memory<N: Size>(output: &mut [Vector<i8, N>], input: &[f16]) {
-    let mut mem = SharedMemory::<Vector<i8, N>>::new(1usize);
+    let mut mem = Shared::<Vector<i8, N>>::new_array(1usize);
     let mut list = ReinterpretSliceMut::<_, f16>::new(mem.as_mut_slice());
     let unit_pos = UNIT_POS as usize;
     list.write(unit_pos, input[unit_pos]);

--- a/crates/cubecl-std/src/tests/reinterpret_slice.rs
+++ b/crates/cubecl-std/src/tests/reinterpret_slice.rs
@@ -72,7 +72,7 @@ pub fn run_test_write_global<R: Runtime>(client: ComputeClient<R>, vector_size: 
 
 #[cube(launch_unchecked)]
 fn kernel_read_shared_memory(output: &mut [f16]) {
-    let mut mem = Shared::<Vector<i8, Const<4>>>::new_array(1usize);
+    let mut mem: Shared<[Vector<i8, Const<4>>]> = Shared::new_slice(1usize);
     if UNIT_POS == 0 {
         let mut vector = Vector::empty();
         vector.insert(0, 0_i8);
@@ -112,7 +112,7 @@ pub fn run_test_read_shared_memory<R: Runtime>(client: ComputeClient<R>) {
 
 #[cube(launch_unchecked)]
 fn kernel_write_shared_memory<N: Size>(output: &mut [Vector<i8, N>], input: &[f16]) {
-    let mut mem = Shared::<Vector<i8, N>>::new_array(1usize);
+    let mut mem: Shared<[Vector<i8, N>]> = Shared::new_slice(1usize);
     let mut list = ReinterpretSliceMut::<_, f16>::new(mem.as_mut_slice());
     let unit_pos = UNIT_POS as usize;
     list.write(unit_pos, input[unit_pos]);

--- a/crates/cubecl-std/src/tests/view/quantized.rs
+++ b/crates/cubecl-std/src/tests/view/quantized.rs
@@ -40,7 +40,7 @@ impl Layout for TestPerTensorScaleLayout {
 
 #[cube(launch_unchecked)]
 pub fn kernel_quantized_view<F: Float, N: Size>(
-    lhs: View<Vector<F, N>, Coords1d>,
+    lhs: View<'_, Vector<F, N>, Coords1d>,
     output: &mut [Vector<F, N>],
 ) {
     if (UNIT_POS as usize) < lhs.shape() {


### PR DESCRIPTION
Adds a lifetime to `View`, so it borrows the source buffer for the duration of the view when it's created from a reference.
I also looked into adding one to `VirtualTensor` but that's used for much more hacky and niche cases, so it didn't seem worth it.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
