### PR TITLE
fix(memory): resolve stale page lookups instead of panicking

### DIFF
--- a/crates/cubecl-common/Cargo.toml
+++ b/crates/cubecl-common/Cargo.toml
@@ -19,6 +19,11 @@ workspace = true
 
 
 [features]
+# Enables runtime backtrace capture outside of `cfg(test)` (see build.rs).
+# Implies `std` since the `backtrace` crate rides on it. Used by diagnostic
+# builds (e.g. cubecl-runtime's `debug-mem`) that need real producer/consumer
+# stacks in a non-test binary.
+backtrace-capture = ["std"]
 cache = ["std", "serde_json", "dirs", "sanitize-filename"]
 compilation-cache = ["cache", "dep:ciborium"]
 default = ["std"]

--- a/crates/cubecl-common/build.rs
+++ b/crates/cubecl-common/build.rs
@@ -12,6 +12,7 @@ fn main() {
         // Filesystem and environment access for config loading and caching.
         std_io: { all(feature = "std", any(target_os = "windows", target_os = "linux", target_os = "macos", target_os = "android")) },
         // TODO: We can't yet activate it for everything because of how error handling is done in matmul.
-        backtrace: { all(test, feature="std") },
+        // `backtrace-capture` widens this to non-test diagnostic builds (e.g. `debug-mem`).
+        backtrace: { all(feature="std", any(test, feature="backtrace-capture")) },
     }
 }

--- a/crates/cubecl-cuda/Cargo.toml
+++ b/crates/cubecl-cuda/Cargo.toml
@@ -23,6 +23,10 @@ default = [
     "cubecl-core/default",
 ]
 ptx-wmma = []
