### PR TITLE
fix(cuda): route F16 ↔ BF16 casts through special_cast

### DIFF
--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -127,6 +127,10 @@ pub(crate) fn special_cast<D: Dialect>(
         return cast_to_fp8(f, current_in, *out);
     }
 
+    if matches!(current_in.elem(), Elem::F16) && matches!(out.elem(), Elem::BF16) {
+        return cast_half_to_bfloat(f, current_in, *out);
+    }
+
     if current_in.item() != out.item() {
         let assign = Instruction::Assign(UnaryInstruction {
             input: current_in,
@@ -136,6 +140,30 @@ pub(crate) fn special_cast<D: Dialect>(
     }
 
     Ok(())
+}
+
+/// Convert f16 to bf16. CUDA has no direct constructor between them, so we
+/// round-trip through f32 using the native CUDA intrinsics.
+fn cast_half_to_bfloat<D: Dialect>(
+    f: &mut fmt::Formatter,
+    input: Variable<D>,
+    out: Variable<D>,
+) -> fmt::Result {
+    let in_opt = input.optimized();
+    let out_opt = out.optimized().item();
+
+    handle_unroll(f, out, |f, i| {
+        let input = in_opt.index(i);
+        match out_opt.elem() {
+            Elem::BF16x2 => {
+                write!(f, "__float22bfloat162_rn(__half22float2({input}))")
+            }
+            Elem::BF16 => {
+                write!(f, "__float2bfloat16_rn(__half2float({input}))")
+            }
+            _ => unreachable!("cast_half_to_bfloat: out type must be bf16/bf16x2"),
+        }
+    })
 }
 
 /// Convert any float to fp4/fp6, with round to nearest

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -1585,7 +1585,9 @@ impl<D: Dialect> CppCompiler<D> {
             }),
             // Needs special conversion semantics
             gpu::Operator::Cast(op)
-                if (is_fp4_fp6_fp8(op.input.elem_type()) || is_fp4_fp6_fp8(out.elem_type()))
+                if (is_fp4_fp6_fp8(op.input.elem_type())
+                    || is_fp4_fp6_fp8(out.elem_type())
+                    || is_f16_bf16_cross(op.input.elem_type(), out.elem_type()))
                 // Trivial broadcast shouldn't use special cast logic
                     && op.input.elem_type() != out.elem_type() =>
             {
@@ -2078,6 +2080,19 @@ fn is_fp4_fp6_fp8(elem: gpu::ElemType) -> bool {
         ),
         _ => false,
     }
+}
+
+/// CUDA has no direct `__nv_bfloat16(__half)` / `__nv_bfloat162(__half2)` constructor,
+/// so F16 ↔ BF16 casts must route through `special_cast` (which round-trips via F32).
+/// A naive `Instruction::Assign` would emit an invalid constructor call.
+fn is_f16_bf16_cross(a: gpu::ElemType, b: gpu::ElemType) -> bool {
+    let is_half_or_bhalf = |e: gpu::ElemType| {
+        matches!(
+            e,
+            gpu::ElemType::Float(FloatKind::F16) | gpu::ElemType::Float(FloatKind::BF16)
+        )
+    };
+    is_half_or_bhalf(a) && is_half_or_bhalf(b) && a != b
 }
 
 fn const_u32<D: Dialect>(value: u32) -> Variable<D> {


### PR DESCRIPTION
## Summary

CUDA has no direct `__nv_bfloat16(__half)` or `__nv_bfloat162(__half2)` constructor. When a kernel casts between F16 and BF16 (e.g. on quantized dequantize paths where an F16 intermediate feeds a BF16 output), the `Instruction::Assign` path emits an invalid constructor call that fails nvcc compilation.

This adds:
- `is_f16_bf16_cross()` in `base.rs` to detect F16↔BF16 cross-casts and route them through `SpecialCast` instead of `Assign`
- `cast_half_to_bfloat()` in `convert.rs` to emit the correct round-trip through F32 using `__half2float` / `__float2bfloat16_rn` (scalar) and `__half22float2` / `__float22bfloat162_rn` (packed)

## Motivation

Discovered while implementing NVFP4 E2M1 weight-only quantization. The `QuantizedView` dequant path reads e2m1x2 values, produces an F16 intermediate, and needs to output BF16. Without this fix, the generated CUDA code tries to construct `__nv_bfloat162` directly from `__half2`, which doesn't exist — nvcc rejects the kernel.

The same issue would affect any kernel that mixes F16 and BF16 operands through a `Cast` operator.

## Changes

- `crates/cubecl-cpp/src/shared/base.rs`: Add `is_f16_bf16_cross()` and extend the `SpecialCast` guard to include F16↔BF16 cross-casts
- `crates/cubecl-cpp/src/cuda/convert.rs`: Add `cast_half_to_bfloat()` emitting F32 round-trip, and a branch in `special_cast()` to call it