### PR TITLE
fix: CubeOr expand methods computed AND instead of OR

### DIFF
--- a/crates/cubecl-core/src/frontend/operation/binary.rs
+++ b/crates/cubecl-core/src/frontend/operation/binary.rs
@@ -330,18 +330,18 @@ impl<T: CubeAnd + CubePrimitive> AndExpand for NativeExpand<T> {
     }
 }
 
-pub trait CubeOr: CubePrimitive + Into<Variable> + CubeType<ExpandType: AndExpand> + Sized {
+pub trait CubeOr: CubePrimitive + Into<Variable> + CubeType<ExpandType: OrExpand> + Sized {
     fn __expand_or_method(self, scope: &Scope, rhs: NativeExpand<Self>) -> NativeExpand<Self> {
         let this: Variable = self.into();
         let this: NativeExpand<Self> = this.into();
-        this.__expand_and_method(scope, rhs)
+        this.__expand_or_method(scope, rhs)
     }
     fn __expand_or(
         scope: &Scope,
         lhs: NativeExpand<Self>,
         rhs: NativeExpand<Self>,
     ) -> NativeExpand<Self> {
-        lhs.__expand_and_method(scope, rhs)
+        lhs.__expand_or_method(scope, rhs)
     }
 }
 pub trait OrExpand {


### PR DESCRIPTION
`CubeOr` was a copy of `CubeAnd` with the names switched to "or", but the method bodies and trait bound still referenced "and", so it emitted a logical AND.

This error was entirely latent today: `||` codegen always operates on `NativeExpand<bool>`, which uses the correct `OrExpand` impl, so the buggy `bool` path is never reached. Codegen can't exercise that path to my understanding at this time, but I thought it was a timebomb to be left as it was.