### PR TITLE
fix: `Assign`/`init_mut`

### DIFF
--- a/crates/cubecl-core/src/frontend/barrier.rs
+++ b/crates/cubecl-core/src/frontend/barrier.rs
@@ -208,7 +208,6 @@ impl Barrier {
     ///
     /// If all units in the cube arrive on the barrier, use `CUBE_DIM` as the arrival count. For
     /// other purposes, only a subset may need to arrive.
-    #[allow(unused_variables)]
     pub fn shared(arrival_count: u32, is_elected: bool) -> Shared<Barrier> {
         intrinsic!(|scope| {
             let variable =
@@ -245,7 +244,6 @@ impl Barrier {
     /// ensure only one unit performs the initialization, and synchronize the cube afterwards. There
     /// may also be additional synchronization requirements for bulk copy operations, like
     /// [`sync_async_proxy_shared()`].
-    #[allow(unused_variables)]
     pub fn init_manual(&self, arrival_count: u32) {
         intrinsic!(|scope| {
             let barrier = self.expand;
@@ -268,7 +266,6 @@ impl Barrier {
     ///
     /// This will try to copy the whole source slice, so
     /// make sure source length <= destination length
-    #[allow(unused_variables)]
     pub fn memcpy_async<C: CubePrimitive>(&self, source: &[C], destination: &mut [C]) {
         intrinsic!(|scope| {
             let barrier = self.expand;
@@ -293,7 +290,6 @@ impl Barrier {
     ///
     /// This will try to copy the whole source slice, so
     /// make sure source length <= destination length
-    #[allow(unused_variables)]
     pub fn memcpy_async_cooperative<C: CubePrimitive>(&self, source: &[C], destination: &mut [C]) {
         intrinsic!(|scope| {
             let barrier = self.expand;
@@ -319,7 +315,6 @@ impl Barrier {
     ///
     /// This will try to copy the whole source slice, so
     /// make sure source length <= destination length
-    #[allow(unused_variables)]
     pub fn memcpy_async_tx<C: CubePrimitive>(&self, source: &[C], destination: &mut [C]) {
         intrinsic!(|scope| {
             let barrier = self.expand;
@@ -357,7 +352,6 @@ impl Barrier {
     }
 
     /// Arrive at the barrier, decrementing arrival count. Additionally increments expected count.
-    #[allow(unused_variables)]
     pub fn arrive_and_expect_tx(&self, arrival_count: u32, transaction_count: u32) -> BarrierToken {
         intrinsic!(|scope| {
             let barrier = self.expand;
@@ -380,7 +374,6 @@ impl Barrier {
     }
 
     /// Increments the expected count of the barrier.
-    #[allow(unused_variables)]
     pub fn expect_tx(&self, expected_count: u32) {
         intrinsic!(|scope| {
             let barrier = self.expand;
@@ -401,7 +394,6 @@ impl Barrier {
     }
 
     /// Wait at the barrier until all arrivals are done
-    #[allow(unused_variables)]
     pub fn wait(&self, token: BarrierToken) {
         intrinsic!(|scope| {
             let barrier = self.expand;
@@ -412,7 +404,6 @@ impl Barrier {
 
     /// Wait at the barrier until the `phase` is completed. Doesn't require a token, but needs phase
     /// to be managed manually.
-    #[allow(unused_variables)]
     pub fn wait_parity(&self, phase: u32) {
         intrinsic!(|scope| {
             let barrier = self.expand;

--- a/crates/cubecl-core/src/frontend/branch.rs
+++ b/crates/cubecl-core/src/frontend/branch.rs
@@ -1,6 +1,7 @@
 use alloc::{boxed::Box, vec::Vec};
 
 use crate::{
+    frontend::RuntimeAssign,
     ir::Switch,
     prelude::{CubeEnum, ExpandTypeClone},
 };
@@ -138,7 +139,11 @@ pub enum IfElseExprExpand<C: Assign> {
 }
 
 impl<C: Assign> IfElseExprExpand<C> {
-    pub fn or_else(self, scope: &Scope, else_block: impl FnOnce(&Scope) -> C) -> C {
+    pub fn or_else<R: RuntimeAssign<Expand = C>>(
+        self,
+        scope: &Scope,
+        else_block: impl FnOnce(&Scope) -> R,
+    ) -> C {
         match self {
             Self::Runtime {
                 runtime_cond,
@@ -147,7 +152,7 @@ impl<C: Assign> IfElseExprExpand<C> {
             } => {
                 let else_child = scope.child();
                 let ret = else_block(&else_child);
-                out.__expand_assign_method(&else_child, ret);
+                out.__expand_assign_method(&else_child, ret.into_expand(scope));
 
                 scope.register(Branch::IfElse(Box::new(IfElse {
                     cond: runtime_cond.expand,
@@ -156,29 +161,29 @@ impl<C: Assign> IfElseExprExpand<C> {
                 })));
                 out
             }
-            Self::ComptimeElse => else_block(scope),
+            Self::ComptimeElse => else_block(scope).into_expand(scope),
             Self::ComptimeThen(ret) => ret,
         }
     }
 }
 
-pub fn if_else_expr_expand<C: Assign>(
+pub fn if_else_expr_expand<C: RuntimeAssign>(
     scope: &Scope,
     condition: NativeExpand<bool>,
     then_block: impl FnOnce(&Scope) -> C,
-) -> IfElseExprExpand<C> {
+) -> IfElseExprExpand<C::Expand> {
     let comptime_cond = condition.expand.as_const().map(|it| it.as_bool());
     match comptime_cond {
         Some(true) => {
             let ret = then_block(scope);
-            IfElseExprExpand::ComptimeThen(ret)
+            IfElseExprExpand::ComptimeThen(ret.into_expand(scope))
         }
         Some(false) => IfElseExprExpand::ComptimeElse,
         None => {
             let then_child = scope.child();
             let ret = then_block(&then_child);
             let mut out = ret.init_mut(scope);
-            out.__expand_assign_method(&then_child, ret);
+            out.__expand_assign_method(&then_child, ret.into_expand(scope));
 
             IfElseExprExpand::Runtime {
                 runtime_cond: condition,
@@ -241,11 +246,17 @@ pub struct SwitchExpandExpr<I: Int, C: Assign> {
 }
 
 impl<I: Int, C: Assign> SwitchExpandExpr<I, C> {
-    pub fn case(mut self, scope: &Scope, value: impl Int, block: impl FnOnce(&Scope) -> C) -> Self {
+    pub fn case<T: RuntimeAssign<Expand = C>>(
+        mut self,
+        scope: &Scope,
+        value: impl Int,
+        block: impl FnOnce(&Scope) -> T,
+    ) -> Self {
         let value = I::from(value).unwrap();
         let case_child = scope.child();
         let ret = block(&case_child);
-        self.out.__expand_assign_method(&case_child, ret);
+        self.out
+            .__expand_assign_method(&case_child, ret.into_expand(scope));
         self.cases.push((value.into(), case_child));
         self
     }
@@ -265,15 +276,15 @@ impl<I: Int, C: Assign> SwitchExpandExpr<I, C> {
     }
 }
 
-pub fn switch_expand_expr<I: Int, C: Assign>(
+pub fn switch_expand_expr<I: Int, C: RuntimeAssign>(
     scope: &Scope,
     value: NativeExpand<I>,
     default_block: impl FnOnce(&Scope) -> C,
-) -> SwitchExpandExpr<I, C> {
+) -> SwitchExpandExpr<I, C::Expand> {
     let default_child = scope.child();
     let default = default_block(&default_child);
     let mut out = default.init_mut(scope);
-    out.__expand_assign_method(&default_child, default);
+    out.__expand_assign_method(&default_child, default.into_expand(scope));
 
     SwitchExpandExpr {
         value,
@@ -435,11 +446,11 @@ pub enum MatchExpandExpr<T: CubeEnum, C: Assign> {
 }
 
 impl<T: CubeEnum, C: Assign> MatchExpandExpr<T, C> {
-    pub fn case(
+    pub fn case<R: RuntimeAssign<Expand = C>>(
         mut self,
         scope: &Scope,
         value: i32,
-        block: impl FnOnce(&Scope, T::RuntimeValue) -> C,
+        block: impl FnOnce(&Scope, T::RuntimeValue) -> R,
     ) -> Self {
         match &mut self {
             Self::RuntimeVariant {
@@ -450,7 +461,7 @@ impl<T: CubeEnum, C: Assign> MatchExpandExpr<T, C> {
             } => {
                 let case_child = scope.child();
                 let ret_val = block(&case_child, (*runtime_value).clone_unchecked());
-                out.__expand_assign_method(&case_child, ret_val);
+                out.__expand_assign_method(&case_child, ret_val.into_expand(scope));
                 cases.push((value.into(), case_child));
             }
             Self::ComptimeVariant {
@@ -460,7 +471,8 @@ impl<T: CubeEnum, C: Assign> MatchExpandExpr<T, C> {
                 matched,
             } => {
                 if value == *variant {
-                    *out = Some(block(scope, (*runtime_value).clone_unchecked()));
+                    *out =
+                        Some(block(scope, (*runtime_value).clone_unchecked()).into_expand(scope));
                     *matched = true;
                 }
             }
@@ -468,10 +480,10 @@ impl<T: CubeEnum, C: Assign> MatchExpandExpr<T, C> {
         self
     }
 
-    pub fn default(
+    pub fn default<R: RuntimeAssign<Expand = C>>(
         mut self,
         scope: &Scope,
-        block: impl FnOnce(&Scope, T::RuntimeValue) -> C,
+        block: impl FnOnce(&Scope, T::RuntimeValue) -> R,
     ) -> Self {
         match &mut self {
             Self::RuntimeVariant {
@@ -482,7 +494,7 @@ impl<T: CubeEnum, C: Assign> MatchExpandExpr<T, C> {
             } => {
                 let case_child = scope.child();
                 let ret_val = block(&case_child, (*runtime_value).clone_unchecked());
-                out.__expand_assign_method(&case_child, ret_val);
+                out.__expand_assign_method(&case_child, ret_val.into_expand(scope));
                 *default = Some(case_child);
             }
             Self::ComptimeVariant {
@@ -492,7 +504,8 @@ impl<T: CubeEnum, C: Assign> MatchExpandExpr<T, C> {
                 ..
             } => {
                 if !*matched {
-                    *out = Some(block(scope, (*runtime_value).clone_unchecked()));
+                    *out =
+                        Some(block(scope, (*runtime_value).clone_unchecked()).into_expand(scope));
                     *matched = true;
                 }
             }
@@ -529,12 +542,12 @@ impl<T: CubeEnum, C: Assign> MatchExpandExpr<T, C> {
     }
 }
 
-pub fn match_expand_expr<T: CubeEnum, C: Assign>(
+pub fn match_expand_expr<T: CubeEnum, C: RuntimeAssign>(
     scope: &Scope,
     value: T,
     discriminant0: i32,
     arm0: impl FnOnce(&Scope, T::RuntimeValue) -> C,
-) -> MatchExpandExpr<T, C> {
+) -> MatchExpandExpr<T, C::Expand> {
     let discriminant = value.discriminant();
     match discriminant.constant() {
         Some(const_variant) if const_variant.as_i32() == discriminant0 => {
@@ -542,7 +555,7 @@ pub fn match_expand_expr<T: CubeEnum, C: Assign>(
             let out = arm0(scope, runtime_value.clone_unchecked());
             MatchExpandExpr::ComptimeVariant {
                 variant: const_variant.as_i32(),
-                out: Some(out),
+                out: Some(out.into_expand(scope)),
                 runtime_value,
                 matched: true,
             }
@@ -559,7 +572,7 @@ pub fn match_expand_expr<T: CubeEnum, C: Assign>(
             let ret_val = arm0(&case_child, runtime_value.clone_unchecked());
 
             let mut out = ret_val.init_mut(scope);
-            out.__expand_assign_method(&case_child, ret_val);
+            out.__expand_assign_method(&case_child, ret_val.into_expand(scope));
 
             MatchExpandExpr::RuntimeVariant {
                 variant: discriminant,

--- a/crates/cubecl-core/src/frontend/cmma.rs
+++ b/crates/cubecl-core/src/frontend/cmma.rs
@@ -232,7 +232,6 @@ impl<C: CubePrimitive, S: MatrixScope> Matrix<C, S> {
     /// Not all shapes are supported, and the permitted shapes depend on the element type.
     ///
     /// Refer to [nvidia documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#element-types-and-matrix-sizes).
-    #[allow(unused_variables)]
     pub unsafe fn uninitialized(
         #[comptime] ident: MatrixIdent,
         #[comptime] m: usize,
@@ -265,7 +264,6 @@ impl<C: CubePrimitive, S: MatrixScope> Matrix<C, S> {
     /// Not all shapes are supported, and the permitted shapes depend on the element type.
     ///
     /// Refer to [nvidia documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#element-types-and-matrix-sizes).
-    #[allow(unused_variables)]
     pub fn from_value(
         #[comptime] ident: MatrixIdent,
         #[comptime] m: usize,
@@ -295,7 +293,6 @@ impl<C: CubePrimitive, S: MatrixScope> Matrix<C, S> {
     /// Not all shapes are supported, and the permitted shapes depend on the element type.
     ///
     /// Refer to [nvidia documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#element-types-and-matrix-sizes).
-    #[allow(unused_variables)]
     pub fn from_slice(
         #[comptime] ident: MatrixIdent,
         #[comptime] m: usize,
@@ -328,7 +325,6 @@ impl<C: CubePrimitive, S: MatrixScope> Matrix<C, S> {
     /// Not all shapes are supported, and the permitted shapes depend on the element type.
     ///
     /// Refer to [nvidia documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#element-types-and-matrix-sizes).
-    #[allow(unused_variables)]
     pub fn from_tensor(
         #[comptime] ident: MatrixIdent,
         #[comptime] m: usize,
@@ -359,7 +355,6 @@ impl<A: Scalar, B: Scalar, CD: Scalar> MmaDefinition<A, B, CD> {
     /// Use [`Self::vector_layout`] to check the correct data layout for each element.
     ///
     /// Refer to [nvidia documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#element-types-and-matrix-sizes).
-    #[allow(unused_variables)]
     pub fn new(#[comptime] m: usize, #[comptime] n: usize, #[comptime] k: usize) -> Self {
         intrinsic!(|scope| {
             let a_type = A::__expand_as_type(scope).storage_type();
@@ -397,7 +392,6 @@ impl<A: Scalar, B: Scalar, CD: Scalar> MmaDefinition<A, B, CD> {
     /// Use [`Self::vector_layout`] to check the correct data layout for each element.
     ///
     /// Refer to [nvidia documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#element-types-and-matrix-sizes).
-    #[allow(unused_variables)]
     pub fn new_scaled<S: CubePrimitive>(
         #[comptime] m: usize,
         #[comptime] n: usize,
@@ -487,7 +481,6 @@ impl<A: Scalar, B: Scalar, CD: Scalar> MmaDefinition<A, B, CD> {
 
     /// Number of elements in each vector passed to the execute function. Represents the maximum
     /// number of contiguous elements held by the thread.
-    #[allow(unused_variables)]
     pub fn vector_size(&self, #[comptime] ident: MatrixIdent) -> comptime_type!(VectorSize) {
         intrinsic!(|scope| {
             let storage = match ident {
@@ -520,7 +513,6 @@ impl<A: Scalar, B: Scalar, CD: Scalar> MmaDefinition<A, B, CD> {
     /// # Note
     /// "Lane" here refers to the unit relative to a plane, to distinguish it from a unit relative
     /// to a cube.
-    #[allow(unused_variables)]
     pub fn position_of_nth(
         &self,
         lane_id: u32,
@@ -616,7 +608,6 @@ impl<A: Scalar, B: Scalar, CD: Scalar> MmaDefinition<A, B, CD> {
     /// # Constraints:
     /// Address must be aligned to 16 bytes
     /// Address must be in shared memory
-    #[allow(unused_variables)]
     pub fn load_matrix<E: CubePrimitive, NO: Size>(
         &self,
         row: &[E],
@@ -640,7 +631,6 @@ impl<A: Scalar, B: Scalar, CD: Scalar> MmaDefinition<A, B, CD> {
         })
     }
 
-    #[allow(unused_variables)]
     pub fn load_matrix_inplace<E: Scalar, N: Size>(
         &self,
         row: &[E],
@@ -675,7 +665,6 @@ impl<A: Scalar, B: Scalar, CD: Scalar> MmaDefinition<A, B, CD> {
     /// # Constraints:
     /// Address must be aligned to 16 bytes
     /// Address must be in shared memory
-    #[allow(unused_variables)]
     pub fn store_matrix<E: CubePrimitive, N: Size>(
         &self,
         row: &mut [E],
@@ -884,7 +873,6 @@ pub mod load {
     use super::*;
 
     /// Expand method of [`load()`].
-    #[allow(unused_variables)]
     pub fn expand<C: CubePrimitive, V: CubePrimitive, S: MatrixScope>(
         scope: &Scope,
         mat: &mut MatrixExpand<C, S>,
@@ -925,7 +913,6 @@ pub mod load_tensor {
     use super::*;
 
     /// Expand method of [`load()`].
-    #[allow(unused_variables)]
     pub fn expand<C: CubePrimitive, V: CubePrimitive, S: MatrixScope>(
         scope: &Scope,
         mat: &mut MatrixExpand<C, S>,
@@ -969,7 +956,6 @@ pub mod load_with_layout {
     use super::*;
 
     /// Expand method of [`load_with_layout()`].
-    #[allow(unused_variables)]
     pub fn expand<C: CubeType, V: CubePrimitive, S: MatrixScope>(
         scope: &Scope,
         mat: &mut MatrixExpand<C, S>,
@@ -1007,7 +993,6 @@ pub mod store {
     use super::*;
 
     /// Expand method of [`store()`].
-    #[allow(unused_variables)]
     pub fn expand<C: CubePrimitive, O: CubePrimitive, S: MatrixScope>(
         scope: &Scope,
         output: &mut SliceExpand<O>,
@@ -1042,7 +1027,6 @@ pub mod store_tensor {
     use super::*;
 
     /// Expand method of [`store()`].
-    #[allow(unused_variables)]
     pub fn expand<C: CubePrimitive, O: CubePrimitive, S: MatrixScope>(
         scope: &Scope,
         output: &mut TensorViewExpand<O>,
@@ -1122,7 +1106,6 @@ pub mod cast {
     use super::*;
 
     /// Expand method of [`cast()`].
-    #[allow(unused_variables)]
     pub fn expand<C: CubePrimitive, O: CubePrimitive, S: MatrixScope>(
         scope: &Scope,
         input: &MatrixExpand<C, S>,
@@ -1182,7 +1165,6 @@ pub mod cast_with_ident {
     use super::*;
 
     /// Expand method of [`cast()`].
-    #[allow(unused_variables)]
     pub fn expand<C: CubePrimitive, O: CubePrimitive, S: MatrixScope>(
         scope: &Scope,
         input: MatrixExpand<C, S>,

--- a/crates/cubecl-core/src/frontend/comptime.rs
+++ b/crates/cubecl-core/src/frontend/comptime.rs
@@ -6,14 +6,12 @@ use cubecl_macros::intrinsic;
 
 /// Retrieves the [`device_properties`](DeviceProperties).
 #[cube]
-#[allow(unused_variables)]
 pub fn device_properties() -> comptime_type!(Rc<DeviceProperties>) {
     intrinsic!(|scope| scope.state().device_properties.as_ref().unwrap().clone())
 }
 
 /// Retrieves the [`hardware_properties`](HardwareProperties).
 #[cube]
-#[allow(unused_variables)]
 pub fn hardware_properties() -> comptime_type!(HardwareProperties) {
     let props = &device_properties().comptime().hardware;
     comptime!(props.clone())

--- a/crates/cubecl-core/src/frontend/container/array/base.rs
+++ b/crates/cubecl-core/src/frontend/container/array/base.rs
@@ -37,7 +37,6 @@ mod new {
     #[cube]
     impl<T: CubePrimitive + Clone> Array<T> {
         /// Create a new array of the given length.
-        #[allow(unused_variables)]
         pub fn new(#[comptime] length: usize) -> Self {
             intrinsic!(|scope| {
                 // Allocate as a slice even though it's statically sized, so we can deref to it.
@@ -150,9 +149,11 @@ impl<C: CubePrimitive> Assign for ArrayExpand<C> {
         );
         assign::expand_element(scope, value, arr);
     }
+}
 
-    fn init_mut(&self, _: &Scope) -> Self {
-        *self
+impl<C: CubePrimitive> RuntimeAssign for ArrayExpand<C> {
+    fn init_mut(&self, scope: &Scope) -> Self::Expand {
+        Array::__expand_new(scope, self.expand.ty.array_size())
     }
 }
 

--- a/crates/cubecl-core/src/frontend/container/cell/runtime.rs
+++ b/crates/cubecl-core/src/frontend/container/cell/runtime.rs
@@ -53,7 +53,6 @@ impl<T: CubeType> cubecl::prelude::CubeDebug for RuntimeCellExpand<T> {}
 #[cube]
 impl<T: CubePrimitive> RuntimeCell<T> {
     /// Create a new runtime cell with the given initial value.
-    #[allow(unused_variables)]
     pub fn new(init: T) -> Self {
         intrinsic!(|scope| {
             let value = init_expand(scope, init.expand, true, Operation::Copy);
@@ -64,7 +63,6 @@ impl<T: CubePrimitive> RuntimeCell<T> {
     }
 
     /// Store a new value in the cell.
-    #[allow(unused_variables)]
     pub fn store(&self, value: T) {
         intrinsic!(|scope| {
             let mut this = self.value.clone();
@@ -89,13 +87,11 @@ impl<T: CubePrimitive> RuntimeCell<T> {
 #[cube]
 impl<S: Scalar, N: Size> RuntimeCell<Vector<S, N>> {
     /// Extract the value in the cell at the given index.
-    #[allow(unused_variables)]
     pub fn extract(&mut self, index: usize) -> S {
         intrinsic!(|scope| { self.value.__expand_extract_method(scope, index) })
     }
 
     /// Store a new value in the cell at the given index.
-    #[allow(unused_variables)]
     pub fn insert(&mut self, index: usize, value: S) {
         intrinsic!(|scope| { self.value.__expand_insert_method(scope, index, value) })
     }

--- a/crates/cubecl-core/src/frontend/container/sequence/base.rs
+++ b/crates/cubecl-core/src/frontend/container/sequence/base.rs
@@ -79,13 +79,13 @@ impl<T: CubeType> Sequence<T> {
     }
 
     /// Get the variable at the given position in the sequence.
-    #[allow(unused_variables, clippy::should_implement_trait)]
+    #[allow(clippy::should_implement_trait)]
     pub fn index(&self, index: usize) -> &T {
         self.values.get(index).unwrap()
     }
 
     /// Get the variable at the given position in the sequence.
-    #[allow(unused_variables, clippy::should_implement_trait)]
+    #[allow(clippy::should_implement_trait)]
     pub fn index_mut(&mut self, index: usize) -> &mut T {
         self.values.get_mut(index).unwrap()
     }
@@ -96,7 +96,7 @@ impl<T: CubeType> Sequence<T> {
     }
 
     /// Insert an item at the given index.
-    #[allow(unused_variables, clippy::should_implement_trait)]
+    #[allow(clippy::should_implement_trait)]
     pub fn insert(&mut self, index: usize, value: T) {
         *self.index_mut(index) = value;
     }

--- a/crates/cubecl-core/src/frontend/container/shared_memory.rs
+++ b/crates/cubecl-core/src/frontend/container/shared_memory.rs
@@ -54,7 +54,6 @@ impl<T: CubePrimitive> Shared<[T]> {
     /// # Safety
     /// Shared memory is always uninitialized by default. Reading uninitialized shared values is
     /// undefined behavior.
-    #[allow(unused_variables)]
     pub fn new_slice(#[comptime] len: usize) -> Self {
         intrinsic!(|scope| {
             let ty = Type::array(T::__expand_as_type(scope), len, AddressSpace::Shared);
@@ -253,8 +252,10 @@ impl<T: CubePrimitive> Assign<NativeExpand<T>> for SharedExpand<T> {
         self.__expand_deref_method(scope)
             .__expand_assign_method(scope, value);
     }
+}
 
-    fn init_mut(&self, _: &Scope) -> Self {
-        self.clone()
+impl<T: CubePrimitive> RuntimeAssign<NativeExpand<T>> for SharedExpand<T> {
+    fn init_mut(&self, scope: &Scope) -> Self::Expand {
+        Shared::<T>::__expand_new(scope)
     }
 }

--- a/crates/cubecl-core/src/frontend/container/tensor/base.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/base.rs
@@ -71,7 +71,6 @@ mod metadata {
     #[cube]
     impl<T: CubePrimitive> Tensor<T> {
         /// Obtain the stride of input at dimension dim
-        #[allow(unused_variables)]
         pub fn stride(&self, dim: usize) -> usize {
             intrinsic!(|scope| {
                 let dim: Variable = dim.into();
@@ -89,7 +88,6 @@ mod metadata {
         }
 
         /// Obtain the shape of input at dimension dim
-        #[allow(unused_variables)]
         pub fn shape(&self, dim: usize) -> usize {
             intrinsic!(|scope| {
                 let dim: Variable = dim.into();
@@ -110,7 +108,6 @@ mod metadata {
         ///
         /// A coordinate is a list of indices corresponding to the multi-dimensional position of an element in the tensor.
         /// The `dim` element in a coordinate is the position along the `dim` dimension of the tensor.
-        #[allow(unused_variables)]
         pub fn coordinate(&self, index: usize, dim: usize) -> usize {
             intrinsic!(|scope| {
                 let index: Variable = index.into();

--- a/crates/cubecl-core/src/frontend/container/vector/base.rs
+++ b/crates/cubecl-core/src/frontend/container/vector/base.rs
@@ -156,7 +156,6 @@ mod fill {
         /// vector[0] = 1;
         /// vector[1] = 2;
         /// ```
-        #[allow(unused_variables)]
         pub fn fill(self, value: P) -> Self {
             intrinsic!(|scope| {
                 let output = scope.create_local(Vector::<P, N>::__expand_as_type(scope));
@@ -252,7 +251,6 @@ macro_rules! impl_vector_comparison {
                         $comment,
                         " the second vector."
                     )]
-                    #[allow(unused_variables)]
                     pub fn $name(&self, other: &Self) -> Vector<bool, N> {
                         intrinsic!(|scope| {
                             let this = self.__expand_deref_method(scope);
@@ -295,7 +293,6 @@ mod bool_and {
     #[cube]
     impl<N: Size> Vector<bool, N> {
         /// Return a new vector with the element-wise and of the vectors
-        #[allow(unused_variables)]
         pub fn vec_and(self, other: Self) -> Vector<bool, N> {
             intrinsic!(
                 |scope| binary_expand(scope, self.expand, other.expand, Operator::And).into()
@@ -314,7 +311,6 @@ mod bool_or {
     #[cube]
     impl<N: Size> Vector<bool, N> {
         /// Return a new vector with the element-wise and of the vectors
-        #[allow(unused_variables)]
         pub fn or(self, other: Self) -> Vector<bool, N> {
             intrinsic!(|scope| binary_expand(scope, self.expand, other.expand, Operator::Or).into())
         }

--- a/crates/cubecl-core/src/frontend/element/atomic.rs
+++ b/crates/cubecl-core/src/frontend/element/atomic.rs
@@ -22,7 +22,6 @@ type AtomicExpand<Inner> = NativeExpand<Atomic<Inner>>;
 #[cube]
 impl<Inner: CubePrimitive<Scalar: Numeric>> Atomic<Inner> {
     /// Load the value of the atomic.
-    #[allow(unused_variables)]
     pub fn load(&self) -> Inner {
         intrinsic!(|scope| {
             let pointer: Variable = self.clone().into();
@@ -33,7 +32,6 @@ impl<Inner: CubePrimitive<Scalar: Numeric>> Atomic<Inner> {
     }
 
     /// Store the value of the atomic.
-    #[allow(unused_variables)]
     pub fn store(&self, value: Inner) {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();
@@ -46,7 +44,6 @@ impl<Inner: CubePrimitive<Scalar: Numeric>> Atomic<Inner> {
     }
 
     /// Atomically stores the value into the atomic and returns the old value.
-    #[allow(unused_variables)]
     pub fn swap(&self, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();
@@ -61,7 +58,6 @@ impl<Inner: CubePrimitive<Scalar: Numeric>> Atomic<Inner> {
     }
 
     /// Atomically add a number to the atomic variable. Returns the old value.
-    #[allow(unused_variables)]
     pub fn fetch_add(&self, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();
@@ -76,7 +72,6 @@ impl<Inner: CubePrimitive<Scalar: Numeric>> Atomic<Inner> {
     }
 
     /// Atomically subtracts a number from the atomic variable. Returns the old value.
-    #[allow(unused_variables)]
     pub fn fetch_sub(&self, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();
@@ -92,7 +87,6 @@ impl<Inner: CubePrimitive<Scalar: Numeric>> Atomic<Inner> {
 
     /// Atomically sets the value of the atomic variable to `max(current_value, value)`. Returns
     /// the old value.
-    #[allow(unused_variables)]
     pub fn fetch_max(&self, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();
@@ -108,7 +102,6 @@ impl<Inner: CubePrimitive<Scalar: Numeric>> Atomic<Inner> {
 
     /// Atomically sets the value of the atomic variable to `min(current_value, value)`. Returns the
     /// old value.
-    #[allow(unused_variables)]
     pub fn fetch_min(&self, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();
@@ -130,7 +123,6 @@ impl<Inner: CubePrimitive<Scalar: Int>> Atomic<Inner> {
     ///
     /// ### Tip
     /// Compare the returned value to `cmp` to determine whether the store was successful.
-    #[allow(unused_variables)]
     pub fn compare_exchange_weak(&self, cmp: Inner, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let pointer: Variable = self.clone().into();
@@ -150,7 +142,6 @@ impl<Inner: CubePrimitive<Scalar: Int>> Atomic<Inner> {
     }
 
     /// Executes an atomic bitwise and operation on the atomic variable. Returns the old value.
-    #[allow(unused_variables)]
     pub fn fetch_and(&self, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();
@@ -165,7 +156,6 @@ impl<Inner: CubePrimitive<Scalar: Int>> Atomic<Inner> {
     }
 
     /// Executes an atomic bitwise or operation on the atomic variable. Returns the old value.
-    #[allow(unused_variables)]
     pub fn fetch_or(&self, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();
@@ -180,7 +170,6 @@ impl<Inner: CubePrimitive<Scalar: Int>> Atomic<Inner> {
     }
 
     /// Executes an atomic bitwise xor operation on the atomic variable. Returns the old value.
-    #[allow(unused_variables)]
     pub fn fetch_xor(&self, value: Inner) -> Inner {
         intrinsic!(|scope| {
             let ptr: Variable = self.clone().into();

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -240,8 +240,11 @@ pub trait CubeEnum: Sized {
 pub trait Assign<T = Self> {
     /// Assign `value` to `self` in `scope`.
     fn __expand_assign_method(&mut self, scope: &Scope, value: T);
+}
+
+pub trait RuntimeAssign<T = <Self as IntoExpand>::Expand>: IntoExpand<Expand: Assign<T>> {
     /// Create a new mutable variable of this type in `scope`.
-    fn init_mut(&self, scope: &Scope) -> Self;
+    fn init_mut(&self, scope: &Scope) -> Self::Expand;
 }
 
 pub fn __expand_assign<T: Assign<T>>(scope: &Scope, target: &mut T, value: T) {
@@ -252,8 +255,11 @@ impl<T: CubePrimitive> Assign for T {
     fn __expand_assign_method(&mut self, _scope: &Scope, value: Self) {
         *self = value;
     }
-    fn init_mut(&self, _scope: &Scope) -> Self {
-        *self
+}
+
+impl<T: CubePrimitive + IntoExpand<Expand = NativeExpand<T>>> RuntimeAssign for T {
+    fn init_mut(&self, scope: &Scope) -> NativeExpand<T> {
+        init_mut_expand_element(scope, T::__expand_as_type(scope)).into()
     }
 }
 
@@ -261,7 +267,10 @@ impl<T: NativeAssign> Assign for NativeExpand<T> {
     fn __expand_assign_method(&mut self, scope: &Scope, value: Self) {
         assign::expand(scope, value, self);
     }
-    fn init_mut(&self, scope: &Scope) -> Self {
+}
+
+impl<T: NativeAssign> RuntimeAssign for NativeExpand<T> {
+    fn init_mut(&self, scope: &Scope) -> Self::Expand {
         T::elem_init_mut(scope, self.expand).into()
     }
 }
@@ -274,9 +283,6 @@ impl<T: Assign> Assign for Option<T> {
             _ => panic!("Can't assign mismatched enum variants"),
         }
     }
-    fn init_mut(&self, scope: &Scope) -> Self {
-        self.as_ref().map(|value| value.init_mut(scope))
-    }
 }
 
 impl<T: Assign> Assign for Vec<T> {
@@ -288,9 +294,6 @@ impl<T: Assign> Assign for Vec<T> {
         for (this, other) in self.iter_mut().zip(value) {
             this.__expand_assign_method(scope, other);
         }
-    }
-    fn init_mut(&self, scope: &Scope) -> Self {
-        self.iter().map(|it| it.init_mut(scope)).collect()
     }
 }
 
@@ -354,9 +357,9 @@ impl<T: IntoMut> IntoMut for *mut T {
     }
 }
 
-pub fn into_mut_assign<T: Assign>(value: T, scope: &Scope) -> T {
+pub fn into_mut_assign<T: RuntimeAssign>(value: T, scope: &Scope) -> T::Expand {
     let mut out = value.init_mut(scope);
-    out.__expand_assign_method(scope, value);
+    out.__expand_assign_method(scope, value.into_expand(scope));
     out
 }
 
@@ -728,8 +731,11 @@ macro_rules! tuple_assign {
                     $P.__expand_assign_method(scope, value.$n);
                 )*
             }
+        }
+
+        impl<$($P: RuntimeAssign),*> RuntimeAssign for ($($P,)*) {
             #[allow(non_snake_case, unused, clippy::unused_unit)]
-            fn init_mut(&self, scope: &Scope) -> Self {
+            fn init_mut(&self, scope: &Scope) -> Self::Expand {
                 let ($($P,)*) = self;
                 ($(
                     $P.init_mut(scope),
@@ -748,7 +754,7 @@ all_tuples_enumerated!(tuple_assign, 2, 12, P);
 /// Trait for native types that can be assigned. For non-native composites, use the normal [`Assign`].
 pub trait NativeAssign: CubeType {
     fn elem_init_mut(scope: &Scope, elem: Variable) -> Variable {
-        init_mut_expand_element(scope, &elem)
+        init_mut_expand_element(scope, elem.ty)
     }
 }
 
@@ -809,11 +815,11 @@ impl<T: Scalar + Into<ConstantValue>> NativeExpand<T> {
     }
 }
 
-pub(crate) fn init_mut_expand_element(scope: &Scope, element: &Variable) -> Variable {
-    if element.ty.is_ptr() {
-        panic!("tried initializing mut for ptr {}", element.ty);
+pub(crate) fn init_mut_expand_element(scope: &Scope, ty: Type) -> Variable {
+    if ty.is_ptr() {
+        panic!("tried initializing mut for ptr {}", ty);
     }
-    scope.create_local_mut(element.ty)
+    scope.create_local_mut(ty)
 }
 
 impl<T: IntoMut> IntoMut for Option<T> {
@@ -885,7 +891,10 @@ impl LaunchArg for () {
 
 impl Assign for () {
     fn __expand_assign_method(&mut self, _: &Scope, _: Self) {}
-    fn init_mut(&self, _: &Scope) -> Self {}
+}
+
+impl RuntimeAssign for () {
+    fn init_mut(&self, _: &Scope) {}
 }
 
 impl IntoRuntime for () {

--- a/crates/cubecl-core/src/frontend/operation/branch.rs
+++ b/crates/cubecl-core/src/frontend/operation/branch.rs
@@ -20,7 +20,6 @@ pub fn select<C: CubePrimitive>(condition: bool, then: C, or_else: C) -> C {
 
 /// Same as [`select()`] but with vectors instead.
 #[cube]
-#[allow(unused_variables)]
 pub fn select_many<C: Scalar, N: Size>(
     condition: Vector<bool, N>,
     then: Vector<C, N>,

--- a/crates/cubecl-core/src/frontend/runtime_option.rs
+++ b/crates/cubecl-core/src/frontend/runtime_option.rs
@@ -178,7 +178,7 @@ mod impls {
             scope: &Scope,
             f: impl FnOnce(&Scope, T::ExpandType) -> NativeExpand<bool>,
         ) -> NativeExpand<bool> {
-            match_expand_expr(scope, self, discriminant("None"), |_, _| false.into())
+            match_expand_expr(scope, self, discriminant("None"), |_, _| false)
                 .case(scope, discriminant("Some"), |scope, value| f(scope, value))
                 .finish(scope)
         }
@@ -188,14 +188,14 @@ mod impls {
             scope: &Scope,
             f: impl FnOnce(&Scope, T::ExpandType) -> NativeExpand<bool>,
         ) -> NativeExpand<bool> {
-            match_expand_expr(scope, self, discriminant("None"), |_, _| true.into())
+            match_expand_expr(scope, self, discriminant("None"), |_, _| true)
                 .case(scope, discriminant("Some"), |scope, value| f(scope, value))
                 .finish(scope)
         }
 
         pub fn __expand_expect_method(self, scope: &Scope, msg: &str) -> T::ExpandType
         where
-            T::ExpandType: Assign,
+            T::ExpandType: RuntimeAssign,
         {
             // Replace with `trap` eventually to ensure execution doesn't continue to the next kernel
             match_expand_expr(scope, self, discriminant("Some"), |_, value| value)
@@ -210,7 +210,7 @@ mod impls {
         pub fn __expand_unwrap_or_else_method<F>(self, scope: &Scope, f: F) -> T::ExpandType
         where
             F: FnOnce(&Scope) -> T::ExpandType,
-            T::ExpandType: Assign,
+            T::ExpandType: RuntimeAssign,
         {
             match_expand_expr(scope, self, discriminant("Some"), |_, value| value)
                 .case(scope, discriminant("None"), |scope, _| f(scope))
@@ -221,7 +221,7 @@ mod impls {
         where
             F: FnOnce(&Scope, T::ExpandType) -> U::ExpandType,
             U: CubeType + IntoRuntime + Default,
-            OptionExpand<U>: Assign,
+            OptionExpand<U>: RuntimeAssign<Expand = OptionExpand<U>>,
         {
             match_expand_expr(scope, self, discriminant("Some"), |scope, value| {
                 let value = f(scope, value);
@@ -257,7 +257,7 @@ mod impls {
         where
             F: FnOnce(&Scope, T::ExpandType) -> U::ExpandType,
             U: CubeType + Default + IntoRuntime,
-            U::ExpandType: Assign,
+            U::ExpandType: RuntimeAssign,
         {
             match_expand_expr(scope, self, discriminant("Some"), f)
                 .case(scope, discriminant("None"), |_, _| default)
@@ -274,7 +274,7 @@ mod impls {
             D: FnOnce(&Scope) -> U::ExpandType,
             F: FnOnce(&Scope, T::ExpandType) -> U::ExpandType,
             U: CubeType + Default + IntoRuntime,
-            U::ExpandType: Assign,
+            U::ExpandType: RuntimeAssign,
         {
             match_expand_expr(scope, self, discriminant("Some"), f)
                 .case(scope, discriminant("None"), |scope, _| default(scope))
@@ -285,7 +285,7 @@ mod impls {
         where
             U: CubeType + IntoRuntime + Default,
             F: FnOnce(&Scope, T::ExpandType) -> U::ExpandType,
-            U::ExpandType: Assign,
+            U::ExpandType: RuntimeAssign,
         {
             match_expand_expr(scope, self, discriminant("Some"), f)
                 .case(scope, discriminant("None"), |scope, _| {
@@ -298,7 +298,7 @@ mod impls {
         where
             T: Deref<Target: CubeType + Default + IntoRuntime>,
             T::ExpandType: DerefExpand<Target = <T::Target as CubeType>::ExpandType>,
-            <T::Target as CubeType>::ExpandType: Assign,
+            <T::Target as CubeType>::ExpandType: RuntimeAssign,
         {
             self.__expand_map_method(scope, |scope, value| value.__expand_deref_method(scope))
         }
@@ -307,7 +307,7 @@ mod impls {
         where
             T: DerefMut<Target: CubeType + Default + IntoRuntime>,
             T::ExpandType: DerefExpand<Target = <T::Target as CubeType>::ExpandType>,
-            <T::Target as CubeType>::ExpandType: Assign,
+            <T::Target as CubeType>::ExpandType: RuntimeAssign,
         {
             self.__expand_map_method(scope, |scope, value| value.__expand_deref_method(scope))
         }
@@ -316,7 +316,7 @@ mod impls {
         where
             F: FnOnce(&Scope, T::ExpandType) -> OptionExpand<U>,
             U: CubeType + IntoRuntime + Default,
-            U::ExpandType: Assign,
+            U::ExpandType: RuntimeAssign,
         {
             match_expand_expr(scope, self, discriminant("Some"), f)
                 .case(scope, discriminant("None"), |scope, _| {
@@ -329,7 +329,7 @@ mod impls {
         where
             P: FnOnce(&Scope, &T::ExpandType) -> NativeExpand<bool>,
             T: Default + IntoRuntime,
-            Self: Assign,
+            Self: RuntimeAssign + IntoExpand<Expand = Self>,
         {
             match_expand_expr(scope, self, discriminant("Some"), |scope, value| {
                 let cond = predicate(scope, &value);
@@ -345,7 +345,7 @@ mod impls {
         pub fn __expand_or_else_method<F>(self, scope: &Scope, f: F) -> OptionExpand<T>
         where
             F: FnOnce(&Scope) -> OptionExpand<T>,
-            OptionExpand<T>: Assign,
+            OptionExpand<T>: RuntimeAssign + IntoExpand<Expand = OptionExpand<T>>,
         {
             let is_some = self.__expand_is_some_method(scope);
             if_else_expr_expand(scope, is_some, |_| self).or_else(scope, |scope| f(scope))
@@ -361,7 +361,7 @@ mod impls {
             F: FnOnce(&Scope, T::ExpandType, U::ExpandType) -> R::ExpandType,
             U: CubeType,
             R: CubeType + IntoRuntime + Default,
-            OptionExpand<R>: Assign,
+            OptionExpand<R>: RuntimeAssign + IntoExpand<Expand = OptionExpand<R>>,
         {
             match_expand_expr(scope, self, discriminant("Some"), |scope, value| {
                 match_expand_expr(scope, other, discriminant("Some"), |scope, other| {
@@ -391,7 +391,7 @@ mod impls {
             F: FnOnce(&Scope, T::ExpandType, U::ExpandType) -> R::ExpandType,
             U: CubeType + IntoRuntime + Default,
             R: CubeType + IntoRuntime + Default,
-            OptionExpand<R>: Assign,
+            OptionExpand<R>: RuntimeAssign + IntoExpand<Expand = OptionExpand<R>>,
         {
             match_expand_expr(scope, self, discriminant("Some"), {
                 let other = other.clone_unchecked();
@@ -424,7 +424,7 @@ mod impls {
         #[allow(clippy::missing_safety_doc)]
         pub unsafe fn __expand_unwrap_unchecked_method(self, scope: &Scope) -> T::ExpandType
         where
-            T::ExpandType: Assign,
+            T::ExpandType: RuntimeAssign,
         {
             match_expand_expr(scope, self, discriminant("Some"), |_, value| value).finish(scope)
         }
@@ -487,7 +487,7 @@ mod impls {
         /// ```
         pub fn unwrap(self) -> T
         where
-            T::ExpandType: Assign,
+            T::ExpandType: RuntimeAssign,
         {
             self.expect("called `Option::unwrap()` on a `None` value")
         }
@@ -508,7 +508,7 @@ mod impls {
         /// ```
         pub fn unwrap_or(self, default: T) -> T
         where
-            T::ExpandType: Assign,
+            T::ExpandType: RuntimeAssign,
         {
             match self {
                 Some(x) => x,
@@ -538,7 +538,7 @@ mod impls {
         pub fn unwrap_or_default(self) -> T
         where
             T: Default + IntoRuntime,
-            T::ExpandType: Assign,
+            T::ExpandType: RuntimeAssign,
         {
             match self {
                 Some(x) => x,
@@ -584,7 +584,7 @@ mod impls {
         pub fn and<U>(self, optb: Option<U>) -> Option<U>
         where
             U: CubeType + IntoRuntime + Default,
-            U::ExpandType: Assign,
+            U::ExpandType: RuntimeAssign,
         {
             match self {
                 Option::Some(_) => optb,
@@ -621,7 +621,7 @@ mod impls {
         /// ```
         pub fn or(self, optb: Option<T>) -> Option<T>
         where
-            T::ExpandType: Assign,
+            T::ExpandType: RuntimeAssign,
         {
             if self.is_some() { self } else { optb }
         }
@@ -650,7 +650,7 @@ mod impls {
         pub fn xor(self, optb: Option<T>) -> Option<T>
         where
             T: Default + IntoRuntime,
-            T::ExpandType: Assign,
+            T::ExpandType: RuntimeAssign,
         {
             let this_is_none = self.is_none();
 
@@ -689,7 +689,7 @@ mod impls {
             U: CubeType,
             (T, U): Default + CubeType + IntoRuntime,
             (T::ExpandType, U::ExpandType): Into<<(T, U) as CubeType>::ExpandType>,
-            OptionExpand<(T, U)>: Assign,
+            OptionExpand<(T, U)>: RuntimeAssign + IntoExpand<Expand = OptionExpand<(T, U)>>,
         {
             match self {
                 Some(a) => match other {
@@ -703,8 +703,8 @@ mod impls {
 
     #[cube(expand_only)]
     impl<
-        T: CubeType<ExpandType: Assign + Clone> + IntoRuntime + Default,
-        U: CubeType<ExpandType: Assign + Clone> + IntoRuntime + Default,
+        T: CubeType<ExpandType: RuntimeAssign> + IntoRuntime + Default,
+        U: CubeType<ExpandType: RuntimeAssign> + IntoRuntime + Default,
     > Option<(T, U)>
     {
         /// Unzips an option containing a tuple of two options.

--- a/crates/cubecl-core/src/frontend/validation.rs
+++ b/crates/cubecl-core/src/frontend/validation.rs
@@ -4,7 +4,6 @@ use cubecl::prelude::*;
 use cubecl_macros::intrinsic;
 
 #[cube]
-#[allow(unused_variables)]
 /// Push a validation error that will make the kernel compilation to fail.
 ///
 /// # Notes

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -3,6 +3,72 @@ use alloc::{vec, vec::Vec};
 use crate::{self as cubecl, as_bytes};
 use cubecl::prelude::*;
 
+// Regression: a value-form if/else with literal-constant arms must honor the runtime
+// condition (it used to select at comptime and always return the else value). One kernel
+// per type, plus a checker asserting the two conditions produce different output.
+macro_rules! lit_value_form {
+    ($kernel:ident, $check:ident, $ty:ty, $a:expr, $b:expr) => {
+        #[cube(launch)]
+        pub fn $kernel(output: &mut [$ty], cond: u32) {
+            if UNIT_POS == 0 {
+                let flag = cond != 0u32;
+                output[0] = if flag { $a } else { $b };
+            }
+        }
+
+        fn $check<R: Runtime>(client: &ComputeClient<R>) {
+            let run = |cond: u32| -> Vec<u8> {
+                let handle = client.empty(core::mem::size_of::<$ty>());
+                $kernel::launch::<R>(
+                    client,
+                    CubeCount::Static(1, 1, 1),
+                    CubeDim::new_1d(1),
+                    unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+                    cond,
+                );
+                client.read_one_unchecked(handle).to_vec()
+            };
+            assert_ne!(
+                run(1),
+                run(0),
+                "value-form if/else miscompiled for {}",
+                stringify!($ty)
+            );
+        }
+    };
+}
+
+lit_value_form!(kernel_lit_i8, check_i8, i8, 30i8, 50i8);
+lit_value_form!(kernel_lit_i16, check_i16, i16, 30i16, 50i16);
+lit_value_form!(kernel_lit_i32, check_i32, i32, 30i32, 50i32);
+lit_value_form!(kernel_lit_i64, check_i64, i64, 30i64, 50i64);
+lit_value_form!(kernel_lit_u8, check_u8, u8, 30u8, 50u8);
+lit_value_form!(kernel_lit_u16, check_u16, u16, 30u16, 50u16);
+lit_value_form!(kernel_lit_u32, check_u32, u32, 30u32, 50u32);
+lit_value_form!(kernel_lit_u64, check_u64, u64, 30u64, 50u64);
+lit_value_form!(kernel_lit_f32, check_f32, f32, 30.0f32, 50.0f32);
+lit_value_form!(kernel_lit_f64, check_f64, f64, 30.0f64, 50.0f64);
+
+pub fn test_value_form_literals<R: Runtime>(client: ComputeClient<R>) {
+    check_i8(&client);
+    check_i16(&client);
+    check_i32(&client);
+    check_i64(&client);
+    check_u8(&client);
+    check_u16(&client);
+    check_u32(&client);
+    check_u64(&client);
+    check_f32(&client);
+    check_f64(&client);
+}
+
+// Subset using only types every backend supports (wgpu rejects i8/i16/u8/u16/f64).
+pub fn test_value_form_literals_portable<R: Runtime>(client: ComputeClient<R>) {
+    check_f32(&client);
+    check_i32(&client);
+    check_u32(&client);
+}
+
 #[cube(launch_unchecked)]
 pub fn kernel_switch_simple<F: Float>(output: &mut [F], case: u32) {
     match case {
@@ -244,6 +310,14 @@ macro_rules! testgen_branch {
         }
 
         #[$crate::runtime_tests::test_log::test]
+        fn test_value_form_literals_portable() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::branch::test_value_form_literals_portable::<TestRuntime>(
+                client,
+            );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
         fn test_select_true() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::branch::test_select::<TestRuntime, FloatType>(client, true);
@@ -269,6 +343,24 @@ macro_rules! testgen_branch {
             cubecl_core::runtime_tests::branch::test_for_loop_with_break::<TestRuntime, FloatType>(
                 client,
             );
+        }
+    };
+}
+
+/// All-types literal value-form if/else test, for backends supporting every scalar type
+/// (CUDA, CPU). Kept out of `testgen_branch` since wgpu rejects i8/i16/u8/u16/f64.
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! testgen_value_form_literals {
+    () => {
+        mod value_form_literals {
+            use super::*;
+
+            #[$crate::runtime_tests::test_log::test]
+            fn test_value_form_literals() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_core::runtime_tests::branch::test_value_form_literals::<TestRuntime>(client);
+            }
         }
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -69,6 +69,97 @@ pub fn test_value_form_literals_portable<R: Runtime>(client: ComputeClient<R>) {
     check_u32(&client);
 }
 
+// KNOWN BUG (red): `match` used as a value with literal arms has the same comptime-select
+// bug as if/else, on every type, and the if/else fix does not cover this codegen path.
+// One kernel per type, with a single-pattern arm, an or-pattern arm, and a default; the
+// checker asserts each selector picks the right arm's value.
+macro_rules! lit_match_value {
+    ($kernel:ident, $check:ident, $ty:ty, $a:expr, $b:expr, $c:expr) => {
+        #[cube(launch)]
+        pub fn $kernel(output: &mut [$ty], sel: u32) {
+            if UNIT_POS == 0 {
+                output[0] = match sel {
+                    0 => $a,
+                    1 | 2 => $b,
+                    _ => $c,
+                };
+            }
+        }
+
+        fn $check<R: Runtime>(client: &ComputeClient<R>) {
+            let run = |sel: u32| -> Vec<u8> {
+                let handle = client.empty(core::mem::size_of::<$ty>());
+                $kernel::launch::<R>(
+                    client,
+                    CubeCount::Static(1, 1, 1),
+                    CubeDim::new_1d(1),
+                    unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+                    sel,
+                );
+                client.read_one_unchecked(handle).to_vec()
+            };
+            let ty = stringify!($ty);
+            assert_eq!(run(0), <$ty>::as_bytes(&[$a]).to_vec(), "{ty}: arm 0");
+            assert_eq!(
+                run(1),
+                <$ty>::as_bytes(&[$b]).to_vec(),
+                "{ty}: or-arm sel=1"
+            );
+            assert_eq!(
+                run(2),
+                <$ty>::as_bytes(&[$b]).to_vec(),
+                "{ty}: or-arm sel=2"
+            );
+            assert_eq!(run(3), <$ty>::as_bytes(&[$c]).to_vec(), "{ty}: default");
+        }
+    };
+}
+
+lit_match_value!(kernel_match_i8, match_check_i8, i8, 10i8, 20i8, 30i8);
+lit_match_value!(kernel_match_i16, match_check_i16, i16, 10i16, 20i16, 30i16);
+lit_match_value!(kernel_match_i32, match_check_i32, i32, 10i32, 20i32, 30i32);
+lit_match_value!(kernel_match_i64, match_check_i64, i64, 10i64, 20i64, 30i64);
+lit_match_value!(kernel_match_u8, match_check_u8, u8, 10u8, 20u8, 30u8);
+lit_match_value!(kernel_match_u16, match_check_u16, u16, 10u16, 20u16, 30u16);
+lit_match_value!(kernel_match_u32, match_check_u32, u32, 10u32, 20u32, 30u32);
+lit_match_value!(kernel_match_u64, match_check_u64, u64, 10u64, 20u64, 30u64);
+lit_match_value!(
+    kernel_match_f32,
+    match_check_f32,
+    f32,
+    10.0f32,
+    20.0f32,
+    30.0f32
+);
+lit_match_value!(
+    kernel_match_f64,
+    match_check_f64,
+    f64,
+    10.0f64,
+    20.0f64,
+    30.0f64
+);
+
+pub fn test_match_value_literals<R: Runtime>(client: ComputeClient<R>) {
+    match_check_i8(&client);
+    match_check_i16(&client);
+    match_check_i32(&client);
+    match_check_i64(&client);
+    match_check_u8(&client);
+    match_check_u16(&client);
+    match_check_u32(&client);
+    match_check_u64(&client);
+    match_check_f32(&client);
+    match_check_f64(&client);
+}
+
+// Subset using only types every backend supports (wgpu rejects i8/i16/u8/u16/f64).
+pub fn test_match_value_literals_portable<R: Runtime>(client: ComputeClient<R>) {
+    match_check_f32(&client);
+    match_check_i32(&client);
+    match_check_u32(&client);
+}
+
 #[cube(launch_unchecked)]
 pub fn kernel_switch_simple<F: Float>(output: &mut [F], case: u32) {
     match case {
@@ -318,6 +409,15 @@ macro_rules! testgen_branch {
         }
 
         #[$crate::runtime_tests::test_log::test]
+        #[ignore = "known bug: match/switch value-form with literal arms selects at comptime (if/else fix does not cover this path)"]
+        fn test_match_value_literals_portable() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::branch::test_match_value_literals_portable::<TestRuntime>(
+                client,
+            );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
         fn test_select_true() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::branch::test_select::<TestRuntime, FloatType>(client, true);
@@ -360,6 +460,13 @@ macro_rules! testgen_value_form_literals {
             fn test_value_form_literals() {
                 let client = TestRuntime::client(&Default::default());
                 cubecl_core::runtime_tests::branch::test_value_form_literals::<TestRuntime>(client);
+            }
+
+            #[$crate::runtime_tests::test_log::test]
+            #[ignore = "known bug: match/switch value-form with literal arms selects at comptime (if/else fix does not cover this path)"]
+            fn test_match_value_literals() {
+                let client = TestRuntime::client(&Default::default());
+                cubecl_core::runtime_tests::branch::test_match_value_literals::<TestRuntime>(client);
             }
         }
     };

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -409,7 +409,6 @@ macro_rules! testgen_branch {
         }
 
         #[$crate::runtime_tests::test_log::test]
-        #[ignore = "known bug: match/switch value-form with literal arms selects at comptime (if/else fix does not cover this path)"]
         fn test_match_value_literals_portable() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::branch::test_match_value_literals_portable::<TestRuntime>(
@@ -463,7 +462,6 @@ macro_rules! testgen_value_form_literals {
             }
 
             #[$crate::runtime_tests::test_log::test]
-            #[ignore = "known bug: match/switch value-form with literal arms selects at comptime (if/else fix does not cover this path)"]
             fn test_match_value_literals() {
                 let client = TestRuntime::client(&Default::default());
                 cubecl_core::runtime_tests::branch::test_match_value_literals::<TestRuntime>(client);

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -464,7 +464,9 @@ macro_rules! testgen_value_form_literals {
             #[$crate::runtime_tests::test_log::test]
             fn test_match_value_literals() {
                 let client = TestRuntime::client(&Default::default());
-                cubecl_core::runtime_tests::branch::test_match_value_literals::<TestRuntime>(client);
+                cubecl_core::runtime_tests::branch::test_match_value_literals::<TestRuntime>(
+                    client,
+                );
             }
         }
     };

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -69,8 +69,8 @@ pub fn test_value_form_literals_portable<R: Runtime>(client: ComputeClient<R>) {
     check_u32(&client);
 }
 
-// KNOWN BUG (red): `match` used as a value with literal arms has the same comptime-select
-// bug as if/else, on every type, and the if/else fix does not cover this codegen path.
+// Regression: `match` used as a value with literal arms had the same comptime-select
+// bug as if/else, and should act the same way now.
 // One kernel per type, with a single-pattern arm, an or-pattern arm, and a default; the
 // checker asserts each selector picks the right arm's value.
 macro_rules! lit_match_value {

--- a/crates/cubecl-core/src/runtime_tests/const_match.rs
+++ b/crates/cubecl-core/src/runtime_tests/const_match.rs
@@ -17,7 +17,7 @@ pub fn kernel_const_match_simple<F: Float, U: Int + hash::Hash + Eq + Debug>(
 ) {
     match op {
         Operation::IndexAssign(index, value) => {
-            output[index.runtime()] = F::cast_from(value.runtime());
+            output[index] = F::cast_from(value.runtime());
         }
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/short_circuit.rs
+++ b/crates/cubecl-core/src/runtime_tests/short_circuit.rs
@@ -8,7 +8,7 @@ use cubecl_runtime::server::Handle;
 #[cube]
 fn mark_side_channel(side_channel: &mut Array<u32>) -> bool {
     side_channel[0] = 1u32;
-    false.runtime()
+    false
 }
 
 #[cube(launch)]

--- a/crates/cubecl-cpu/src/compute/affinity/windows.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/windows.rs
@@ -8,7 +8,7 @@ use super::CoreId;
 pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
     let mask = get_affinity_mask();
 
-    (0..64u64)
+    (0..64_u64)
         .filter(move |&i| (mask & 1 << i) == 1 << i)
         .map(|i| CoreId(i as usize))
 }

--- a/crates/cubecl-cpu/src/frontend/unaligned_vector.rs
+++ b/crates/cubecl-cpu/src/frontend/unaligned_vector.rs
@@ -70,7 +70,6 @@ impl_unaligned_vector!(Shared<[E]>);
 // and still needs the loaded elements to be contiguous
 
 #[cube]
-#[allow(unused_variables)]
 fn unaligned_vector_read<E: Scalar, N: Size>(this: &[E], index: usize) -> Vector<E, N> {
     intrinsic!(|scope| {
         let list: Variable = this.__extract_list(scope);
@@ -95,7 +94,6 @@ fn unaligned_vector_read<E: Scalar, N: Size>(this: &[E], index: usize) -> Vector
 }
 
 #[cube]
-#[allow(unused_variables)]
 fn unaligned_vector_write<E: Scalar, N: Size>(this: &mut [E], index: usize, value: Vector<E, N>) {
     intrinsic!(|scope| {
         let list: Variable = this.__extract_list(scope);

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -14,6 +14,7 @@ mod tests {
     use cubecl_core::prelude::*;
 
     cubecl_core::testgen_all!(f32: [f16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
+    cubecl_core::testgen_value_form_literals!();
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, f32, u32]);
     cubecl_std::testgen_quantized_view!(f32);

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -14,7 +14,6 @@ mod tests {
     use cubecl_core::prelude::*;
 
     cubecl_core::testgen_all!(f32: [f16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
-    cubecl_core::testgen_value_form_literals!();
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, f32, u32]);
     cubecl_std::testgen_quantized_view!(f32);

--- a/crates/cubecl-cuda/src/lib.rs
+++ b/crates/cubecl-cuda/src/lib.rs
@@ -74,7 +74,6 @@ mod tests {
     pub use half::{bf16, f16};
 
     cubecl_core::testgen_all!(f32: [f16, bf16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
-    cubecl_core::testgen_value_form_literals!();
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, bf16, f32, u32]);
     cubecl_std::testgen_quantized_view!(f16);

--- a/crates/cubecl-cuda/src/lib.rs
+++ b/crates/cubecl-cuda/src/lib.rs
@@ -74,6 +74,7 @@ mod tests {
     pub use half::{bf16, f16};
 
     cubecl_core::testgen_all!(f32: [f16, bf16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
+    cubecl_core::testgen_value_form_literals!();
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, bf16, f32, u32]);
     cubecl_std::testgen_quantized_view!(f16);

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -173,7 +173,7 @@ pub enum Expression {
     Comment {
         content: LitStr,
     },
-    RustMacro {
+    PanickingMacro {
         ident: Ident,
         tokens: TokenStream,
     },

--- a/crates/cubecl-macros/src/generate/assign.rs
+++ b/crates/cubecl-macros/src/generate/assign.rs
@@ -21,8 +21,8 @@ impl ToTokens for Assign {
         let name = &self.ident;
         let expand_name = format_ident!("{name}Expand");
         let (generics, generic_names, _) = self.generics.split_for_impl();
-        let where_clause = self.where_clause(prelude_type("Assign"));
-        let where_clause_init = self.where_clause(prelude_type("RuntimeAssign"));
+        let where_clause = self.where_clause(&assign);
+        let where_clause_init = self.where_clause(&runtime_assign);
 
         let init_mut_body = match &self.data {
             Data::Enum(_) if self.runtime_variants.is_present() => {
@@ -228,7 +228,7 @@ impl Assign {
         }
     }
 
-    fn where_clause(&self, trait_: Path) -> Option<WhereClause> {
+    fn where_clause(&self, trait_: &Path) -> Option<WhereClause> {
         let cube_type = prelude_type("CubeType");
 
         let fields: Vec<_> = match &self.data {

--- a/crates/cubecl-macros/src/generate/assign.rs
+++ b/crates/cubecl-macros/src/generate/assign.rs
@@ -4,7 +4,7 @@ use darling::{
 };
 use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote};
-use syn::{DeriveInput, Index, WhereClause};
+use syn::{DeriveInput, Index, Path, WhereClause};
 
 use crate::{
     generate::bounded_where_clause,
@@ -15,12 +15,14 @@ use crate::{
 impl ToTokens for Assign {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let assign = prelude_type("Assign");
+        let runtime_assign = prelude_type("RuntimeAssign");
         let scope = prelude_type("Scope");
 
         let name = &self.ident;
         let expand_name = format_ident!("{name}Expand");
         let (generics, generic_names, _) = self.generics.split_for_impl();
-        let where_clause = self.where_clause();
+        let where_clause = self.where_clause(prelude_type("Assign"));
+        let where_clause_init = self.where_clause(prelude_type("RuntimeAssign"));
 
         let init_mut_body = match &self.data {
             Data::Enum(_) if self.runtime_variants.is_present() => {
@@ -42,7 +44,9 @@ impl ToTokens for Assign {
                     use #assign as _;
                     #assign_body
                 }
+            }
 
+            impl #generics #runtime_assign for #expand_name #generic_names #where_clause_init {
                 fn init_mut(&self, scope: &#scope) -> Self {
                     use #assign as _;
                     #init_mut_body
@@ -224,9 +228,8 @@ impl Assign {
         }
     }
 
-    fn where_clause(&self) -> Option<WhereClause> {
+    fn where_clause(&self, trait_: Path) -> Option<WhereClause> {
         let cube_type = prelude_type("CubeType");
-        let assign = prelude_type("Assign");
 
         let fields: Vec<_> = match &self.data {
             Data::Enum(variants) => variants
@@ -244,7 +247,7 @@ impl Assign {
         bounded_where_clause(
             &self.generics,
             fields,
-            |param| quote!(<#param as #cube_type>::ExpandType: #assign),
+            |param| quote!(<#param as #cube_type>::ExpandType: #trait_),
         )
     }
 }

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -694,7 +694,7 @@ impl Expression {
                 let frontend_path = frontend_path();
                 quote![#frontend_path::cube_comment::expand(scope, #content)]
             }
-            Expression::RustMacro { ident, tokens } => {
+            Expression::PanickingMacro { ident, tokens } => {
                 quote![#ident!(#tokens)]
             }
             Expression::Terminate => {
@@ -843,11 +843,14 @@ impl Block {
     pub fn to_tokens_runtime_return(&self, context: &mut Context) -> TokenStream {
         let inner: Vec<_> = self.inner.iter().map(|it| it.to_tokens(context)).collect();
         let ret = if let Some(ret) = self.ret.as_ref() {
-            ret.to_tokens(context)
+            if let Expression::PanickingMacro { .. } = &**ret {
+                ret.to_tokens(context)
+            } else {
+                into_expand(ret.to_tokens(context))
+            }
         } else {
             quote![()]
         };
-        let ret = into_expand(ret);
 
         quote! {
             {

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -306,9 +306,12 @@ impl Expression {
                 let condition = into_expand(condition.to_tokens(context));
                 let then_block = then_block.to_tokens(context);
                 let else_branch = else_branch.to_tokens(context);
+                // Force the arms to runtime. The condition is runtime here (comptime
+                // ones match the `condition.is_const()` arm above), so a comptime arm
+                // (e.g. a literal) must not make the select happen at comptime.
                 quote! {{
-                    #path::branch::if_else_expr_expand(scope, #condition, |scope| #then_block)
-                        .or_else(scope, |scope| #else_branch)
+                    #path::branch::if_else_expr_expand(scope, #condition, |scope| (#then_block).into_expand(scope))
+                        .or_else(scope, |scope| (#else_branch).into_expand(scope))
                 }}
             }
             Expression::If {

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -306,12 +306,9 @@ impl Expression {
                 let condition = into_expand(condition.to_tokens(context));
                 let then_block = then_block.to_tokens(context);
                 let else_branch = else_branch.to_tokens(context);
-                // Force the arms to runtime. The condition is runtime here (comptime
-                // ones match the `condition.is_const()` arm above), so a comptime arm
-                // (e.g. a literal) must not make the select happen at comptime.
                 quote! {{
-                    #path::branch::if_else_expr_expand(scope, #condition, |scope| (#then_block).into_expand(scope))
-                        .or_else(scope, |scope| (#else_branch).into_expand(scope))
+                    #path::branch::if_else_expr_expand(scope, #condition, |scope| (#then_block))
+                        .or_else(scope, |scope| (#else_branch))
                 }}
             }
             Expression::If {
@@ -834,6 +831,23 @@ impl Block {
         } else {
             quote![()]
         };
+
+        quote! {
+            {
+                #(#inner)*
+                #ret
+            }
+        }
+    }
+
+    pub fn to_tokens_runtime_return(&self, context: &mut Context) -> TokenStream {
+        let inner: Vec<_> = self.inner.iter().map(|it| it.to_tokens(context)).collect();
+        let ret = if let Some(ret) = self.ret.as_ref() {
+            ret.to_tokens(context)
+        } else {
+            quote![()]
+        };
+        let ret = into_expand(ret);
 
         quote! {
             {

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -7,9 +7,12 @@ use quote::{format_ident, quote, quote_spanned};
 use syn::{Ident, TypeParamBound, parse_quote};
 
 use crate::{
-    parse::kernel::{
-        DefinedGeneric, KernelBody, KernelFn, Launch, anon_lifetime_to_static, map_type_normalized,
-        strip_ref,
+    parse::{
+        kernel::{
+            DefinedGeneric, KernelBody, KernelFn, Launch, anon_lifetime_to_static,
+            map_type_normalized, strip_ref,
+        },
+        signature::KernelReturns,
     },
     paths::{frontend_type, prelude_type},
 };
@@ -19,8 +22,14 @@ impl KernelFn {
         let attrs = &self.attrs;
         let vis = &self.vis;
         let sig = &self.sig;
+
         let body = match &self.body {
-            KernelBody::Block(block) => &block.to_tokens(&mut self.context),
+            KernelBody::Block(block) => match matches!(sig.returns, KernelReturns::ExpandType(_))
+                && !self.context.is_intrinsic
+            {
+                true => &block.to_tokens_runtime_return(&mut self.context),
+                false => &block.to_tokens(&mut self.context),
+            },
             KernelBody::Verbatim(tokens) => tokens,
         };
         let name = &self.full_name;

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -70,8 +70,14 @@ fn cube_impl(args: TokenStream, input: TokenStream) -> syn::Result<TokenStream> 
             RemoveHelpers.visit_item_mut(&mut item);
             ReplaceDefines.visit_item_mut(&mut item);
 
+            let extra_allow = match kernel.func.context.is_intrinsic {
+                true => quote![#[allow(unused_variables)]],
+                false => quote![],
+            };
+
             return Ok(TokenStream::from(quote! {
-                #[allow(dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
+                #[allow(dead_code, clippy::too_many_arguments)]
+                #extra_allow
                 #item
                 #kernel
             }));

--- a/crates/cubecl-macros/src/parse/cube_impl.rs
+++ b/crates/cubecl-macros/src/parse/cube_impl.rs
@@ -1,7 +1,7 @@
 use quote::{ToTokens, format_ident, quote};
 use syn::{
     FnArg, GenericArgument, Generics, Ident, ImplItem, ItemImpl, PathArguments, Token, Type,
-    TypePath, spanned::Spanned, visit_mut::VisitMut,
+    TypePath, parse_quote, spanned::Spanned, visit_mut::VisitMut,
 };
 
 use crate::{
@@ -145,6 +145,7 @@ impl CubeImplItem {
             context: Context::new(
                 func.context.return_type.clone(),
                 cfg_debug || func.args.debug_symbols.is_present(),
+                func.context.is_intrinsic,
             ),
             args: func.args.clone(),
             analysis: func.analysis.clone(),
@@ -207,9 +208,19 @@ impl CubeImplItem {
             context: Context::new(
                 func.context.return_type.clone(),
                 cfg_debug || func.args.debug_symbols.is_present(),
+                func.context.is_intrinsic,
             ),
             args: func.args.clone(),
             analysis: func.analysis.clone(),
+        }
+    }
+
+    fn is_intrinsic(&self) -> bool {
+        match self {
+            CubeImplItem::Fn(kernel_fn) => kernel_fn.context.is_intrinsic,
+            CubeImplItem::MethodExpand(kernel_fn) => kernel_fn.context.is_intrinsic,
+            CubeImplItem::FnExpand(kernel_fn) => kernel_fn.context.is_intrinsic,
+            CubeImplItem::Other => false,
         }
     }
 }
@@ -220,9 +231,18 @@ impl CubeImpl {
 
         let items = item_impl
             .items
-            .iter()
-            .cloned()
-            .map(|item| CubeImplItem::from_impl_item(&struct_name, item, args))
+            .iter_mut()
+            .map(|item| {
+                let expands = CubeImplItem::from_impl_item(&struct_name, item.clone(), args)?;
+                let is_intrinsic = expands.iter().any(|it| it.is_intrinsic());
+                if is_intrinsic {
+                    *item = parse_quote! {
+                        #[allow(unused_variables)]
+                        #item
+                    }
+                }
+                Ok(expands)
+            })
             .flat_map(|items| {
                 let result: Vec<syn::Result<CubeImplItem>> = match items {
                     Ok(items) => items.into_iter().map(Ok).collect(),

--- a/crates/cubecl-macros/src/parse/cube_trait.rs
+++ b/crates/cubecl-macros/src/parse/cube_trait.rs
@@ -171,6 +171,14 @@ impl CubeTraitImplItem {
             CubeTraitImplItem::Fn(_) | CubeTraitImplItem::Method(_) => None,
         }
     }
+
+    fn is_intrinsic(&self) -> bool {
+        match self {
+            CubeTraitImplItem::Fn(kernel_fn) => kernel_fn.context.is_intrinsic,
+            CubeTraitImplItem::Method(kernel_fn) => kernel_fn.context.is_intrinsic,
+            CubeTraitImplItem::Other(_) => false,
+        }
+    }
 }
 
 impl CubeTrait {
@@ -226,9 +234,18 @@ impl CubeTraitImpl {
     pub fn from_item_impl(mut item_impl: ItemImpl, args: &KernelArgs) -> syn::Result<Self> {
         let items = item_impl
             .items
-            .iter()
-            .cloned()
-            .map(|item| CubeTraitImplItem::from_impl_item(&item_impl.self_ty, item, args))
+            .iter_mut()
+            .map(|item| {
+                let impl_item =
+                    CubeTraitImplItem::from_impl_item(&item_impl.self_ty, item.clone(), args)?;
+                if impl_item.is_intrinsic() {
+                    *item = parse_quote! {
+                        #[allow(unused_variables)]
+                        #item
+                    }
+                }
+                Ok::<CubeTraitImplItem, syn::Error>(impl_item)
+            })
             .collect::<Result<_, _>>()?;
 
         RemoveHelpers.visit_item_impl_mut(&mut item_impl);

--- a/crates/cubecl-macros/src/parse/kernel.rs
+++ b/crates/cubecl-macros/src/parse/kernel.rs
@@ -361,7 +361,7 @@ impl KernelFn {
         let analysis =
             GenericAnalysis::from_generics(&sig.generics, args.explicit_define.is_present());
 
-        let mut context = Context::new(sig.returns.ty(), debug_symbols);
+        let mut context = Context::new(sig.returns.ty(), debug_symbols, false);
         context.extend(sig.parameters.clone());
 
         Desugar.visit_block_mut(&mut block);

--- a/crates/cubecl-macros/src/parse/statement.rs
+++ b/crates/cubecl-macros/src/parse/statement.rs
@@ -149,8 +149,7 @@ pub fn parse_macros(mac: Macro, context: &mut Context) -> syn::Result<Expression
     .into_iter()
     .any(|target| mac.path.is_ident(&target))
     {
-        context.is_intrinsic = true;
-        Ok(Expression::RustMacro {
+        Ok(Expression::PanickingMacro {
             ident: mac.path.segments.last().unwrap().ident.clone(),
             tokens: mac.tokens,
         })

--- a/crates/cubecl-macros/src/parse/statement.rs
+++ b/crates/cubecl-macros/src/parse/statement.rs
@@ -149,6 +149,7 @@ pub fn parse_macros(mac: Macro, context: &mut Context) -> syn::Result<Expression
     .into_iter()
     .any(|target| mac.path.is_ident(&target))
     {
+        context.is_intrinsic = true;
         Ok(Expression::RustMacro {
             ident: mac.path.segments.last().unwrap().ident.clone(),
             tokens: mac.tokens,
@@ -171,6 +172,7 @@ pub fn parse_macros(mac: Macro, context: &mut Context) -> syn::Result<Expression
     } else if mac.path.is_ident("terminate") {
         Ok(Expression::Terminate)
     } else if mac.path.is_ident("intrinsic") {
+        context.is_intrinsic = true;
         let closure: syn::ExprClosure = mac.parse_body()?;
         let arg = &closure.inputs[0];
         let block = *closure.body;

--- a/crates/cubecl-macros/src/scope.rs
+++ b/crates/cubecl-macros/src/scope.rs
@@ -53,10 +53,11 @@ pub struct Context {
     level: usize,
     mut_scope_idx: usize,
     pub debug_symbols: bool,
+    pub is_intrinsic: bool,
 }
 
 impl Context {
-    pub fn new(return_type: Type, debug_symbols: bool) -> Self {
+    pub fn new(return_type: Type, debug_symbols: bool, is_intrinsic: bool) -> Self {
         let mut root_scope = ManagedScope::default();
         root_scope.extend(KEYWORDS.iter().map(|it| {
             let name = format_ident!("{it}");
@@ -77,6 +78,7 @@ impl Context {
             level: 0,
             mut_scope_idx: 0,
             debug_symbols,
+            is_intrinsic,
         }
     }
 

--- a/crates/cubecl-std/src/event/mod.rs
+++ b/crates/cubecl-std/src/event/mod.rs
@@ -48,7 +48,6 @@ impl ComptimeEventBus {
         })
     }
 
-    #[allow(unused_variables)]
     /// Registers a new callback to be called when its event is launched.
     ///
     /// # Notes
@@ -90,7 +89,6 @@ impl ComptimeEventBus {
         })
     }
 
-    #[allow(unused_variables)]
     /// Registers a new event to be processed by [registered listeners](EventListener).
     pub fn event<E: CubeType + 'static>(&mut self, event: E) {
         intrinsic!(|scope| {

--- a/crates/cubecl-std/src/tests/view/quantized.rs
+++ b/crates/cubecl-std/src/tests/view/quantized.rs
@@ -22,15 +22,15 @@ impl Layout for TestPerTensorScaleLayout {
     type SourceCoordinates = Coords1d;
 
     fn to_source_pos(&self, _pos: Self::Coordinates) -> Self::SourceCoordinates {
-        0usize.runtime()
+        0
     }
 
     fn to_source_pos_checked(&self, pos: Self::Coordinates) -> (Self::SourceCoordinates, bool) {
-        (self.to_source_pos(pos), true.runtime())
+        (self.to_source_pos(pos), true)
     }
 
     fn is_in_bounds(&self, _pos: Self::Coordinates) -> bool {
-        true.runtime()
+        true
     }
 
     fn shape(&self) -> Self::Coordinates {


### PR DESCRIPTION
Fixes https://github.com/tracel-ai/cubecl/pull/1351 at a more fundamental level, by requiring `init_mut` to always return the runtime version (via the `IntoExpand::Expand` associated type).

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
