### PR TITLE
fix: Remove unused CUtensorMap import

### DIFF
--- a/crates/cubecl-cuda/src/compute/command.rs
+++ b/crates/cubecl-cuda/src/compute/command.rs
@@ -29,7 +29,7 @@ use cubecl_runtime::{
     stream::ResolvedStreams,
 };
 use cudarc::driver::sys::{
-    CUDA_MEMCPY2D_st, CUmemorytype, CUstream_st, CUtensorMap, cuMemcpy2DAsync_v2,
+    CUDA_MEMCPY2D_st, CUmemorytype, CUstream_st, cuMemcpy2DAsync_v2,
 };
 use std::{ffi::c_void, ops::DerefMut, sync::Arc};
 


### PR DESCRIPTION
### 问题背景
代码中导入了 `cudarc::driver::sys::CUtensorMap`，但该导入未被使用，导致编译器或 lint 工具发出未解析导入警告。这会影响代码质量并可能干扰 CI 检查。

### 修改内容
- **修改了什么**：移除了未使用的导入 `CUtensorMap` 从 `cudarc::driver::sys` 模块中。
- **为什么这样改**：清理未使用的导入以解决 lint 警告，提高代码整洁度和可维护性。
- **提升**：减少编译噪音，遵循 Rust 最佳实践，确保代码库更干净。

### 验证方式
- 通过 `cargo check` 和 `cargo clippy` 验证代码编译无警告。
- 运行现有测试套件（如 `cargo test`）以确保无功能变化或回归。

### 其他信息
- 没有 breaking changes：这是一个纯代码清理，不影响公共 API 或行为。
- 不需要更新文档：修改仅涉及内部代码，不影响用户文档。