### PR TITLE
fix: skip kernel launch when cube count is zero

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/launch.rs
+++ b/crates/cubecl-core/src/runtime_tests/launch.rs
@@ -138,6 +138,43 @@ pub fn test_kernel_without_generics<R: Runtime>(client: ComputeClient<R>) {
     assert_eq!(actual[0], 5.0);
 }
 
+pub fn test_kernel_zero_cube_count<R: Runtime>(client: ComputeClient<R>) {
+    // A zero-element fill resolves to `Static(0, 0, 0)`. Launching it is a no-op.
+    let handle = client.create_from_slice(f32::as_bytes(&[7.0, 8.0]));
+
+    kernel_without_generics::launch(
+        &client,
+        CubeCount::Static(0, 0, 0),
+        CubeDim::new_1d(1),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 2) },
+    );
+
+    let actual = client.read_one_unchecked(handle);
+    let actual = f32::from_bytes(&actual);
+
+    assert_eq!(actual, &[7.0, 8.0]);
+}
+
+pub fn test_kernel_dynamic_zero_cube_count<R: Runtime>(client: ComputeClient<R>) {
+    // The (0, 0, 0) count lives in a buffer, so the client guard can't see it.
+    // Scoped to CUDA/HIP because wgpu can't bind a storage buffer for indirect
+    // dispatch.
+    let handle = client.create_from_slice(f32::as_bytes(&[7.0, 8.0]));
+    let count = client.create_from_slice(u32::as_bytes(&[0, 0, 0]));
+
+    kernel_without_generics::launch(
+        &client,
+        CubeCount::Dynamic(count.binding()),
+        CubeDim::new_1d(1),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 2) },
+    );
+
+    let actual = client.read_one_unchecked(handle);
+    let actual = f32::from_bytes(&actual);
+
+    assert_eq!(actual, &[7.0, 8.0]);
+}
+
 pub fn test_kernel_max_shared<R: Runtime>(client: ComputeClient<R>) {
     let total_shared_size = client.properties().hardware.max_shared_memory_size;
 
@@ -331,6 +368,12 @@ macro_rules! testgen_launch {
         }
 
         #[$crate::runtime_tests::test_log::test]
+        fn test_launch_zero_cube_count() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::launch::test_kernel_zero_cube_count::<TestRuntime>(client);
+        }
+
+        #[$crate::runtime_tests::test_log::test]
         fn test_launch_with_comptime_tag() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::launch::test_kernel_with_comptime_tag::<TestRuntime>(
@@ -343,6 +386,25 @@ macro_rules! testgen_launch {
         fn test_launch_with_max_shared() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::launch::test_kernel_max_shared::<TestRuntime>(client);
+        }
+    };
+}
+
+/// Launch tests for backends that resolve a dynamic cube count to host (CUDA, HIP).
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! testgen_launch_dynamic_count {
+    () => {
+        mod launch_dynamic_count {
+            use super::*;
+
+            #[$crate::runtime_tests::test_log::test]
+            fn test_launch_dynamic_zero_cube_count() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_core::runtime_tests::launch::test_kernel_dynamic_zero_cube_count::<
+                    TestRuntime,
+                >(client);
+            }
         }
     };
 }

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -674,6 +674,11 @@ impl CudaServer {
             }
         };
 
+        // A dynamic count can resolve to zero, which the driver rejects.
+        if count.0 == 0 || count.1 == 0 || count.2 == 0 {
+            return Ok(());
+        }
+
         let (info_const, info_binding) = if grid_constants {
             let info = &bindings.info;
 

--- a/crates/cubecl-cuda/src/lib.rs
+++ b/crates/cubecl-cuda/src/lib.rs
@@ -74,6 +74,7 @@ mod tests {
     pub use half::{bf16, f16};
 
     cubecl_core::testgen_all!(f32: [f16, bf16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
+    cubecl_core::testgen_launch_dynamic_count!();
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, bf16, f32, u32]);
     cubecl_std::testgen_quantized_view!(f16);

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -375,6 +375,11 @@ impl HipServer {
             }
         };
 
+        // A dynamic count can resolve to zero, which the driver rejects.
+        if count.0 == 0 || count.1 == 0 || count.2 == 0 {
+            return Ok(());
+        }
+
         let KernelArguments {
             buffers,
             info,

--- a/crates/cubecl-hip/src/lib.rs
+++ b/crates/cubecl-hip/src/lib.rs
@@ -22,4 +22,5 @@ mod tests {
 
     cubecl_std::testgen!();
     cubecl_core::testgen_all!(f32: [f16, f32], i32: [i16, i32], u32: [u16, u32]);
+    cubecl_core::testgen_launch_dynamic_count!();
 }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -696,6 +696,13 @@ impl<R: Runtime> ComputeClient<R> {
         mode: ExecutionMode,
         stream_id: StreamId,
     ) {
+        // No work, and some drivers reject a zero grid dim.
+        if let CubeCount::Static(x, y, z) = &count
+            && (*x == 0 || *y == 0 || *z == 0)
+        {
+            return;
+        }
+
         let level = self.utilities.logger.profile_level();
 
         match level {


### PR DESCRIPTION
A zero-element tensor like `Tensor::zeros([0, 0])` makes the fill kernel launch with a cube count of (0, 0, 0), which the CUDA driver rejects with `CUDA_ERROR_INVALID_VALUE`. The failed launch poisons the device server, so the error does not surface at allocation but at the next read (into_data/into_scalar) as `ServerUnhealthy`, which makes it look unrelated to the allocation that caused it. The ndarray backend handles these tensors without complaint.

The guard sits in two layers by necessity. A static count is known at the shared client layer, so it is filtered once in `launch_inner` for every backend. A dynamic count lives in a device buffer that each backend resolves to a host value on its own, so CUDA and HIP guard again right after resolving it. HIP gets the same fix because it shares the driver limitation, though I could not run it here (no AMD GPU access any longer *cries*). wgpu and cpu already treat a zero count as a no-op.

The dynamic-count test is registered only for CUDA and HIP instead of the shared runtime-test macro. wgpu dispatches indirectly and cannot bind a plain storage buffer as the indirect source, so the test would fail there for a reason unrelated to the zero count.

Verified on an RTX 4090: launches with a static (0, 0, 0) and a dynamic (0, 0, 0) both crashed before and pass now.