### PR TITLE
Don't panic when const-folding an unfoldable const expression

### DIFF
--- a/crates/cubecl-macros/src/parse/expression.rs
+++ b/crates/cubecl-macros/src/parse/expression.rs
@@ -47,9 +47,16 @@ impl Expression {
                     Self::from_expr(*binary.left, context)?
                 };
 
-                if left.is_const() && right.is_const() {
-                    let left = left.as_const(context).unwrap();
-                    let right = right.as_const(context).unwrap();
+                // `is_const()` doesn't guarantee `as_const()` succeeds (e.g. a compiler
+                // intrinsic), so fall back to runtime instead of unwrapping a `None`.
+                let folded = if left.is_const() && right.is_const() {
+                    let left = left.as_const(context);
+                    let right = right.as_const(context);
+                    left.zip(right)
+                } else {
+                    None
+                };
+                if let Some((left, right)) = folded {
                     let op = binary.op;
                     Expression::Verbatim {
                         tokens: quote![(#left #op #right)],
@@ -87,8 +94,8 @@ impl Expression {
             Expr::Unary(unary) => {
                 let span = unary.span();
                 let input = Self::from_expr(*unary.expr, context)?;
-                if input.is_const() {
-                    let input = input.as_const(context).unwrap();
+                let folded = input.is_const().then(|| input.as_const(context)).flatten();
+                if let Some(input) = folded {
                     let op = unary.op;
                     Expression::Verbatim {
                         tokens: quote![(#op #input)],
@@ -635,6 +642,22 @@ mod tests {
     fn call_on_indexed_value_does_not_panic() {
         let mut context = Context::new(parse_quote!(()), false, false);
         let expr: Expr = parse_quote!(out[0]());
+        assert!(Expression::from_expr(expr, &mut context).is_ok());
+    }
+
+    // A const expression that can't be rendered as const tokens (a compiler intrinsic)
+    // used to make the `as_const().unwrap()` fold path panic.
+    #[test]
+    fn const_fold_on_unfoldable_const_binary_does_not_panic() {
+        let mut context = Context::new(parse_quote!(()), false, false);
+        let expr: Expr = parse_quote!(vectorization_of(x) + vectorization_of(x));
+        assert!(Expression::from_expr(expr, &mut context).is_ok());
+    }
+
+    #[test]
+    fn const_fold_on_unfoldable_const_unary_does_not_panic() {
+        let mut context = Context::new(parse_quote!(()), false, false);
+        let expr: Expr = parse_quote!(-vectorization_of(x));
         assert!(Expression::from_expr(expr, &mut context).is_ok());
     }
 }


### PR DESCRIPTION
As with #1372 and #1373, this turns a fuzzer-found panic in the `#[cube]` macro into correct behavior, on the way to differential fuzzing once the front end is stable (see #1364).

The binary and unary `const-folding` paths in parse/expression.rs call `as_const(context).unwrap()` after checking `is_const()`. That assumes every const expression can be rendered back as a `const` token stream, but some cannot: a compiler intrinsic such as `vectorization_of` reports `is_const()` as `true` while `as_const()` returns `None`, so the macro aborted the user's build with an opaque panic. The fix falls back to a runtime expression when folding is not possible.

Reproducer: `vectorization_of(x) + vectorization_of(x)`.

<img width="1046" height="800" alt="image" src="https://github.com/user-attachments/assets/649f786b-05be-4cab-9279-910bfd6f0e39" />
