### PR TITLE
Don't panic when calling a non-path expression in a kernel

### DIFF
--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -576,10 +576,6 @@ fn generate_strided_index(
 }
 
 fn fn_associated_type(path: &Expression) -> Option<(Path, Option<QSelf>, PathSegment)> {
-    if !matches!(path, Expression::Path { .. }) {
-        panic!("path: {path:?}");
-    }
-
     match path {
         Expression::Path { path, qself } => {
             let second_last = path.segments.iter().nth_back(1)?;
@@ -625,5 +621,20 @@ pub(crate) fn is_runtime_compatible_variant(pat: &Pat) -> bool {
         Pat::TupleStruct(pat) => pat.elems.len() == 1,
         Pat::Wild(_) => true,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scope::Context;
+    use syn::parse_quote;
+
+    // Calling a non-path expression like `out[0]()` used to panic in `fn_associated_type`.
+    #[test]
+    fn call_on_indexed_value_does_not_panic() {
+        let mut context = Context::new(parse_quote!(()), false, false);
+        let expr: Expr = parse_quote!(out[0]());
+        assert!(Expression::from_expr(expr, &mut context).is_ok());
     }
 }


### PR DESCRIPTION
Pretty trivial as per title. This is necessary so that the failures are detected by the rust compiler, not as a panic, otherwise fuzzing the cube derive macro is non viable and we cannot get to fuzzing differential execution of kernels on gpu/cpu.

<img width="1046" height="800" alt="image" src="https://github.com/user-attachments/assets/12988381-5d3f-42c0-9604-7dc95881b186" />