+# Forwards to `cubecl-runtime/debug-mem`; diagnostic builds only. See that
+# feature for details. Enable on the Modal/burn-lm patch build to capture the
+# orphaning-bind backtrace behind the "Memory page N doesn't exist" crash.
+debug-mem = ["cubecl-runtime/debug-mem"]
 std = [
     "cubecl-runtime/std",
     "cubecl-common/std",

--- a/crates/cubecl-cuda/src/compute/stream.rs
+++ b/crates/cubecl-cuda/src/compute/stream.rs
@@ -148,10 +148,23 @@ impl EventStreamBackend for CudaStreamBackend {
     }
 
     fn handle_cursor(stream: &Self::Stream, binding: &Binding) -> u64 {
-        stream
-            .memory_management_gpu
-            .get_cursor(binding.memory.clone())
-            .unwrap()
+        match stream.memory_management_gpu.get_cursor(binding.memory.clone()) {
+            Ok(cursor) => cursor,
+            // This value only decides whether the current stream must wait for the
+            // one that owns the buffer. A cross-stream binding can name a buffer that
+            // stream has already retired or renumbered, and `.unwrap()`-ing that
+            // lookup miss is what surfaced as the `Memory page N doesn't exist` panic
+            // under batched serving. So on a miss, return `u64::MAX` instead: it
+            // always errs toward inserting the wait. The worst case is a redundant
+            // synchronization — never a skipped one that would let the GPU read a
+            // half-written buffer.
+            Err(err) => {
+                log::warn!(
+                    "handle_cursor: unresolved cross-stream binding ({err:?}); forcing sync"
+                );
+                u64::MAX
+            }
+        }
     }
 
     fn is_healthy(stream: &Self::Stream) -> bool {

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -18,6 +18,13 @@ workspace = true
 [features]
 autotune-checks = []
 channel-cell = []
+# Diagnostic build only: records the backtrace of any `bind` that orphans a
+# descriptor still referenced by live bindings, and dumps it (alongside the
+# consumer/lookup backtrace) when that stale binding later fails to resolve.
+# Used to hunt the "Memory page N doesn't exist" root cause. Adds per-`bind`
+# overhead and is never enabled in release. Pulls in real backtrace capture so
+# the producer/consumer stacks resolve in a non-test binary.
+debug-mem = ["std", "cubecl-common/backtrace-capture"]
 channel-mpsc = []
 channel-mutex = []
 default = [

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -415,7 +415,21 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> {
 
         let slice = pool.find(&binding)?;
 
-        assert_eq!(slice.handle.descriptor(), binding.descriptor());
+        // Re-check what the pool handed back: a stale binding must never resolve to
+        // a *different* live buffer. This used to be an `assert_eq!` — which is how a
+        // renumbered page, pointing a binding at the wrong survivor, took down the
+        // dispatch thread — so return a graceful `NotFound` instead.
+        if slice.handle.descriptor() != binding.descriptor() {
+            return Err(IoError::NotFound {
+                backtrace: BackTrace::capture(),
+                reason: format!(
+                    "Resolved slice id {:?} does not match requested binding id {:?}",
+                    slice.handle.descriptor().id,
+                    binding.descriptor().id,
+                )
+                .into(),
+            });
+        }
 
         Ok(slice)
     }
@@ -1097,5 +1111,129 @@ mod tests {
         assert_eq!(usage_before.number_allocs, usage_after.number_allocs);
         assert_eq!(usage_before.bytes_in_use, usage_after.bytes_in_use);
         assert_eq!(usage_before.bytes_reserved, usage_after.bytes_reserved);
+    }
+
+    /// Repro for the cubecl-cuda `DSD-0-0` panic
+    /// `couldn't find resource for that handle: Memory page N doesn't exist`
+    /// (cubecl-cuda/src/compute/stream.rs:154 -> `get_cursor(..).unwrap()`).
+    ///
+    /// The crash is a single-threaded stale-page-index bug, not a data race:
+    /// `bind` reassigns a page's `slice.handle` to a *new* descriptor and orphans
+    /// the previous one, then `ExclusiveMemoryPool::cleanup` renumbers the
+    /// surviving page by writing the new index into the *current* handle only.
+    /// A binding that still references the orphaned descriptor keeps a stale page
+    /// index; a later `get_cursor` indexes a page past `pages.len()`.
+    #[test_log::test]
+    fn repro_stale_page_after_bind_and_cleanup() {
+        let mut mm = MemoryManagement::from_configuration(
+            BytesStorage::default(),
+            &DUMMY_MEM_PROPS,
+            // Force the exclusive pool: only `ExclusiveMemoryPool` renumbers pages
+            // in cleanup and only it mints the "Memory page N doesn't exist"
+            // message. The default `SubSlices`/`SlicedPool` cannot reproduce it.
+            MemoryConfiguration::Custom {
+                pool_options: vec![MemoryPoolOptions {
+                    pool_type: PoolType::ExclusivePages {
+                        max_alloc_size: 1024,
+                    },
+                    dealloc_period: Some(5),
+                }],
+            },
+            Arc::new(ServerLogger::default()),
+            options(),
+        );
+
+        // Three live exclusive pages: 0, 1, 2 (each kept alive so every reserve
+        // allocates a fresh page rather than reusing one).
+        let h0 = mm.reserve(100).unwrap();
+        let h1 = mm.reserve(100).unwrap();
+        let reserved = mm.reserve(100).unwrap(); // page 2, descriptor R
+
+        // A binding that outlives `bind` and keeps the orphaned descriptor R alive.
+        let orphan = reserved.clone().binding();
+
+        // `bind` moves page 2's `slice.handle` to `assigned` (M) and copies R's
+        // location into M. R is now orphaned: still carrying page = 2, but no
+        // longer the page's handle.
+        let assigned = ManagedMemoryHandle::new();
+        mm.bind(reserved, assigned.clone(), 7).unwrap();
+
+        // Free pages 0 and 1 so the next cleanup deallocates them and renumbers
+        // the survivor (page 2 -> 0).
+        drop(h0);
+        drop(h1);
+
+        // Explicit cleanup: deallocs the two free pages, renumbers the survivor M
+        // (2 -> 0) via `update_page` on M's descriptor only; R is never updated.
+        // `assigned` (M) is still alive here, so page 2 survives the cleanup.
+        mm.cleanup(true);
+
+        // Looking the orphan up indexes `pages[2]` on a length-1 Vec -> NotFound.
+        let result = mm.get_cursor(orphan);
+        drop(assigned);
+
+        let err = result.expect_err("orphaned descriptor currently fails to resolve (the bug)");
+        let msg = alloc::format!("{err:?}");
+        assert!(
+            msg.contains("Memory page"),
+            "expected the stale-page NotFound, got: {msg}"
+        );
+    }
+
+    /// Companion to [`repro_stale_page_after_bind_and_cleanup`] for the *other*
+    /// panic shape. Here the orphaned descriptor's stale page index stays
+    /// **in bounds** after the cleanup renumber but points at a *different*
+    /// survivor. `find` then returns the wrong slice and the
+    /// `assert_eq!(slice.handle.descriptor(), binding.descriptor())` at the end
+    /// of `MemoryManagement::find` panics — a second crash shape, this one inside
+    /// cubecl-runtime itself rather than at the cuda `unwrap`.
+    ///
+    /// On clean `main` this test panics at that assert. After the fix it must
+    /// resolve gracefully (a clean `NotFound`, no panic).
+    #[test_log::test]
+    fn repro_stale_page_inbounds_wrong_survivor() {
+        let mut mm = MemoryManagement::from_configuration(
+            BytesStorage::default(),
+            &DUMMY_MEM_PROPS,
+            MemoryConfiguration::Custom {
+                pool_options: vec![MemoryPoolOptions {
+                    pool_type: PoolType::ExclusivePages {
+                        max_alloc_size: 1024,
+                    },
+                    dealloc_period: Some(5),
+                }],
+            },
+            Arc::new(ServerLogger::default()),
+            options(),
+        );
+
+        let h0 = mm.reserve(100).unwrap(); // page 0
+        let reserved1 = mm.reserve(100).unwrap(); // page 1, descriptor R
+        let orphan = reserved1.clone().binding();
+
+        // Orphan page 1: its handle becomes M1, R keeps page = 1.
+        let assigned1 = ManagedMemoryHandle::new();
+        mm.bind(reserved1, assigned1.clone(), 7).unwrap();
+
+        let h2 = mm.reserve(100).unwrap(); // page 2
+
+        // Free page 0 only; M1 and h2 stay alive and survive the cleanup.
+        drop(h0);
+
+        // cleanup deallocs page 0 and renumbers survivors: M1 (1 -> 0), h2 (2 -> 1).
+        // R still carries page = 1, which is now h2's slot (in bounds, wrong id).
+        mm.cleanup(true);
+
+        let result = mm.get_cursor(orphan);
+        drop(assigned1);
+        drop(h2);
+
+        // Post-fix expectation: a graceful error, never a panic.
+        let err = result.expect_err("a retired binding must not resolve to a different buffer");
+        let msg = alloc::format!("{err:?}");
+        assert!(
+            msg.contains("Memory page") || msg.contains("doesn't"),
+            "expected a graceful NotFound, got: {msg}"
+        );
     }
 }

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -23,6 +23,27 @@ use cubecl_ir::MemoryDeviceProperties;
 
 pub use super::memory_pool::{ManagedMemoryBinding, handle::*};
 
+/// Diagnostic build only: a binding failed to resolve. Logs the binding's
+/// identity/location, the current (consumer/lookup) backtrace, and — if this
+/// descriptor was ever stranded by a `bind` — the producer backtrace of that
+/// orphaning bind, so the root cause can be traced across cubecl/burn/burn-lm.
+#[cfg(feature = "debug-mem")]
+fn log_stale_binding(binding: &ManagedMemoryBinding, context: &str) {
+    let desc = binding.descriptor();
+    let consumer = BackTrace::capture();
+    let producer = desc.orphan_bind_report();
+    log::error!(
+        "stale memory binding ({context}): id={:?} location={:?}\n\
+         --- consumer (lookup) backtrace ---\n{consumer}\n\
+         --- producer (orphaning bind) ---\n{}",
+        desc.id,
+        desc.location(),
+        producer
+            .as_deref()
+            .unwrap_or("no orphaning bind recorded — stale state came from elsewhere (cleanup renumber / cross-pool lookup)"),
+    );
+}
+
 // These are 288 bytes vs 64 bytes. Adding boxing isn't really worth
 // saving the 200 bytes.
 #[allow(clippy::large_enum_variant)]
@@ -413,13 +434,24 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> {
                     reason: format!("Pool {} doesn't exist", id.location().pool).into(),
                 })?;
 
-        let slice = pool.find(&binding)?;
+        let slice = match pool.find(&binding) {
+            Ok(slice) => slice,
+            Err(err) => {
+                // Diagnostic build: dump where this binding was minted (the
+                // orphaning bind, if any) alongside this lookup stack.
+                #[cfg(feature = "debug-mem")]
+                log_stale_binding(&binding, "pool lookup miss");
+                return Err(err);
+            }
+        };
 
         // Re-check what the pool handed back: a stale binding must never resolve to
         // a *different* live buffer. This used to be an `assert_eq!` — which is how a
         // renumbered page, pointing a binding at the wrong survivor, took down the
         // dispatch thread — so return a graceful `NotFound` instead.
         if slice.handle.descriptor() != binding.descriptor() {
+            #[cfg(feature = "debug-mem")]
+            log_stale_binding(&binding, "resolved to a different live buffer");
             return Err(IoError::NotFound {
                 backtrace: BackTrace::capture(),
                 reason: format!(
@@ -1235,5 +1267,58 @@ mod tests {
             msg.contains("Memory page") || msg.contains("doesn't"),
             "expected a graceful NotFound, got: {msg}"
         );
+    }
+
+    /// `debug-mem` instrumentation: a `bind` that strands a still-referenced
+    /// descriptor must record the producer (orphaning-bind) backtrace on it,
+    /// while a plain reserve/handle that was never orphaned records nothing.
+    /// This is the probe that, in the field, names where the stale binding was
+    /// minted across cubecl/burn/burn-lm.
+    #[cfg(feature = "debug-mem")]
+    #[test_log::test]
+    fn debug_mem_records_only_the_orphaning_bind() {
+        let mut mm = MemoryManagement::from_configuration(
+            BytesStorage::default(),
+            &DUMMY_MEM_PROPS,
+            MemoryConfiguration::Custom {
+                pool_options: vec![MemoryPoolOptions {
+                    pool_type: PoolType::ExclusivePages {
+                        max_alloc_size: 1024,
+                    },
+                    dealloc_period: Some(5),
+                }],
+            },
+            Arc::new(ServerLogger::default()),
+            options(),
+        );
+
+        // A plain reserve that is never bound records nothing.
+        let untouched = mm.reserve(100).unwrap();
+        assert!(
+            untouched.descriptor().orphan_bind_report().is_none(),
+            "a descriptor that was never orphaned must have no record"
+        );
+
+        // Reserve, then keep a binding alive across the bind so the descriptor
+        // is stranded — the predicate in `bind` must fire and capture.
+        let reserved = mm.reserve(100).unwrap();
+        let orphan = reserved.clone().binding();
+        let assigned = ManagedMemoryHandle::new();
+        mm.bind(reserved, assigned.clone(), 42).unwrap();
+
+        let report = orphan
+            .descriptor()
+            .orphan_bind_report()
+            .expect("orphaning bind must be recorded under debug-mem");
+        assert!(
+            report.contains("cursor=42"),
+            "report missing cursor: {report}"
+        );
+        assert!(
+            report.contains("stranded 1 live binding"),
+            "report should count the single stranded binding: {report}"
+        );
+
+        drop(assigned);
     }
 }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
@@ -233,11 +233,27 @@ impl MemoryPool for ExclusiveMemoryPool {
         cursor: u64,
     ) -> Result<(), IoError> {
         let id_old = old.descriptor();
-        let page = &mut self.pages[id_old.page()];
-        new.descriptor().update_location(id_old.location());
+        let old_page = id_old.page();
+        let old_location = id_old.location();
+        let page = &mut self.pages[old_page];
+        new.descriptor().update_location(old_location);
 
         page.slice.handle = new;
         page.slice.cursor = cursor;
+
+        // The page no longer references `old`'s descriptor. If anything other
+        // than the `old` handle below still does, those are live bindings we are
+        // stranding — exactly the invariant break behind the stale-page crash.
+        // This predicate is false for every well-behaved bind (`old` is a fresh
+        // throwaway), so the capture only ever runs on the pathological case.
+        #[cfg(feature = "debug-mem")]
+        {
+            let strong_count = old.descriptor_strong_count();
+            if strong_count > 1 {
+                old.descriptor()
+                    .record_orphan_bind(cursor, old_page as u16, strong_count);
+            }
+        }
 
         Ok(())
     }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
@@ -246,14 +246,24 @@ impl MemoryPool for ExclusiveMemoryPool {
         let binding_descriptor = binding.descriptor();
         let page_index = binding_descriptor.page();
 
-        let page = self
-            .pages
-            .get(page_index)
-            .ok_or_else(|| IoError::NotFound {
-                backtrace: BackTrace::capture(),
-                reason: alloc::format!("Memory page {} doesn't exist", page_index).into(),
-            })?;
+        // The cached page index is only a hint. `cleanup` renumbers surviving pages
+        // and writes the new index into each page's *current* `slice.handle`, so a
+        // binding that has since diverged from that handle (e.g. after a `bind`)
+        // carries a stale index. Trust the hint only when its page still holds this
+        // binding's id; otherwise report a clean miss rather than indexing blindly —
+        // that blind index, landing out of bounds or on the wrong survivor, is what
+        // aborted the CUDA dispatch thread. A diverged binding is not re-resolved by
+        // scanning for its id: a live binding always shares its page's handle, so
+        // that path is unreachable, and real repair belongs in an explicit API.
+        if let Some(page) = self.pages.get(page_index) {
+            if page.slice.handle.descriptor().id == binding_descriptor.id {
+                return Ok(&page.slice);
+            }
+        }
 
-        Ok(&page.slice)
+        Err(IoError::NotFound {
+            backtrace: BackTrace::capture(),
+            reason: alloc::format!("Memory page {} doesn't exist", page_index).into(),
+        })
     }
 }

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/handle.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/handle.rs
@@ -1,6 +1,8 @@
 use crate::memory_management::MemoryHandle;
 use alloc::sync::Arc;
 use core::cell::Cell;
+#[cfg(feature = "debug-mem")]
+use core::cell::RefCell;
 
 /// Managed Memory handle
 #[derive(Debug)]
@@ -39,6 +41,26 @@ impl Clone for ManagedMemoryHandle {
 pub(crate) struct ManagedMemoryDescriptor {
     pub(crate) id: ManagedMemoryId,
     location: Cell<MemoryLocation>,
+    /// Diagnostic record of the last `bind` that orphaned this descriptor while
+    /// it still had live bindings — the producer of a stale binding. Captured
+    /// lazily (only when the invariant breaks) and read back at the lookup miss.
+    #[cfg(feature = "debug-mem")]
+    orphan_bind: RefCell<Option<OrphanBind>>,
+}
+
+/// The forensic record stored on a descriptor when a `bind` strands it while
+/// bindings to it are still alive. See [`ManagedMemoryDescriptor::record_orphan_bind`].
+#[cfg(feature = "debug-mem")]
+struct OrphanBind {
+    /// Backtrace of the `bind` call that did the orphaning (the producer stack).
+    backtrace: cubecl_common::backtrace::BackTrace,
+    /// Stream cursor passed to that `bind`.
+    cursor: u64,
+    /// Page index the descriptor was sitting on at the time of the orphaning.
+    old_page: u16,
+    /// `Arc` strong count of the descriptor right after the orphaning bind.
+    /// `strong_count - 1` is the number of still-live bindings that were stranded.
+    strong_count: usize,
 }
 
 // SAFETY: The channel requires ManagedMemoryHandle to be Send + Sync.
@@ -118,6 +140,36 @@ impl ManagedMemoryDescriptor {
     pub(crate) fn page(&self) -> usize {
         self.location.get().page as usize
     }
+
+    /// Records that a `bind` just orphaned this descriptor while `strong_count`
+    /// references (one being the `bind`'s own `old` handle, the rest live
+    /// bindings) still pointed at it. Captures the producer backtrace so the
+    /// eventual lookup miss can name where the stale binding was minted.
+    #[cfg(feature = "debug-mem")]
+    pub(crate) fn record_orphan_bind(&self, cursor: u64, old_page: u16, strong_count: usize) {
+        *self.orphan_bind.borrow_mut() = Some(OrphanBind {
+            backtrace: cubecl_common::backtrace::BackTrace::capture(),
+            cursor,
+            old_page,
+            strong_count,
+        });
+    }
+
+    /// Renders the recorded orphaning-bind backtrace, if any. `None` means no
+    /// `bind` ever stranded this descriptor — so the stale state came from
+    /// elsewhere (e.g. a `cleanup` renumber or a cross-pool lookup).
+    #[cfg(feature = "debug-mem")]
+    pub(crate) fn orphan_bind_report(&self) -> Option<alloc::string::String> {
+        self.orphan_bind.borrow().as_ref().map(|o| {
+            alloc::format!(
+                "orphaning bind stranded {} live binding(s) (cursor={}, old_page={}):\n{}",
+                o.strong_count.saturating_sub(1),
+                o.cursor,
+                o.old_page,
+                o.backtrace
+            )
+        })
+    }
 }
 
 impl MemoryLocation {
@@ -151,6 +203,8 @@ impl ManagedMemoryHandle {
             descriptor: Arc::new(ManagedMemoryDescriptor {
                 id: ManagedMemoryId { value },
                 location: Cell::new(MemoryLocation::uninit()),
+                #[cfg(feature = "debug-mem")]
+                orphan_bind: RefCell::new(None),
             }),
             handle_count: Arc::new(()),
         }
@@ -169,6 +223,14 @@ impl ManagedMemoryHandle {
     /// Return whether the current handle is free.
     pub fn is_free(&self) -> bool {
         Arc::strong_count(&self.descriptor) <= 1
+    }
+
+    /// Strong count of the shared descriptor. Used by `bind` (under `debug-mem`)
+    /// to detect when it is about to orphan a descriptor that still has live
+    /// bindings.
+    #[cfg(feature = "debug-mem")]
+    pub(crate) fn descriptor_strong_count(&self) -> usize {
+        Arc::strong_count(&self.descriptor)
     }
 
     /// Returns the binding for the current handle.


### PR DESCRIPTION
## Summary

While trying to benchmark on burn-lm's continuous-batching server (tracel-ai/burn-lm#57), I ran into an issue where as soon as that server handles two or more concurrent requests, the cubecl-cuda dispatch thread (`DSD-0-0`) panics with `couldn't find resource for that handle: Memory page N doesn't exist` and takes the inference worker down with it. It made batched serving unusable at concurrency >= 2.

It looks like a concurrency bug but isn't: a device's compute server and all its per-stream memory managers run on one runner thread (`update_shared_bindings` / `find` / `cleanup` are all `&mut self` there), so there's nothing to race. It's a single-threaded stale-page-index bug that batched serving just happens to trigger.

## The issue

* A memory binding caches a page index in its `ManagedMemoryDescriptor`. 
* `ExclusiveMemoryPool::cleanup` deallocates free pages and renumbers the survivors, but writes the new index only into each page's current `slice.handle`. 
* A binding whose descriptor has diverged from that handle (which the cross-stream cursor lookup in batched serving keeps alive) is left holding a stale index, so `ExclusiveMemoryPool::find` then either 
    - indexes out of bounds (-> `NotFound` -> cubecl-cuda's `handle_cursor` `.unwrap()` aborts the dispatch thread) or
    -  lands in-bounds on the wrong survivor (-> the `assert_eq!` in `MemoryManagement::find` panics). 
 * In normal use this can't happen: the handle you keep alive is the very one the pool renumbers, so every binding made from it picks up the corrected page index for free. The crash only appears when a binding is left pointing at an older descriptor the pool has since stopped updating.

## The fix

- `ExclusiveMemoryPool::find` now treats the cached page as a hint, validate it by `ManagedMemoryId`, and return a clean `NotFound` for a stale/diverged binding instead of indexing blindly (one `usize` compare on the hot path).
- `MemoryManagement::find` replaces the `assert_eq!` with a graceful `NotFound`, so a stale binding can never resolve to a different buffer or panic there.
- cubecl-cuda `handle_cursor` doesn't `.unwrap()` a failed lookup (that's what aborts the dispatch thread). Its value only decides whether one stream must wait for another, so on a miss we return `u64::MAX`, which always errs toward adding the wait: the worst case is a redundant synchronization, never a skipped one that would let the GPU read a half-written buffer.

## How it was reproduced and proven

- Deterministic, no GPU: two single-threaded `cubecl-runtime` unit tests reproduce both panic shapes on clean `main` and pass after the fix (full suite + `cargo check -p cubecl-cuda` stay green).
- Live A/B on a Modal T4. I deployed the real burn-lm server (Llama-3.2-1B) twice — unfixed `ba103c7`, and the same tree with this fix on top, nothing else changed, and ran the identical concurrent chat load against both. The crash only reproduced reliably once all the load was pinned to a single GPU container; left to autoscale, the platform spread it thin enough to mask the bug. Counting dispatch-thread panics in each run's logs:

| | Unfixed `ba103c7` | Fixed |
|---|---|---|
| page-race assert panics (`memory_manage.rs`, every one a `pool:0 page:0` descriptor) | 161 | 0 |
| downstream out-of-memory panics (`server.rs` `reserve().unwrap()`) | 794 | 0 |
| total dispatch-thread panics | ~955 | 0 |

Same code, same load, only the fix differs. The 794 out-of-memory panics are a knock-on effect of the same bug: once the pool's page bookkeeping is corrupted it mis-accounts free space and asks for impossible allocations (several requesting ~1.5 GB for a 1B model), so fixing the lookup clears those too, and the server runs measurably faster for no longer thrashing a broken pool.