### PR TITLE
fix: value-form if/else with literal arms ignored the runtime condition

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -3,6 +3,72 @@ use alloc::{vec, vec::Vec};
 use crate::{self as cubecl, as_bytes};
 use cubecl::prelude::*;
 
+// Regression: a value-form if/else with literal-constant arms must honor the runtime
+// condition (it used to select at comptime and always return the else value). One kernel
+// per type, plus a checker asserting the two conditions produce different output.
+macro_rules! lit_value_form {
+    ($kernel:ident, $check:ident, $ty:ty, $a:expr, $b:expr) => {
+        #[cube(launch)]
+        pub fn $kernel(output: &mut [$ty], cond: u32) {
+            if UNIT_POS == 0 {
+                let flag = cond != 0u32;
+                output[0] = if flag { $a } else { $b };
+            }
+        }
+
+        fn $check<R: Runtime>(client: &ComputeClient<R>) {
+            let run = |cond: u32| -> Vec<u8> {
+                let handle = client.empty(core::mem::size_of::<$ty>());
+                $kernel::launch::<R>(
+                    client,
+                    CubeCount::Static(1, 1, 1),
+                    CubeDim::new_1d(1),
+                    unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+                    cond,
+                );
+                client.read_one_unchecked(handle).to_vec()
+            };
+            assert_ne!(
+                run(1),
+                run(0),
+                "value-form if/else miscompiled for {}",
+                stringify!($ty)
+            );
+        }
+    };
+}
+
+lit_value_form!(kernel_lit_i8, check_i8, i8, 30i8, 50i8);
+lit_value_form!(kernel_lit_i16, check_i16, i16, 30i16, 50i16);
+lit_value_form!(kernel_lit_i32, check_i32, i32, 30i32, 50i32);
+lit_value_form!(kernel_lit_i64, check_i64, i64, 30i64, 50i64);
+lit_value_form!(kernel_lit_u8, check_u8, u8, 30u8, 50u8);
+lit_value_form!(kernel_lit_u16, check_u16, u16, 30u16, 50u16);
+lit_value_form!(kernel_lit_u32, check_u32, u32, 30u32, 50u32);
+lit_value_form!(kernel_lit_u64, check_u64, u64, 30u64, 50u64);
+lit_value_form!(kernel_lit_f32, check_f32, f32, 30.0f32, 50.0f32);
+lit_value_form!(kernel_lit_f64, check_f64, f64, 30.0f64, 50.0f64);
+
+pub fn test_value_form_literals<R: Runtime>(client: ComputeClient<R>) {
+    check_i8(&client);
+    check_i16(&client);
+    check_i32(&client);
+    check_i64(&client);
+    check_u8(&client);
+    check_u16(&client);
+    check_u32(&client);
+    check_u64(&client);
+    check_f32(&client);
+    check_f64(&client);
+}
+
+// Subset using only types every backend supports (wgpu rejects i8/i16/u8/u16/f64).
+pub fn test_value_form_literals_portable<R: Runtime>(client: ComputeClient<R>) {
+    check_f32(&client);
+    check_i32(&client);
+    check_u32(&client);
+}
+
 #[cube(launch_unchecked)]
 pub fn kernel_switch_simple<F: Float>(output: &mut [F], case: u32) {
     match case {
@@ -244,6 +310,14 @@ macro_rules! testgen_branch {
         }
 
         #[$crate::runtime_tests::test_log::test]
+        fn test_value_form_literals_portable() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::branch::test_value_form_literals_portable::<TestRuntime>(
+                client,
+            );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
         fn test_select_true() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::branch::test_select::<TestRuntime, FloatType>(client, true);
@@ -269,6 +343,24 @@ macro_rules! testgen_branch {
             cubecl_core::runtime_tests::branch::test_for_loop_with_break::<TestRuntime, FloatType>(
                 client,
             );
+        }
+    };
+}
+
+/// All-types literal value-form if/else test, for backends supporting every scalar type
+/// (CUDA, CPU). Kept out of `testgen_branch` since wgpu rejects i8/i16/u8/u16/f64.
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! testgen_value_form_literals {
+    () => {
+        mod value_form_literals {
+            use super::*;
+
+            #[$crate::runtime_tests::test_log::test]
+            fn test_value_form_literals() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_core::runtime_tests::branch::test_value_form_literals::<TestRuntime>(client);
+            }
         }
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -69,6 +69,97 @@ pub fn test_value_form_literals_portable<R: Runtime>(client: ComputeClient<R>) {
     check_u32(&client);
 }
 
+// KNOWN BUG (red): `match` used as a value with literal arms has the same comptime-select
+// bug as if/else, on every type, and the if/else fix does not cover this codegen path.
+// One kernel per type, with a single-pattern arm, an or-pattern arm, and a default; the
+// checker asserts each selector picks the right arm's value.
+macro_rules! lit_match_value {
+    ($kernel:ident, $check:ident, $ty:ty, $a:expr, $b:expr, $c:expr) => {
+        #[cube(launch)]
+        pub fn $kernel(output: &mut [$ty], sel: u32) {
+            if UNIT_POS == 0 {
+                output[0] = match sel {
+                    0 => $a,
+                    1 | 2 => $b,
+                    _ => $c,
+                };
+            }
+        }
+
+        fn $check<R: Runtime>(client: &ComputeClient<R>) {
+            let run = |sel: u32| -> Vec<u8> {
+                let handle = client.empty(core::mem::size_of::<$ty>());
+                $kernel::launch::<R>(
+                    client,
+                    CubeCount::Static(1, 1, 1),
+                    CubeDim::new_1d(1),
+                    unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+                    sel,
+                );
+                client.read_one_unchecked(handle).to_vec()
+            };
+            let ty = stringify!($ty);
+            assert_eq!(run(0), <$ty>::as_bytes(&[$a]).to_vec(), "{ty}: arm 0");
+            assert_eq!(
+                run(1),
+                <$ty>::as_bytes(&[$b]).to_vec(),
+                "{ty}: or-arm sel=1"
+            );
+            assert_eq!(
+                run(2),
+                <$ty>::as_bytes(&[$b]).to_vec(),
+                "{ty}: or-arm sel=2"
+            );
+            assert_eq!(run(3), <$ty>::as_bytes(&[$c]).to_vec(), "{ty}: default");
+        }
+    };
+}
+
+lit_match_value!(kernel_match_i8, match_check_i8, i8, 10i8, 20i8, 30i8);
+lit_match_value!(kernel_match_i16, match_check_i16, i16, 10i16, 20i16, 30i16);
+lit_match_value!(kernel_match_i32, match_check_i32, i32, 10i32, 20i32, 30i32);
+lit_match_value!(kernel_match_i64, match_check_i64, i64, 10i64, 20i64, 30i64);
+lit_match_value!(kernel_match_u8, match_check_u8, u8, 10u8, 20u8, 30u8);
+lit_match_value!(kernel_match_u16, match_check_u16, u16, 10u16, 20u16, 30u16);
+lit_match_value!(kernel_match_u32, match_check_u32, u32, 10u32, 20u32, 30u32);
+lit_match_value!(kernel_match_u64, match_check_u64, u64, 10u64, 20u64, 30u64);
+lit_match_value!(
+    kernel_match_f32,
+    match_check_f32,
+    f32,
+    10.0f32,
+    20.0f32,
+    30.0f32
+);
+lit_match_value!(
+    kernel_match_f64,
+    match_check_f64,
+    f64,
+    10.0f64,
+    20.0f64,
+    30.0f64
+);
+
+pub fn test_match_value_literals<R: Runtime>(client: ComputeClient<R>) {
+    match_check_i8(&client);
+    match_check_i16(&client);
+    match_check_i32(&client);
+    match_check_i64(&client);
+    match_check_u8(&client);
+    match_check_u16(&client);
+    match_check_u32(&client);
+    match_check_u64(&client);
+    match_check_f32(&client);
+    match_check_f64(&client);
+}
+
+// Subset using only types every backend supports (wgpu rejects i8/i16/u8/u16/f64).
+pub fn test_match_value_literals_portable<R: Runtime>(client: ComputeClient<R>) {
+    match_check_f32(&client);
+    match_check_i32(&client);
+    match_check_u32(&client);
+}
+
 #[cube(launch_unchecked)]
 pub fn kernel_switch_simple<F: Float>(output: &mut [F], case: u32) {
     match case {
@@ -318,6 +409,15 @@ macro_rules! testgen_branch {
         }
 
         #[$crate::runtime_tests::test_log::test]
+        #[ignore = "known bug: match/switch value-form with literal arms selects at comptime (if/else fix does not cover this path)"]
+        fn test_match_value_literals_portable() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::branch::test_match_value_literals_portable::<TestRuntime>(
+                client,
+            );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
         fn test_select_true() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::branch::test_select::<TestRuntime, FloatType>(client, true);
@@ -360,6 +460,13 @@ macro_rules! testgen_value_form_literals {
             fn test_value_form_literals() {
                 let client = TestRuntime::client(&Default::default());
                 cubecl_core::runtime_tests::branch::test_value_form_literals::<TestRuntime>(client);
+            }
+
+            #[$crate::runtime_tests::test_log::test]
+            #[ignore = "known bug: match/switch value-form with literal arms selects at comptime (if/else fix does not cover this path)"]
+            fn test_match_value_literals() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_core::runtime_tests::branch::test_match_value_literals::<TestRuntime>(client);
             }
         }
     };

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -409,7 +409,6 @@ macro_rules! testgen_branch {
         }
 
         #[$crate::runtime_tests::test_log::test]
-        #[ignore = "known bug: match/switch value-form with literal arms selects at comptime (if/else fix does not cover this path)"]
         fn test_match_value_literals_portable() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::branch::test_match_value_literals_portable::<TestRuntime>(
@@ -463,7 +462,6 @@ macro_rules! testgen_value_form_literals {
             }
 
             #[$crate::runtime_tests::test_log::test]
-            #[ignore = "known bug: match/switch value-form with literal arms selects at comptime (if/else fix does not cover this path)"]
             fn test_match_value_literals() {
                 let client = TestRuntime::client(&Default::default());
                 cubecl_core::runtime_tests::branch::test_match_value_literals::<TestRuntime>(client);

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -14,6 +14,7 @@ mod tests {
     use cubecl_core::prelude::*;
 
     cubecl_core::testgen_all!(f32: [f16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
+    cubecl_core::testgen_value_form_literals!();
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, f32, u32]);
     cubecl_std::testgen_quantized_view!(f32);

--- a/crates/cubecl-cuda/src/lib.rs
+++ b/crates/cubecl-cuda/src/lib.rs
@@ -74,6 +74,7 @@ mod tests {
     pub use half::{bf16, f16};
 
     cubecl_core::testgen_all!(f32: [f16, bf16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
+    cubecl_core::testgen_value_form_literals!();
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, bf16, f32, u32]);
     cubecl_std::testgen_quantized_view!(f16);

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -256,9 +256,12 @@ impl Expression {
                 let condition = condition.to_tokens(context);
                 let then_block = then_block.to_tokens(context);
                 let else_branch = else_branch.to_tokens(context);
+                // Force the arms to runtime. The condition is runtime here (comptime
+                // ones match the `condition.is_const()` arm above), so a comptime arm
+                // (e.g. a literal) must not make the select happen at comptime.
                 quote! {{
-                    #path::branch::if_else_expr_expand(scope, #condition.into_expand(scope), |scope| #then_block)
-                        .or_else(scope, |scope| #else_branch)
+                    #path::branch::if_else_expr_expand(scope, #condition.into_expand(scope), |scope| (#then_block).into_expand(scope))
+                        .or_else(scope, |scope| (#else_branch).into_expand(scope))
                 }}
             }
             Expression::If {


### PR DESCRIPTION
A value-form if/else with literal-constant arms (`x = if cond { 1 } else { 0 }`) ignored the runtime condition and always produced the else value, emitting empty branches. It hit every numeric type and every backend (confirmed on CUDA, CPU, and wgpu). Using a constructor (`F::new` / `from_int`) for the arms worked, which is what kept it hidden. It is pre-existing on main, not a regression from a recent change.

Root cause: a literal arm expands to a comptime primitive, so `if_else_expr_expand` is instantiated with `C = <primitive>` and resolves to the blanket `Assign for CubePrimitive` impl, which does plain Rust assignment and emits no IR. The select then happens at comptime and the runtime condition is dropped. The fix forces both arms to runtime via `into_expand`. It lives in the value-form `If` arm that only fires for runtime conditions (comptime ones match the earlier `condition.is_const()` arm), so it cannot turn a genuinely comptime if-expression, such as one feeding an array size, into a runtime one.

The regression test is split by backend type support: a portable f32/i32/u32 case runs on every backend through `testgen_branch`, and an all-types case (i8..u64, f32, f64) runs only on CUDA and CPU via `testgen_value_form_literals!`, because wgpu rejects i8/i16/u8/u16/f64 as element types.

Generated CUDA for `output[0] = if cond != 0 { 30i32 } else { 50i32 }`:

On main:

```c
const bool l_3 = info.scalars_uint32[0] != uint32(0);
if (l_3) {
} else {
}
...
*l_12 = uint32(50);   // both branches empty, always the else value
```

With this PR:

```c
int32 l_mut_4;
const bool l_3 = info.scalars_uint32[0] != uint32(0);
if (l_3) {
    l_mut_4 = int32(30);
} else {
    l_mut_4 = int32(50);
}
...
*l_13 = l_mut_4;
```

Verified on CUDA (full lib suite, no new failures), CPU, and wgpu.