### PR TITLE
fix shared memory bytes

### DIFF
--- a/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
@@ -64,11 +64,7 @@ pub struct ComputeShader {
 
 impl ComputeShader {
     pub fn shared_memory_bytes(&self) -> usize {
-        self.shared_values
-            .iter()
-            .map(|it| it.item.size())
-            .chain(self.shared_values.iter().map(|it| it.item.size()))
-            .sum()
+        self.shared_values.iter().map(|it| it.item.size()).sum()
     }
 }
 


### PR DESCRIPTION
Shared memory values were counted twice, causing some kernels to be incorrectly rejected for exceeding the shared memory limit on WGPU.