### PR TITLE
Improve CPU backend by removing need to flush, add atomics test and add atomic to cubecl-cpu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,8 @@ tracel-llvm-bundler = { version = "22.1.4-3" }
 #     "mlir-helpers",
 # ] }
 # tracel-llvm-bundler = { path = "../tracel-llvm/crates/tracel-llvm-bundler" }
+libc = "^0.2.186"
+winapi = { version = "^0.3.9", features = ["processthreadsapi", "winbase"] }
 
 
 cudarc = { version = "0.19.6", features = [
@@ -164,7 +166,6 @@ renderdoc = "0.12"
 
 # Build deps
 cfg_aliases = "0.2.1"
-
 
 [profile.dev.build-override]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,13 +129,13 @@ futures-lite = { version = "2.3.0", default-features = false }
 
 # CubeCL-CPU
 sysinfo = "0.38"
-# tracel-llvm = { version = "22.1.5-3", features = ["mlir-helpers"] }
-# tracel-llvm-bundler = { version = "22.1.5-3" }
+tracel-llvm = { git = "https://github.com/tracel-ai/tracel-llvm", rev = "82401e3c00a35a3fb7d5e2b415e79692e09e1079", features = ["mlir-helpers"] }
+tracel-llvm-bundler = { git = "https://github.com/tracel-ai/tracel-llvm", rev = "82401e3c00a35a3fb7d5e2b415e79692e09e1079" }
 ### For development
-tracel-llvm = { path = "../tracel-llvm/crates/tracel-llvm", features = [
-    "mlir-helpers",
-] }
-tracel-llvm-bundler = { path = "../tracel-llvm/crates/tracel-llvm-bundler" }
+# tracel-llvm = { path = "../tracel-llvm/crates/tracel-llvm", features = [
+#     "mlir-helpers",
+# ] }
+# tracel-llvm-bundler = { path = "../tracel-llvm/crates/tracel-llvm-bundler" }
 libc = "^0.2.186"
 winapi = { version = "^0.3.9", features = ["processthreadsapi", "winbase"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,13 +129,13 @@ futures-lite = { version = "2.3.0", default-features = false }
 
 # CubeCL-CPU
 sysinfo = "0.38"
-tracel-llvm = { version = "22.1.4-3", features = ["mlir-helpers"] }
-tracel-llvm-bundler = { version = "22.1.4-3" }
+# tracel-llvm = { version = "22.1.5-3", features = ["mlir-helpers"] }
+# tracel-llvm-bundler = { version = "22.1.5-3" }
 ### For development
-# tracel-llvm = { path = "../tracel-llvm/crates/tracel-llvm", features = [
-#     "mlir-helpers",
-# ] }
-# tracel-llvm-bundler = { path = "../tracel-llvm/crates/tracel-llvm-bundler" }
+tracel-llvm = { path = "../tracel-llvm/crates/tracel-llvm", features = [
+    "mlir-helpers",
+] }
+tracel-llvm-bundler = { path = "../tracel-llvm/crates/tracel-llvm-bundler" }
 libc = "^0.2.186"
 winapi = { version = "^0.3.9", features = ["processthreadsapi", "winbase"] }
 

--- a/crates/cubecl-core/src/post_processing/visitor.rs
+++ b/crates/cubecl-core/src/post_processing/visitor.rs
@@ -371,7 +371,7 @@ impl<T> Visitor<T> {
                 visit_read(self, &mut store.value);
             }
             AtomicOp::CompareAndSwap(op) => {
-                visit_read(self, &mut op.cmp);
+                visit_read(self, &mut op.ptr);
                 visit_read(self, &mut op.cmp);
                 visit_read(self, &mut op.val);
             }

--- a/crates/cubecl-core/src/runtime_tests/atomic.rs
+++ b/crates/cubecl-core/src/runtime_tests/atomic.rs
@@ -78,8 +78,9 @@ fn numeric_op_name(op: NumericAtomicOp) -> &'static str {
 
 fn numeric_op_feature(op: NumericAtomicOp) -> AtomicUsage {
     match op {
-        NumericAtomicOp::Load | NumericAtomicOp::Store => AtomicUsage::LoadStore,
-        NumericAtomicOp::Swap => AtomicUsage::Swap,
+        NumericAtomicOp::Load | NumericAtomicOp::Store | NumericAtomicOp::Swap => {
+            AtomicUsage::LoadStore
+        }
         NumericAtomicOp::Add | NumericAtomicOp::Sub => AtomicUsage::Add,
         NumericAtomicOp::Min | NumericAtomicOp::Max => AtomicUsage::MinMax,
     }

--- a/crates/cubecl-core/src/runtime_tests/atomic.rs
+++ b/crates/cubecl-core/src/runtime_tests/atomic.rs
@@ -200,7 +200,11 @@ pub fn test_kernel_atomic_numeric_all_sizes<R: Runtime, F: Numeric + CubeElement
 }
 
 #[cube(launch)]
-pub fn kernel_atomic_int<I: Int>(atomics: &[Atomic<I>], #[comptime] op: IntAtomicOp) {
+pub fn kernel_atomic_int<I: Int>(
+    atomics: &[Atomic<I>],
+    output: &mut [I],
+    #[comptime] op: IntAtomicOp,
+) {
     if UNIT_POS == 0 {
         match op {
             IntAtomicOp::And => {
@@ -213,7 +217,7 @@ pub fn kernel_atomic_int<I: Int>(atomics: &[Atomic<I>], #[comptime] op: IntAtomi
                 atomics[0].fetch_xor(I::from_int(0b0110));
             }
             IntAtomicOp::CompareExchange => {
-                atomics[0].compare_exchange_weak(I::from_int(12), I::from_int(5));
+                output[0] = atomics[0].compare_exchange_weak(I::from_int(12), I::from_int(5));
             }
         }
     }
@@ -228,12 +232,14 @@ pub fn test_kernel_atomic_int<R: Runtime, I: Int + CubeElement>(
     }
 
     let handle = client.create_from_slice(I::as_bytes(&[I::from_int(int_atomic_initial_value())]));
+    let output_handle = client.create_from_slice(I::as_bytes(&[I::from_int(0)]));
 
     kernel_atomic_int::launch::<I, R>(
         &client,
         CubeCount::new_single(),
         CubeDim::new_1d(1),
         unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+        unsafe { BufferArg::from_raw_parts(output_handle.clone(), 1) },
         op,
     );
 
@@ -241,6 +247,13 @@ pub fn test_kernel_atomic_int<R: Runtime, I: Int + CubeElement>(
     let actual = I::from_bytes(&actual);
 
     assert_eq!(actual, &[int_expected::<I>(op)]);
+
+    if op == IntAtomicOp::CompareExchange {
+        let output = client.read_one_unchecked(output_handle);
+        let output = I::from_bytes(&output);
+
+        assert_eq!(output, &[I::from_int(int_atomic_initial_value())]);
+    }
 }
 
 #[macro_export]

--- a/crates/cubecl-core/src/runtime_tests/atomic.rs
+++ b/crates/cubecl-core/src/runtime_tests/atomic.rs
@@ -5,11 +5,23 @@ use crate::{self as cubecl};
 use cubecl::prelude::*;
 use cubecl_ir::features::AtomicUsage;
 
-#[cube(launch)]
-pub fn kernel_atomic_add<I: Numeric, N: Size>(output: &mut [Atomic<Vector<I, N>>]) {
-    if UNIT_POS == 0 {
-        output[0].fetch_add(Vector::from_int(5));
-    }
+#[derive(CubeType, Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum NumericAtomicOp {
+    Load,
+    Store,
+    Swap,
+    Add,
+    Sub,
+    Min,
+    Max,
+}
+
+#[derive(CubeType, Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum IntAtomicOp {
+    And,
+    Or,
+    Xor,
+    CompareExchange,
 }
 
 fn supports_feature<R: Runtime, F: Numeric>(
@@ -21,193 +33,372 @@ fn supports_feature<R: Runtime, F: Numeric>(
     client.properties().atomic_type_usage(ty).contains(feat)
 }
 
-pub fn test_kernel_atomic_add<R: Runtime, F: Numeric + CubeElement>(
-    client: ComputeClient<R>,
+fn require_feature<R: Runtime, F: Numeric>(
+    client: &ComputeClient<R>,
+    feat: AtomicUsage,
     vector_size: usize,
-) {
-    if !supports_feature::<R, F>(&client, AtomicUsage::Add, vector_size) {
-        println!(
-            "{} Add not supported - skipped",
-            Atomic::<F>::as_type_native_unchecked().with_vector_size(vector_size)
-        );
-        return;
+    operation: &str,
+) -> bool {
+    let ty = Atomic::<F>::as_type_native_unchecked().with_vector_size(vector_size);
+
+    if supports_feature::<R, F>(client, feat, vector_size) {
+        println!("{ty} {operation} supported - running");
+        true
     } else {
-        println!(
-            "{} Add supported - running",
-            Atomic::<F>::as_type_native_unchecked().with_vector_size(vector_size)
-        );
+        println!("{ty} {operation} not supported - skipped");
+        false
     }
+}
 
-    let data = (0..vector_size)
-        .map(|_| F::from_int(12))
-        .collect::<Vec<_>>();
-    let handle = client.create_from_slice(F::as_bytes(&data));
+fn filled_data<F: Numeric>(vector_size: usize, value: i64) -> Vec<F> {
+    (0..vector_size)
+        .map(|_| F::from_int(value))
+        .collect::<Vec<_>>()
+}
 
-    kernel_atomic_add::launch::<F, R>(
-        &client,
-        CubeCount::Static(1, 1, 1),
-        CubeDim::new(&client, 1),
-        vector_size,
-        unsafe { BufferArg::from_raw_parts(handle.clone(), vector_size) },
-    );
+fn int_atomic_initial_value() -> i64 {
+    0b1010
+}
 
-    let actual = client.read_one_unchecked(handle);
-    let actual = F::from_bytes(&actual);
+fn assert_all_eq<F: Numeric + CubeElement>(actual: &[F], expected: i64) {
+    assert!(actual.iter().all(|actual| actual == &F::from_int(expected)));
+}
 
-    assert!(actual.iter().all(|actual| actual == &F::from_int(17)));
+fn numeric_op_name(op: NumericAtomicOp) -> &'static str {
+    match op {
+        NumericAtomicOp::Load => "Load",
+        NumericAtomicOp::Store => "Store",
+        NumericAtomicOp::Swap => "Swap",
+        NumericAtomicOp::Add => "Add",
+        NumericAtomicOp::Sub => "Sub",
+        NumericAtomicOp::Min => "Min",
+        NumericAtomicOp::Max => "Max",
+    }
+}
+
+fn numeric_op_feature(op: NumericAtomicOp) -> AtomicUsage {
+    match op {
+        NumericAtomicOp::Load | NumericAtomicOp::Store => AtomicUsage::LoadStore,
+        NumericAtomicOp::Swap => AtomicUsage::Swap,
+        NumericAtomicOp::Add | NumericAtomicOp::Sub => AtomicUsage::Add,
+        NumericAtomicOp::Min | NumericAtomicOp::Max => AtomicUsage::MinMax,
+    }
+}
+
+fn numeric_expected(op: NumericAtomicOp) -> i64 {
+    match op {
+        NumericAtomicOp::Load => 12,
+        NumericAtomicOp::Store => 5,
+        NumericAtomicOp::Swap => 5,
+        NumericAtomicOp::Add => 17,
+        NumericAtomicOp::Sub => 7,
+        NumericAtomicOp::Min => 5,
+        NumericAtomicOp::Max => 12,
+    }
+}
+
+fn int_op_name(op: IntAtomicOp) -> &'static str {
+    match op {
+        IntAtomicOp::And => "And",
+        IntAtomicOp::Or => "Or",
+        IntAtomicOp::Xor => "Xor",
+        IntAtomicOp::CompareExchange => "CompareExchange",
+    }
+}
+
+fn int_op_feature(op: IntAtomicOp) -> AtomicUsage {
+    match op {
+        IntAtomicOp::And | IntAtomicOp::Or | IntAtomicOp::Xor => AtomicUsage::Bitwise,
+        IntAtomicOp::CompareExchange => AtomicUsage::CompareExchange,
+    }
+}
+
+fn int_expected<I: Int>(op: IntAtomicOp) -> I {
+    match op {
+        IntAtomicOp::And => I::from_int(0b0010),
+        IntAtomicOp::Or => I::from_int(0b1110),
+        IntAtomicOp::Xor => I::from_int(0b1100),
+        IntAtomicOp::CompareExchange => I::from_int(int_atomic_initial_value()),
+    }
 }
 
 #[cube(launch)]
-pub fn kernel_atomic_min<I: Numeric, N: Size>(output: &mut [Atomic<Vector<I, N>>]) {
+pub fn kernel_atomic_numeric<I: Numeric, N: Size>(
+    input: &[Vector<I, N>],
+    atomics: &[Atomic<Vector<I, N>>],
+    output: &mut [Vector<I, N>],
+    #[comptime] op: NumericAtomicOp,
+) {
     if UNIT_POS == 0 {
-        output[0].fetch_min(Vector::from_int(5));
+        match op {
+            NumericAtomicOp::Load => output[0] = atomics[0].load(),
+            NumericAtomicOp::Store => atomics[0].store(input[0]),
+            NumericAtomicOp::Swap => {
+                atomics[0].swap(Vector::from_int(5));
+            }
+            NumericAtomicOp::Add => {
+                atomics[0].fetch_add(Vector::from_int(5));
+            }
+            NumericAtomicOp::Sub => {
+                atomics[0].fetch_sub(Vector::from_int(5));
+            }
+            NumericAtomicOp::Min => {
+                atomics[0].fetch_min(Vector::from_int(5));
+            }
+            NumericAtomicOp::Max => {
+                atomics[0].fetch_max(Vector::from_int(5));
+            }
+        }
     }
 }
 
-pub fn test_kernel_atomic_min<R: Runtime, F: Numeric + CubeElement>(
+pub fn test_kernel_atomic_numeric<R: Runtime, F: Numeric + CubeElement>(
     client: ComputeClient<R>,
     vector_size: usize,
+    op: NumericAtomicOp,
 ) {
-    if !supports_feature::<R, F>(&client, AtomicUsage::MinMax, vector_size) {
-        println!(
-            "{} Min not supported - skipped",
-            Atomic::<F>::as_type_native_unchecked().with_vector_size(vector_size)
-        );
-        return;
-    } else {
-        println!(
-            "{} Min supported - running",
-            Atomic::<F>::as_type_native_unchecked().with_vector_size(vector_size)
-        );
-    }
-    let data = (0..vector_size)
-        .map(|_| F::from_int(12))
-        .collect::<Vec<_>>();
-    let handle = client.create_from_slice(F::as_bytes(&data));
-
-    kernel_atomic_min::launch::<F, R>(
+    if !require_feature::<R, F>(
         &client,
-        CubeCount::Static(1, 1, 1),
+        numeric_op_feature(op),
+        vector_size,
+        numeric_op_name(op),
+    ) {
+        return;
+    }
+
+    let input_handle = client.create_from_slice(F::as_bytes(&filled_data::<F>(vector_size, 5)));
+    let atomic_handle = client.create_from_slice(F::as_bytes(&filled_data::<F>(vector_size, 12)));
+    let output_handle = client.create_from_slice(F::as_bytes(&filled_data::<F>(vector_size, 0)));
+
+    kernel_atomic_numeric::launch::<F, R>(
+        &client,
+        CubeCount::new_single(),
         CubeDim::new_1d(1),
         vector_size,
-        unsafe { BufferArg::from_raw_parts(handle.clone(), vector_size) },
+        unsafe { BufferArg::from_raw_parts(input_handle, 1) },
+        unsafe { BufferArg::from_raw_parts(atomic_handle.clone(), vector_size) },
+        unsafe { BufferArg::from_raw_parts(output_handle.clone(), 1) },
+        op,
     );
 
-    let actual = client.read_one_unchecked(handle);
+    let actual = match op {
+        NumericAtomicOp::Load => client.read_one_unchecked(output_handle),
+        _ => client.read_one_unchecked(atomic_handle),
+    };
     let actual = F::from_bytes(&actual);
 
-    assert!(actual.iter().all(|actual| actual == &F::from_int(5)));
+    assert_all_eq(&actual, numeric_expected(op));
 }
 
-#[cube(launch)]
-pub fn kernel_atomic_max<I: Numeric, N: Size>(output: &mut [Atomic<Vector<I, N>>]) {
-    if UNIT_POS == 0 {
-        output[0].fetch_max(Vector::from_int(5));
-    }
-}
-
-pub fn test_kernel_atomic_max<R: Runtime, F: Numeric + CubeElement>(
+pub fn test_kernel_atomic_numeric_all_sizes<R: Runtime, F: Numeric + CubeElement>(
     client: ComputeClient<R>,
-    vector_size: usize,
+    op: NumericAtomicOp,
 ) {
-    if !supports_feature::<R, F>(&client, AtomicUsage::MinMax, vector_size) {
-        println!(
-            "{} Max not supported - skipped",
-            Atomic::<F>::as_type_native_unchecked().with_vector_size(vector_size)
-        );
-        return;
-    } else {
-        println!(
-            "{} Max supported - running",
-            Atomic::<F>::as_type_native_unchecked().with_vector_size(vector_size)
-        );
+    for vector_size in [1, 2, 4] {
+        test_kernel_atomic_numeric::<R, F>(client.clone(), vector_size, op);
     }
-    let data = (0..vector_size)
-        .map(|_| F::from_int(12))
-        .collect::<Vec<_>>();
-    let handle = client.create_from_slice(F::as_bytes(&data));
-
-    kernel_atomic_max::launch::<F, R>(
-        &client,
-        CubeCount::Static(1, 1, 1),
-        CubeDim::new_1d(1),
-        vector_size,
-        unsafe { BufferArg::from_raw_parts(handle.clone(), vector_size) },
-    );
-
-    let actual = client.read_one_unchecked(handle);
-    let actual = F::from_bytes(&actual);
-
-    assert!(actual.iter().all(|actual| actual == &F::from_int(12)));
 }
 
 #[cube(launch)]
-fn regression_issue_1218_kernel(x: &[Atomic<u32>]) {
-    x[0].store(0);
+pub fn kernel_atomic_int<I: Int>(atomics: &[Atomic<I>], #[comptime] op: IntAtomicOp) {
+    if UNIT_POS == 0 {
+        match op {
+            IntAtomicOp::And => {
+                atomics[0].fetch_and(I::from_int(0b0110));
+            }
+            IntAtomicOp::Or => {
+                atomics[0].fetch_or(I::from_int(0b0110));
+            }
+            IntAtomicOp::Xor => {
+                atomics[0].fetch_xor(I::from_int(0b0110));
+            }
+            IntAtomicOp::CompareExchange => {
+                atomics[0].compare_exchange_weak(I::from_int(12), I::from_int(5));
+            }
+        }
+    }
 }
 
-pub fn test_regression_issue_1218<R: Runtime>(client: ComputeClient<R>) {
-    if !supports_feature::<R, u32>(&client, AtomicUsage::LoadStore, 1) {
+pub fn test_kernel_atomic_int<R: Runtime, I: Int + CubeElement>(
+    client: ComputeClient<R>,
+    op: IntAtomicOp,
+) {
+    if !require_feature::<R, I>(&client, int_op_feature(op), 1, int_op_name(op)) {
         return;
     }
-    let handle = client.create_from_slice(u32::as_bytes(&[10]));
 
-    regression_issue_1218_kernel::launch::<R>(
+    let handle = client.create_from_slice(I::as_bytes(&[I::from_int(int_atomic_initial_value())]));
+
+    kernel_atomic_int::launch::<I, R>(
         &client,
-        CubeCount::Static(1, 1, 1),
+        CubeCount::new_single(),
         CubeDim::new_1d(1),
         unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+        op,
     );
 
     let actual = client.read_one_unchecked(handle);
-    let actual = u32::from_bytes(&actual);
+    let actual = I::from_bytes(&actual);
 
-    assert_eq!(actual, &[0]);
+    assert_eq!(actual, &[int_expected::<I>(op)]);
 }
 
-#[allow(missing_docs)]
-#[macro_export]
-macro_rules! testgen_atomic_untyped {
-    () => {
-        use super::*;
-
-        #[$crate::runtime_tests::test_log::test]
-        fn test_regression_issue_1218() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_regression_issue_1218::<TestRuntime>(client);
-        }
-    };
-}
-
-#[allow(missing_docs)]
 #[macro_export]
 macro_rules! testgen_atomic_int {
     () => {
         use super::*;
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_add_int() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_add::<TestRuntime, IntType>(
-                client, 1,
-            );
+        macro_rules! test_numeric_op {
+            ($name:ident, $op:expr) => {
+                #[$crate::runtime_tests::test_log::test]
+                fn $name() {
+                    let client = TestRuntime::client(&Default::default());
+                    cubecl_core::runtime_tests::atomic::test_kernel_atomic_numeric::<
+                        TestRuntime,
+                        IntType,
+                    >(client, 1, $op);
+                }
+            };
         }
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_min_int() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_min::<TestRuntime, IntType>(
-                client, 1,
-            );
+        macro_rules! test_int_op {
+            ($name:ident, $op:expr) => {
+                #[$crate::runtime_tests::test_log::test]
+                fn $name() {
+                    let client = TestRuntime::client(&Default::default());
+                    cubecl_core::runtime_tests::atomic::test_kernel_atomic_int::<
+                        TestRuntime,
+                        IntType,
+                    >(client, $op);
+                }
+            };
         }
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_max_int() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_max::<TestRuntime, IntType>(
-                client, 1,
-            );
+        test_numeric_op!(
+            test_atomic_load_int,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Load
+        );
+        test_numeric_op!(
+            test_atomic_store_int,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Store
+        );
+        test_numeric_op!(
+            test_atomic_swap_int,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Swap
+        );
+        test_numeric_op!(
+            test_atomic_add_int,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Add
+        );
+        test_numeric_op!(
+            test_atomic_sub_int,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Sub
+        );
+        test_numeric_op!(
+            test_atomic_min_int,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Min
+        );
+        test_numeric_op!(
+            test_atomic_max_int,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Max
+        );
+
+        test_int_op!(
+            test_atomic_and_int,
+            cubecl_core::runtime_tests::atomic::IntAtomicOp::And
+        );
+        test_int_op!(
+            test_atomic_or_int,
+            cubecl_core::runtime_tests::atomic::IntAtomicOp::Or
+        );
+        test_int_op!(
+            test_atomic_xor_int,
+            cubecl_core::runtime_tests::atomic::IntAtomicOp::Xor
+        );
+        test_int_op!(
+            test_atomic_compare_exchange_int,
+            cubecl_core::runtime_tests::atomic::IntAtomicOp::CompareExchange
+        );
+    };
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! testgen_atomic_uint {
+    () => {
+        use super::*;
+
+        macro_rules! test_numeric_op {
+            ($name:ident, $op:expr) => {
+                #[$crate::runtime_tests::test_log::test]
+                fn $name() {
+                    let client = TestRuntime::client(&Default::default());
+                    cubecl_core::runtime_tests::atomic::test_kernel_atomic_numeric::<
+                        TestRuntime,
+                        UintType,
+                    >(client, 1, $op);
+                }
+            };
         }
+
+        macro_rules! test_int_op {
+            ($name:ident, $op:expr) => {
+                #[$crate::runtime_tests::test_log::test]
+                fn $name() {
+                    let client = TestRuntime::client(&Default::default());
+                    cubecl_core::runtime_tests::atomic::test_kernel_atomic_int::<
+                        TestRuntime,
+                        UintType,
+                    >(client, $op);
+                }
+            };
+        }
+
+        test_numeric_op!(
+            test_atomic_load_uint,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Load
+        );
+        test_numeric_op!(
+            test_atomic_store_uint,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Store
+        );
+        test_numeric_op!(
+            test_atomic_swap_uint,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Swap
+        );
+        test_numeric_op!(
+            test_atomic_add_uint,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Add
+        );
+        test_numeric_op!(
+            test_atomic_sub_uint,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Sub
+        );
+        test_numeric_op!(
+            test_atomic_min_uint,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Min
+        );
+        test_numeric_op!(
+            test_atomic_max_uint,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Max
+        );
+
+        test_int_op!(
+            test_atomic_and_uint,
+            cubecl_core::runtime_tests::atomic::IntAtomicOp::And
+        );
+        test_int_op!(
+            test_atomic_or_uint,
+            cubecl_core::runtime_tests::atomic::IntAtomicOp::Or
+        );
+        test_int_op!(
+            test_atomic_xor_uint,
+            cubecl_core::runtime_tests::atomic::IntAtomicOp::Xor
+        );
+        test_int_op!(
+            test_atomic_compare_exchange_uint,
+            cubecl_core::runtime_tests::atomic::IntAtomicOp::CompareExchange
+        );
     };
 }
 
@@ -217,80 +408,56 @@ macro_rules! testgen_atomic_float {
     () => {
         use super::*;
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_add_float() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_add::<TestRuntime, FloatType>(
-                client, 1,
-            );
+        macro_rules! test_numeric_op {
+            ($name:ident, $op:expr) => {
+                #[$crate::runtime_tests::test_log::test]
+                fn $name() {
+                    let client = TestRuntime::client(&Default::default());
+                    cubecl_core::runtime_tests::atomic::test_kernel_atomic_numeric_all_sizes::<
+                        TestRuntime,
+                        FloatType,
+                    >(client, $op);
+                }
+            };
         }
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_add_float_vec2() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_add::<TestRuntime, FloatType>(
-                client, 2,
-            );
-        }
+        test_numeric_op!(
+            test_atomic_load_float,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Load
+        );
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_add_float_vec4() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_add::<TestRuntime, FloatType>(
-                client, 4,
-            );
-        }
+        test_numeric_op!(
+            test_atomic_store_float,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Store
+        );
 
-        /// Not available on CUDA and I have no access to a GPU that supports it in SPIR-V, but
-        /// here for future proofing. Requires support for `VK_EXT_shader_atomic_float2`.
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_min_float() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_min::<TestRuntime, FloatType>(
-                client, 1,
-            );
-        }
+        test_numeric_op!(
+            test_atomic_swap_float,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Swap
+        );
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_min_float_vec2() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_min::<TestRuntime, FloatType>(
-                client, 2,
-            );
-        }
+        test_numeric_op!(
+            test_atomic_add_float,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Add
+        );
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_min_float_vec4() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_min::<TestRuntime, FloatType>(
-                client, 4,
-            );
-        }
+        test_numeric_op!(
+            test_atomic_sub_float,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Sub
+        );
 
         /// Not available on CUDA and I have no access to a GPU that supports it in SPIR-V, but
         /// here for future proofing. Requires support for `VK_EXT_shader_atomic_float2`.
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_max_float() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_max::<TestRuntime, FloatType>(
-                client, 1,
-            );
-        }
+        test_numeric_op!(
+            test_atomic_min_float,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Min
+        );
 
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_max_float_vec2() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_max::<TestRuntime, FloatType>(
-                client, 2,
-            );
-        }
-
-        #[$crate::runtime_tests::test_log::test]
-        fn test_atomic_max_float_vec4() {
-            let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::atomic::test_kernel_atomic_max::<TestRuntime, FloatType>(
-                client, 4,
-            );
-        }
+        /// Not available on CUDA and I have no access to a GPU that supports it in SPIR-V, but
+        /// here for future proofing. Requires support for `VK_EXT_shader_atomic_float2`.
+        test_numeric_op!(
+            test_atomic_max_float,
+            cubecl_core::runtime_tests::atomic::NumericAtomicOp::Max
+        );
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -128,6 +128,7 @@ macro_rules! testgen_int {
 macro_rules! testgen_uint {
     () => {
         cubecl_core::testgen_const_match!();
+        cubecl_core::testgen_atomic_uint!();
         cubecl_core::testgen_saturating_uint!();
     };
 }
@@ -148,7 +149,6 @@ macro_rules! testgen_untyped {
 
         cubecl_core::testgen_constants!();
         cubecl_core::testgen_sync_plane!();
-        cubecl_core::testgen_atomic_untyped!();
         cubecl_core::testgen_tensor_indexing!();
         cubecl_core::testgen_debug!();
         cubecl_core::testgen_binary_untyped!();

--- a/crates/cubecl-cpu/Cargo.toml
+++ b/crates/cubecl-cpu/Cargo.toml
@@ -61,6 +61,12 @@ serde = { workspace = true }
 sysinfo = { workspace = true }
 tracel-llvm = { workspace = true }
 
+[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "freebsd"))'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { workspace = true }
+
 [dev-dependencies]
 cubecl-core = { path = "../cubecl-core", version = "=0.11.0-pre.1", features = [
     "export_tests",

--- a/crates/cubecl-cpu/src/compiler/external_function.rs
+++ b/crates/cubecl-cpu/src/compiler/external_function.rs
@@ -1,26 +1,18 @@
 use tracel_llvm::mlir_rs::{
     Context, ExecutionEngine,
-    dialect::{
-        func,
-        llvm::{
-            self,
-            attributes::{Linkage, linkage},
-        },
+    dialect::llvm::{
+        self,
+        attributes::{Linkage, linkage},
     },
     ir::{
         BlockLike, Identifier, Location, Region,
         attribute::{StringAttribute, TypeAttribute},
-        r#type::{FunctionType, IntegerType},
+        r#type::IntegerType,
     },
 };
 
-use crate::compute::compute_task::sync_cube;
-
 pub fn register_external_function(execution_engine: &ExecutionEngine) {
     unsafe {
-        execution_engine.register_symbol("sync_cube", sync_cube as *mut ());
-        // This is only there to fool the execution engine to generate .so for inspection even if symbol resolution will probably not work.
-        execution_engine.register_symbol("_mlir_sync_cube", sync_cube as *mut ());
         execution_engine.register_symbol("rsqrtf", rsqrtf as *mut ());
         execution_engine.register_symbol("rsqrt", rsqrt as *mut ());
     }
@@ -38,6 +30,7 @@ pub fn add_external_function_to_module<'a>(
     context: &'a Context,
     module: &tracel_llvm::mlir_rs::ir::Module<'a>,
 ) {
+    let location = Location::unknown(context);
     let integer_type = IntegerType::new(context, 32).into();
     let func_type = TypeAttribute::new(llvm::r#type::function(
         integer_type,
@@ -53,19 +46,6 @@ pub fn add_external_function_to_module<'a>(
             Identifier::new(context, "linkage"),
             linkage(context, Linkage::External),
         )],
-        Location::unknown(context),
-    ));
-    let func_name = StringAttribute::new(context, "sync_cube");
-    let func_type = TypeAttribute::new(FunctionType::new(context, &[], &[]).into());
-    module.body().append_operation(func::func(
-        context,
-        func_name,
-        func_type,
-        Region::new(),
-        &[(
-            Identifier::new(context, "sym_visibility"),
-            StringAttribute::new(context, "private").into(),
-        )],
-        Location::unknown(context),
+        location,
     ));
 }

--- a/crates/cubecl-cpu/src/compiler/mlir_data.rs
+++ b/crates/cubecl-cpu/src/compiler/mlir_data.rs
@@ -76,7 +76,8 @@ impl MlirData {
         let cube_dim_size = cube_dim.num_elems() as i32;
 
         let builtin = BuiltinArray::new(cube_dim, cube_count);
-        let max_buffer_size = resources.len() + shared_memories.0.len() + BuiltinArray::len() + 2;
+        let indirect_args_len = resources.len() + shared_memories.0.len() + 2;
+        let total_args_len = indirect_args_len + BuiltinArray::len();
 
         let args_zero_indirection = Vec::with_capacity(indirect_args_len);
         let args_first_indirection = Vec::with_capacity(indirect_args_len);

--- a/crates/cubecl-cpu/src/compiler/mlir_data.rs
+++ b/crates/cubecl-cpu/src/compiler/mlir_data.rs
@@ -5,12 +5,42 @@ use crate::{
 };
 use cubecl_core::CubeDim;
 use cubecl_runtime::{memory_management::MemoryManagement, storage::BytesStorage};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicI32, Ordering},
+};
+
+pub const SYNC_BARRIER_COUNTER_INDEX: usize = 0;
+pub const SYNC_STOPPED_COUNTER_INDEX: usize = 1;
+pub const SYNC_BARRIER_TARGET_INDEX: usize = 2;
+pub const SYNC_CURRENT_CUBE_DIM_INDEX: usize = 3;
+
+pub struct SyncCubeState {
+    pub atomics: [AtomicI32; Self::len()],
+}
+
+impl SyncCubeState {
+    pub const fn len() -> usize {
+        4
+    }
+
+    fn new(cube_dim_size: i32) -> Self {
+        Self {
+            atomics: [
+                AtomicI32::new(0),
+                AtomicI32::new(0),
+                AtomicI32::new(cube_dim_size),
+                AtomicI32::new(cube_dim_size),
+            ],
+        }
+    }
+}
 
 pub struct SharedMlirData {
     pub args_zero_indirection: Vec<LineMemRef>,
     pub info: Vec<u64>,
     pub args_first_indirection: Vec<*mut ()>,
+    pub sync_cube_state: Box<SyncCubeState>,
 }
 
 unsafe impl Send for SharedMlirData {}
@@ -43,10 +73,10 @@ impl MlirData {
         cube_count: [u32; 3],
     ) -> Self {
         let BindingsResource { resources, info } = bindings;
+        let cube_dim_size = cube_dim.num_elems() as i32;
 
         let builtin = BuiltinArray::new(cube_dim, cube_count);
-        let indirect_args_len = resources.len() + shared_memories.0.len() + 1;
-        let total_args_len = indirect_args_len + BuiltinArray::len();
+        let max_buffer_size = resources.len() + shared_memories.0.len() + BuiltinArray::len() + 2;
 
         let args_zero_indirection = Vec::with_capacity(indirect_args_len);
         let args_first_indirection = Vec::with_capacity(indirect_args_len);
@@ -57,6 +87,7 @@ impl MlirData {
             args_zero_indirection,
             args_first_indirection,
             info,
+            sync_cube_state: Box::new(SyncCubeState::new(cube_dim_size)),
         };
 
         let mut push_undirected = |line_memref: LineMemRef| {
@@ -102,6 +133,9 @@ impl MlirData {
         let line_memref = LineMemRef::new(ptr, info_len_bytes);
         push_undirected(line_memref);
 
+        let sync_cube_state = shared_mlir_data.sync_cube_state.atomics.as_mut_ptr() as *mut u8;
+        push_undirected(LineMemRef::new(sync_cube_state, SyncCubeState::len()));
+
         let shared_mlir_data = Arc::new(shared_mlir_data);
 
         Self {
@@ -116,5 +150,10 @@ impl MlirData {
             self.args_second_indirection
                 .push(arg as *mut u32 as *mut ());
         }
+    }
+
+    pub fn complete_unit(&self) {
+        self.shared_mlir_data.sync_cube_state.atomics[SYNC_CURRENT_CUBE_DIM_INDEX]
+            .fetch_sub(1, Ordering::AcqRel);
     }
 }

--- a/crates/cubecl-cpu/src/compiler/visitor/args_manager.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/args_manager.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use cubecl_core::{
     Info, Metadata,
-    ir::{Builtin, ElemType, StorageType, UIntKind},
+    ir::{Builtin, ElemType, IntKind, StorageType, UIntKind},
     prelude::{KernelDefinition, ScalarKernelArg},
 };
 use tracel_llvm::mlir_rs::{
@@ -21,6 +21,7 @@ use crate::compiler::{
 use super::prelude::*;
 
 const NB_BUILTIN: usize = 31;
+const NB_SYNC_CUBE_ARGS: usize = 1;
 
 pub(super) struct ArgsManagerBuilder<'a, 'b> {
     scalars: Vec<ScalarKernelArg>,
@@ -44,6 +45,7 @@ impl<'a, 'b> ArgsManagerBuilder<'a, 'b> {
     ) -> Self {
         let total_arg_len = kernel.buffers.len()
             + kernel.scalars.len()
+            + NB_SYNC_CUBE_ARGS
             + NB_PASSED_BUILTIN
             + shared_memories.0.len();
 
@@ -105,6 +107,16 @@ impl<'a, 'b> ArgsManagerBuilder<'a, 'b> {
         args.function_types.push(memref);
         args.block_inputs.push((memref, location));
 
+        let sync_memref = MemRefType::new(
+            ElemType::Int(IntKind::I32).to_type(context),
+            &[4],
+            None,
+            None,
+        )
+        .into();
+        args.function_types.push(sync_memref);
+        args.block_inputs.push((sync_memref, location));
+
         let integer_type: Type<'_> = IntegerType::new(context, 32).into();
         for _ in 0..9 {
             args.function_types.push(integer_type);
@@ -135,6 +147,7 @@ impl<'a, 'b> ArgsManagerBuilder<'a, 'b> {
             ext_meta_positions: self.ext_meta_positions.clone(),
             addr_type: self.addr_type,
             addr_size: self.addr_size,
+            sync_cube_state: None,
         };
 
         let block = Block::new(&self.block_inputs);
@@ -227,6 +240,9 @@ impl<'a, 'b> ArgsManagerBuilder<'a, 'b> {
                 Some(block.append_operation(view).result(0).unwrap().into());
         }
 
+        args.sync_cube_state = Some(block.argument(total_len).unwrap().into());
+        total_len += 1;
+
         for (i, builtin) in BuiltinArray::builtin_order().into_iter().enumerate() {
             let i = i + total_len;
             args.set(builtin, block.argument(i).unwrap().into());
@@ -248,6 +264,7 @@ pub(super) struct ArgsManager<'a> {
     pub builtin: [Option<Value<'a, 'a>>; NB_BUILTIN],
     pub addr_type: Type<'a>,
     pub addr_size: usize,
+    pub sync_cube_state: Option<Value<'a, 'a>>,
 }
 
 const NB_PASSED_BUILTIN: usize = 9;

--- a/crates/cubecl-cpu/src/compiler/visitor/elem.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/elem.rs
@@ -1,6 +1,6 @@
 use cubecl_core::ir::{
     AddressType, DeviceProperties, ElemType, FloatKind, IntKind, OpaqueType, StorageType, UIntKind,
-    features::TypeUsage,
+    features::{AtomicUsage, TypeUsage},
 };
 use tracel_llvm::mlir_rs::{
     dialect::index,
@@ -89,5 +89,22 @@ pub fn register_supported_types(props: &mut DeviceProperties) {
 
     for ty in supported_types {
         props.register_type_usage(ty, TypeUsage::all());
+    }
+
+    let atomic_types = [
+        ElemType::Int(IntKind::I8),
+        ElemType::Int(IntKind::I16),
+        ElemType::Int(IntKind::I32),
+        ElemType::Int(IntKind::I64),
+        ElemType::UInt(UIntKind::U8),
+        ElemType::UInt(UIntKind::U16),
+        ElemType::UInt(UIntKind::U32),
+        ElemType::UInt(UIntKind::U64),
+        ElemType::Float(FloatKind::F32),
+        ElemType::Float(FloatKind::F64),
+    ];
+
+    for ty in atomic_types {
+        props.register_atomic_type_usage(cubecl_core::ir::Type::atomic(ty), AtomicUsage::all())
     }
 }

--- a/crates/cubecl-cpu/src/compiler/visitor/elem.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/elem.rs
@@ -81,15 +81,10 @@ pub fn register_supported_types(props: &mut DeviceProperties) {
         ElemType::Int(IntKind::I16),
         ElemType::Int(IntKind::I32),
         ElemType::Int(IntKind::I64),
-        // Elem::AtomicInt(IntKind::I32),
-        // Elem::AtomicInt(IntKind::I64),
-        // Elem::AtomicUInt(UIntKind::U32),
-        // Elem::AtomicUInt(UIntKind::U64),
         ElemType::Float(FloatKind::BF16),
         ElemType::Float(FloatKind::F16),
         ElemType::Float(FloatKind::F32),
         ElemType::Float(FloatKind::F64),
-        // Elem::Bool,
     ];
 
     for ty in supported_types {

--- a/crates/cubecl-cpu/src/compiler/visitor/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/mod.rs
@@ -202,7 +202,7 @@ impl<'a> Visitor<'a> {
             ));
         }
         add_external_function_to_module(context, module);
-        add_sync_cube_function(context, module, location);
+        add_sync_cube_function(context, module).unwrap();
         module.body().append_operation(func::func(
             context,
             name,

--- a/crates/cubecl-cpu/src/compiler/visitor/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/mod.rs
@@ -37,6 +37,8 @@ use tracel_llvm::mlir_rs::{
 use prelude::*;
 use variables::Variables;
 
+use crate::compiler::visitor::operation::synchronization::add_sync_cube_function;
+
 use super::{
     external_function::add_external_function_to_module, passes::shared_memories::SharedMemories,
 };
@@ -200,6 +202,7 @@ impl<'a> Visitor<'a> {
             ));
         }
         add_external_function_to_module(context, module);
+        add_sync_cube_function(context, module, location);
         module.body().append_operation(func::func(
             context,
             name,

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/atomic.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/atomic.rs
@@ -1,0 +1,60 @@
+use cubecl_core::ir::{AtomicBinaryOperands, AtomicOp, Variable};
+use tracel_llvm::mlir_rs::{
+    dialect::{arith::AtomicRMWKind, memref},
+    ir::{Attribute, Operation, attribute::StringAttribute},
+};
+
+use crate::compiler::visitor::{Visitor, operation, prelude::IntoType};
+
+impl<'a> Visitor<'a> {
+    pub fn visit_atomic(&mut self, atomic: &AtomicOp, out: Variable) {
+        let operation = match atomic {
+            AtomicOp::Load(variable) => todo!(),
+            AtomicOp::Store(store_operands) => todo!(),
+            AtomicOp::Swap(op)
+            | AtomicOp::Add(op)
+            | AtomicOp::Sub(op)
+            | AtomicOp::Max(op)
+            | AtomicOp::Min(op)
+            | AtomicOp::And(op)
+            | AtomicOp::Or(op)
+            | AtomicOp::Xor(op) => self.visit_atomic_binary_operands(atomic, op),
+            AtomicOp::CompareAndSwap(compare_and_swap_operands) => todo!(),
+        };
+        let value = self.append_operation_with_result(operation);
+        self.insert_variable(out, value);
+    }
+    fn visit_atomic_binary_operands(
+        &self,
+        atomic: &AtomicOp,
+        atomic_binary_operands: &AtomicBinaryOperands,
+    ) -> Operation<'a> {
+        let ty = atomic_binary_operands.ptr.ty.elem_type();
+        let value = if let AtomicOp::Sub(_) = atomic {
+            self.get_neg_val(atomic_binary_operands.value)
+        } else {
+            self.get_variable(atomic_binary_operands.value)
+        };
+        let kind = match atomic {
+            AtomicOp::Swap(_) => AtomicRMWKind::Assign,
+            AtomicOp::Add(_) if ty.is_float() => AtomicRMWKind::AddF,
+            AtomicOp::Add(_) if ty.is_int() => AtomicRMWKind::AddI,
+            AtomicOp::Sub(_) if ty.is_float() => AtomicRMWKind::AddF,
+            AtomicOp::Sub(_) if ty.is_int() => AtomicRMWKind::AddI,
+            AtomicOp::Max(_) if ty.is_float() => AtomicRMWKind::MaximumF,
+            AtomicOp::Max(_) if ty.is_signed_int() => AtomicRMWKind::MaxS,
+            AtomicOp::Max(_) if ty.is_unsigned_int() => AtomicRMWKind::MaxU,
+            AtomicOp::Min(_) if ty.is_float() => AtomicRMWKind::MinimumF,
+            AtomicOp::Min(_) if ty.is_signed_int() => AtomicRMWKind::MinS,
+            AtomicOp::Min(_) if ty.is_unsigned_int() => AtomicRMWKind::MinU,
+            AtomicOp::And(_) => AtomicRMWKind::AndI,
+            AtomicOp::Or(_) => AtomicRMWKind::OrI,
+            AtomicOp::Xor(_) => AtomicRMWKind::XOrI,
+            _ => unreachable!(),
+        };
+        let memref = self.get_variable(atomic_binary_operands.ptr);
+        let zero = self.create_constant_index(0);
+
+        memref::atomic_rmw(self.context, kind, value, memref, &[zero], self.location).into()
+    }
+}

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/atomic.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/atomic.rs
@@ -5,7 +5,11 @@ use tracel_llvm::mlir_rs::{
         llvm::{self, CmpXchgOptions, LoadStoreOptions, attributes::AtomicOrdering, r#type},
         memref,
     },
-    ir::{BlockLike, Value, attribute::IntegerAttribute, r#type::IntegerType},
+    ir::{
+        BlockLike, Value,
+        attribute::{DenseI64ArrayAttribute, IntegerAttribute},
+        r#type::IntegerType,
+    },
 };
 
 use crate::compiler::visitor::{Visitor, prelude::IntoType};
@@ -74,6 +78,13 @@ impl<'a> Visitor<'a> {
                     extra_options,
                 ));
                 if let Some(out) = out {
+                    let value = self.append_operation_with_result(llvm::extract_value(
+                        self.context,
+                        value,
+                        DenseI64ArrayAttribute::new(self.context, &[0]),
+                        out.ty.to_type(self.context),
+                        self.location,
+                    ));
                     self.insert_variable(out, value);
                 }
             }

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/atomic.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/atomic.rs
@@ -11,8 +11,28 @@ use tracel_llvm::mlir_rs::{
 use crate::compiler::visitor::{Visitor, prelude::IntoType};
 
 impl<'a> Visitor<'a> {
-    pub fn visit_atomic_without_out(&mut self, atomic: &AtomicOp) {
+    pub fn visit_atomic(&mut self, atomic: &AtomicOp, out: Option<Variable>) {
         match atomic {
+            AtomicOp::Load(variable) => {
+                let raw_ptr = self.get_raw_ptr(*variable);
+                let size = variable.ty.elem_type().size();
+                let integer_type = IntegerType::new(self.context, 64).into();
+                let size = IntegerAttribute::new(integer_type, size as i64);
+                let extra_options = LoadStoreOptions::new()
+                    .atomic(AtomicOrdering::Unordered)
+                    .align(Some(size));
+                let ty = variable.ty.to_type(self.context);
+                let value = self.append_operation_with_result(llvm::load(
+                    self.context,
+                    raw_ptr,
+                    ty,
+                    self.location,
+                    extra_options,
+                ));
+                if let Some(out) = out {
+                    self.insert_variable(out, value);
+                }
+            }
             AtomicOp::Store(store_operands) => {
                 let raw_ptr = self.get_raw_ptr(store_operands.ptr);
                 let value = self.get_variable(store_operands.value);
@@ -30,32 +50,6 @@ impl<'a> Visitor<'a> {
                     extra_options,
                 ));
             }
-            _ => unreachable!("Impossible to reach all other operation require an out"),
-        }
-    }
-    pub fn visit_atomic_with_out(&mut self, atomic: &AtomicOp, out: Variable) {
-        match atomic {
-            AtomicOp::Load(variable) => {
-                let raw_ptr = self.get_raw_ptr(*variable);
-                let size = out.ty.elem_type().size();
-                let integer_type = IntegerType::new(self.context, 64).into();
-                let size = IntegerAttribute::new(integer_type, size as i64);
-                let extra_options = LoadStoreOptions::new()
-                    .atomic(AtomicOrdering::Unordered)
-                    .align(Some(size));
-                let ty = out.ty.to_type(self.context);
-                let value = self.append_operation_with_result(llvm::load(
-                    self.context,
-                    raw_ptr,
-                    ty,
-                    self.location,
-                    extra_options,
-                ));
-                self.insert_variable(out, value);
-            }
-            AtomicOp::Store(_) => {
-                unreachable!("A store operand can't have an out")
-            }
             AtomicOp::Swap(op)
             | AtomicOp::Add(op)
             | AtomicOp::Sub(op)
@@ -69,7 +63,7 @@ impl<'a> Visitor<'a> {
                 let cmp = self.get_variable(compare_and_swap_operands.cmp);
                 let val = self.get_variable(compare_and_swap_operands.val);
                 let extra_options = CmpXchgOptions::new();
-                self.block.append_operation(llvm::cmpxchg(
+                let value = self.append_operation_with_result(llvm::cmpxchg(
                     self.context,
                     ptr,
                     cmp,
@@ -79,6 +73,9 @@ impl<'a> Visitor<'a> {
                     self.location,
                     extra_options,
                 ));
+                if let Some(out) = out {
+                    self.insert_variable(out, value);
+                }
             }
         };
     }
@@ -101,7 +98,7 @@ impl<'a> Visitor<'a> {
         &mut self,
         atomic: &AtomicOp,
         atomic_binary_operands: &AtomicBinaryOperands,
-        out: Variable,
+        out: Option<Variable>,
     ) {
         let ty = atomic_binary_operands.ptr.ty.elem_type();
         let value = if let AtomicOp::Sub(_) = atomic {
@@ -137,6 +134,8 @@ impl<'a> Visitor<'a> {
             &[zero],
             self.location,
         ));
-        self.insert_variable(out, value);
+        if let Some(out) = out {
+            self.insert_variable(out, value);
+        }
     }
 }

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/atomic.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/atomic.rs
@@ -1,16 +1,61 @@
 use cubecl_core::ir::{AtomicBinaryOperands, AtomicOp, Variable};
 use tracel_llvm::mlir_rs::{
-    dialect::{arith::AtomicRMWKind, memref},
-    ir::{Attribute, Operation, attribute::StringAttribute},
+    dialect::{
+        arith::{self, AtomicRMWKind},
+        llvm::{self, CmpXchgOptions, LoadStoreOptions, attributes::AtomicOrdering, r#type},
+        memref,
+    },
+    ir::{BlockLike, Value, attribute::IntegerAttribute, r#type::IntegerType},
 };
 
-use crate::compiler::visitor::{Visitor, operation, prelude::IntoType};
+use crate::compiler::visitor::{Visitor, prelude::IntoType};
 
 impl<'a> Visitor<'a> {
-    pub fn visit_atomic(&mut self, atomic: &AtomicOp, out: Variable) {
-        let operation = match atomic {
-            AtomicOp::Load(variable) => todo!(),
-            AtomicOp::Store(store_operands) => todo!(),
+    pub fn visit_atomic_without_out(&mut self, atomic: &AtomicOp) {
+        match atomic {
+            AtomicOp::Store(store_operands) => {
+                let raw_ptr = self.get_raw_ptr(store_operands.ptr);
+                let value = self.get_variable(store_operands.value);
+                let size = store_operands.value.ty.elem_type().size();
+                let integer_type = IntegerType::new(self.context, 64).into();
+                let size = IntegerAttribute::new(integer_type, size as i64);
+                let extra_options = LoadStoreOptions::new()
+                    .atomic(AtomicOrdering::Unordered)
+                    .align(Some(size));
+                self.block.append_operation(llvm::store(
+                    self.context,
+                    value,
+                    raw_ptr,
+                    self.location,
+                    extra_options,
+                ));
+            }
+            _ => unreachable!("Impossible to reach all other operation require an out"),
+        }
+    }
+    pub fn visit_atomic_with_out(&mut self, atomic: &AtomicOp, out: Variable) {
+        match atomic {
+            AtomicOp::Load(variable) => {
+                let raw_ptr = self.get_raw_ptr(*variable);
+                let size = out.ty.elem_type().size();
+                let integer_type = IntegerType::new(self.context, 64).into();
+                let size = IntegerAttribute::new(integer_type, size as i64);
+                let extra_options = LoadStoreOptions::new()
+                    .atomic(AtomicOrdering::Unordered)
+                    .align(Some(size));
+                let ty = out.ty.to_type(self.context);
+                let value = self.append_operation_with_result(llvm::load(
+                    self.context,
+                    raw_ptr,
+                    ty,
+                    self.location,
+                    extra_options,
+                ));
+                self.insert_variable(out, value);
+            }
+            AtomicOp::Store(_) => {
+                unreachable!("A store operand can't have an out")
+            }
             AtomicOp::Swap(op)
             | AtomicOp::Add(op)
             | AtomicOp::Sub(op)
@@ -18,17 +63,46 @@ impl<'a> Visitor<'a> {
             | AtomicOp::Min(op)
             | AtomicOp::And(op)
             | AtomicOp::Or(op)
-            | AtomicOp::Xor(op) => self.visit_atomic_binary_operands(atomic, op),
-            AtomicOp::CompareAndSwap(compare_and_swap_operands) => todo!(),
+            | AtomicOp::Xor(op) => self.visit_atomic_binary_operands(atomic, op, out),
+            AtomicOp::CompareAndSwap(compare_and_swap_operands) => {
+                let ptr = self.get_raw_ptr(compare_and_swap_operands.ptr);
+                let cmp = self.get_variable(compare_and_swap_operands.cmp);
+                let val = self.get_variable(compare_and_swap_operands.val);
+                let extra_options = CmpXchgOptions::new();
+                self.block.append_operation(llvm::cmpxchg(
+                    self.context,
+                    ptr,
+                    cmp,
+                    val,
+                    AtomicOrdering::Monotonic,
+                    AtomicOrdering::Monotonic,
+                    self.location,
+                    extra_options,
+                ));
+            }
         };
-        let value = self.append_operation_with_result(operation);
-        self.insert_variable(out, value);
+    }
+    fn get_raw_ptr(&mut self, variable: Variable) -> Value<'a, 'a> {
+        let value = self.get_memory(variable);
+        let value = self.append_operation_with_result(memref::extract_aligned_pointer_as_index(
+            value,
+            self.location,
+        ));
+        let integer_ty = IntegerType::new(self.context, 64);
+        let int = self.append_operation_with_result(arith::index_cast(
+            value,
+            integer_ty.into(),
+            self.location,
+        ));
+        let ptr_ty = r#type::pointer(self.context, 0);
+        self.append_operation_with_result(llvm::inttoptr(int, ptr_ty, self.location))
     }
     fn visit_atomic_binary_operands(
-        &self,
+        &mut self,
         atomic: &AtomicOp,
         atomic_binary_operands: &AtomicBinaryOperands,
-    ) -> Operation<'a> {
+        out: Variable,
+    ) {
         let ty = atomic_binary_operands.ptr.ty.elem_type();
         let value = if let AtomicOp::Sub(_) = atomic {
             self.get_neg_val(atomic_binary_operands.value)
@@ -52,9 +126,17 @@ impl<'a> Visitor<'a> {
             AtomicOp::Xor(_) => AtomicRMWKind::XOrI,
             _ => unreachable!(),
         };
-        let memref = self.get_variable(atomic_binary_operands.ptr);
+        let memref = self.get_memory(atomic_binary_operands.ptr);
         let zero = self.create_constant_index(0);
 
-        memref::atomic_rmw(self.context, kind, value, memref, &[zero], self.location).into()
+        let value = self.append_operation_with_result(memref::atomic_rmw(
+            self.context,
+            kind,
+            value,
+            memref,
+            &[zero],
+            self.location,
+        ));
+        self.insert_variable(out, value);
     }
 }

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
@@ -115,6 +115,9 @@ impl<'a> Visitor<'a> {
                 self.visit_synchronization(synchronization);
             }
             Operation::Marker(_) => {}
+            Operation::Atomic(atomic) => {
+                self.visit_atomic_without_out(atomic);
+            }
             operation => {
                 todo!(
                     "This operation ({}) is not implemented without an out",
@@ -130,7 +133,7 @@ impl<'a> Visitor<'a> {
                 self.visit_memory(memory, Some(out));
             }
             Operation::Atomic(atomic) => {
-                self.visit_atomic(atomic, out);
+                self.visit_atomic_with_out(atomic, out);
             }
             Operation::Arithmetic(arithmetic) => {
                 self.visit_arithmetic(arithmetic, out);

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod arithmetic;
+pub(super) mod atomic;
 pub(super) mod bitwise;
 pub(super) mod comparison;
 pub(super) mod metadata;
@@ -128,8 +129,8 @@ impl<'a> Visitor<'a> {
             Operation::Memory(memory) => {
                 self.visit_memory(memory, Some(out));
             }
-            Operation::Atomic(_atomic) => {
-                todo!("Atomic operation are not yet supported");
+            Operation::Atomic(atomic) => {
+                self.visit_atomic(atomic, out);
             }
             Operation::Arithmetic(arithmetic) => {
                 self.visit_arithmetic(arithmetic, out);

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
@@ -7,7 +7,7 @@ pub(super) mod operator;
 pub(super) mod synchronization;
 
 use cubecl_core::ir::{
-    BarrierLevel, BarrierOps, Memory, NonSemantic, OpaqueType, Operation, StorageType,
+    AtomicOp, BarrierLevel, BarrierOps, Memory, NonSemantic, OpaqueType, Operation, StorageType,
     Synchronization,
 };
 use tracel_llvm::mlir_rs::{
@@ -165,9 +165,10 @@ impl<'a> Visitor<'a> {
             }
             Operation::WorkgroupUniformLoad(input) => {
                 if input.ty.is_atomic() {
-                    todo!("Atomic operations are not yet supported on CPU");
+                    self.visit_atomic(&AtomicOp::Load(*input), Some(out));
+                } else {
+                    self.visit_memory(&Memory::Load(*input), Some(out));
                 }
-                self.visit_memory(&Memory::Load(*input), Some(out));
             }
             Operation::CoopMma(_)
             | Operation::Plane(_)

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/mod.rs
@@ -116,7 +116,7 @@ impl<'a> Visitor<'a> {
             }
             Operation::Marker(_) => {}
             Operation::Atomic(atomic) => {
-                self.visit_atomic_without_out(atomic);
+                self.visit_atomic(atomic, None);
             }
             operation => {
                 todo!(
@@ -133,7 +133,7 @@ impl<'a> Visitor<'a> {
                 self.visit_memory(memory, Some(out));
             }
             Operation::Atomic(atomic) => {
-                self.visit_atomic_with_out(atomic, out);
+                self.visit_atomic(atomic, Some(out));
             }
             Operation::Arithmetic(arithmetic) => {
                 self.visit_arithmetic(arithmetic, out);

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
@@ -1,7 +1,350 @@
-use cubecl_core::ir::Synchronization;
-use tracel_llvm::mlir_rs::{dialect::func, ir::attribute::FlatSymbolRefAttribute};
+use std::ops::Deref;
 
-use crate::compiler::visitor::prelude::*;
+use cubecl_core::ir::Synchronization;
+use tracel_llvm::mlir_rs::{
+    dialect::{
+        arith::{self, AtomicRMWKind, CmpiPredicate},
+        cf, func,
+        llvm::{self, LoadStoreOptions, attributes::AtomicOrdering},
+        memref,
+    },
+    ir::{
+        Block, BlockRef, Identifier, Location, Region,
+        attribute::{FlatSymbolRefAttribute, IntegerAttribute, StringAttribute, TypeAttribute},
+        r#type::{FunctionType, IntegerType, MemRefType},
+    },
+};
+
+use crate::compiler::{
+    mlir_data::{
+        SYNC_BARRIER_COUNTER_INDEX, SYNC_BARRIER_TARGET_INDEX, SYNC_STOPPED_COUNTER_INDEX,
+    },
+    visitor::prelude::*,
+};
+
+pub fn add_sync_cube_function<'a>(
+    context: &'a Context,
+    module: &tracel_llvm::mlir_rs::ir::Module<'a>,
+    location: Location<'a>,
+) {
+    let i32_type = IntegerType::new(context, 32).into();
+    let memref_type = MemRefType::new(i32_type, &[4], None, None).into();
+    let func_type = TypeAttribute::new(FunctionType::new(context, &[memref_type], &[]).into());
+
+    module.body().append_operation(func::func(
+        context,
+        StringAttribute::new(context, "sync_cube"),
+        func_type,
+        {
+            let region = Region::new();
+            let entry = region.append_block(Block::new(&[(memref_type, location)]));
+            let wait_stopped = region.append_block(Block::new(&[]));
+            let arrive = region.append_block(Block::new(&[]));
+            let wait_arrived = region.append_block(Block::new(&[]));
+            let increment_stopped = region.append_block(Block::new(&[]));
+            let reset = region.append_block(Block::new(&[]));
+            let done = region.append_block(Block::new(&[]));
+
+            let sync_cube_state: Value<'a, 'a> = entry.argument(0).unwrap().into();
+            let zero_i32 = const_i32(context, entry, location, 0);
+            let one_i32 = const_i32(context, entry, location, 1);
+            let barrier_counter_index =
+                const_index(context, entry, location, SYNC_BARRIER_COUNTER_INDEX as i64);
+            let stopped_counter_index =
+                const_index(context, entry, location, SYNC_STOPPED_COUNTER_INDEX as i64);
+            let barrier_target_index =
+                const_index(context, entry, location, SYNC_BARRIER_TARGET_INDEX as i64);
+            let barrier_target_value = atomic_load_i32(
+                context,
+                entry,
+                sync_cube_state,
+                barrier_target_index,
+                location,
+            );
+            let skip_sync = entry
+                .append_op_result(arith::cmpi(
+                    context,
+                    CmpiPredicate::Sle,
+                    barrier_target_value,
+                    one_i32,
+                    location,
+                ))
+                .unwrap();
+            entry.append_operation(cf::cond_br(
+                context,
+                skip_sync,
+                done.deref(),
+                wait_stopped.deref(),
+                &[],
+                &[],
+                location,
+            ));
+
+            let stopped_value = atomic_load_i32(
+                context,
+                wait_stopped,
+                sync_cube_state,
+                stopped_counter_index,
+                location,
+            );
+            let stopped_is_busy = wait_stopped
+                .append_op_result(arith::cmpi(
+                    context,
+                    CmpiPredicate::Ne,
+                    stopped_value,
+                    zero_i32,
+                    location,
+                ))
+                .unwrap();
+            wait_stopped.append_operation(cf::cond_br(
+                context,
+                stopped_is_busy,
+                wait_stopped.deref(),
+                arrive.deref(),
+                &[],
+                &[],
+                location,
+            ));
+
+            arrive.append_operation(llvm::fence(
+                context,
+                AtomicOrdering::Release,
+                None,
+                location,
+            ));
+            let arrived_prev = arrive
+                .append_op_result(memref::atomic_rmw(
+                    context,
+                    AtomicRMWKind::AddI,
+                    one_i32,
+                    sync_cube_state,
+                    &[barrier_counter_index],
+                    location,
+                ))
+                .unwrap();
+            let arrived = arrive
+                .append_op_result(arith::addi(arrived_prev, one_i32, location))
+                .unwrap();
+            let arrived_needs_wait = arrive
+                .append_op_result(arith::cmpi(
+                    context,
+                    CmpiPredicate::Slt,
+                    arrived,
+                    barrier_target_value,
+                    location,
+                ))
+                .unwrap();
+            arrive.append_operation(cf::cond_br(
+                context,
+                arrived_needs_wait,
+                wait_arrived.deref(),
+                increment_stopped.deref(),
+                &[],
+                &[],
+                location,
+            ));
+
+            let barrier_counter_value = atomic_load_i32(
+                context,
+                wait_arrived,
+                sync_cube_state,
+                barrier_counter_index,
+                location,
+            );
+            let wait_more = wait_arrived
+                .append_op_result(arith::cmpi(
+                    context,
+                    CmpiPredicate::Slt,
+                    barrier_counter_value,
+                    barrier_target_value,
+                    location,
+                ))
+                .unwrap();
+            wait_arrived.append_operation(cf::cond_br(
+                context,
+                wait_more,
+                wait_arrived.deref(),
+                increment_stopped.deref(),
+                &[],
+                &[],
+                location,
+            ));
+
+            increment_stopped.append_operation(llvm::fence(
+                context,
+                AtomicOrdering::Acquire,
+                None,
+                location,
+            ));
+            let stopped_prev = increment_stopped
+                .append_op_result(memref::atomic_rmw(
+                    context,
+                    AtomicRMWKind::AddI,
+                    one_i32,
+                    sync_cube_state,
+                    &[stopped_counter_index],
+                    location,
+                ))
+                .unwrap();
+            let stopped = increment_stopped
+                .append_op_result(arith::addi(stopped_prev, one_i32, location))
+                .unwrap();
+            let should_reset = increment_stopped
+                .append_op_result(arith::cmpi(
+                    context,
+                    CmpiPredicate::Eq,
+                    stopped,
+                    barrier_target_value,
+                    location,
+                ))
+                .unwrap();
+            increment_stopped.append_operation(cf::cond_br(
+                context,
+                should_reset,
+                reset.deref(),
+                done.deref(),
+                &[],
+                &[],
+                location,
+            ));
+
+            atomic_store_i32(
+                context,
+                reset,
+                sync_cube_state,
+                barrier_counter_index,
+                zero_i32,
+                location,
+            );
+            atomic_store_i32(
+                context,
+                reset,
+                sync_cube_state,
+                stopped_counter_index,
+                zero_i32,
+                location,
+            );
+            reset.append_operation(cf::br(done.deref(), &[], location));
+
+            done.append_operation(func::r#return(&[], location));
+            region
+        },
+        &[(
+            Identifier::new(context, "sym_visibility"),
+            StringAttribute::new(context, "private").into(),
+        )],
+        location,
+    ));
+}
+
+fn const_i32<'a>(
+    context: &'a Context,
+    block: BlockRef<'a, 'a>,
+    location: Location<'a>,
+    value: i64,
+) -> Value<'a, 'a> {
+    block
+        .append_op_result(arith::constant(
+            context,
+            IntegerAttribute::new(IntegerType::new(context, 32).into(), value).into(),
+            location,
+        ))
+        .unwrap()
+}
+
+fn const_index<'a>(
+    context: &'a Context,
+    block: BlockRef<'a, 'a>,
+    location: Location<'a>,
+    value: i64,
+) -> Value<'a, 'a> {
+    block
+        .append_op_result(arith::constant(
+            context,
+            IntegerAttribute::new(Type::index(context), value).into(),
+            location,
+        ))
+        .unwrap()
+}
+
+fn memref_to_atomic_i32<'a>(
+    context: &'a Context,
+    block: BlockRef<'a, 'a>,
+    memref: Value<'a, 'a>,
+    index: Value<'a, 'a>,
+    location: Location<'a>,
+) -> Value<'a, 'a> {
+    let index_ptr = block
+        .append_op_result(memref::extract_aligned_pointer_as_index(memref, location))
+        .unwrap();
+    let int_ptr = block
+        .append_op_result(arith::index_cast(
+            index_ptr,
+            IntegerType::new(context, 64).into(),
+            location,
+        ))
+        .unwrap();
+    let ptr = block
+        .append_op_result(llvm::inttoptr(
+            int_ptr,
+            llvm::r#type::pointer(context, 0),
+            location,
+        ))
+        .unwrap();
+    block
+        .append_op_result(llvm::get_element_ptr_dynamic(
+            context,
+            ptr,
+            &[index],
+            IntegerType::new(context, 32).into(),
+            llvm::r#type::pointer(context, 0),
+            location,
+        ))
+        .unwrap()
+}
+
+fn atomic_load_i32<'a>(
+    context: &'a Context,
+    block: BlockRef<'a, 'a>,
+    memref: Value<'a, 'a>,
+    index: Value<'a, 'a>,
+    location: Location<'a>,
+) -> Value<'a, 'a> {
+    let ptr = memref_to_atomic_i32(context, block, memref, index, location);
+    let options = LoadStoreOptions::new()
+        .atomic(AtomicOrdering::Acquire)
+        .align(Some(IntegerAttribute::new(
+            IntegerType::new(context, 64).into(),
+            4,
+        )));
+    block
+        .append_op_result(llvm::load(
+            context,
+            ptr,
+            IntegerType::new(context, 32).into(),
+            location,
+            options,
+        ))
+        .unwrap()
+}
+
+fn atomic_store_i32<'a>(
+    context: &'a Context,
+    block: BlockRef<'a, 'a>,
+    memref: Value<'a, 'a>,
+    index: Value<'a, 'a>,
+    value: Value<'a, 'a>,
+    location: Location<'a>,
+) {
+    let ptr = memref_to_atomic_i32(context, block, memref, index, location);
+    let options = LoadStoreOptions::new()
+        .atomic(AtomicOrdering::Release)
+        .align(Some(IntegerAttribute::new(
+            IntegerType::new(context, 64).into(),
+            4,
+        )));
+    block.append_operation(llvm::store(context, value, ptr, location, options));
+}
 
 impl<'a> Visitor<'a> {
     pub fn visit_synchronization(&mut self, synchronization: &Synchronization) {
@@ -11,7 +354,10 @@ impl<'a> Visitor<'a> {
                 self.block.append_operation(func::call(
                     self.context,
                     func_name,
-                    &[],
+                    &[self
+                        .args_manager
+                        .sync_cube_state
+                        .expect("sync_cube state arg missing")],
                     &[],
                     self.location,
                 ));

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 
 use cubecl_core::ir::Synchronization;
 use tracel_llvm::mlir_rs::{
+    Error,
     dialect::{
         arith::{self, AtomicRMWKind, CmpiPredicate},
         cf, func,
@@ -25,11 +26,11 @@ use crate::compiler::{
 pub fn add_sync_cube_function<'a>(
     context: &'a Context,
     module: &tracel_llvm::mlir_rs::ir::Module<'a>,
-    location: Location<'a>,
-) {
+) -> Result<(), Error> {
     let i32_type = IntegerType::new(context, 32).into();
     let memref_type = MemRefType::new(i32_type, &[4], None, None).into();
     let func_type = TypeAttribute::new(FunctionType::new(context, &[memref_type], &[]).into());
+    let location = Location::unknown(context);
 
     module.body().append_operation(func::func(
         context,
@@ -45,31 +46,24 @@ pub fn add_sync_cube_function<'a>(
             let reset = region.append_block(Block::new(&[]));
             let done = region.append_block(Block::new(&[]));
 
-            let sync_cube_state: Value<'a, 'a> = entry.argument(0).unwrap().into();
-            let zero_i32 = const_i32(context, entry, location, 0);
-            let one_i32 = const_i32(context, entry, location, 1);
+            let sync_cube_state: Value<'a, 'a> = entry.argument(0)?.into();
+            let zero_i32 = const_i32(context, entry, 0)?;
+            let one_i32 = const_i32(context, entry, 1)?;
             let barrier_counter_index =
-                const_index(context, entry, location, SYNC_BARRIER_COUNTER_INDEX as i64);
+                const_index(context, entry, SYNC_BARRIER_COUNTER_INDEX as i64)?;
             let stopped_counter_index =
-                const_index(context, entry, location, SYNC_STOPPED_COUNTER_INDEX as i64);
+                const_index(context, entry, SYNC_STOPPED_COUNTER_INDEX as i64)?;
             let barrier_target_index =
-                const_index(context, entry, location, SYNC_BARRIER_TARGET_INDEX as i64);
-            let barrier_target_value = atomic_load_i32(
+                const_index(context, entry, SYNC_BARRIER_TARGET_INDEX as i64)?;
+            let barrier_target_value =
+                atomic_load_i32(context, entry, sync_cube_state, barrier_target_index)?;
+            let skip_sync = entry.append_op_result(arith::cmpi(
                 context,
-                entry,
-                sync_cube_state,
-                barrier_target_index,
+                CmpiPredicate::Sle,
+                barrier_target_value,
+                one_i32,
                 location,
-            );
-            let skip_sync = entry
-                .append_op_result(arith::cmpi(
-                    context,
-                    CmpiPredicate::Sle,
-                    barrier_target_value,
-                    one_i32,
-                    location,
-                ))
-                .unwrap();
+            ))?;
             entry.append_operation(cf::cond_br(
                 context,
                 skip_sync,
@@ -85,17 +79,14 @@ pub fn add_sync_cube_function<'a>(
                 wait_stopped,
                 sync_cube_state,
                 stopped_counter_index,
+            )?;
+            let stopped_is_busy = wait_stopped.append_op_result(arith::cmpi(
+                context,
+                CmpiPredicate::Ne,
+                stopped_value,
+                zero_i32,
                 location,
-            );
-            let stopped_is_busy = wait_stopped
-                .append_op_result(arith::cmpi(
-                    context,
-                    CmpiPredicate::Ne,
-                    stopped_value,
-                    zero_i32,
-                    location,
-                ))
-                .unwrap();
+            ))?;
             wait_stopped.append_operation(cf::cond_br(
                 context,
                 stopped_is_busy,
@@ -112,28 +103,22 @@ pub fn add_sync_cube_function<'a>(
                 None,
                 location,
             ));
-            let arrived_prev = arrive
-                .append_op_result(memref::atomic_rmw(
-                    context,
-                    AtomicRMWKind::AddI,
-                    one_i32,
-                    sync_cube_state,
-                    &[barrier_counter_index],
-                    location,
-                ))
-                .unwrap();
-            let arrived = arrive
-                .append_op_result(arith::addi(arrived_prev, one_i32, location))
-                .unwrap();
-            let arrived_needs_wait = arrive
-                .append_op_result(arith::cmpi(
-                    context,
-                    CmpiPredicate::Slt,
-                    arrived,
-                    barrier_target_value,
-                    location,
-                ))
-                .unwrap();
+            let arrived_prev = arrive.append_op_result(memref::atomic_rmw(
+                context,
+                AtomicRMWKind::AddI,
+                one_i32,
+                sync_cube_state,
+                &[barrier_counter_index],
+                location,
+            ))?;
+            let arrived = arrive.append_op_result(arith::addi(arrived_prev, one_i32, location))?;
+            let arrived_needs_wait = arrive.append_op_result(arith::cmpi(
+                context,
+                CmpiPredicate::Slt,
+                arrived,
+                barrier_target_value,
+                location,
+            ))?;
             arrive.append_operation(cf::cond_br(
                 context,
                 arrived_needs_wait,
@@ -149,17 +134,14 @@ pub fn add_sync_cube_function<'a>(
                 wait_arrived,
                 sync_cube_state,
                 barrier_counter_index,
+            )?;
+            let wait_more = wait_arrived.append_op_result(arith::cmpi(
+                context,
+                CmpiPredicate::Slt,
+                barrier_counter_value,
+                barrier_target_value,
                 location,
-            );
-            let wait_more = wait_arrived
-                .append_op_result(arith::cmpi(
-                    context,
-                    CmpiPredicate::Slt,
-                    barrier_counter_value,
-                    barrier_target_value,
-                    location,
-                ))
-                .unwrap();
+            ))?;
             wait_arrived.append_operation(cf::cond_br(
                 context,
                 wait_more,
@@ -176,28 +158,23 @@ pub fn add_sync_cube_function<'a>(
                 None,
                 location,
             ));
-            let stopped_prev = increment_stopped
-                .append_op_result(memref::atomic_rmw(
-                    context,
-                    AtomicRMWKind::AddI,
-                    one_i32,
-                    sync_cube_state,
-                    &[stopped_counter_index],
-                    location,
-                ))
-                .unwrap();
-            let stopped = increment_stopped
-                .append_op_result(arith::addi(stopped_prev, one_i32, location))
-                .unwrap();
-            let should_reset = increment_stopped
-                .append_op_result(arith::cmpi(
-                    context,
-                    CmpiPredicate::Eq,
-                    stopped,
-                    barrier_target_value,
-                    location,
-                ))
-                .unwrap();
+            let stopped_prev = increment_stopped.append_op_result(memref::atomic_rmw(
+                context,
+                AtomicRMWKind::AddI,
+                one_i32,
+                sync_cube_state,
+                &[stopped_counter_index],
+                location,
+            ))?;
+            let stopped =
+                increment_stopped.append_op_result(arith::addi(stopped_prev, one_i32, location))?;
+            let should_reset = increment_stopped.append_op_result(arith::cmpi(
+                context,
+                CmpiPredicate::Eq,
+                stopped,
+                barrier_target_value,
+                location,
+            ))?;
             increment_stopped.append_operation(cf::cond_br(
                 context,
                 should_reset,
@@ -214,16 +191,14 @@ pub fn add_sync_cube_function<'a>(
                 sync_cube_state,
                 barrier_counter_index,
                 zero_i32,
-                location,
-            );
+            )?;
             atomic_store_i32(
                 context,
                 reset,
                 sync_cube_state,
                 stopped_counter_index,
                 zero_i32,
-                location,
-            );
+            )?;
             reset.append_operation(cf::br(done.deref(), &[], location));
 
             done.append_operation(func::r#return(&[], location));
@@ -235,36 +210,33 @@ pub fn add_sync_cube_function<'a>(
         )],
         location,
     ));
+    Ok(())
 }
 
 fn const_i32<'a>(
     context: &'a Context,
     block: BlockRef<'a, 'a>,
-    location: Location<'a>,
     value: i64,
-) -> Value<'a, 'a> {
-    block
-        .append_op_result(arith::constant(
-            context,
-            IntegerAttribute::new(IntegerType::new(context, 32).into(), value).into(),
-            location,
-        ))
-        .unwrap()
+) -> Result<Value<'a, 'a>, Error> {
+    let location = Location::unknown(context);
+    block.append_op_result(arith::constant(
+        context,
+        IntegerAttribute::new(IntegerType::new(context, 32).into(), value).into(),
+        location,
+    ))
 }
 
 fn const_index<'a>(
     context: &'a Context,
     block: BlockRef<'a, 'a>,
-    location: Location<'a>,
     value: i64,
-) -> Value<'a, 'a> {
-    block
-        .append_op_result(arith::constant(
-            context,
-            IntegerAttribute::new(Type::index(context), value).into(),
-            location,
-        ))
-        .unwrap()
+) -> Result<Value<'a, 'a>, Error> {
+    let location = Location::unknown(context);
+    block.append_op_result(arith::constant(
+        context,
+        IntegerAttribute::new(Type::index(context), value).into(),
+        location,
+    ))
 }
 
 fn memref_to_atomic_i32<'a>(
@@ -272,35 +244,28 @@ fn memref_to_atomic_i32<'a>(
     block: BlockRef<'a, 'a>,
     memref: Value<'a, 'a>,
     index: Value<'a, 'a>,
-    location: Location<'a>,
-) -> Value<'a, 'a> {
-    let index_ptr = block
-        .append_op_result(memref::extract_aligned_pointer_as_index(memref, location))
-        .unwrap();
-    let int_ptr = block
-        .append_op_result(arith::index_cast(
-            index_ptr,
-            IntegerType::new(context, 64).into(),
-            location,
-        ))
-        .unwrap();
-    let ptr = block
-        .append_op_result(llvm::inttoptr(
-            int_ptr,
-            llvm::r#type::pointer(context, 0),
-            location,
-        ))
-        .unwrap();
-    block
-        .append_op_result(llvm::get_element_ptr_dynamic(
-            context,
-            ptr,
-            &[index],
-            IntegerType::new(context, 32).into(),
-            llvm::r#type::pointer(context, 0),
-            location,
-        ))
-        .unwrap()
+) -> Result<Value<'a, 'a>, Error> {
+    let location = Location::unknown(context);
+    let index_ptr =
+        block.append_op_result(memref::extract_aligned_pointer_as_index(memref, location))?;
+    let int_ptr = block.append_op_result(arith::index_cast(
+        index_ptr,
+        IntegerType::new(context, 64).into(),
+        location,
+    ))?;
+    let ptr = block.append_op_result(llvm::inttoptr(
+        int_ptr,
+        llvm::r#type::pointer(context, 0),
+        location,
+    ))?;
+    block.append_op_result(llvm::get_element_ptr_dynamic(
+        context,
+        ptr,
+        &[index],
+        IntegerType::new(context, 32).into(),
+        llvm::r#type::pointer(context, 0),
+        location,
+    ))
 }
 
 fn atomic_load_i32<'a>(
@@ -308,24 +273,22 @@ fn atomic_load_i32<'a>(
     block: BlockRef<'a, 'a>,
     memref: Value<'a, 'a>,
     index: Value<'a, 'a>,
-    location: Location<'a>,
-) -> Value<'a, 'a> {
-    let ptr = memref_to_atomic_i32(context, block, memref, index, location);
+) -> Result<Value<'a, 'a>, Error> {
+    let location = Location::unknown(context);
+    let ptr = memref_to_atomic_i32(context, block, memref, index)?;
     let options = LoadStoreOptions::new()
         .atomic(AtomicOrdering::Acquire)
         .align(Some(IntegerAttribute::new(
             IntegerType::new(context, 64).into(),
             4,
         )));
-    block
-        .append_op_result(llvm::load(
-            context,
-            ptr,
-            IntegerType::new(context, 32).into(),
-            location,
-            options,
-        ))
-        .unwrap()
+    block.append_op_result(llvm::load(
+        context,
+        ptr,
+        IntegerType::new(context, 32).into(),
+        location,
+        options,
+    ))
 }
 
 fn atomic_store_i32<'a>(
@@ -334,9 +297,9 @@ fn atomic_store_i32<'a>(
     memref: Value<'a, 'a>,
     index: Value<'a, 'a>,
     value: Value<'a, 'a>,
-    location: Location<'a>,
-) {
-    let ptr = memref_to_atomic_i32(context, block, memref, index, location);
+) -> Result<(), Error> {
+    let location = Location::unknown(context);
+    let ptr = memref_to_atomic_i32(context, block, memref, index)?;
     let options = LoadStoreOptions::new()
         .atomic(AtomicOrdering::Release)
         .align(Some(IntegerAttribute::new(
@@ -344,6 +307,7 @@ fn atomic_store_i32<'a>(
             4,
         )));
     block.append_operation(llvm::store(context, value, ptr, location, options));
+    Ok(())
 }
 
 impl<'a> Visitor<'a> {

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
@@ -47,159 +47,36 @@ pub fn add_sync_cube_function<'a>(
             let done = region.append_block(Block::new(&[]));
 
             let sync_cube_state: Value<'a, 'a> = entry.argument(0)?.into();
-            let zero_i32 = const_i32(context, entry, 0)?;
-            let one_i32 = const_i32(context, entry, 1)?;
-            let barrier_counter_index =
-                const_index(context, entry, SYNC_BARRIER_COUNTER_INDEX as i64)?;
-            let stopped_counter_index =
-                const_index(context, entry, SYNC_STOPPED_COUNTER_INDEX as i64)?;
-            let barrier_target_index =
-                const_index(context, entry, SYNC_BARRIER_TARGET_INDEX as i64)?;
-            let barrier_target_value =
-                atomic_load_i32(context, entry, sync_cube_state, barrier_target_index)?;
-            let skip_sync = entry.append_op_result(arith::cmpi(
+            let shared = SyncCubeShared {
                 context,
-                CmpiPredicate::Sle,
-                barrier_target_value,
-                one_i32,
+                sync_cube_state,
+                zero_i32: const_i32(context, entry, 0)?,
+                one_i32: const_i32(context, entry, 1)?,
+                barrier_counter_index: const_index(
+                    context,
+                    entry,
+                    SYNC_BARRIER_COUNTER_INDEX as i64,
+                )?,
+                stopped_counter_index: const_index(
+                    context,
+                    entry,
+                    SYNC_STOPPED_COUNTER_INDEX as i64,
+                )?,
+                barrier_target_value: atomic_load_i32(
+                    context,
+                    entry,
+                    sync_cube_state,
+                    const_index(context, entry, SYNC_BARRIER_TARGET_INDEX as i64)?,
+                )?,
                 location,
-            ))?;
-            entry.append_operation(cf::cond_br(
-                context,
-                skip_sync,
-                done.deref(),
-                wait_stopped.deref(),
-                &[],
-                &[],
-                location,
-            ));
+            };
 
-            let stopped_value = atomic_load_i32(
-                context,
-                wait_stopped,
-                sync_cube_state,
-                stopped_counter_index,
-            )?;
-            let stopped_is_busy = wait_stopped.append_op_result(arith::cmpi(
-                context,
-                CmpiPredicate::Ne,
-                stopped_value,
-                zero_i32,
-                location,
-            ))?;
-            wait_stopped.append_operation(cf::cond_br(
-                context,
-                stopped_is_busy,
-                wait_stopped.deref(),
-                arrive.deref(),
-                &[],
-                &[],
-                location,
-            ));
-
-            arrive.append_operation(llvm::fence(
-                context,
-                AtomicOrdering::Release,
-                None,
-                location,
-            ));
-            let arrived_prev = arrive.append_op_result(memref::atomic_rmw(
-                context,
-                AtomicRMWKind::AddI,
-                one_i32,
-                sync_cube_state,
-                &[barrier_counter_index],
-                location,
-            ))?;
-            let arrived = arrive.append_op_result(arith::addi(arrived_prev, one_i32, location))?;
-            let arrived_needs_wait = arrive.append_op_result(arith::cmpi(
-                context,
-                CmpiPredicate::Slt,
-                arrived,
-                barrier_target_value,
-                location,
-            ))?;
-            arrive.append_operation(cf::cond_br(
-                context,
-                arrived_needs_wait,
-                wait_arrived.deref(),
-                increment_stopped.deref(),
-                &[],
-                &[],
-                location,
-            ));
-
-            let barrier_counter_value = atomic_load_i32(
-                context,
-                wait_arrived,
-                sync_cube_state,
-                barrier_counter_index,
-            )?;
-            let wait_more = wait_arrived.append_op_result(arith::cmpi(
-                context,
-                CmpiPredicate::Slt,
-                barrier_counter_value,
-                barrier_target_value,
-                location,
-            ))?;
-            wait_arrived.append_operation(cf::cond_br(
-                context,
-                wait_more,
-                wait_arrived.deref(),
-                increment_stopped.deref(),
-                &[],
-                &[],
-                location,
-            ));
-
-            increment_stopped.append_operation(llvm::fence(
-                context,
-                AtomicOrdering::Acquire,
-                None,
-                location,
-            ));
-            let stopped_prev = increment_stopped.append_op_result(memref::atomic_rmw(
-                context,
-                AtomicRMWKind::AddI,
-                one_i32,
-                sync_cube_state,
-                &[stopped_counter_index],
-                location,
-            ))?;
-            let stopped =
-                increment_stopped.append_op_result(arith::addi(stopped_prev, one_i32, location))?;
-            let should_reset = increment_stopped.append_op_result(arith::cmpi(
-                context,
-                CmpiPredicate::Eq,
-                stopped,
-                barrier_target_value,
-                location,
-            ))?;
-            increment_stopped.append_operation(cf::cond_br(
-                context,
-                should_reset,
-                reset.deref(),
-                done.deref(),
-                &[],
-                &[],
-                location,
-            ));
-
-            atomic_store_i32(
-                context,
-                reset,
-                sync_cube_state,
-                barrier_counter_index,
-                zero_i32,
-            )?;
-            atomic_store_i32(
-                context,
-                reset,
-                sync_cube_state,
-                stopped_counter_index,
-                zero_i32,
-            )?;
-            reset.append_operation(cf::br(done.deref(), &[], location));
+            build_sync_cube_entry(entry, done, wait_stopped, &shared)?;
+            build_sync_cube_wait_stopped(wait_stopped, arrive, &shared)?;
+            build_sync_cube_arrive(arrive, wait_arrived, increment_stopped, &shared)?;
+            build_sync_cube_wait_arrived(wait_arrived, increment_stopped, &shared)?;
+            build_sync_cube_increment_stopped(increment_stopped, reset, done, &shared)?;
+            build_sync_cube_reset(reset, done, &shared)?;
 
             done.append_operation(func::r#return(&[], location));
             region
@@ -210,6 +87,210 @@ pub fn add_sync_cube_function<'a>(
         )],
         location,
     ));
+    Ok(())
+}
+
+struct SyncCubeShared<'a> {
+    context: &'a Context,
+    sync_cube_state: Value<'a, 'a>,
+    zero_i32: Value<'a, 'a>,
+    one_i32: Value<'a, 'a>,
+    barrier_counter_index: Value<'a, 'a>,
+    stopped_counter_index: Value<'a, 'a>,
+    barrier_target_value: Value<'a, 'a>,
+    location: Location<'a>,
+}
+
+fn build_sync_cube_entry<'a>(
+    entry: BlockRef<'a, 'a>,
+    done: BlockRef<'a, 'a>,
+    wait_stopped: BlockRef<'a, 'a>,
+    shared: &SyncCubeShared<'a>,
+) -> Result<(), Error> {
+    let skip_sync = entry.append_op_result(arith::cmpi(
+        shared.context,
+        CmpiPredicate::Sle,
+        shared.barrier_target_value,
+        shared.one_i32,
+        shared.location,
+    ))?;
+    entry.append_operation(cf::cond_br(
+        shared.context,
+        skip_sync,
+        done.deref(),
+        wait_stopped.deref(),
+        &[],
+        &[],
+        shared.location,
+    ));
+    Ok(())
+}
+
+fn build_sync_cube_wait_stopped<'a>(
+    wait_stopped: BlockRef<'a, 'a>,
+    arrive: BlockRef<'a, 'a>,
+    shared: &SyncCubeShared<'a>,
+) -> Result<(), Error> {
+    let stopped_value = atomic_load_i32(
+        shared.context,
+        wait_stopped,
+        shared.sync_cube_state,
+        shared.stopped_counter_index,
+    )?;
+    let stopped_is_busy = wait_stopped.append_op_result(arith::cmpi(
+        shared.context,
+        CmpiPredicate::Ne,
+        stopped_value,
+        shared.zero_i32,
+        shared.location,
+    ))?;
+    wait_stopped.append_operation(cf::cond_br(
+        shared.context,
+        stopped_is_busy,
+        wait_stopped.deref(),
+        arrive.deref(),
+        &[],
+        &[],
+        shared.location,
+    ));
+    Ok(())
+}
+
+fn build_sync_cube_arrive<'a>(
+    arrive: BlockRef<'a, 'a>,
+    wait_arrived: BlockRef<'a, 'a>,
+    increment_stopped: BlockRef<'a, 'a>,
+    shared: &SyncCubeShared<'a>,
+) -> Result<(), Error> {
+    arrive.append_operation(llvm::fence(
+        shared.context,
+        AtomicOrdering::Release,
+        None,
+        shared.location,
+    ));
+    let arrived_prev = arrive.append_op_result(memref::atomic_rmw(
+        shared.context,
+        AtomicRMWKind::AddI,
+        shared.one_i32,
+        shared.sync_cube_state,
+        &[shared.barrier_counter_index],
+        shared.location,
+    ))?;
+    let arrived =
+        arrive.append_op_result(arith::addi(arrived_prev, shared.one_i32, shared.location))?;
+    let arrived_needs_wait = arrive.append_op_result(arith::cmpi(
+        shared.context,
+        CmpiPredicate::Slt,
+        arrived,
+        shared.barrier_target_value,
+        shared.location,
+    ))?;
+    arrive.append_operation(cf::cond_br(
+        shared.context,
+        arrived_needs_wait,
+        wait_arrived.deref(),
+        increment_stopped.deref(),
+        &[],
+        &[],
+        shared.location,
+    ));
+    Ok(())
+}
+
+fn build_sync_cube_wait_arrived<'a>(
+    wait_arrived: BlockRef<'a, 'a>,
+    increment_stopped: BlockRef<'a, 'a>,
+    shared: &SyncCubeShared<'a>,
+) -> Result<(), Error> {
+    let barrier_counter_value = atomic_load_i32(
+        shared.context,
+        wait_arrived,
+        shared.sync_cube_state,
+        shared.barrier_counter_index,
+    )?;
+    let wait_more = wait_arrived.append_op_result(arith::cmpi(
+        shared.context,
+        CmpiPredicate::Slt,
+        barrier_counter_value,
+        shared.barrier_target_value,
+        shared.location,
+    ))?;
+    wait_arrived.append_operation(cf::cond_br(
+        shared.context,
+        wait_more,
+        wait_arrived.deref(),
+        increment_stopped.deref(),
+        &[],
+        &[],
+        shared.location,
+    ));
+    Ok(())
+}
+
+fn build_sync_cube_increment_stopped<'a>(
+    increment_stopped: BlockRef<'a, 'a>,
+    reset: BlockRef<'a, 'a>,
+    done: BlockRef<'a, 'a>,
+    shared: &SyncCubeShared<'a>,
+) -> Result<(), Error> {
+    increment_stopped.append_operation(llvm::fence(
+        shared.context,
+        AtomicOrdering::Acquire,
+        None,
+        shared.location,
+    ));
+    let stopped_prev = increment_stopped.append_op_result(memref::atomic_rmw(
+        shared.context,
+        AtomicRMWKind::AddI,
+        shared.one_i32,
+        shared.sync_cube_state,
+        &[shared.stopped_counter_index],
+        shared.location,
+    ))?;
+    let stopped = increment_stopped.append_op_result(arith::addi(
+        stopped_prev,
+        shared.one_i32,
+        shared.location,
+    ))?;
+    let should_reset = increment_stopped.append_op_result(arith::cmpi(
+        shared.context,
+        CmpiPredicate::Eq,
+        stopped,
+        shared.barrier_target_value,
+        shared.location,
+    ))?;
+    increment_stopped.append_operation(cf::cond_br(
+        shared.context,
+        should_reset,
+        reset.deref(),
+        done.deref(),
+        &[],
+        &[],
+        shared.location,
+    ));
+    Ok(())
+}
+
+fn build_sync_cube_reset<'a>(
+    reset: BlockRef<'a, 'a>,
+    done: BlockRef<'a, 'a>,
+    shared: &SyncCubeShared<'a>,
+) -> Result<(), Error> {
+    atomic_store_i32(
+        shared.context,
+        reset,
+        shared.sync_cube_state,
+        shared.barrier_counter_index,
+        shared.zero_i32,
+    )?;
+    atomic_store_i32(
+        shared.context,
+        reset,
+        shared.sync_cube_state,
+        shared.stopped_counter_index,
+        shared.zero_i32,
+    )?;
+    reset.append_operation(cf::br(done.deref(), &[], shared.location));
     Ok(())
 }
 

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
@@ -23,6 +23,14 @@ use crate::compiler::{
     visitor::prelude::*,
 };
 
+/// Builds the private `sync_cube` MLIR function used by the CPU backend.
+///
+/// Conceptually this emits the MLIR equivalent of the following Rust algorithm:
+/// 1. Load `barrier_target`; return immediately when `barrier_target <= 1`.
+/// 2. Spin while `stopped_counter != 0` so a previous barrier reset can complete.
+/// 3. Release fence, increment `barrier_counter`, then wait until all participants arrived.
+/// 4. Acquire fence, increment `stopped_counter`.
+/// 5. Last participant resets both counters to zero.
 pub fn add_sync_cube_function<'a>(
     context: &'a Context,
     module: &tracel_llvm::mlir_rs::ir::Module<'a>,
@@ -101,6 +109,9 @@ struct SyncCubeShared<'a> {
     location: Location<'a>,
 }
 
+/// Entry block:
+/// - Compare `barrier_target <= 1`.
+/// - Branch to `done` when sync is unnecessary, otherwise enter `wait_stopped`.
 fn build_sync_cube_entry<'a>(
     entry: BlockRef<'a, 'a>,
     done: BlockRef<'a, 'a>,
@@ -126,6 +137,9 @@ fn build_sync_cube_entry<'a>(
     Ok(())
 }
 
+/// Wait block for prior reset completion:
+/// - Spin while `stopped_counter != 0`.
+/// - Continue to `arrive` once no thread is in the reset phase.
 fn build_sync_cube_wait_stopped<'a>(
     wait_stopped: BlockRef<'a, 'a>,
     arrive: BlockRef<'a, 'a>,
@@ -156,6 +170,11 @@ fn build_sync_cube_wait_stopped<'a>(
     Ok(())
 }
 
+/// Arrival block:
+/// - Emit release fence.
+/// - Atomically increment `barrier_counter`.
+/// - If this participant is not the last to arrive, branch to `wait_arrived`.
+/// - Otherwise continue to `increment_stopped`.
 fn build_sync_cube_arrive<'a>(
     arrive: BlockRef<'a, 'a>,
     wait_arrived: BlockRef<'a, 'a>,
@@ -197,6 +216,9 @@ fn build_sync_cube_arrive<'a>(
     Ok(())
 }
 
+/// Post-arrival wait block:
+/// - Spin while `barrier_counter < barrier_target`.
+/// - Once all participants have arrived, continue to `increment_stopped`.
 fn build_sync_cube_wait_arrived<'a>(
     wait_arrived: BlockRef<'a, 'a>,
     increment_stopped: BlockRef<'a, 'a>,
@@ -227,6 +249,10 @@ fn build_sync_cube_wait_arrived<'a>(
     Ok(())
 }
 
+/// Completion accounting block:
+/// - Emit acquire fence.
+/// - Atomically increment `stopped_counter`.
+/// - Last participant branches to `reset`, others branch to `done`.
 fn build_sync_cube_increment_stopped<'a>(
     increment_stopped: BlockRef<'a, 'a>,
     reset: BlockRef<'a, 'a>,
@@ -271,6 +297,10 @@ fn build_sync_cube_increment_stopped<'a>(
     Ok(())
 }
 
+/// Reset block executed by the last participant:
+/// - Store `0` to `barrier_counter`.
+/// - Store `0` to `stopped_counter`.
+/// - Branch to `done`.
 fn build_sync_cube_reset<'a>(
     reset: BlockRef<'a, 'a>,
     done: BlockRef<'a, 'a>,

--- a/crates/cubecl-cpu/src/compute/affinity/linux.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/linux.rs
@@ -10,9 +10,8 @@ pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
     let affinity_mask = get_affinity_mask();
 
     (0..CPU_SETSIZE as usize)
-        .into_iter()
         .filter(move |i| unsafe { CPU_ISSET(*i, &affinity_mask) })
-        .map(|i| CoreId(i))
+        .map(CoreId)
 }
 
 pub fn set_for_current(core_id: CoreId) {

--- a/crates/cubecl-cpu/src/compute/affinity/linux.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/linux.rs
@@ -1,7 +1,10 @@
 use std::mem;
 
 use super::CoreId;
-use libc::{CPU_ISSET, CPU_SET, CPU_SETSIZE, cpu_set_t, sched_getaffinity, sched_setaffinity};
+use libc::{
+    CPU_ISSET, CPU_SET, CPU_SETSIZE, SYS_gettid, cpu_set_t, sched_getaffinity, sched_setaffinity,
+    syscall,
+};
 
 pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
     let affinity_mask = get_affinity_mask();
@@ -14,6 +17,8 @@ pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
 
 pub fn set_for_current(core_id: CoreId) {
     let mut set = new_cpu_set();
+    let tid = unsafe { syscall(SYS_gettid) } as libc::id_t;
+    unsafe { libc::setpriority(libc::PRIO_PROCESS, tid, 0) };
     unsafe { CPU_SET(core_id.0, &mut set) };
     unsafe { sched_setaffinity(0, mem::size_of::<cpu_set_t>(), &set) };
 }

--- a/crates/cubecl-cpu/src/compute/affinity/linux.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/linux.rs
@@ -1,0 +1,29 @@
+use std::mem;
+
+use super::CoreId;
+use libc::{CPU_ISSET, CPU_SET, CPU_SETSIZE, cpu_set_t, sched_getaffinity, sched_setaffinity};
+
+pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
+    let affinity_mask = get_affinity_mask();
+
+    (0..CPU_SETSIZE as usize)
+        .into_iter()
+        .filter(move |i| unsafe { CPU_ISSET(*i, &affinity_mask) })
+        .map(|i| CoreId(i))
+}
+
+pub fn set_for_current(core_id: CoreId) {
+    let mut set = new_cpu_set();
+    unsafe { CPU_SET(core_id.0, &mut set) };
+    unsafe { sched_setaffinity(0, mem::size_of::<cpu_set_t>(), &set) };
+}
+
+fn get_affinity_mask() -> cpu_set_t {
+    let mut set = new_cpu_set();
+    unsafe { sched_getaffinity(0, mem::size_of::<cpu_set_t>(), &mut set) };
+    set
+}
+
+fn new_cpu_set() -> cpu_set_t {
+    unsafe { std::mem::zeroed::<cpu_set_t>() }
+}

--- a/crates/cubecl-cpu/src/compute/affinity/mod.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/mod.rs
@@ -1,0 +1,27 @@
+#[cfg(any(target_os = "android", target_os = "linux"))]
+mod linux;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use linux::get_active_cores;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use linux::set_for_current;
+
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+pub use windows::get_active_cores;
+#[cfg(target_os = "windows")]
+pub use windows::set_for_current;
+
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CoreId(usize);
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows",)))]
+#[inline]
+pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
+    [].into_iter()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows",)))]
+#[inline]
+pub fn set_for_current(_core_id: CoreId) {}

--- a/crates/cubecl-cpu/src/compute/affinity/windows.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/windows.rs
@@ -1,0 +1,35 @@
+use winapi::shared::basetsd::{DWORD_PTR, PDWORD_PTR};
+use winapi::um::processthreadsapi::{GetCurrentProcess, GetCurrentThread};
+use winapi::um::winbase::{GetProcessAffinityMask, SetThreadAffinityMask};
+
+use super::CoreId;
+
+/// System with more than 64 cores needs another API on windows that is not currently implemented
+pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
+    let mask = get_affinity_mask();
+
+    (0..64 as u64)
+        .into_iter()
+        .filter(|&i| (mask & 1 << i) == 1 << i)
+        .map(|i| CoreId(i as usize))
+}
+
+pub fn set_for_current(core_id: CoreId) {
+    let mask: u64 = 1 << core_id.id;
+    unsafe { SetThreadAffinityMask(GetCurrentThread(), mask as DWORD_PTR) };
+}
+
+fn get_affinity_mask() -> u64 {
+    let mut system_mask: usize = 0;
+    let mut process_mask: usize = 0;
+
+    unsafe {
+        GetProcessAffinityMask(
+            GetCurrentProcess(),
+            &mut process_mask as PDWORD_PTR,
+            &mut system_mask as PDWORD_PTR,
+        )
+    }
+
+    process_mask as u64
+}

--- a/crates/cubecl-cpu/src/compute/affinity/windows.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/windows.rs
@@ -15,7 +15,7 @@ pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
 }
 
 pub fn set_for_current(core_id: CoreId) {
-    let mask: u64 = 1 << core_id.id;
+    let mask: u64 = 1 << core_id.0;
     unsafe { SetThreadAffinityMask(GetCurrentThread(), mask as DWORD_PTR) };
 }
 

--- a/crates/cubecl-cpu/src/compute/compute_task.rs
+++ b/crates/cubecl-cpu/src/compute/compute_task.rs
@@ -2,40 +2,6 @@ use crate::{
     compiler::{mlir_data::MlirData, mlir_engine::MlirEngine},
     compute::notification::Notifications,
 };
-use std::sync::atomic::{AtomicI32, Ordering};
-
-pub static BARRIER_COUNTER: AtomicI32 = AtomicI32::new(0);
-pub static STOPPED_COUNTER: AtomicI32 = AtomicI32::new(0);
-pub static BARRIER_TARGET: AtomicI32 = AtomicI32::new(0);
-pub static CURRENT_CUBE_DIM: AtomicI32 = AtomicI32::new(-1);
-
-pub fn sync_cube() {
-    let barrier_target = BARRIER_TARGET.load(Ordering::Acquire);
-    if barrier_target <= 1 {
-        return;
-    }
-
-    while STOPPED_COUNTER.load(Ordering::Acquire) != 0 {
-        std::hint::spin_loop();
-    }
-
-    std::sync::atomic::fence(Ordering::Release);
-    let arrived = BARRIER_COUNTER.fetch_add(1, Ordering::AcqRel) + 1;
-
-    if arrived < barrier_target {
-        while BARRIER_COUNTER.load(Ordering::Acquire) < barrier_target {
-            std::hint::spin_loop();
-        }
-    }
-
-    std::sync::atomic::fence(Ordering::Acquire);
-
-    let stopped = STOPPED_COUNTER.fetch_add(1, Ordering::AcqRel) + 1;
-    if stopped == barrier_target {
-        BARRIER_COUNTER.store(0, Ordering::Release);
-        STOPPED_COUNTER.store(0, Ordering::Release);
-    }
-}
 
 pub struct ComputeTask {
     pub mlir_engine: MlirEngine,
@@ -49,7 +15,7 @@ impl ComputeTask {
         unsafe {
             self.mlir_engine.run_kernel(&mut self.mlir_data);
         }
-        CURRENT_CUBE_DIM.fetch_sub(1, Ordering::AcqRel);
+        self.mlir_data.complete_unit();
         self.notifications.send();
     }
 }

--- a/crates/cubecl-cpu/src/compute/mod.rs
+++ b/crates/cubecl-cpu/src/compute/mod.rs
@@ -1,7 +1,7 @@
 pub mod affinity;
 pub mod compute_task;
-pub mod runner;
 pub mod server;
+pub mod threadpool;
 pub mod worker;
 
 pub(crate) mod alloc_controller;

--- a/crates/cubecl-cpu/src/compute/mod.rs
+++ b/crates/cubecl-cpu/src/compute/mod.rs
@@ -1,3 +1,4 @@
+pub mod affinity;
 pub mod compute_task;
 pub mod runner;
 pub mod server;

--- a/crates/cubecl-cpu/src/compute/queue.rs
+++ b/crates/cubecl-cpu/src/compute/queue.rs
@@ -100,6 +100,7 @@ impl CpuExecutionQueueServer {
     }
 
     fn write(&mut self, data: Bytes, mut buffer: BytesResource) {
+        self.flush();
         buffer.write().copy_from_slice(&data);
     }
 

--- a/crates/cubecl-cpu/src/compute/queue.rs
+++ b/crates/cubecl-cpu/src/compute/queue.rs
@@ -1,4 +1,3 @@
-/// BIG TODO remove threading from that and just run the kernel instead of spawning another thread
 use crate::{
     compiler::mlir_engine::MlirEngine,
     compute::{

--- a/crates/cubecl-cpu/src/compute/queue.rs
+++ b/crates/cubecl-cpu/src/compute/queue.rs
@@ -2,7 +2,7 @@
 use crate::{
     compiler::mlir_engine::MlirEngine,
     compute::{
-        notification::Notification,
+        notification::{Notification, Notifications},
         schedule::{BindingsResource, ScheduleTask},
         threadpool::Threadpool,
     },
@@ -53,6 +53,7 @@ impl CpuExecutionQueue {
         std::thread::spawn(move || {
             let mut server = CpuExecutionQueueServer {
                 runner: Threadpool::new(logger),
+                pending_notifications: Vec::new(),
             };
 
             loop {
@@ -60,6 +61,7 @@ impl CpuExecutionQueue {
                     Ok(item) => match item {
                         QueueItem::Task(task) => server.execute_task(task),
                         QueueItem::Flush(notification) => {
+                            server.flush();
                             notification.send();
                         }
                     },
@@ -74,6 +76,7 @@ impl CpuExecutionQueue {
 
 struct CpuExecutionQueueServer {
     runner: Threadpool,
+    pending_notifications: Vec<Notifications>,
 }
 
 impl CpuExecutionQueueServer {
@@ -90,6 +93,12 @@ impl CpuExecutionQueueServer {
         }
     }
 
+    fn flush(&mut self) {
+        for notifications in self.pending_notifications.drain(..) {
+            notifications.wait();
+        }
+    }
+
     fn write(&mut self, data: Bytes, mut buffer: BytesResource) {
         buffer.write().copy_from_slice(&data);
     }
@@ -101,7 +110,9 @@ impl CpuExecutionQueueServer {
         cube_dim: CubeDim,
         cube_count: [u32; 3],
     ) {
-        self.runner
-            .execute_data(mlir_engine, bindings, cube_dim, cube_count)
+        let notifications = self
+            .runner
+            .execute_data(mlir_engine, bindings, cube_dim, cube_count);
+        self.pending_notifications.push(notifications);
     }
 }

--- a/crates/cubecl-cpu/src/compute/queue.rs
+++ b/crates/cubecl-cpu/src/compute/queue.rs
@@ -1,9 +1,10 @@
+/// BIG TODO remove threading from that and just run the kernel instead of spawning another thread
 use crate::{
     compiler::mlir_engine::MlirEngine,
     compute::{
         notification::Notification,
-        runner::KernelRunner,
         schedule::{BindingsResource, ScheduleTask},
+        threadpool::Threadpool,
     },
 };
 use cubecl_common::bytes::Bytes;
@@ -51,7 +52,7 @@ impl CpuExecutionQueue {
 
         std::thread::spawn(move || {
             let mut server = CpuExecutionQueueServer {
-                runner: KernelRunner::new(logger),
+                runner: Threadpool::new(logger),
             };
 
             loop {
@@ -72,7 +73,7 @@ impl CpuExecutionQueue {
 }
 
 struct CpuExecutionQueueServer {
-    runner: KernelRunner,
+    runner: Threadpool,
 }
 
 impl CpuExecutionQueueServer {

--- a/crates/cubecl-cpu/src/compute/runner.rs
+++ b/crates/cubecl-cpu/src/compute/runner.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     compiler::{MlirCompiler, mlir_data::MlirData, mlir_engine::MlirEngine},
-    compute::notification::Notifications,
+    compute::{affinity::get_active_cores, notification::Notifications},
 };
 use cubecl_core::{
     CubeDim, MemoryConfiguration, ir::MemoryDeviceProperties, prelude::CompiledKernel,
@@ -83,11 +83,8 @@ impl KernelRunner {
             MemoryManagementOptions::new("Shared Memory"),
         );
 
-        let available_parallelism = std::thread::available_parallelism()
-            .expect("Can't get available parallelism on this platform")
-            .get();
-        let workers = (0..available_parallelism)
-            .map(|_| Worker::default())
+        let workers = get_active_cores()
+            .map(|core_id| Worker::new_with_affinity(core_id))
             .collect();
 
         KernelRunner {
@@ -111,7 +108,7 @@ impl KernelRunner {
 
         if cube_dim_size > self.workers.len() as u32 {
             self.workers
-                .extend((0..cube_dim_size - self.workers.len() as u32).map(|_| Worker::default()));
+                .extend((0..cube_dim_size - self.workers.len() as u32).map(|_| Worker::new()));
         }
 
         let mlir_data = MlirData::new(

--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -2,8 +2,8 @@ use crate::{
     CpuCompiler,
     compiler::MlirCompilerOptions,
     compute::{
-        runner::CpuKernel,
         schedule::{BindingsResource, ScheduleTask, ScheduledCpuBackend},
+        threadpool::CpuKernel,
     },
 };
 use cubecl_common::{

--- a/crates/cubecl-cpu/src/compute/threadpool.rs
+++ b/crates/cubecl-cpu/src/compute/threadpool.rs
@@ -27,7 +27,7 @@ use sysinfo::System;
 ///
 /// A single kernel runner is currently used for all kernels.
 /// To register work, you have to use the execution queue.
-pub struct KernelRunner {
+pub struct Threadpool {
     workers: Vec<Worker>,
     memory_management_shared_memory: MemoryManagement<BytesStorage>,
 }
@@ -54,13 +54,13 @@ impl Debug for CpuKernel {
     }
 }
 
-impl Debug for KernelRunner {
+impl Debug for Threadpool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", &self.workers)
     }
 }
 
-impl KernelRunner {
+impl Threadpool {
     pub fn new(logger: Arc<ServerLogger>) -> Self {
         let mut system = System::new();
         system.refresh_memory();
@@ -87,7 +87,7 @@ impl KernelRunner {
             .map(|core_id| Worker::new_with_affinity(core_id))
             .collect();
 
-        KernelRunner {
+        Self {
             workers,
             memory_management_shared_memory,
         }

--- a/crates/cubecl-cpu/src/compute/threadpool.rs
+++ b/crates/cubecl-cpu/src/compute/threadpool.rs
@@ -87,7 +87,7 @@ impl Threadpool {
         resources: BindingsResource,
         cube_dim: CubeDim,
         cube_count: [u32; 3],
-    ) {
+    ) -> Notifications {
         let cube_dim_size = cube_dim.num_elems();
 
         if cube_dim_size > self.workers.len() as u32 {
@@ -125,6 +125,6 @@ impl Threadpool {
             }
         }
 
-        notifications.wait();
+        notifications
     }
 }

--- a/crates/cubecl-cpu/src/compute/threadpool.rs
+++ b/crates/cubecl-cpu/src/compute/threadpool.rs
@@ -1,10 +1,4 @@
-use super::{
-    compute_task::{
-        BARRIER_COUNTER, BARRIER_TARGET, CURRENT_CUBE_DIM, ComputeTask, STOPPED_COUNTER,
-    },
-    schedule::BindingsResource,
-    worker::Worker,
-};
+use super::{compute_task::ComputeTask, schedule::BindingsResource, worker::Worker};
 use crate::{
     compiler::{MlirCompiler, mlir_data::MlirData, mlir_engine::MlirEngine},
     compute::{affinity::get_active_cores, notification::Notifications},
@@ -17,10 +11,7 @@ use cubecl_runtime::{
     memory_management::{MemoryManagement, MemoryManagementOptions},
     storage::BytesStorage,
 };
-use std::{
-    fmt::Debug,
-    sync::{Arc, atomic::Ordering},
-};
+use std::{fmt::Debug, sync::Arc};
 use sysinfo::System;
 
 /// The kernel runner is responsible to manage shared memory as well as threads to execute kernels.
@@ -83,9 +74,7 @@ impl Threadpool {
             MemoryManagementOptions::new("Shared Memory"),
         );
 
-        let workers = get_active_cores()
-            .map(|core_id| Worker::new_with_affinity(core_id))
-            .collect();
+        let workers = get_active_cores().map(Worker::new_with_affinity).collect();
 
         Self {
             workers,
@@ -100,11 +89,6 @@ impl Threadpool {
         cube_count: [u32; 3],
     ) {
         let cube_dim_size = cube_dim.num_elems();
-
-        BARRIER_TARGET.store(cube_dim_size as i32, Ordering::Release);
-        CURRENT_CUBE_DIM.store(cube_dim_size as i32, Ordering::Release);
-        BARRIER_COUNTER.store(0, Ordering::Release);
-        STOPPED_COUNTER.store(0, Ordering::Release);
 
         if cube_dim_size > self.workers.len() as u32 {
             self.workers

--- a/crates/cubecl-cpu/src/compute/threadpool.rs
+++ b/crates/cubecl-cpu/src/compute/threadpool.rs
@@ -64,14 +64,14 @@ impl Threadpool {
     pub fn new(logger: Arc<ServerLogger>) -> Self {
         let mut system = System::new();
         system.refresh_memory();
-        let max_shared_memory_size = system
+        let max_page_size = system
             .cgroup_limits()
             .map(|g| g.total_memory)
-            .unwrap_or(system.total_memory()) as usize;
+            .unwrap_or(system.total_memory());
 
         const ALIGNMENT: u64 = 4;
         let memory_properties = MemoryDeviceProperties {
-            max_page_size: max_shared_memory_size as u64,
+            max_page_size,
             alignment: ALIGNMENT,
         };
 

--- a/crates/cubecl-cpu/src/compute/worker.rs
+++ b/crates/cubecl-cpu/src/compute/worker.rs
@@ -2,6 +2,7 @@ use std::sync::mpsc;
 use std::thread;
 
 use super::compute_task::ComputeTask;
+use crate::compute::affinity::{CoreId, set_for_current};
 
 pub const MAX_STACK_SIZE: usize = 16 * 1024 * 1024;
 pub const DEFAULT_STACK_SIZE: usize = 64 * 1024 * 1024;
@@ -26,8 +27,20 @@ pub struct Worker {
     tx: mpsc::Sender<ComputeTask>,
 }
 
-impl Default for Worker {
-    fn default() -> Self {
+impl Worker {
+    pub fn new_with_affinity(core_id: CoreId) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let inner_worker = InnerWorker { rx };
+        thread::Builder::new()
+            .stack_size(resolve_stack_size())
+            .spawn(move || {
+                set_for_current(core_id);
+                inner_worker.work()
+            })
+            .unwrap();
+        Self { tx }
+    }
+    pub fn new() -> Self {
         let (tx, rx) = mpsc::channel();
         let inner_worker = InnerWorker { rx };
         thread::Builder::new()
@@ -36,9 +49,6 @@ impl Default for Worker {
             .unwrap();
         Self { tx }
     }
-}
-
-impl Worker {
     pub fn send_task(&mut self, compute_task: ComputeTask) {
         self.tx.send(compute_task).unwrap();
     }

--- a/crates/cubecl-cpu/src/compute/worker.rs
+++ b/crates/cubecl-cpu/src/compute/worker.rs
@@ -27,6 +27,12 @@ pub struct Worker {
     tx: mpsc::Sender<ComputeTask>,
 }
 
+impl Default for Worker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Worker {
     pub fn new_with_affinity(core_id: CoreId) -> Self {
         let (tx, rx) = mpsc::channel();

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -250,11 +250,11 @@ impl DeviceService for CudaServer {
                 .insert(ElemType::Float(FloatKind::BF16).into());
             device_props.register_atomic_type_usage(
                 Type::atomic(Type::scalar(ElemType::Float(FloatKind::F32)).with_vector_size(2)),
-                AtomicUsage::LoadStore | AtomicUsage::Add,
+                AtomicUsage::LoadStore | AtomicUsage::Add | AtomicUsage::Swap,
             );
             device_props.register_atomic_type_usage(
                 Type::atomic(Type::scalar(ElemType::Float(FloatKind::F32)).with_vector_size(4)),
-                AtomicUsage::LoadStore | AtomicUsage::Add,
+                AtomicUsage::LoadStore | AtomicUsage::Add | AtomicUsage::Swap,
             );
         }
 

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -250,11 +250,11 @@ impl DeviceService for CudaServer {
                 .insert(ElemType::Float(FloatKind::BF16).into());
             device_props.register_atomic_type_usage(
                 Type::atomic(Type::scalar(ElemType::Float(FloatKind::F32)).with_vector_size(2)),
-                AtomicUsage::LoadStore | AtomicUsage::Add | AtomicUsage::Swap,
+                AtomicUsage::LoadStore | AtomicUsage::Add,
             );
             device_props.register_atomic_type_usage(
                 Type::atomic(Type::scalar(ElemType::Float(FloatKind::F32)).with_vector_size(4)),
-                AtomicUsage::LoadStore | AtomicUsage::Add | AtomicUsage::Swap,
+                AtomicUsage::LoadStore | AtomicUsage::Add,
             );
         }
 

--- a/crates/cubecl-ir/src/features.rs
+++ b/crates/cubecl-ir/src/features.rs
@@ -108,8 +108,6 @@ impl TypeUsage {
 pub enum AtomicUsage {
     /// Atomic loads and stores
     LoadStore,
-    /// Atomic exchange
-    Swap,
     /// Atomic add/sub
     Add,
     /// Atomic min/max

--- a/crates/cubecl-ir/src/features.rs
+++ b/crates/cubecl-ir/src/features.rs
@@ -108,10 +108,16 @@ impl TypeUsage {
 pub enum AtomicUsage {
     /// Atomic loads and stores
     LoadStore,
+    /// Atomic exchange
+    Swap,
     /// Atomic add/sub
     Add,
     /// Atomic min/max
     MinMax,
+    /// Atomic bitwise and/or/xor
+    Bitwise,
+    /// Atomic compare-and-exchange
+    CompareExchange,
 }
 
 impl AtomicUsage {

--- a/crates/cubecl-opt/src/instructions.rs
+++ b/crates/cubecl-opt/src/instructions.rs
@@ -314,7 +314,7 @@ impl Function {
                 visit_read(self, &mut store.value);
             }
             AtomicOp::CompareAndSwap(op) => {
-                visit_read(self, &mut op.cmp);
+                visit_read(self, &mut op.ptr);
                 visit_read(self, &mut op.cmp);
                 visit_read(self, &mut op.val);
             }

--- a/crates/cubecl-spirv/src/atomic.rs
+++ b/crates/cubecl-spirv/src/atomic.rs
@@ -168,10 +168,6 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                 let memory = self.scope(&ptr);
                 let semantics = self.semantics_rw(&ptr);
 
-                assert!(
-                    matches!(out_ty.elem(), Elem::Int(_, _)),
-                    "sub doesn't support float atomics"
-                );
                 match out_ty.elem() {
                     Elem::Int(_, _) => self
                         .atomic_i_sub(ty, Some(out_id), ptr_id, memory, semantics, value_id)
@@ -193,8 +189,6 @@ impl<T: SpirvTarget> SpirvCompiler<T> {
                     }
                     _ => unreachable!(),
                 };
-                self.atomic_i_sub(ty, Some(out_id), ptr_id, memory, semantics, value_id)
-                    .unwrap();
                 self.write(&out, out_id);
             }
             AtomicOp::Max(op) => {


### PR DESCRIPTION
It's quite a big PR, a following PR for optimizing the threadpool with a work steal scheduler will come later

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
