### PR TITLE
fixed cargo xtask validate failures (typos check and CPU bitwise unary_int tests)

### DIFF
--- a/crates/cubecl-cpu/src/compiler/visitor/operation/bitwise.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/bitwise.rs
@@ -132,7 +132,7 @@ impl<'a> Visitor<'a> {
                 let value = self.append_operation_with_result(llvm::intr_ctlz(
                     self.context,
                     value,
-                    true,
+                    false,
                     result_type,
                     self.location,
                 ));
@@ -144,7 +144,7 @@ impl<'a> Visitor<'a> {
                 let value = self.append_operation_with_result(llvm::intr_cttz(
                     self.context,
                     value,
-                    true,
+                    false,
                     result_type,
                     self.location,
                 ));

--- a/typos.toml
+++ b/typos.toml
@@ -3,8 +3,10 @@ extend-ignore-identifiers-re = ["CU_DEVICE_ATTRIBUTE_*", "HSA_*"]
 
 [default.extend-identifiers]
 Olt = "Olt"
+Sned = "Sned" # Intentional typo example in obfuscation.rs's macro docs.
 UE4M3 = "UE4M3"
 UE8M0 = "UE8M0"
 arange = "arange"
+cpy = "cpy" # Shorthand for "copy" (CUDA_MEMCPY2D_st locals).
 ue4m3 = "ue4m3"
 ue8m0 = "ue8m0"


### PR DESCRIPTION
Fixed #1368

Verified `cargo xtask validate` passed on my end.