### PR TITLE
use read only buffers when it's possible (WebGPU)

### DIFF
--- a/crates/cubecl-wgpu/src/backend/wgsl.rs
+++ b/crates/cubecl-wgpu/src/backend/wgsl.rs
@@ -12,17 +12,18 @@ pub fn bindings(
     repr: &<WgslCompiler as Compiler>::Representation,
     args: &KernelArguments,
 ) -> (Vec<Visibility>, usize) {
+    let force_read_write = !cfg!(exclusive_memory_only)
+        && repr
+            .buffers
+            .iter()
+            .any(|buffer| buffer.visibility == Visibility::ReadWrite);
+
     let mut bindings = repr
         .buffers
         .iter()
-        .map(|it| {
-            // When slices are shared, it needs to be read-write if ANY of the slices is read-write,
-            // and since we can't be sure, we'll assume everything is read-write.
-            if cfg!(exclusive_memory_only) {
-                it.visibility
-            } else {
-                Visibility::ReadWrite
-            }
+        .map(|it| match (force_read_write, it.visibility) {
+            (false, Visibility::Read) => Visibility::Read,
+            _ => Visibility::ReadWrite,
         })
         .collect::<Vec<_>>();
     if !args.info.data.is_empty() {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
@@ -229,12 +229,18 @@ impl ComputeShader {
         bindings: &[KernelArg],
         num_entry: usize,
     ) -> core::fmt::Result {
+        let force_read_write = !cfg!(exclusive_memory_only)
+            && bindings
+                .iter()
+                .any(|binding| binding.visibility == Visibility::ReadWrite);
+
         for (i, binding) in bindings.iter().enumerate() {
             Self::format_binding(
                 f,
                 format!("{prefix}_{i}_global").as_str(),
                 binding,
                 num_entry + i,
+                force_read_write,
             )?;
         }
 
@@ -246,13 +252,13 @@ impl ComputeShader {
         name: &str,
         binding: &KernelArg,
         num_entry: usize,
+        force_read_write: bool,
     ) -> core::fmt::Result {
         let ty = format!("array<{}>", binding.item);
 
         let location = "storage";
-        let visibility = match binding.visibility {
-            #[cfg(exclusive_memory_only)]
-            Visibility::Read => "read",
+        let visibility = match (force_read_write, binding.visibility) {
+            (false, Visibility::Read) => "read",
             _ => "read_write",
         };
 


### PR DESCRIPTION
Preserve WGSL `read` storage buffers for kernels that have no writable buffers and only use read-write when it's needed 