### PR TITLE
Refactor/wgpu compilers

### DIFF
--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -1,6 +1,7 @@
 use super::wgsl;
 use crate::WgpuServer;
 use crate::{AutoRepresentationRef, CompilerInfo};
+use cubecl_core::Compiler;
 use cubecl_core::{
     CubeDim, ExecutionMode, WgpuCompilationOptions, hash::StableHash, server::KernelArguments,
 };
@@ -22,7 +23,7 @@ use super::metal;
 #[cfg(all(feature = "msl", target_os = "macos"))]
 use cubecl_cpp::metal as cpp_metal;
 
-impl WgpuServer {
+impl<C: Compiler> WgpuServer<C> {
     /// Loads a cached kernel if present and creates the pipeline for it.
     /// Returns `None` if the cache isn't enabled, `Some(Ok(pipeline))` if a cache entry was found,
     /// and `Some(Err(cache_key))` if the cache is enabled but doesn't contain this kernel.

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -1,7 +1,6 @@
 use super::wgsl;
 use crate::WgpuServer;
-use crate::{AutoRepresentationRef, CompilerInfo};
-use cubecl_core::Compiler;
+use crate::{AutoRepresentationRef, CompilerInfo, WgpuCompiler};
 use cubecl_core::{
     CubeDim, ExecutionMode, WgpuCompilationOptions, hash::StableHash, server::KernelArguments,
 };
@@ -23,7 +22,7 @@ use super::metal;
 #[cfg(all(feature = "msl", target_os = "macos"))]
 use cubecl_cpp::metal as cpp_metal;
 
-impl<C: Compiler> WgpuServer<C> {
+impl<C: WgpuCompiler> WgpuServer<C> {
     /// Loads a cached kernel if present and creates the pipeline for it.
     /// Returns `None` if the cache isn't enabled, `Some(Ok(pipeline))` if a cache entry was found,
     /// and `Some(Err(cache_key))` if the cache is enabled but doesn't contain this kernel.

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -34,7 +34,7 @@ use wgpu::{
     },
 };
 
-use crate::{AutoCompiler, WgpuServer};
+use crate::{WgpuCompiler, WgpuServer};
 
 mod features;
 
@@ -736,13 +736,16 @@ fn convert_type(vk_ty: ComponentTypeKHR) -> Option<ElemType> {
     Some(ty)
 }
 
-/// Check robustness, compile, and optionally dump SPIR-V
-pub(crate) fn compile(
-    dyn_comp: &mut AutoCompiler,
-    server: &mut WgpuServer,
-    kernel: <WgpuServer as ComputeServer>::Kernel,
+/// Check robustness and compile.
+pub(crate) fn compile<C>(
+    dyn_comp: &mut C,
+    server: &mut WgpuServer<C>,
+    kernel: <WgpuServer<C> as ComputeServer>::Kernel,
     mode: ExecutionMode,
-) -> Result<CompiledKernel<AutoCompiler>, CompilationError> {
+) -> Result<CompiledKernel<C>, CompilationError>
+where
+    C: WgpuCompiler<CompilationOptions = WgpuCompilationOptions>,
+{
     log::debug!("Compiling {}", kernel.name());
     let compiled = kernel.compile(
         dyn_comp,
@@ -750,25 +753,17 @@ pub(crate) fn compile(
         mode,
         kernel.address_type(),
     )?;
-    #[cfg(feature = "spirv-dump")]
-    dump_spirv(&compiled, kernel.name(), kernel.id());
     Ok(compiled)
 }
 
 #[cfg(feature = "spirv-dump")]
-fn dump_spirv(
-    compiled: &CompiledKernel<AutoCompiler>,
-    name: &str,
-    id: cubecl_runtime::id::KernelId,
-) {
+pub(crate) fn dump_spirv(repr: &SpirvKernel, name: &str, id: cubecl_runtime::id::KernelId) {
     use std::{
         fs,
         hash::{DefaultHasher, Hash, Hasher},
     };
 
-    if let Ok(dir) = std::env::var("CUBECL_DEBUG_SPIRV")
-        && let Some(repr) = compiled.repr.as_ref().and_then(|repr| repr.as_spirv())
-    {
+    if let Ok(dir) = std::env::var("CUBECL_DEBUG_SPIRV") {
         std::fs::create_dir_all(&dir).unwrap();
         let name = name
             .split("<")

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -13,6 +13,8 @@ use cubecl_ir::DeviceProperties;
 use cubecl_runtime::compiler::CompilationError;
 use derive_more::derive::From;
 
+#[cfg(feature = "spirv")]
+use crate::ParamsTransfer;
 use crate::{CompilerInfo, WgpuServer, WgslCompiler};
 
 use super::wgsl;
@@ -175,7 +177,16 @@ impl WgpuCompiler for AutoCompiler {
                 kernel.address_type(),
             ),
             #[cfg(feature = "spirv")]
-            AutoCompiler::SpirV(_) => crate::vulkan::compile(self, server, kernel, mode),
+            AutoCompiler::SpirV(_) => {
+                #[cfg(feature = "spirv-dump")]
+                let (name, id) = (kernel.name().to_string(), kernel.id());
+                let compiled = crate::vulkan::compile(self, server, kernel, mode)?;
+                #[cfg(feature = "spirv-dump")]
+                if let Some(spirv) = compiled.repr.as_ref().and_then(|r| r.as_spirv()) {
+                    crate::vulkan::dump_spirv(spirv, &name, id);
+                }
+                Ok(compiled)
+            }
             #[cfg(feature = "msl")]
             AutoCompiler::Msl(_) => kernel.compile(
                 self,
@@ -208,25 +219,14 @@ impl WgpuCompiler for AutoCompiler {
             #[cfg(feature = "spirv")]
             AutoRepresentation::SpirV(repr) => repr.shared_size,
         });
-        let max_smem = props.hardware.max_shared_memory_size;
-        if let Some(shared_bytes) = shared_bytes
-            && shared_bytes > max_smem
-        {
-            return Err(ResourceLimitError::SharedMemory {
-                requested: shared_bytes,
-                max: max_smem,
-                backtrace: BackTrace::capture(),
-            }
-            .into());
-        }
-
-        Ok(())
+        check_shared_memory(shared_bytes, props)
     }
-    fn into_auto(
+
+    fn to_auto(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>) {
-        let compiler_info = match repr {
+        let compiler_info = match &repr {
             #[cfg(feature = "spirv")]
             Some(AutoRepresentation::SpirV(repr)) => CompilerInfo::Vulkan {
                 params_transfer: match repr.immediate_size {
@@ -248,6 +248,7 @@ impl WgpuCompiler for WgslCompiler {
     fn init(_backend: wgpu::Backend, _options: &WgpuCompilationOptions) -> Self {
         Self::default()
     }
+
     fn wgpu_compile(
         &mut self,
         server: &mut WgpuServer<Self>,
@@ -265,15 +266,17 @@ impl WgpuCompiler for WgslCompiler {
     fn lang_tag(&self) -> &'static str {
         "wgsl"
     }
+
     fn validate_ir(
         &self,
         repr: &Option<Self::Representation>,
         props: &DeviceProperties,
     ) -> Result<(), LaunchError> {
-        todo!()
+        let shared_bytes = repr.as_ref().map(|repr| repr.shared_memory_bytes());
+        check_shared_memory(shared_bytes, props)
     }
 
-    fn into_auto(
+    fn to_auto(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>) {
@@ -282,28 +285,36 @@ impl WgpuCompiler for WgslCompiler {
 }
 
 #[cfg(feature = "msl")]
-impl WgpuCompiler for MslComputeKernel {
+impl WgpuCompiler for cubecl_cpp::MslCompiler {
     fn init(_backend: wgpu::Backend, _options: &WgpuCompilationOptions) -> Self {
         Self::default()
     }
+
     fn wgpu_compile(
         &mut self,
-        server: &mut WgpuServer<Self>,
+        _server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError> {
-        kernel.compile(
-            self,
-            &server.compilation_options,
-            mode,
-            kernel.address_type(),
-        )
+        // The MSL compiler uses its own CompilationOptions, not WgpuCompilationOptions.
+        let compilation_options = cubecl_cpp::shared::CompilationOptions::default();
+        kernel.compile(self, &compilation_options, mode, kernel.address_type())
     }
 
     fn lang_tag(&self) -> &'static str {
         "msl"
     }
-    fn into_auto(
+
+    fn validate_ir(
+        &self,
+        repr: &Option<Self::Representation>,
+        props: &DeviceProperties,
+    ) -> Result<(), LaunchError> {
+        let shared_bytes = repr.as_ref().map(|repr| repr.shared_memory_size());
+        check_shared_memory(shared_bytes, props)
+    }
+
+    fn to_auto(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>) {
@@ -312,41 +323,74 @@ impl WgpuCompiler for MslComputeKernel {
 }
 
 #[cfg(feature = "spirv")]
-impl WgpuCompiler for cubecl_spirv::SpirvCompiler {
-    type Representation;
-
+impl<T: cubecl_spirv::SpirvTarget> WgpuCompiler for cubecl_spirv::SpirvCompiler<T> {
     fn init(_backend: wgpu::Backend, _options: &WgpuCompilationOptions) -> Self {
         Self::default()
     }
+
     fn wgpu_compile(
         &mut self,
         server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError> {
-        crate::vulkan::compile(self, server, kernel, mode)
+        #[cfg(feature = "spirv-dump")]
+        let (name, id) = (kernel.name().to_string(), kernel.id());
+        let compiled = crate::vulkan::compile(self, server, kernel, mode)?;
+        #[cfg(feature = "spirv-dump")]
+        if let Some(spirv) = compiled.repr.as_ref() {
+            crate::vulkan::dump_spirv(spirv, &name, id);
+        }
+        Ok(compiled)
     }
 
     fn lang_tag(&self) -> &'static str {
         "spirv"
     }
-    fn into_auto(
+
+    fn validate_ir(
+        &self,
+        repr: &Option<Self::Representation>,
+        props: &DeviceProperties,
+    ) -> Result<(), LaunchError> {
+        let shared_bytes = repr.as_ref().map(|repr| repr.shared_size);
+        check_shared_memory(shared_bytes, props)
+    }
+
+    fn to_auto(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>) {
+        let params_transfer = match repr.as_ref().and_then(|r| r.immediate_size) {
+            Some(_) => ParamsTransfer::Immediate,
+            None => ParamsTransfer::Uniform,
+        };
         (
-            CompilerInfo::Vulkan {
-                params_transfer: match repr.immediate_size {
-                    Some(_) => ParamsTransfer::Immediate,
-                    None => ParamsTransfer::Uniform,
-                },
-            },
+            CompilerInfo::Vulkan { params_transfer },
             repr.map(|r| r.into()),
         )
     }
 }
 
-pub(crate) trait WgpuCompiler: Compiler {
+fn check_shared_memory(
+    shared_bytes: Option<usize>,
+    props: &DeviceProperties,
+) -> Result<(), LaunchError> {
+    let max_smem = props.hardware.max_shared_memory_size;
+    if let Some(shared_bytes) = shared_bytes
+        && shared_bytes > max_smem
+    {
+        return Err(ResourceLimitError::SharedMemory {
+            requested: shared_bytes,
+            max: max_smem,
+            backtrace: BackTrace::capture(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+pub trait WgpuCompiler: Compiler {
     fn init(backend: wgpu::Backend, options: &WgpuCompilationOptions) -> Self;
     fn validate_ir(
         &self,
@@ -360,7 +404,7 @@ pub(crate) trait WgpuCompiler: Compiler {
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError>;
     fn lang_tag(&self) -> &'static str;
-    fn into_auto(
+    fn to_auto(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>);

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -15,9 +15,15 @@ use derive_more::derive::From;
 
 #[cfg(feature = "spirv")]
 use crate::ParamsTransfer;
-use crate::{CompilerInfo, WgpuServer, WgslCompiler};
+use crate::{CompilerInfo, WgpuServer};
 
 use super::wgsl;
+
+#[cfg(feature = "msl")]
+pub use cubecl_cpp::MslCompiler;
+#[cfg(feature = "spirv")]
+pub use cubecl_spirv::SpirvCompiler;
+pub use wgsl::WgslCompiler;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
@@ -26,7 +32,7 @@ pub enum AutoCompiler {
     #[cfg(feature = "spirv")]
     SpirV(cubecl_spirv::SpirvCompiler),
     #[cfg(feature = "msl")]
-    Msl(cubecl_cpp::MslCompiler),
+    Msl(MslCompiler),
 }
 
 #[derive(From)]
@@ -285,7 +291,7 @@ impl WgpuCompiler for WgslCompiler {
 }
 
 #[cfg(feature = "msl")]
-impl WgpuCompiler for cubecl_cpp::MslCompiler {
+impl WgpuCompiler for MslCompiler {
     fn init(_backend: wgpu::Backend, _options: &WgpuCompilationOptions) -> Self {
         Self::default()
     }

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -2,16 +2,18 @@ use std::fmt::Display;
 
 use cubecl_core::{
     Compiler, ExecutionMode, WgpuCompilationOptions,
+    backtrace::BackTrace,
     ir::StorageType,
     prelude::{CompiledKernel, KernelDefinition},
-    server::ComputeServer,
+    server::{ComputeServer, LaunchError, ResourceLimitError},
 };
 #[cfg(feature = "msl")]
 use cubecl_cpp::shared::MslComputeKernel;
+use cubecl_ir::DeviceProperties;
 use cubecl_runtime::compiler::CompilationError;
 use derive_more::derive::From;
 
-use crate::{WgpuServer, WgslCompiler};
+use crate::{CompilerInfo, WgpuServer, WgslCompiler};
 
 use super::wgsl;
 
@@ -145,11 +147,24 @@ impl Compiler for AutoCompiler {
     }
 }
 
-impl AutoCompiler {
-    pub fn compile(
+impl WgpuCompiler for AutoCompiler {
+    fn init(backend: wgpu::Backend, options: &WgpuCompilationOptions) -> Self {
+        let _ = options; // Unused without `spirv` feature
+        match backend {
+            #[cfg(feature = "spirv")]
+            wgpu::Backend::Vulkan if options.supports_vulkan_compiler => {
+                AutoCompiler::SpirV(Default::default())
+            }
+            #[cfg(feature = "msl")]
+            wgpu::Backend::Metal => AutoCompiler::Msl(Default::default()),
+            _ => AutoCompiler::Wgsl(Default::default()),
+        }
+    }
+
+    fn wgpu_compile(
         &mut self,
-        server: &mut WgpuServer,
-        kernel: <WgpuServer as ComputeServer>::Kernel,
+        server: &mut WgpuServer<AutoCompiler>,
+        kernel: <WgpuServer<AutoCompiler> as ComputeServer>::Kernel,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError> {
         match self {
@@ -171,7 +186,7 @@ impl AutoCompiler {
         }
     }
 
-    pub fn lang_tag(&self) -> &'static str {
+    fn lang_tag(&self) -> &'static str {
         match self {
             AutoCompiler::Wgsl(_) => "wgsl",
             #[cfg(feature = "spirv")]
@@ -180,4 +195,173 @@ impl AutoCompiler {
             AutoCompiler::Msl(_) => "msl",
         }
     }
+
+    fn validate_ir(
+        &self,
+        repr: &Option<Self::Representation>,
+        props: &DeviceProperties,
+    ) -> Result<(), LaunchError> {
+        let shared_bytes = repr.as_ref().map(|repr| match repr {
+            AutoRepresentation::Wgsl(repr) => repr.shared_memory_bytes(),
+            #[cfg(feature = "msl")]
+            AutoRepresentation::Msl(repr) => repr.shared_memory_size(),
+            #[cfg(feature = "spirv")]
+            AutoRepresentation::SpirV(repr) => repr.shared_size,
+        });
+        let max_smem = props.hardware.max_shared_memory_size;
+        if let Some(shared_bytes) = shared_bytes
+            && shared_bytes > max_smem
+        {
+            return Err(ResourceLimitError::SharedMemory {
+                requested: shared_bytes,
+                max: max_smem,
+                backtrace: BackTrace::capture(),
+            }
+            .into());
+        }
+
+        Ok(())
+    }
+    fn into_auto(
+        &self,
+        repr: Option<Self::Representation>,
+    ) -> (CompilerInfo, Option<AutoRepresentation>) {
+        let compiler_info = match repr {
+            #[cfg(feature = "spirv")]
+            Some(AutoRepresentation::SpirV(repr)) => CompilerInfo::Vulkan {
+                params_transfer: match repr.immediate_size {
+                    Some(_) => ParamsTransfer::Immediate,
+                    None => ParamsTransfer::Uniform,
+                },
+            },
+            #[cfg(feature = "msl")]
+            Some(AutoRepresentation::Msl(_)) => CompilerInfo::Metal,
+            Some(AutoRepresentation::Wgsl(_)) => CompilerInfo::WGSL,
+            None => CompilerInfo::None,
+        };
+
+        (compiler_info, repr)
+    }
+}
+
+impl WgpuCompiler for WgslCompiler {
+    fn init(_backend: wgpu::Backend, _options: &WgpuCompilationOptions) -> Self {
+        Self::default()
+    }
+    fn wgpu_compile(
+        &mut self,
+        server: &mut WgpuServer<Self>,
+        kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
+        mode: ExecutionMode,
+    ) -> Result<CompiledKernel<Self>, CompilationError> {
+        kernel.compile(
+            self,
+            &server.compilation_options,
+            mode,
+            kernel.address_type(),
+        )
+    }
+
+    fn lang_tag(&self) -> &'static str {
+        "wgsl"
+    }
+    fn validate_ir(
+        &self,
+        repr: &Option<Self::Representation>,
+        props: &DeviceProperties,
+    ) -> Result<(), LaunchError> {
+        todo!()
+    }
+
+    fn into_auto(
+        &self,
+        repr: Option<Self::Representation>,
+    ) -> (CompilerInfo, Option<AutoRepresentation>) {
+        (CompilerInfo::WGSL, repr.map(|r| r.into()))
+    }
+}
+
+#[cfg(feature = "msl")]
+impl WgpuCompiler for MslComputeKernel {
+    fn init(_backend: wgpu::Backend, _options: &WgpuCompilationOptions) -> Self {
+        Self::default()
+    }
+    fn wgpu_compile(
+        &mut self,
+        server: &mut WgpuServer<Self>,
+        kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
+        mode: ExecutionMode,
+    ) -> Result<CompiledKernel<Self>, CompilationError> {
+        kernel.compile(
+            self,
+            &server.compilation_options,
+            mode,
+            kernel.address_type(),
+        )
+    }
+
+    fn lang_tag(&self) -> &'static str {
+        "msl"
+    }
+    fn into_auto(
+        &self,
+        repr: Option<Self::Representation>,
+    ) -> (CompilerInfo, Option<AutoRepresentation>) {
+        (CompilerInfo::Metal, repr.map(|r| r.into()))
+    }
+}
+
+#[cfg(feature = "spirv")]
+impl WgpuCompiler for cubecl_spirv::SpirvCompiler {
+    type Representation;
+
+    fn init(_backend: wgpu::Backend, _options: &WgpuCompilationOptions) -> Self {
+        Self::default()
+    }
+    fn wgpu_compile(
+        &mut self,
+        server: &mut WgpuServer<Self>,
+        kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
+        mode: ExecutionMode,
+    ) -> Result<CompiledKernel<Self>, CompilationError> {
+        crate::vulkan::compile(self, server, kernel, mode)
+    }
+
+    fn lang_tag(&self) -> &'static str {
+        "spirv"
+    }
+    fn into_auto(
+        &self,
+        repr: Option<Self::Representation>,
+    ) -> (CompilerInfo, Option<AutoRepresentation>) {
+        (
+            CompilerInfo::Vulkan {
+                params_transfer: match repr.immediate_size {
+                    Some(_) => ParamsTransfer::Immediate,
+                    None => ParamsTransfer::Uniform,
+                },
+            },
+            repr.map(|r| r.into()),
+        )
+    }
+}
+
+pub(crate) trait WgpuCompiler: Compiler {
+    fn init(backend: wgpu::Backend, options: &WgpuCompilationOptions) -> Self;
+    fn validate_ir(
+        &self,
+        repr: &Option<Self::Representation>,
+        props: &DeviceProperties,
+    ) -> Result<(), LaunchError>;
+    fn wgpu_compile(
+        &mut self,
+        server: &mut WgpuServer<Self>,
+        kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
+        mode: ExecutionMode,
+    ) -> Result<CompiledKernel<Self>, CompilationError>;
+    fn lang_tag(&self) -> &'static str;
+    fn into_auto(
+        &self,
+        repr: Option<Self::Representation>,
+    ) -> (CompilerInfo, Option<AutoRepresentation>);
 }

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -25,38 +25,55 @@ pub use cubecl_cpp::MslCompiler;
 pub use cubecl_spirv::SpirvCompiler;
 pub use wgsl::WgslCompiler;
 
+/// Compiler that dispatches to the most appropriate shader language backend for the active
+/// `wgpu` backend.
+///
+/// The variant is selected at runtime by [`WgpuCompiler::init`] based on the `wgpu::Backend`
+/// in use and the enabled cargo features (`spirv`, `msl`).
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum AutoCompiler {
+    /// WGSL backend, available on every `wgpu` backend.
     Wgsl(WgslCompiler),
+    /// SPIR-V backend used on Vulkan when the device supports the required features.
     #[cfg(feature = "spirv")]
     SpirV(cubecl_spirv::SpirvCompiler),
+    /// Metal Shading Language backend used on the Metal backend.
     #[cfg(feature = "msl")]
     Msl(MslCompiler),
 }
 
+/// Owned compiled kernel representation matching the variants of [`AutoCompiler`].
 #[derive(From)]
 #[allow(clippy::large_enum_variant)]
 pub enum AutoRepresentation {
+    /// WGSL compute shader source.
     Wgsl(wgsl::ComputeShader),
+    /// Compiled SPIR-V kernel.
     #[cfg(feature = "spirv")]
     SpirV(cubecl_spirv::SpirvKernel),
+    /// Compiled Metal Shading Language kernel.
     #[cfg(feature = "msl")]
     Msl(MslComputeKernel),
 }
 
+/// Borrowed counterpart of [`AutoRepresentation`], useful when only read access is needed.
 #[derive(From, Clone, Copy)]
 #[allow(clippy::large_enum_variant)]
 pub enum AutoRepresentationRef<'a> {
+    /// Borrowed WGSL compute shader.
     Wgsl(&'a wgsl::ComputeShader),
+    /// Borrowed SPIR-V kernel.
     #[cfg(feature = "spirv")]
     SpirV(&'a cubecl_spirv::SpirvKernel),
+    /// Borrowed Metal Shading Language kernel.
     #[cfg(feature = "msl")]
     Msl(&'a MslComputeKernel),
 }
 
 #[cfg(feature = "spirv")]
 impl AutoRepresentation {
+    /// Returns the SPIR-V kernel if this representation is the SPIR-V variant.
     pub fn as_spirv(&self) -> Option<&cubecl_spirv::SpirvKernel> {
         match self {
             AutoRepresentation::SpirV(repr) => Some(repr),
@@ -67,6 +84,7 @@ impl AutoRepresentation {
 
 #[cfg(feature = "msl")]
 impl AutoRepresentation {
+    /// Returns the MSL kernel if this representation is the MSL variant.
     pub fn as_msl(&self) -> Option<&MslComputeKernel> {
         match self {
             AutoRepresentation::Msl(repr) => Some(repr),
@@ -76,6 +94,7 @@ impl AutoRepresentation {
 }
 
 impl AutoRepresentation {
+    /// Borrow this representation as an [`AutoRepresentationRef`].
     pub fn as_ref(&self) -> AutoRepresentationRef<'_> {
         match self {
             AutoRepresentation::Wgsl(compute_shader) => AutoRepresentationRef::Wgsl(compute_shader),
@@ -169,7 +188,7 @@ impl WgpuCompiler for AutoCompiler {
         }
     }
 
-    fn wgpu_compile(
+    fn compile_kernel(
         &mut self,
         server: &mut WgpuServer<AutoCompiler>,
         kernel: <WgpuServer<AutoCompiler> as ComputeServer>::Kernel,
@@ -228,7 +247,7 @@ impl WgpuCompiler for AutoCompiler {
         check_shared_memory(shared_bytes, props)
     }
 
-    fn to_auto(
+    fn normalize_repr(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>) {
@@ -255,7 +274,7 @@ impl WgpuCompiler for WgslCompiler {
         Self::default()
     }
 
-    fn wgpu_compile(
+    fn compile_kernel(
         &mut self,
         server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
@@ -282,7 +301,7 @@ impl WgpuCompiler for WgslCompiler {
         check_shared_memory(shared_bytes, props)
     }
 
-    fn to_auto(
+    fn normalize_repr(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>) {
@@ -296,7 +315,7 @@ impl WgpuCompiler for MslCompiler {
         Self::default()
     }
 
-    fn wgpu_compile(
+    fn compile_kernel(
         &mut self,
         _server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
@@ -320,7 +339,7 @@ impl WgpuCompiler for MslCompiler {
         check_shared_memory(shared_bytes, props)
     }
 
-    fn to_auto(
+    fn normalize_repr(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>) {
@@ -334,7 +353,7 @@ impl<T: cubecl_spirv::SpirvTarget> WgpuCompiler for cubecl_spirv::SpirvCompiler<
         Self::default()
     }
 
-    fn wgpu_compile(
+    fn compile_kernel(
         &mut self,
         server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
@@ -363,7 +382,7 @@ impl<T: cubecl_spirv::SpirvTarget> WgpuCompiler for cubecl_spirv::SpirvCompiler<
         check_shared_memory(shared_bytes, props)
     }
 
-    fn to_auto(
+    fn normalize_repr(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>) {
@@ -396,21 +415,55 @@ fn check_shared_memory(
     Ok(())
 }
 
+/// Extension trait implemented by every compiler usable with the `wgpu` runtime.
+///
+/// The base [`Compiler`] trait already exposes a `compile` method that turns a
+/// [`KernelDefinition`] into a backend representation. [`WgpuCompiler`] sits one level
+/// higher: it owns the wgpu-specific lifecycle around a [`CubeTask`](cubecl_runtime::compiler::CubeTask)
+/// kernel — initializing the compiler for a given `wgpu::Backend`, compiling a kernel using
+/// the server's [`WgpuCompilationOptions`], validating the resulting IR against the device,
+/// and projecting the typed representation into the runtime-erased [`AutoRepresentation`].
 pub trait WgpuCompiler: Compiler {
+    /// Build the compiler instance appropriate for the given `wgpu` backend.
+    ///
+    /// `options` is consulted to decide between alternative implementations (for example, to
+    /// opt into the SPIR-V compiler on Vulkan when the device advertises the required
+    /// features).
     fn init(backend: wgpu::Backend, options: &WgpuCompilationOptions) -> Self;
+
+    /// Validate that the compiled representation fits within the device's resource limits.
+    ///
+    /// Today this checks shared memory usage; additional checks may be added without
+    /// breaking the contract.
     fn validate_ir(
         &self,
         repr: &Option<Self::Representation>,
         props: &DeviceProperties,
     ) -> Result<(), LaunchError>;
-    fn wgpu_compile(
+
+    /// Compile a runtime kernel into a [`CompiledKernel`] ready for pipeline creation.
+    ///
+    /// Distinct from [`Compiler::compile`], which only translates a [`KernelDefinition`].
+    /// This entry point operates on a full server-level kernel and pulls compilation
+    /// options from `server`, so its signature cannot collide with the base trait method.
+    fn compile_kernel(
         &mut self,
         server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError>;
+
+    /// Short identifier of the shader language produced by this compiler (e.g. `"wgsl"`).
+    ///
+    /// Used for logging and debug-info tagging.
     fn lang_tag(&self) -> &'static str;
-    fn to_auto(
+
+    /// Normalize the backend-specific representation into the [`AutoRepresentation`] shared
+    /// by every wgpu compiler, and report the [`CompilerInfo`] derived from it.
+    ///
+    /// The [`CompilerInfo`] tells the server which parameter-passing strategy to use for
+    /// the resulting pipeline.
+    fn normalize_repr(
         &self,
         repr: Option<Self::Representation>,
     ) -> (CompilerInfo, Option<AutoRepresentation>);

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -196,8 +196,8 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         self.scheduler.logger.log_compilation(&compiled);
 
         compiler.validate_ir(&compiled.repr, &self.utilities.properties)?;
-        let (compiler_info, repr) = compiler.into_auto(compiled.repr);
-        let repr = repr.as_ref().map(|r| r.as_ref());
+        let (compiler_info, auto_repr) = compiler.to_auto(compiled.repr);
+        let repr = auto_repr.as_ref().map(|r| r.as_ref());
 
         // /!\ Do not delete the following commented code.
         // This is useful while working on the metal compiler.
@@ -236,7 +236,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
 
         #[cfg(feature = "spirv")]
         if let Some(Err(key)) = cached
-            && let Some(crate::AutoRepresentation::SpirV(kernel)) = compiled.repr
+            && let Some(crate::AutoRepresentation::SpirV(kernel)) = auto_repr
         {
             let cache = self.spirv_cache.as_mut().unwrap();
             let result = cache.insert(

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -185,7 +185,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         validate_units(&self.utilities.properties, &kernel_id)?;
 
         let mut compiler = C::init(self.backend, &self.compilation_options);
-        let mut compiled = compiler.wgpu_compile(self, kernel, mode)?;
+        let mut compiled = compiler.compile_kernel(self, kernel, mode)?;
 
         if self.scheduler.logger.compilation_activated() {
             compiled.debug_info = Some(DebugInformation::new(
@@ -196,7 +196,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         self.scheduler.logger.log_compilation(&compiled);
 
         compiler.validate_ir(&compiled.repr, &self.utilities.properties)?;
-        let (compiler_info, auto_repr) = compiler.to_auto(compiled.repr);
+        let (compiler_info, auto_repr) = compiler.normalize_repr(compiled.repr);
         let repr = auto_repr.as_ref().map(|r| r.as_ref());
 
         // /!\ Do not delete the following commented code.

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -1,9 +1,8 @@
+use std::marker::PhantomData;
+
 use super::storage::{WgpuResource, WgpuStorage};
-use crate::{AutoCompiler, AutoRepresentation};
-use crate::{
-    AutoRepresentationRef,
-    schedule::{BindingsResource, ScheduleTask, ScheduledWgpuBackend},
-};
+use crate::WgpuCompiler;
+use crate::schedule::{BindingsResource, ScheduleTask, ScheduledWgpuBackend};
 use alloc::sync::Arc;
 use cubecl_common::{
     backtrace::BackTrace,
@@ -19,7 +18,7 @@ use cubecl_core::{
     prelude::*,
     server::{
         CopyDescriptor, IoError, KernelArguments, LaunchError, ProfileError, ProfilingToken,
-        ResourceLimitError, ServerCommunication, ServerError, ServerUtilities,
+        ServerCommunication, ServerError, ServerUtilities,
     },
     zspace::{Strides, strides},
 };
@@ -58,7 +57,7 @@ pub enum CompilerInfo {
 
 /// Wgpu compute server.
 #[derive(Debug)]
-pub struct WgpuServer {
+pub struct WgpuServer<C: WgpuCompiler> {
     pub(crate) device: wgpu::Device,
     // A buffer that can be used to store stream id without extra allocations.
     streams_pool: Vec<StreamId>,
@@ -70,13 +69,14 @@ pub struct WgpuServer {
     pub compilation_options: WgpuCompilationOptions,
     pub(crate) backend: wgpu::Backend,
     pub(crate) utilities: Arc<ServerUtilities<Self>>,
+    _compiler: PhantomData<C>,
 }
 
-impl ServerCommunication for WgpuServer {
+impl<C: WgpuCompiler> ServerCommunication for WgpuServer<C> {
     const SERVER_COMM_ENABLED: bool = false;
 }
 
-impl WgpuServer {
+impl<C: WgpuCompiler> WgpuServer<C> {
     /// Create a new server.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -135,6 +135,7 @@ impl WgpuServer {
             },
             backend,
             utilities: Arc::new(utilities),
+            _compiler: PhantomData,
         }
     }
 
@@ -183,8 +184,8 @@ impl WgpuServer {
         validate_cube_dim(&self.utilities.properties, &kernel_id)?;
         validate_units(&self.utilities.properties, &kernel_id)?;
 
-        let mut compiler = compiler(self.backend, &self.compilation_options);
-        let mut compiled = compiler.compile(self, kernel, mode)?;
+        let mut compiler = C::init(self.backend, &self.compilation_options);
+        let mut compiled = compiler.wgpu_compile(self, kernel, mode)?;
 
         if self.scheduler.logger.compilation_activated() {
             compiled.debug_info = Some(DebugInformation::new(
@@ -194,7 +195,9 @@ impl WgpuServer {
         }
         self.scheduler.logger.log_compilation(&compiled);
 
-        self.validate_shared(&compiled.repr)?;
+        compiler.validate_ir(&compiled.repr, &self.utilities.properties)?;
+        let (compiler_info, repr) = compiler.into_auto(compiled.repr);
+        let repr = repr.as_ref().map(|r| r.as_ref());
 
         // /!\ Do not delete the following commented code.
         // This is useful while working on the metal compiler.
@@ -219,20 +222,6 @@ impl WgpuServer {
         //         .expect("should launch the command");
         //     // std::process::exit(status.code().unwrap());
         // }
-        let repr = compiled.repr.as_ref().map(|it| it.as_ref());
-        let compiler_info = match &repr {
-            #[cfg(feature = "spirv")]
-            Some(AutoRepresentationRef::SpirV(repr)) => CompilerInfo::Vulkan {
-                params_transfer: match repr.immediate_size {
-                    Some(_) => ParamsTransfer::Immediate,
-                    None => ParamsTransfer::Uniform,
-                },
-            },
-            #[cfg(feature = "msl")]
-            Some(AutoRepresentationRef::Msl(_)) => CompilerInfo::Metal,
-            Some(AutoRepresentationRef::Wgsl(_)) => CompilerInfo::WGSL,
-            None => CompilerInfo::None,
-        };
 
         let module = self.create_module(
             &compiled.entrypoint_name,
@@ -261,33 +250,10 @@ impl WgpuServer {
 
         Ok((pipeline, compiler_info))
     }
-
-    fn validate_shared(&self, repr: &Option<crate::AutoRepresentation>) -> Result<(), LaunchError> {
-        let shared_bytes = repr.as_ref().map(|repr| match repr {
-            AutoRepresentation::Wgsl(repr) => repr.shared_memory_bytes(),
-            #[cfg(feature = "msl")]
-            AutoRepresentation::Msl(repr) => repr.shared_memory_size(),
-            #[cfg(feature = "spirv")]
-            AutoRepresentation::SpirV(repr) => repr.shared_size,
-        });
-        let max_smem = self.utilities.properties.hardware.max_shared_memory_size;
-        if let Some(shared_bytes) = shared_bytes
-            && shared_bytes > max_smem
-        {
-            Err(ResourceLimitError::SharedMemory {
-                requested: shared_bytes,
-                max: max_smem,
-                backtrace: BackTrace::capture(),
-            }
-            .into())
-        } else {
-            Ok(())
-        }
-    }
 }
 
-impl ComputeServer for WgpuServer {
-    type Kernel = Box<dyn CubeTask<AutoCompiler>>;
+impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
+    type Kernel = Box<dyn CubeTask<C>>;
     type Storage = WgpuStorage;
     type MemoryLayoutPolicy = ContiguousMemoryLayoutPolicy;
     type Info = wgpu::Backend;
@@ -488,19 +454,6 @@ impl ComputeServer for WgpuServer {
         self.scheduler.execute_streams(vec![stream_id]);
         let stream = self.scheduler.stream(&stream_id);
         stream.mem_manage.mode(mode);
-    }
-}
-
-fn compiler(backend: wgpu::Backend, options: &WgpuCompilationOptions) -> AutoCompiler {
-    let _ = options; // Unused without `spirv` feature
-    match backend {
-        #[cfg(feature = "spirv")]
-        wgpu::Backend::Vulkan if options.supports_vulkan_compiler => {
-            AutoCompiler::SpirV(Default::default())
-        }
-        #[cfg(feature = "msl")]
-        wgpu::Backend::Metal => AutoCompiler::Msl(Default::default()),
-        _ => AutoCompiler::Wgsl(Default::default()),
     }
 }
 

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -12,7 +12,6 @@ mod graphics;
 mod runtime;
 
 pub use compiler::base::*;
-pub use compiler::wgsl::WgslCompiler;
 pub use compute::*;
 pub use device::*;
 pub use element::*;

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -29,9 +29,7 @@ pub struct WgpuRuntime<Compiler = AutoCompiler> {
 
 impl<C> Clone for WgpuRuntime<C> {
     fn clone(&self) -> Self {
-        Self {
-            _p: self._p.clone(),
-        }
+        Self { _p: self._p }
     }
 }
 

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -1,3 +1,6 @@
+use std::marker::PhantomData;
+
+use crate::WgpuCompiler;
 use crate::{
     AutoCompiler, AutoGraphicsApi, GraphicsApi, WgpuDevice, backend, compute::WgpuServer,
     contiguous_strides,
@@ -19,10 +22,20 @@ use wgpu::{InstanceFlags, RequestAdapterOptions};
 /// Runtime that uses the [wgpu] crate with the wgsl compiler. This is used in the Wgpu backend.
 /// For advanced configuration, use [`init_setup`] to pass in runtime options or to select a
 /// specific graphics API.
-#[derive(Debug, Clone)]
-pub struct WgpuRuntime;
+#[derive(Debug)]
+pub struct WgpuRuntime<Compiler = AutoCompiler> {
+    _p: PhantomData<Compiler>,
+}
 
-impl DeviceService for WgpuServer {
+impl<C> Clone for WgpuRuntime<C> {
+    fn clone(&self) -> Self {
+        Self {
+            _p: self._p.clone(),
+        }
+    }
+}
+
+impl<C: WgpuCompiler> DeviceService for WgpuServer<C> {
     fn init(device_id: cubecl_common::device::DeviceId) -> Self {
         let device = WgpuDevice::from_id(device_id);
         let setup = future::block_on(create_setup_for_device(&device, AutoGraphicsApi::backend()));
@@ -34,9 +47,9 @@ impl DeviceService for WgpuServer {
     }
 }
 
-impl Runtime for WgpuRuntime {
-    type Compiler = AutoCompiler;
-    type Server = WgpuServer;
+impl<C: WgpuCompiler> Runtime for WgpuRuntime<C> {
+    type Compiler = C;
+    type Server = WgpuServer<C>;
     type Device = WgpuDevice;
 
     fn client(device: &Self::Device) -> ComputeClient<Self> {
@@ -272,7 +285,10 @@ pub async fn init_setup_async<G: GraphicsApi>(
     return_setup
 }
 
-pub(crate) fn create_server(setup: WgpuSetup, options: RuntimeOptions) -> WgpuServer {
+pub(crate) fn create_server<C: WgpuCompiler>(
+    setup: WgpuSetup,
+    options: RuntimeOptions,
+) -> WgpuServer<C> {
     let limits = setup.device.limits();
     let adapter_limits = setup.adapter.limits();
     let mut adapter_info = setup.adapter.get_info();


### PR DESCRIPTION
Avoid the conflicts of backend with wgpu with different compiler. AutoCompiler keeps the same behavior as before.