### PR TITLE
Keep CPU scheduled buffers alive

### DIFF
--- a/crates/cubecl-cpu/src/compiler/mlir_data.rs
+++ b/crates/cubecl-cpu/src/compiler/mlir_data.rs
@@ -105,7 +105,7 @@ impl MlirData {
         };
 
         for resource in resources {
-            let (ptr, len) = resource.get_write_ptr_and_length();
+            let (ptr, len) = resource.resource().get_write_ptr_and_length();
             let line_memref = LineMemRef::new(ptr, len);
             push_undirected(line_memref);
         }

--- a/crates/cubecl-cpu/src/compute/queue.rs
+++ b/crates/cubecl-cpu/src/compute/queue.rs
@@ -8,7 +8,10 @@ use crate::{
 };
 use cubecl_common::bytes::Bytes;
 use cubecl_core::{CubeDim, stream_id::StreamId};
-use cubecl_runtime::{logging::ServerLogger, storage::BytesResource};
+use cubecl_runtime::{
+    logging::ServerLogger,
+    storage::{BytesResource, ManagedResource},
+};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, mpsc::SyncSender};
 
@@ -118,8 +121,8 @@ impl CpuExecutionQueueServer {
         }
     }
 
-    fn write(&mut self, data: Bytes, mut buffer: BytesResource) {
-        buffer.write().copy_from_slice(&data);
+    fn write(&mut self, data: Bytes, mut buffer: ManagedResource<BytesResource>) {
+        buffer.resource_mut().write().copy_from_slice(&data);
     }
 
     fn kernel(

--- a/crates/cubecl-cpu/src/compute/schedule.rs
+++ b/crates/cubecl-cpu/src/compute/schedule.rs
@@ -6,7 +6,7 @@ use cubecl_core::{
 };
 use cubecl_runtime::{
     logging::ServerLogger,
-    storage::BytesResource,
+    storage::{BytesResource, ManagedResource},
     stream::{StreamFactory, scheduler::SchedulerStreamBackend},
 };
 use std::sync::Arc;
@@ -17,7 +17,7 @@ pub enum ScheduleTask {
     Write {
         stream_id: StreamId,
         data: Bytes,
-        buffer: BytesResource,
+        buffer: ManagedResource<BytesResource>,
     },
     /// Represents a task to execute a kernel.
     Execute {
@@ -65,7 +65,7 @@ impl core::fmt::Debug for ScheduleTask {
 #[derive(Debug)]
 pub struct BindingsResource {
     /// List of cpu resources used in the task.
-    pub resources: Vec<BytesResource>,
+    pub resources: Vec<ManagedResource<BytesResource>>,
     /// Metadata for uniform bindings.
     pub info: MetadataBindingInfo,
 }

--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -77,10 +77,13 @@ impl CpuServer {
             .into_iter()
             .map(|binding| {
                 let stream = self.scheduler.stream(&binding.stream);
-                stream
+                let memory = binding.memory.clone();
+                let resource = stream
                     .memory_management
                     .get_resource(binding.memory, binding.offset_start, binding.offset_end)
-                    .unwrap()
+                    .unwrap();
+
+                ManagedResource::new(memory, resource)
             })
             .collect::<Vec<_>>();
 
@@ -257,10 +260,11 @@ impl ComputeServer for CpuServer {
                     return;
                 }
             };
+            let memory = desc.handle.memory.clone();
             let task = ScheduleTask::Write {
                 stream_id,
                 data,
-                buffer: resource,
+                buffer: ManagedResource::new(memory, resource),
             };
 
             self.scheduler.register(stream_id, task, &[]);

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -10,8 +10,10 @@ mod tests {
 
     pub use half::f16;
 
+    use cubecl_common::{config::RuntimeConfig, stream_id::StreamId};
     use cubecl_core as cubecl;
     use cubecl_core::prelude::*;
+    use cubecl_runtime::config::CubeClRuntimeConfig;
 
     cubecl_core::testgen_all!(f32: [f16, f32, f64], i32: [i8, i16, i32, i64], u32: [u8, u16, u32, u64]);
     cubecl_std::testgen!();
@@ -68,6 +70,17 @@ mod tests {
             sum += mem[i];
         }
         out[idx] = sum;
+    }
+
+    #[cube(launch_unchecked)]
+    fn delayed_copy(input: &[u32], output: &mut [u32], num_loop: usize) {
+        if UNIT_POS == 0 {
+            let mut pos = 0usize;
+            for i in 0..num_loop {
+                pos = (pos + i) % input.len();
+            }
+            output[0] = input[pos];
+        }
     }
 
     #[test]
@@ -144,6 +157,47 @@ mod tests {
         let bytes = client.read_one_unchecked(out);
         let actual = u32::from_bytes(&bytes);
         assert_eq!(actual, &[28u32; 8]);
+    }
+
+    #[test]
+    fn queued_cpu_kernel_keeps_buffer_bindings_alive_until_execution() {
+        let client = TestRuntime::client(&Default::default());
+        let max_streams = CubeClRuntimeConfig::get().streaming.max_streams as u64;
+
+        let stream_a = StreamId { value: 0 };
+        let stream_b = StreamId { value: max_streams };
+
+        let client_a = unsafe {
+            let mut client = client.clone();
+            client.set_stream(stream_a);
+            client
+        };
+        let client_b = unsafe {
+            let mut client = client.clone();
+            client.set_stream(stream_b);
+            client
+        };
+
+        let input = client_a.create_from_slice(u32::as_bytes(&[7, 7]));
+        let output = client_a.empty(core::mem::size_of::<u32>());
+
+        unsafe {
+            delayed_copy::launch_unchecked::<TestRuntime>(
+                &client_a,
+                CubeCount::new_single(),
+                CubeDim::new_1d(1),
+                BufferArg::from_raw_parts(input, 2),
+                BufferArg::from_raw_parts(output.clone(), 1),
+                5_000_001,
+            )
+        }
+
+        let replacement = client_b.create_from_slice(u32::as_bytes(&[99, 99]));
+        drop(replacement);
+
+        let bytes = client_a.read_one_unchecked(output);
+        let actual = u32::from_bytes(&bytes);
+        assert_eq!(actual, &[7]);
     }
 }
 

--- a/crates/cubecl-runtime/src/storage/base.rs
+++ b/crates/cubecl-runtime/src/storage/base.rs
@@ -117,4 +117,9 @@ impl<Resource: Send> ManagedResource<Resource> {
     pub fn resource(&self) -> &Resource {
         &self.resource
     }
+
+    /// Mutable access to the underlying resource.
+    pub fn resource_mut(&mut self) -> &mut Resource {
+        &mut self.resource
+    }
 }


### PR DESCRIPTION
Fixes #1380.

## Summary

- keep managed memory bindings alive for CPU scheduled writes and kernel bindings
- add mutable access for `ManagedResource` so queued CPU writes can retain ownership while mutating the resource
- add a deterministic regression test for scheduler-slot stream reuse overwriting a queued kernel input

## Root cause

`cubecl-cpu` scheduled tasks stored `BytesResource` values without holding the associated managed memory binding. When a launch consumed an input handle and the scheduler had not executed the queued task yet, the memory pool could consider that allocation free. A later allocation on a stream that maps to the same scheduler slot could reuse and overwrite the memory while the queued CPU kernel still held the old raw pointer.

## Validation

- `cargo +stable test -p cubecl-cpu queued_cpu_kernel_keeps_buffer_bindings_alive_until_execution --lib -- --nocapture --color=always`
- `cargo +stable test -p cubecl-cpu --lib -- --test-threads=64 --color=always`
- `cargo +stable xtask check audit`
- `cargo +stable xtask check format`
- `cargo +stable xtask check lint`
- `typos`