### PR TITLE
Fix handling one tuple

### DIFF
--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -494,63 +494,63 @@ impl_launch_arg_ref!(*mut T);
 
 macro_rules! launch_tuple {
     ($(($T:ident, $t:ident)),*) => {
-        impl<$($T: LaunchArg),*> LaunchArg for ($($T),*) {
-            type RuntimeArg<R: Runtime> = ($($T::RuntimeArg<R>),*);
-            type CompilationArg = ($($T::CompilationArg),*);
+        impl<$($T: LaunchArg),*> LaunchArg for ($($T,)*) {
+            type RuntimeArg<R: Runtime> = ($($T::RuntimeArg<R>,)*);
+            type CompilationArg = ($($T::CompilationArg,)*);
 
             fn register<R: Runtime>(runtime_arg: Self::RuntimeArg<R>, launcher: &mut KernelLauncher<R>) -> Self::CompilationArg {
-                let ($($t),*) = runtime_arg;
-                ($($T::register($t, launcher)),*)
+                let ($($t,)*) = runtime_arg;
+                ($($T::register($t, launcher),)*)
             }
 
-            fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> ($(<$T as CubeType>::ExpandType),*) {
-                let ($($t),*) = arg;
-                ($($T::expand($t, builder)),*)
+            fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> ($(<$T as CubeType>::ExpandType,)*) {
+                let ($($t,)*) = arg;
+                ($($T::expand($t, builder),)*)
             }
         }
     };
 }
 
-all_tuples!(launch_tuple, 2, 12, T, t);
+all_tuples!(launch_tuple, 1, 12, T, t);
 
 macro_rules! as_ref_tuple {
     ($(($T:ident, $t:ident)),*) => {
-        impl<$($T: AsRefExpand),*> AsRefExpand for ($($T),*) {
-            fn __expand_ref_method(&self, _: &Scope) -> &($($T),*) {
+        impl<$($T: AsRefExpand),*> AsRefExpand for ($($T,)*) {
+            fn __expand_ref_method(&self, _: &Scope) -> &($($T,)*) {
                 self
             }
         }
     };
 }
 
-all_tuples!(as_ref_tuple, 2, 12, T, t);
+all_tuples!(as_ref_tuple, 1, 12, T, t);
 
 macro_rules! as_mut_tuple {
     ($(($T:ident, $t:ident)),*) => {
-        impl<$($T: AsMutExpand),*> AsMutExpand for ($($T),*) {
-            fn __expand_ref_mut_method(&mut self, _: &Scope) -> &mut ($($T),*) {
+        impl<$($T: AsMutExpand),*> AsMutExpand for ($($T,)*) {
+            fn __expand_ref_mut_method(&mut self, _: &Scope) -> &mut ($($T,)*) {
                 self
             }
         }
     };
 }
 
-all_tuples!(as_mut_tuple, 2, 12, T, t);
+all_tuples!(as_mut_tuple, 1, 12, T, t);
 
 macro_rules! deref_tuple {
     ($(($T:ident, $t:ident)),*) => {
-        impl<$($T: DerefExpand),*> DerefExpand for ($($T),*) {
-            type Target = ($($T::Target),*);
+        impl<$($T: DerefExpand),*> DerefExpand for ($($T,)*) {
+            type Target = ($($T::Target,)*);
 
             fn __expand_deref_method(&self, scope: &Scope) -> Self::Target {
-                let ($($t),*) = self;
-                ($($t.__expand_deref_method(scope)),*)
+                let ($($t,)*) = self;
+                ($($t.__expand_deref_method(scope),)*)
             }
         }
     };
 }
 
-all_tuples!(deref_tuple, 2, 12, T, t);
+all_tuples!(deref_tuple, 1, 12, T, t);
 
 /// Expand type of a native GPU type, i.e. scalar primitives, arrays, shared memory.
 #[derive(new, Clone, Copy, Debug)]
@@ -740,11 +740,11 @@ macro_rules! tuple_assign {
     }
 }
 
-all_tuples!(tuple_cube_type, 2, 12, P);
-all_tuples!(tuple_debug, 2, 12, P);
-all_tuples!(tuple_init, 2, 12, P);
-all_tuples!(tuple_runtime, 2, 12, P);
-all_tuples_enumerated!(tuple_assign, 2, 12, P);
+all_tuples!(tuple_cube_type, 1, 12, P);
+all_tuples!(tuple_debug, 1, 12, P);
+all_tuples!(tuple_init, 1, 12, P);
+all_tuples!(tuple_runtime, 1, 12, P);
+all_tuples_enumerated!(tuple_assign, 1, 12, P);
 
 /// Trait for native types that can be assigned. For non-native composites, use the normal [`Assign`].
 pub trait NativeAssign: CubeType {

--- a/crates/cubecl-core/src/runtime_tests/assign.rs
+++ b/crates/cubecl-core/src/runtime_tests/assign.rs
@@ -11,6 +11,14 @@ pub fn kernel_assign<F: Float>(output: &mut [F]) {
 }
 
 #[cube(launch)]
+pub fn kernel_assign_one_tuple<F: Float>(output: &mut [F]) {
+    if UNIT_POS == 0 {
+        let item = (F::new(5f32),);
+        output[0] = item.0;
+    }
+}
+
+#[cube(launch)]
 pub fn kernel_add_assign_array<F: Float, N: Size>(output: &mut [Vector<F, N>]) {
     if UNIT_POS == 0 {
         output[0] = Vector::new(F::new(5f32));
@@ -54,6 +62,22 @@ pub fn test_kernel_assign_scalar<R: Runtime, F: Float + CubeElement>(client: Com
         CubeCount::Static(1, 1, 1),
         CubeDim::new(&client, 1),
         unsafe { BufferArg::from_raw_parts(handle.clone(), 2) },
+    );
+
+    let actual = client.read_one(handle).unwrap();
+    let actual = F::from_bytes(&actual);
+
+    assert_eq!(actual[0], F::new(5.0));
+}
+
+pub fn test_kernel_assign_one_tuple<R: Runtime, F: Float + CubeElement>(client: ComputeClient<R>) {
+    let handle = client.create_from_slice(F::as_bytes(&[F::new(0.0)]));
+
+    kernel_assign_one_tuple::launch::<F, R>(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new(&client, 1),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
     );
 
     let actual = client.read_one(handle).unwrap();
@@ -129,6 +153,15 @@ macro_rules! testgen_assign {
             cubecl_core::runtime_tests::assign::test_kernel_assign_scalar::<TestRuntime, FloatType>(
                 client,
             );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_assign_one_tuple() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::assign::test_kernel_assign_one_tuple::<
+                TestRuntime,
+                FloatType,
+            >(client);
         }
 
         #[$crate::runtime_tests::test_log::test]

--- a/crates/cubecl-macros/src/expression.rs
+++ b/crates/cubecl-macros/src/expression.rs
@@ -266,7 +266,7 @@ impl Expression {
                     .iter()
                     .map(|it| it.as_const(context))
                     .collect::<Option<Vec<_>>>()?;
-                Some(quote![(#(#elements),*)])
+                Some(quote![(#(#elements,)*)])
             }
             Expression::FieldAccess { base, field, .. } => {
                 base.as_const(context).map(|base| quote![#base.#field])

--- a/crates/cubecl-macros/src/generate/expression.rs
+++ b/crates/cubecl-macros/src/generate/expression.rs
@@ -423,7 +423,7 @@ impl Expression {
                     constant
                 } else {
                     let elements = elements.iter().map(|it| it.to_tokens(context));
-                    quote![(#(#elements),*)]
+                    quote![(#(#elements,)*)]
                 }
             }
             Expression::ArrayInit { init, len } => {


### PR DESCRIPTION
CubeCL compiler can't handle one tuple `(T,)`. This PR add a test which fails the case and a subsequent fix.

```
cargo test -p cubecl-cpu test_assign_one_tuple --no-run

error[E0609]: no field `0` on type `element::base::NativeExpand<F>`
--> crates/cubecl-core/src/runtime_tests/assign.rs:17:26
|
17 |         output[0] = item.0;
|                          ^ unknown field
|
= note: available fields are: `expand`, `_type`
```