### PR TITLE
fix: short-circuit || and && in #[cube] code

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/mod.rs
+++ b/crates/cubecl-core/src/runtime_tests/mod.rs
@@ -26,6 +26,7 @@ pub mod plane;
 pub mod properties;
 pub mod saturating;
 pub mod sequence;
+pub mod short_circuit;
 pub mod slice;
 pub mod stream;
 pub mod synchronization;
@@ -159,6 +160,8 @@ macro_rules! testgen_untyped {
 
         cubecl_core::testgen_to_client!();
         cubecl_core::testgen_all_reduce!();
+
+        cubecl_core::testgen_short_circuit!();
     };
 }
 

--- a/crates/cubecl-core/src/runtime_tests/short_circuit.rs
+++ b/crates/cubecl-core/src/runtime_tests/short_circuit.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::{self as cubecl};
+use cubecl_runtime::server::Handle;
 
 // Pin `||` / `&&` short-circuit semantics. The RHS mutates a side-channel.
 // If short-circuit holds, the channel is never written.
@@ -38,6 +39,32 @@ pub fn kernel_short_circuit_and(output: &mut [u32], left_input: u32) {
     }
 }
 
+// Pure operands take the eager path. The logical result must still be correct.
+
+#[cube(launch)]
+pub fn kernel_pure_or(output: &mut [u32], a: u32, b: u32) {
+    if UNIT_POS == 0 {
+        let flag = (a != 0u32) || (b != 0u32);
+        if flag {
+            output[0] = 1u32;
+        } else {
+            output[0] = 0u32;
+        }
+    }
+}
+
+#[cube(launch)]
+pub fn kernel_pure_and(output: &mut [u32], a: u32, b: u32) {
+    if UNIT_POS == 0 {
+        let flag = (a != 0u32) && (b != 0u32);
+        if flag {
+            output[0] = 1u32;
+        } else {
+            output[0] = 0u32;
+        }
+    }
+}
+
 pub fn test_short_circuit_or<R: Runtime>(client: ComputeClient<R>) {
     let handle = client.empty(core::mem::size_of::<u32>());
     kernel_short_circuit_or::launch::<R>(
@@ -66,6 +93,52 @@ pub fn test_short_circuit_and<R: Runtime>(client: ComputeClient<R>) {
     assert_eq!(actual[0], 0, "`&&` did not short-circuit");
 }
 
+fn run_pure<R: Runtime>(
+    client: &ComputeClient<R>,
+    launch: impl Fn(&ComputeClient<R>, Handle, u32, u32),
+    a: u32,
+    b: u32,
+) -> u32 {
+    let handle = client.empty(core::mem::size_of::<u32>());
+    launch(client, handle.clone(), a, b);
+    let actual = client.read_one_unchecked(handle);
+    u32::from_bytes(&actual)[0]
+}
+
+pub fn test_pure_or<R: Runtime>(client: ComputeClient<R>) {
+    let launch = |client: &ComputeClient<R>, handle: Handle, a, b| {
+        kernel_pure_or::launch::<R>(
+            client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new_1d(1),
+            unsafe { BufferArg::from_raw_parts(handle, 1) },
+            a,
+            b,
+        );
+    };
+    assert_eq!(run_pure(&client, &launch, 0, 0), 0, "0 || 0");
+    assert_eq!(run_pure(&client, &launch, 0, 7), 1, "0 || 7");
+    assert_eq!(run_pure(&client, &launch, 5, 0), 1, "5 || 0");
+    assert_eq!(run_pure(&client, &launch, 5, 7), 1, "5 || 7");
+}
+
+pub fn test_pure_and<R: Runtime>(client: ComputeClient<R>) {
+    let launch = |client: &ComputeClient<R>, handle: Handle, a, b| {
+        kernel_pure_and::launch::<R>(
+            client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new_1d(1),
+            unsafe { BufferArg::from_raw_parts(handle, 1) },
+            a,
+            b,
+        );
+    };
+    assert_eq!(run_pure(&client, &launch, 0, 0), 0, "0 && 0");
+    assert_eq!(run_pure(&client, &launch, 0, 7), 0, "0 && 7");
+    assert_eq!(run_pure(&client, &launch, 5, 0), 0, "5 && 0");
+    assert_eq!(run_pure(&client, &launch, 5, 7), 1, "5 && 7");
+}
+
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! testgen_short_circuit {
@@ -84,6 +157,18 @@ macro_rules! testgen_short_circuit {
             cubecl_core::runtime_tests::short_circuit::test_short_circuit_and::<TestRuntime>(
                 client,
             );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_pure_or() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::short_circuit::test_pure_or::<TestRuntime>(client);
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_pure_and() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::short_circuit::test_pure_and::<TestRuntime>(client);
         }
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/short_circuit.rs
+++ b/crates/cubecl-core/src/runtime_tests/short_circuit.rs
@@ -1,0 +1,87 @@
+use crate::prelude::*;
+use crate::{self as cubecl};
+
+// Pin `||` / `&&` short-circuit semantics. The RHS mutates a side-channel.
+// If short-circuit holds, the channel is never written.
+
+#[cube]
+fn mark_side_channel(side_channel: &mut Array<u32>) -> bool {
+    side_channel[0] = 1u32;
+    false.into()
+}
+
+#[cube(launch)]
+pub fn kernel_short_circuit_or(output: &mut [u32], left_input: u32) {
+    if UNIT_POS == 0 {
+        let mut side_channel = Array::<u32>::new(1usize);
+        side_channel[0] = 0u32;
+        let flag = (left_input != 0u32) || mark_side_channel(&mut side_channel);
+        if flag {
+            output[0] = side_channel[0];
+        } else {
+            output[0] = 999u32;
+        }
+    }
+}
+
+#[cube(launch)]
+pub fn kernel_short_circuit_and(output: &mut [u32], left_input: u32) {
+    if UNIT_POS == 0 {
+        let mut side_channel = Array::<u32>::new(1usize);
+        side_channel[0] = 0u32;
+        let flag = (left_input != 0u32) && mark_side_channel(&mut side_channel);
+        if !flag {
+            output[0] = side_channel[0];
+        } else {
+            output[0] = 999u32;
+        }
+    }
+}
+
+pub fn test_short_circuit_or<R: Runtime>(client: ComputeClient<R>) {
+    let handle = client.empty(core::mem::size_of::<u32>());
+    kernel_short_circuit_or::launch::<R>(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_1d(1),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+        1u32,
+    );
+    let actual = client.read_one_unchecked(handle);
+    let actual = u32::from_bytes(&actual);
+    assert_eq!(actual[0], 0, "`||` did not short-circuit");
+}
+
+pub fn test_short_circuit_and<R: Runtime>(client: ComputeClient<R>) {
+    let handle = client.empty(core::mem::size_of::<u32>());
+    kernel_short_circuit_and::launch::<R>(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_1d(1),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+        0u32,
+    );
+    let actual = client.read_one_unchecked(handle);
+    let actual = u32::from_bytes(&actual);
+    assert_eq!(actual[0], 0, "`&&` did not short-circuit");
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! testgen_short_circuit {
+    () => {
+        use super::*;
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_short_circuit_or() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::short_circuit::test_short_circuit_or::<TestRuntime>(client);
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_short_circuit_and() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::short_circuit::test_short_circuit_and::<TestRuntime>(client);
+        }
+    };
+}

--- a/crates/cubecl-core/src/runtime_tests/short_circuit.rs
+++ b/crates/cubecl-core/src/runtime_tests/short_circuit.rs
@@ -81,7 +81,9 @@ macro_rules! testgen_short_circuit {
         #[$crate::runtime_tests::test_log::test]
         fn test_short_circuit_and() {
             let client = TestRuntime::client(&Default::default());
-            cubecl_core::runtime_tests::short_circuit::test_short_circuit_and::<TestRuntime>(client);
+            cubecl_core::runtime_tests::short_circuit::test_short_circuit_and::<TestRuntime>(
+                client,
+            );
         }
     };
 }

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -214,6 +214,25 @@ impl Expression {
         }
     }
 
+    /// Whether evaluating this expression has no observable effect. Used to skip
+    /// short-circuit codegen for `||`/`&&`. Conservative: anything not known to
+    /// be pure (function calls, indexing, ...) returns false.
+    pub fn is_always_pure(&self) -> bool {
+        match self {
+            Expression::Literal { .. } => true,
+            Expression::Path { .. } => true,
+            Expression::Variable(_) => true,
+            Expression::Keyword { .. } => true,
+            Expression::Binary { left, right, .. } => {
+                left.is_always_pure() && right.is_always_pure()
+            }
+            Expression::Unary { input, .. } => input.is_always_pure(),
+            Expression::Cast { from, .. } => from.is_always_pure(),
+            Expression::FieldAccess { base, .. } => base.is_always_pure(),
+            _ => false,
+        }
+    }
+
     pub fn as_const_primitive(&self, _context: &mut Context) -> Option<TokenStream> {
         match self {
             Expression::Literal { value, .. } => match value {
@@ -272,6 +291,148 @@ impl Expression {
             Expression::VerbatimTerminated { .. } => false,
             _ => true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proc_macro2::Span;
+    use syn::parse_quote;
+
+    // Pure leaves.
+    fn lit() -> Expression {
+        Expression::Literal {
+            value: parse_quote!(1),
+        }
+    }
+    fn path() -> Expression {
+        Expression::Path {
+            path: parse_quote!(foo),
+            qself: None,
+        }
+    }
+    fn keyword() -> Expression {
+        Expression::Keyword {
+            name: parse_quote!(ABSOLUTE_POS),
+        }
+    }
+
+    // Impure leaves.
+    fn call() -> Expression {
+        Expression::FunctionCall {
+            func: Box::new(path()),
+            args: vec![],
+            associated_type: None,
+            span: Span::call_site(),
+        }
+    }
+    fn index(inner: Expression) -> Expression {
+        Expression::Index {
+            expr: Box::new(inner),
+            index: Box::new(lit()),
+            span: Span::call_site(),
+        }
+    }
+    fn method(receiver: Expression) -> Expression {
+        Expression::MethodCall {
+            receiver: Box::new(receiver),
+            method: parse_quote!(foo),
+            generics: None,
+            args: vec![],
+            span: Span::call_site(),
+        }
+    }
+
+    // Recursive nodes.
+    fn binary(left: Expression, right: Expression) -> Expression {
+        Expression::Binary {
+            left: Box::new(left),
+            operator: Operator::And,
+            right: Box::new(right),
+            span: Span::call_site(),
+        }
+    }
+    fn unary(input: Expression) -> Expression {
+        Expression::Unary {
+            input: Box::new(input),
+            operator: Operator::Not,
+            span: Span::call_site(),
+        }
+    }
+    fn cast(from: Expression) -> Expression {
+        Expression::Cast {
+            from: Box::new(from),
+            to: parse_quote!(u32),
+        }
+    }
+    fn field(base: Expression) -> Expression {
+        Expression::FieldAccess {
+            base: Box::new(base),
+            field: parse_quote!(x),
+        }
+    }
+
+    #[test]
+    fn pure_leaves_are_pure() {
+        assert!(lit().is_always_pure());
+        assert!(path().is_always_pure());
+        assert!(keyword().is_always_pure());
+    }
+
+    #[test]
+    fn effectful_leaves_are_impure() {
+        assert!(!call().is_always_pure());
+        assert!(!index(path()).is_always_pure());
+        assert!(!method(path()).is_always_pure());
+    }
+
+    #[test]
+    fn unary_cast_field_follow_their_operand() {
+        assert!(unary(lit()).is_always_pure());
+        assert!(!unary(call()).is_always_pure());
+
+        assert!(cast(path()).is_always_pure());
+        assert!(!cast(index(path())).is_always_pure());
+
+        assert!(field(path()).is_always_pure());
+        assert!(!field(call()).is_always_pure());
+    }
+
+    #[test]
+    fn binary_is_pure_only_when_both_operands_are() {
+        assert!(binary(lit(), path()).is_always_pure());
+        assert!(!binary(lit(), call()).is_always_pure());
+        assert!(!binary(call(), lit()).is_always_pure());
+        assert!(!binary(call(), index(path())).is_always_pure());
+    }
+
+    #[test]
+    fn impurity_propagates_through_nesting() {
+        // A deep tree of only pure nodes stays pure.
+        let pure = binary(binary(path(), lit()), unary(cast(field(path()))));
+        assert!(pure.is_always_pure());
+
+        // The same shape with one call buried in a leaf is impure.
+        let impure = binary(binary(path(), lit()), unary(cast(field(call()))));
+        assert!(!impure.is_always_pure());
+    }
+
+    #[test]
+    fn unhandled_variants_are_conservatively_impure() {
+        // Variants not enumerated are impure even with pure children.
+        assert!(
+            !Expression::Reference {
+                inner: Box::new(lit())
+            }
+            .is_always_pure()
+        );
+        assert!(
+            !Expression::Tuple {
+                elements: vec![lit(), path()]
+            }
+            .is_always_pure()
+        );
     }
 }
 

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -22,13 +22,14 @@ impl Expression {
     pub fn to_tokens(&self, context: &mut Context) -> TokenStream {
         match self {
             // `||` and `&&` short-circuit via if/else over the left operand.
+            // Pure operands fall through to the eager binary path below.
             Expression::Binary {
                 left,
                 operator: op @ (Operator::Or | Operator::And),
                 right,
                 span,
                 ..
-            } => {
+            } if !left.is_always_pure() || !right.is_always_pure() => {
                 let path = frontend_path();
                 let native = frontend_type("NativeExpand");
                 let left = left.to_tokens(context);

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -21,6 +21,38 @@ macro_rules! error {
 impl Expression {
     pub fn to_tokens(&self, context: &mut Context) -> TokenStream {
         match self {
+            // `||` and `&&` short-circuit via if/else over the left operand.
+            Expression::Binary {
+                left,
+                operator: op @ (Operator::Or | Operator::And),
+                right,
+                span,
+                ..
+            } => {
+                let path = frontend_path();
+                let native = frontend_type("NativeExpand");
+                let left = left.to_tokens(context);
+                let right = right.to_tokens(context);
+                let (then_block, else_block) = match op {
+                    // `a || b`  =>  if a { true } else { b }
+                    Operator::Or => (
+                        quote![#native::from_lit(scope, true)],
+                        quote![#right.into_expand(scope)],
+                    ),
+                    // `a && b`  =>  if a { b } else { false }
+                    Operator::And => (
+                        quote![#right.into_expand(scope)],
+                        quote![#native::from_lit(scope, false)],
+                    ),
+                    _ => unreachable!(),
+                };
+                let body = quote! {
+                    #path::branch::if_else_expr_expand(scope, #left.into_expand(scope), |scope| #then_block)
+                        .or_else(scope, |scope| #else_block)
+                };
+                let expand = with_span(context, *span, body);
+                quote! {{#expand}}
+            }
             Expression::Binary {
                 left,
                 operator,


### PR DESCRIPTION
`||` and `&&` inside `#[cube]` evaluated both operands unconditionally, breaking the canonical `idx == 0 || arr[idx - 1] != x` guard. On `idx == 0` the right operand still ran, `0usize - 1` underflowed to `usize::MAX`, and `arr[usize::MAX]` was loaded.

This patch lowers `a || b` as `if a { true } else { b }` and `a && b` as `if a { b } else {false }` via the existing `if_else_expr_expand` plumbing. New regression test in `crates/cubecl-core/src/runtime_tests/short_circuit.rs`.

Standalone reproducer: https://github.com/LucaCappelletti94/cubecl-or-and-shortcircuit (`cargo run --release` shows the bug, `--features fixed` shows it gone).