### PR TITLE
refactor(runtime): aggregate memory_usage + memory_cleanup in client

### DIFF
--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -272,6 +272,10 @@ impl ComputeServer for CpuServer {
         Ok(stream.memory_management.memory_usage())
     }
 
+    fn stream_ids(&self) -> Vec<StreamId> {
+        self.scheduler.stream_ids().collect()
+    }
+
     fn memory_cleanup(&mut self, stream_id: StreamId) {
         let stream = self.scheduler.stream(&stream_id);
         stream.memory_management.cleanup(true)

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -242,6 +242,10 @@ impl ComputeServer for CudaServer {
         Ok(command.memory_usage())
     }
 
+    fn stream_ids(&self) -> Vec<StreamId> {
+        self.streams.stream_ids().collect()
+    }
+
     fn memory_cleanup(&mut self, stream_id: StreamId) {
         let mut command = match self.command_no_inputs(
             stream_id,

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -220,6 +220,10 @@ impl ComputeServer for HipServer {
         Ok(command.memory_usage())
     }
 
+    fn stream_ids(&self) -> Vec<StreamId> {
+        self.streams.stream_ids().collect()
+    }
+
     fn memory_cleanup(&mut self, stream_id: StreamId) {
         let mut command = match self.command_no_inputs(
             stream_id,

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -839,19 +839,21 @@ impl<R: Runtime> ComputeClient<R> {
         Arc::get_mut(&mut self.utilities).map(|state| &mut state.properties)
     }
 
-    /// Get the current memory usage of this client.
+    /// Total memory usage across all streams on this client's device.
+    ///
+    /// The closure iterates the server's `stream_ids()` and folds each
+    /// per-stream `memory_usage(id)` with `MemoryUsage::combine`, so the
+    /// result is correct regardless of which thread queries it.
     pub fn memory_usage(&self) -> Result<MemoryUsage, ServerError> {
-        let stream_id = self.stream_id();
         self.device
-            .submit_blocking(move |server| server.memory_usage(stream_id))
-            .unwrap()
-    }
-
-    /// Total memory usage across all streams, correct from any thread
-    /// (unlike [`Self::memory_usage`], which only sees the calling thread's stream).
-    pub fn memory_usage_total(&self) -> Result<MemoryUsage, ServerError> {
-        self.device
-            .submit_blocking(move |server| server.memory_usage_total())
+            .submit_blocking(move |server| {
+                server
+                    .stream_ids()
+                    .into_iter()
+                    .try_fold(MemoryUsage::default(), |acc, id| {
+                        Ok(acc.combine(server.memory_usage(id)?))
+                    })
+            })
             .unwrap()
     }
 
@@ -891,9 +893,11 @@ impl<R: Runtime> ComputeClient<R> {
     /// Nb: Results will vary on what the memory allocator deems beneficial,
     /// so it's not guaranteed any memory is freed.
     pub fn memory_cleanup(&self) {
-        let stream_id = self.stream_id();
-        self.device
-            .submit(move |server| server.memory_cleanup(stream_id));
+        self.device.submit(move |server| {
+            for id in server.stream_ids() {
+                server.memory_cleanup(id);
+            }
+        });
     }
 
     /// Measure the execution time of some inner operations.

--- a/crates/cubecl-runtime/src/server/base.rs
+++ b/crates/cubecl-runtime/src/server/base.rs
@@ -406,13 +406,16 @@ where
     /// Flush all outstanding tasks in the server.
     fn flush(&mut self, stream_id: StreamId) -> Result<(), ServerError>;
 
-    /// The current memory usage of the server.
+    /// Memory usage of the given stream.
     fn memory_usage(&mut self, stream_id: StreamId) -> Result<MemoryUsage, ServerError>;
 
-    /// Total memory usage across all streams. Default reports only the
-    /// calling stream; multi-stream backends override to aggregate.
-    fn memory_usage_total(&mut self) -> Result<MemoryUsage, ServerError> {
-        self.memory_usage(StreamId::current())
+    /// Stream ids the client should iterate to aggregate across the device.
+    ///
+    /// Default is just the calling stream, which is correct for
+    /// non-multi-stream backends; multi-stream backends override to
+    /// return one id per initialized stream pool slot.
+    fn stream_ids(&self) -> Vec<StreamId> {
+        Vec::from([StreamId::current()])
     }
 
     /// Ask the server to release memory that it can release.

--- a/crates/cubecl-runtime/src/stream/base.rs
+++ b/crates/cubecl-runtime/src/stream/base.rs
@@ -42,6 +42,19 @@ impl<F: StreamFactory> StreamPool<F> {
         self.streams.iter().flatten()
     }
 
+    /// Synthetic [`StreamId`]s, one per initialized regular pool slot.
+    ///
+    /// Each id round-trips through [`Self::get_mut`] to the same slot it
+    /// came from (slot `i` is reachable via `StreamId { value: i }` since
+    /// indexing is `value % max_streams`), so it's safe to feed these
+    /// ids back into per-stream APIs.
+    pub fn stream_ids(&self) -> impl Iterator<Item = StreamId> + '_ {
+        self.streams[..self.max_streams]
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| s.as_ref().map(|_| StreamId { value: i as u64 }))
+    }
+
     /// Retrieves a mutable reference to a stream for a given stream ID.
     pub fn get_mut(&mut self, stream_id: &StreamId) -> &mut F::Stream {
         // Calculate the index for the stream ID.

--- a/crates/cubecl-runtime/src/stream/event.rs
+++ b/crates/cubecl-runtime/src/stream/event.rs
@@ -199,6 +199,11 @@ impl<B: EventStreamBackend> MultiStream<B> {
         }
     }
 
+    /// Synthetic [`StreamId`]s, one per initialized stream (see [`StreamPool::stream_ids`]).
+    pub fn stream_ids(&self) -> impl Iterator<Item = StreamId> + '_ {
+        self.streams.stream_ids()
+    }
+
     /// Enqueue a task to be cleaned.
     pub fn gc(&mut self, gc: GcTask<B>) {
         self.gc.sender.send(gc).unwrap();

--- a/crates/cubecl-runtime/src/stream/scheduler.rs
+++ b/crates/cubecl-runtime/src/stream/scheduler.rs
@@ -119,6 +119,11 @@ impl<B: SchedulerStreamBackend> SchedulerMultiStream<B> {
         self.pool.streams().map(|s| &s.stream)
     }
 
+    /// Synthetic [`StreamId`]s, one per initialized stream (see [`StreamPool::stream_ids`]).
+    pub fn stream_ids(&self) -> impl Iterator<Item = StreamId> + '_ {
+        self.pool.stream_ids()
+    }
+
     /// Registers a task for execution on a specific stream, ensuring stream alignment.
     pub fn register(&mut self, stream_id: StreamId, task: B::Task, args_streams: &[StreamId]) {
         // Align streams to ensure dependencies are handled correctly.

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -444,12 +444,8 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
         Ok(stream.mem_manage.memory_usage())
     }
 
-    fn memory_usage_total(&mut self) -> Result<MemoryUsage, ServerError> {
-        Ok(self
-            .scheduler
-            .streams()
-            .map(|s| s.mem_manage.memory_usage())
-            .fold(MemoryUsage::default(), |acc, usage| acc.combine(usage)))
+    fn stream_ids(&self) -> Vec<StreamId> {
+        self.scheduler.stream_ids().collect()
     }
 
     fn memory_cleanup(&mut self, stream_id: StreamId) {


### PR DESCRIPTION
Follow-up to #1333. That PR added `memory_usage_total` on `ComputeServer` with a default that just delegated to the calling thread's stream. Instead, servers expose their streams. The client can go over all existing streams for memory_usage and memory_cleanup. Servers keep the functions per ID