### PR TITLE
Reject unsupported kernel argument types instead of panicking

### DIFF
--- a/crates/cubecl-core/tests/error/kernel_arg_trait_object.rs
+++ b/crates/cubecl-core/tests/error/kernel_arg_trait_object.rs
@@ -1,0 +1,11 @@
+use cubecl::prelude::*;
+use cubecl_core as cubecl;
+
+trait Foo {}
+
+#[cube]
+fn kernel_arg_trait_object(x: &dyn Foo) {
+    let _ = x;
+}
+
+fn main() {}

--- a/crates/cubecl-core/tests/error/kernel_arg_trait_object.stderr
+++ b/crates/cubecl-core/tests/error/kernel_arg_trait_object.stderr
@@ -1,0 +1,5 @@
+error: trait objects (`dyn Trait`) are not allowed as kernel arguments
+ --> tests/error/kernel_arg_trait_object.rs:7:32
+  |
+7 | fn kernel_arg_trait_object(x: &dyn Foo) {
+  |                                ^^^^^^^

--- a/crates/cubecl-macros/src/generate/kernel.rs
+++ b/crates/cubecl-macros/src/generate/kernel.rs
@@ -221,8 +221,10 @@ impl Launch {
                 true => quote![self.#name.clone()],
                 false => {
                     let mut mapped = it.ty.clone();
-                    map_type_normalized(&mut mapped, &|_| parse_quote![#name]);
-                    quote![#mapped]
+                    match map_type_normalized(&mut mapped, &|_| parse_quote![#name]) {
+                        Ok(()) => quote![#mapped],
+                        Err(err) => err.into_compile_error(),
+                    }
                 }
             }
         });

--- a/crates/cubecl-macros/src/generate/signature.rs
+++ b/crates/cubecl-macros/src/generate/signature.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
+use syn::Type;
 
 use crate::{
     parse::{kernel::expand_kernel_ty, signature::*},
@@ -17,7 +18,8 @@ impl ToTokens for KernelSignature {
 
         let return_type = match &self.returns {
             KernelReturns::ExpandType(ty) => {
-                let normalized_ty = expand_kernel_ty(ty.clone(), false);
+                let normalized_ty = expand_kernel_ty(ty.clone(), false)
+                    .unwrap_or_else(|err| Type::Verbatim(err.into_compile_error()));
                 quote![#normalized_ty]
             }
             KernelReturns::Plain(ty) => quote![#ty],

--- a/crates/cubecl-macros/src/generate/statement.rs
+++ b/crates/cubecl-macros/src/generate/statement.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::{Token, spanned::Spanned};
+use syn::{Token, Type, spanned::Spanned};
 
 use crate::{
     expression::Expression,
@@ -37,7 +37,8 @@ impl Statement {
                     })
                 };
                 let ty = variable.ty.as_ref().map(|ty| {
-                    let ty = expand_kernel_ty(ty.clone(), is_const);
+                    let ty = expand_kernel_ty(ty.clone(), is_const)
+                        .unwrap_or_else(|err| Type::Verbatim(err.into_compile_error()));
                     quote_spanned! {
                         ty.span()=> :#ty
                     }

--- a/crates/cubecl-macros/src/parse/kernel.rs
+++ b/crates/cubecl-macros/src/parse/kernel.rs
@@ -491,42 +491,51 @@ impl Launch {
     }
 }
 
-pub fn expand_kernel_ty(mut ty: Type, is_const: bool) -> Type {
+pub fn expand_kernel_ty(mut ty: Type, is_const: bool) -> syn::Result<Type> {
     if is_const {
-        ty
+        Ok(ty)
     } else {
         let cube_type = prelude_type("CubeType");
-        map_type_normalized(&mut ty, &|ty| parse_quote![<#ty as #cube_type>::ExpandType]);
-        ty
+        map_type_normalized(&mut ty, &|ty| parse_quote![<#ty as #cube_type>::ExpandType])?;
+        Ok(ty)
     }
 }
 
-pub fn map_type_normalized(ty: &mut Type, op: &impl Fn(&Type) -> Type) {
+pub fn map_type_normalized(ty: &mut Type, op: &impl Fn(&Type) -> Type) -> syn::Result<()> {
     match ty {
-        Type::Group(type_group) => map_type_normalized(&mut type_group.elem, op),
-        Type::ImplTrait(_) => {
-            unimplemented!("impl trait not yet supported in kernel args")
+        Type::Group(type_group) => map_type_normalized(&mut type_group.elem, op)?,
+        Type::ImplTrait(impl_trait) => {
+            return Err(syn::Error::new_spanned(
+                impl_trait,
+                "`impl Trait` is not supported in kernel arguments",
+            ));
         }
         // Probably won't work with inference but we can at least try
         Type::Infer(_) => {}
         // Do nothing
         Type::Macro(type_macro) if type_macro.mac.path.is_ident("comptime_type") => {}
-        Type::Macro(_) => {
-            unimplemented!("Macro types not allowed for kernel args")
+        Type::Macro(type_macro) => {
+            return Err(syn::Error::new_spanned(
+                type_macro,
+                "macro types are not allowed as kernel arguments",
+            ));
         }
         Type::Never(_) => {}
-        Type::Paren(type_paren) => map_type_normalized(&mut type_paren.elem, op),
-        Type::Ptr(type_ptr) => map_type_normalized(&mut type_ptr.elem, op),
-        Type::Reference(type_reference) => map_type_normalized(&mut type_reference.elem, op),
-        Type::TraitObject(_) => {
-            unimplemented!("Trait objects are not allowed for kernel args")
+        Type::Paren(type_paren) => map_type_normalized(&mut type_paren.elem, op)?,
+        Type::Ptr(type_ptr) => map_type_normalized(&mut type_ptr.elem, op)?,
+        Type::Reference(type_reference) => map_type_normalized(&mut type_reference.elem, op)?,
+        Type::TraitObject(trait_object) => {
+            return Err(syn::Error::new_spanned(
+                trait_object,
+                "trait objects (`dyn Trait`) are not allowed as kernel arguments",
+            ));
         }
         // the `ExpandType` of tuple equals the expand type of each constituent, so we can
         // probably support more cases by handling each contained type separately. Won't hurt
         // at least.
         Type::Tuple(type_tuple) => {
             for ty in type_tuple.elems.iter_mut() {
-                map_type_normalized(ty, op);
+                map_type_normalized(ty, op)?;
             }
         }
         Type::Verbatim(_) => {}
@@ -534,6 +543,7 @@ pub fn map_type_normalized(ty: &mut Type, op: &impl Fn(&Type) -> Type) {
             *other = op(other);
         }
     }
+    Ok(())
 }
 
 pub fn all_path_args_mut(path: &mut Path) -> impl Iterator<Item = &mut GenericArgument> {

--- a/crates/cubecl-macros/src/parse/signature.rs
+++ b/crates/cubecl-macros/src/parse/signature.rs
@@ -242,7 +242,7 @@ impl KernelParam {
         let param = match param {
             FnArg::Typed(param) => param,
             FnArg::Receiver(param) => {
-                let normalized_ty = expand_kernel_ty(*param.ty.clone(), false);
+                let normalized_ty = expand_kernel_ty(*param.ty.clone(), false)?;
 
                 let mutability = if param.reference.is_none() {
                     param.mutability
@@ -293,7 +293,7 @@ impl KernelParam {
         }
 
         let ty = *param.ty.clone();
-        let normalized_ty = expand_kernel_ty(*param.ty, is_const);
+        let normalized_ty = expand_kernel_ty(*param.ty, is_const)?;
 
         let mut_token = if !is_ref { mutability } else { None };
 


### PR DESCRIPTION
As per title, also here I am propagating the error instead of keeping the `unimplemented`. The reason is the same as #1372 : this way we can arrive to differential fuzzing, once cube is stable.

<img width="1046" height="800" alt="image" src="https://github.com/user-attachments/assets/d5e58b1b-ce17-4300-a9e3-53f4ebe5b747" />
