### PR TITLE
fix: cubecl-cpu synchronisation problem

### DIFF
--- a/crates/cubecl-cpu/src/compute/queue.rs
+++ b/crates/cubecl-cpu/src/compute/queue.rs
@@ -7,8 +7,9 @@ use crate::{
     },
 };
 use cubecl_common::bytes::Bytes;
-use cubecl_core::CubeDim;
+use cubecl_core::{CubeDim, stream_id::StreamId};
 use cubecl_runtime::{logging::ServerLogger, storage::BytesResource};
+use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, mpsc::SyncSender};
 
 static INSTANCE: OnceLock<CpuExecutionQueue> = OnceLock::new();
@@ -52,7 +53,7 @@ impl CpuExecutionQueue {
         std::thread::spawn(move || {
             let mut server = CpuExecutionQueueServer {
                 runner: Threadpool::new(logger),
-                pending_notifications: Vec::new(),
+                pending_notifications: HashMap::new(),
             };
 
             loop {
@@ -75,36 +76,55 @@ impl CpuExecutionQueue {
 
 struct CpuExecutionQueueServer {
     runner: Threadpool,
-    pending_notifications: Vec<Notifications>,
+    pending_notifications: HashMap<StreamId, Vec<Notifications>>,
 }
 
 impl CpuExecutionQueueServer {
     fn execute_task(&mut self, task: ScheduleTask) {
         match task {
-            ScheduleTask::Write { data, buffer } => self.write(data, buffer),
+            ScheduleTask::Write {
+                stream_id,
+                data,
+                buffer,
+            } => {
+                self.flush_stream(stream_id);
+                self.write(data, buffer)
+            }
             ScheduleTask::Execute {
+                stream_id,
                 mlir_engine,
                 bindings,
                 cube_dim,
                 cube_count,
                 ..
-            } => self.kernel(mlir_engine, bindings, cube_dim, cube_count),
+            } => {
+                self.flush_stream(stream_id);
+                self.kernel(stream_id, mlir_engine, bindings, cube_dim, cube_count)
+            }
         }
     }
 
     fn flush(&mut self) {
-        for notifications in self.pending_notifications.drain(..) {
+        for notifications in self.pending_notifications.drain().flat_map(|(_, v)| v) {
             notifications.wait();
         }
     }
 
+    fn flush_stream(&mut self, stream_id: StreamId) {
+        if let Some(notifications) = self.pending_notifications.remove(&stream_id) {
+            for notifications in notifications {
+                notifications.wait();
+            }
+        }
+    }
+
     fn write(&mut self, data: Bytes, mut buffer: BytesResource) {
-        self.flush();
         buffer.write().copy_from_slice(&data);
     }
 
     fn kernel(
         &mut self,
+        stream_id: StreamId,
         mlir_engine: MlirEngine,
         bindings: BindingsResource,
         cube_dim: CubeDim,
@@ -113,6 +133,9 @@ impl CpuExecutionQueueServer {
         let notifications = self
             .runner
             .execute_data(mlir_engine, bindings, cube_dim, cube_count);
-        self.pending_notifications.push(notifications);
+        self.pending_notifications
+            .entry(stream_id)
+            .or_default()
+            .push(notifications);
     }
 }

--- a/crates/cubecl-cpu/src/compute/schedule.rs
+++ b/crates/cubecl-cpu/src/compute/schedule.rs
@@ -1,5 +1,5 @@
 use crate::{compiler::mlir_engine::MlirEngine, compute::stream::CpuStream};
-use cubecl_common::bytes::Bytes;
+use cubecl_common::{bytes::Bytes, stream_id::StreamId};
 use cubecl_core::{
     CubeDim, ExecutionMode, MemoryConfiguration, ir::MemoryDeviceProperties,
     server::MetadataBindingInfo,
@@ -14,9 +14,14 @@ use std::sync::Arc;
 /// Defines tasks that can be scheduled on a cpu stream.
 pub enum ScheduleTask {
     /// Represents a task to write data to a buffer.
-    Write { data: Bytes, buffer: BytesResource },
+    Write {
+        stream_id: StreamId,
+        data: Bytes,
+        buffer: BytesResource,
+    },
     /// Represents a task to execute a kernel.
     Execute {
+        stream_id: StreamId,
         mlir_engine: MlirEngine,
         bindings: BindingsResource,
         kind: ExecutionMode,
@@ -28,12 +33,18 @@ pub enum ScheduleTask {
 impl core::fmt::Debug for ScheduleTask {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Write { data, buffer } => f
+            Self::Write {
+                stream_id,
+                data,
+                buffer,
+            } => f
                 .debug_struct("Write")
+                .field("stream_id", stream_id)
                 .field("data", data)
                 .field("buffer", buffer)
                 .finish(),
             Self::Execute {
+                stream_id,
                 mlir_engine: _,
                 bindings: _,
                 kind,
@@ -41,6 +52,7 @@ impl core::fmt::Debug for ScheduleTask {
                 cube_count,
             } => f
                 .debug_struct("Execute")
+                .field("stream_id", stream_id)
                 .field("kind", kind)
                 .field("cube_dim", cube_dim)
                 .field("cube_count", cube_count)

--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -96,6 +96,7 @@ impl CpuServer {
         count: CubeCount,
         bindings: BindingsResource,
         kind: ExecutionMode,
+        stream_id: StreamId,
     ) -> Result<ScheduleTask, CompilationError> {
         let cube_count = match count {
             CubeCount::Static(x, y, z) => [x, y, z],
@@ -121,7 +122,7 @@ impl CpuServer {
             }
         };
 
-        self.prepare_task_inner(kernel, cube_count, bindings, kind)
+        self.prepare_task_inner(kernel, cube_count, bindings, kind, stream_id)
     }
 
     fn prepare_task_inner(
@@ -130,6 +131,7 @@ impl CpuServer {
         cube_count: [u32; 3],
         bindings: BindingsResource,
         kind: ExecutionMode,
+        stream_id: StreamId,
     ) -> Result<ScheduleTask, CompilationError> {
         let kernel_id = kernel.id();
         let kernel = if let Some(kernel) = self.compilation_cache.get(&kernel_id) {
@@ -153,6 +155,7 @@ impl CpuServer {
         let mlir_engine = kernel.mlir.repr.clone().unwrap();
 
         let task = ScheduleTask::Execute {
+            stream_id,
             mlir_engine,
             bindings,
             cube_dim,
@@ -255,6 +258,7 @@ impl ComputeServer for CpuServer {
                 }
             };
             let task = ScheduleTask::Write {
+                stream_id,
                 data,
                 buffer: resource,
             };
@@ -287,7 +291,9 @@ impl ComputeServer for CpuServer {
             .iter()
             .for_each(|b| self.streams_pool.push(b.stream));
         let bindings = self.prepare_bindings(bindings);
-        let task = self.prepare_task(kernel, count, bindings, kind).unwrap();
+        let task = self
+            .prepare_task(kernel, count, bindings, kind, stream_id)
+            .unwrap();
 
         self.scheduler.register(stream_id, task, &self.streams_pool);
     }


### PR DESCRIPTION
This PR fix a regression introduced by #1345 stream we're not properly flush which caused problem in cubek when dependent stream where used

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
