### PR TITLE
Feat/fix abusive allocation in CPU backend

### DIFF
--- a/crates/cubecl-cpu/src/compiler/mlir_engine.rs
+++ b/crates/cubecl-cpu/src/compiler/mlir_engine.rs
@@ -11,7 +11,7 @@ use std::{
 
 use super::module::Module;
 use cubecl_core::{ir::StorageType, prelude::KernelDefinition};
-use cubecl_opt::Function;
+use cubecl_opt::{Function, GlobalState};
 use tracel_llvm::mlir_rs::{
     Context, ExecutionEngine,
     dialect::DialectRegistry,
@@ -41,7 +41,8 @@ impl Display for MlirEngine {
 impl MlirEngine {
     pub fn from_cubecl_ir(
         kernel: KernelDefinition,
-        func: &Function,
+        func: &mut Function,
+        global_state: &GlobalState,
         shared_memories: SharedMemories,
         addr_type: StorageType,
     ) -> Self {
@@ -57,7 +58,7 @@ impl MlirEngine {
 
         let mut module = Module::new(&context, kernel.options.kernel_name.clone());
 
-        module.visit_kernel(&kernel, func, &shared_memories, addr_type);
+        module.visit_kernel(&kernel, func, global_state, &shared_memories, addr_type);
 
         module.run_pass();
 

--- a/crates/cubecl-cpu/src/compiler/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/mod.rs
@@ -64,7 +64,7 @@ impl Compiler for MlirCompiler {
 
         #[cfg(feature = "mlir-dump")]
         dump_scope(&kernel.body, &kernel.options.kernel_name);
-        let opt = OptimizerBuilder::default()
+        let mut opt = OptimizerBuilder::default()
             .with_transformer(ErfTransform)
             .with_transformer(HypotTransform)
             .with_transformer(RhypotTransform)
@@ -84,7 +84,8 @@ impl Compiler for MlirCompiler {
         dump_opt(&opt, &kernel.options.kernel_name);
         Ok(MlirEngine::from_cubecl_ir(
             kernel,
-            &opt.main,
+            &mut opt.main,
+            &opt.global_state,
             shared_memories,
             addr_type,
         ))

--- a/crates/cubecl-cpu/src/compiler/module.rs
+++ b/crates/cubecl-cpu/src/compiler/module.rs
@@ -1,5 +1,5 @@
 use cubecl_core::{ir::StorageType, prelude::KernelDefinition};
-use cubecl_opt::Function;
+use cubecl_opt::{Function, GlobalState};
 use tracel_llvm::mlir_rs::{
     Context, ExecutionEngine,
     ir::{Location, operation::OperationLike},
@@ -31,7 +31,8 @@ impl<'a> Module<'a> {
     pub(super) fn visit_kernel(
         &mut self,
         kernel: &KernelDefinition,
-        func: &Function,
+        func: &mut Function,
+        global_state: &GlobalState,
         shared_memories: &SharedMemories,
         addr_type: StorageType,
     ) {
@@ -41,6 +42,7 @@ impl<'a> Module<'a> {
             kernel,
             &self.module,
             func,
+            global_state,
             shared_memories,
             addr_type,
         )

--- a/crates/cubecl-cpu/src/compiler/visitor/args_manager.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/args_manager.rs
@@ -255,7 +255,7 @@ impl<'a, 'b> ArgsManagerBuilder<'a, 'b> {
     }
 }
 
-pub(super) struct ArgsManager<'a> {
+pub struct ArgsManager<'a> {
     pub buffers: HashMap<Id, Value<'a, 'a>>,
     pub scalars_memref: HashMap<StorageType, Value<'a, 'a>>,
     pub static_metadata_memref: Option<Value<'a, 'a>>,

--- a/crates/cubecl-cpu/src/compiler/visitor/block.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/block.rs
@@ -2,13 +2,28 @@ use std::ops::Deref;
 
 use cubecl_opt::{ControlFlow, Function, NodeIndex};
 use tracel_llvm::mlir_rs::{
-    dialect::{cf, ods::llvm},
+    dialect::{cf, memref, ods::llvm},
     ir::{Block, BlockLike, BlockRef, RegionLike, Value},
 };
 
 use super::prelude::*;
 
 impl<'a> Visitor<'a> {
+    fn free_memory_end_of_block(&mut self, current_block: NodeIndex, next_blocks: &[NodeIndex]) {
+        for &var in &self.mutable_variables {
+            let is_still_alive = !self.liveness.is_dead(current_block, var);
+            let will_die = next_blocks
+                .iter()
+                .all(|block| self.liveness.is_dead(*block, var));
+            println!("{} {}", is_still_alive, will_die);
+            if is_still_alive && will_die {
+                let alloc = self.values.get(&var).unwrap();
+                self.block
+                    .append_operation(memref::dealloc(*alloc, self.location));
+            }
+        }
+    }
+
     pub fn visit_basic_block(&mut self, block_id: NodeIndex, func: &Function) -> BlockRef<'a, 'a> {
         if let Some(block) = self.blocks.get(&block_id) {
             return *block;
@@ -46,9 +61,12 @@ impl<'a> Visitor<'a> {
         self.block = this_block;
 
         self.blocks.insert(block_id, this_block);
+
         for (_, instruction) in basic_block.ops.borrow().iter() {
             self.visit_instruction(instruction);
         }
+
+        self.free_memory_end_of_block(block_id, &func.successors(block_id));
 
         match basic_block.control_flow.borrow().deref() {
             ControlFlow::IfElse {

--- a/crates/cubecl-cpu/src/compiler/visitor/block.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/block.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 
+use cubecl_core::ir::Id;
 use cubecl_opt::{ControlFlow, Function, NodeIndex};
 use tracel_llvm::mlir_rs::{
     dialect::{cf, memref, ods::llvm},
@@ -9,18 +10,39 @@ use tracel_llvm::mlir_rs::{
 use super::prelude::*;
 
 impl<'a> Visitor<'a> {
-    fn free_memory_end_of_block(&mut self, current_block: NodeIndex, next_blocks: &[NodeIndex]) {
-        for &var in &self.mutable_variables {
-            let is_still_alive = !self.liveness.is_dead(current_block, var);
-            let will_die = next_blocks
-                .iter()
-                .all(|block| self.liveness.is_dead(*block, var));
-            println!("{} {}", is_still_alive, will_die);
-            if is_still_alive && will_die {
-                let alloc = self.values.get(&var).unwrap();
-                self.block
-                    .append_operation(memref::dealloc(*alloc, self.location));
-            }
+    fn is_live_out(&self, func: &Function, block: NodeIndex, var: Id) -> bool {
+        func.successors(block)
+            .iter()
+            .any(|succ| !self.liveness.is_dead(*succ, var))
+    }
+
+    fn free_memory_start_of_block(&mut self, func: &Function, block_id: NodeIndex) {
+        let to_free = self.mutable_variables.iter().filter(|&&var| {
+            self.liveness.is_dead(block_id, var)
+                && func
+                    .predecessors(block_id)
+                    .iter()
+                    .any(|pred| self.is_live_out(func, *pred, var))
+        });
+        for var in to_free {
+            let alloc = self.values.get(&var).unwrap();
+            self.block
+                .append_operation(memref::dealloc(*alloc, self.location));
+        }
+    }
+
+    fn free_memory_end_of_block(&mut self, func: &Function, current_block: NodeIndex) {
+        if !func.successors(current_block).is_empty() {
+            return;
+        }
+        let to_free = self
+            .mutable_variables
+            .iter()
+            .filter(|&&var| !self.liveness.is_dead(current_block, var));
+        for var in to_free {
+            let alloc = self.values.get(&var).unwrap();
+            self.block
+                .append_operation(memref::dealloc(*alloc, self.location));
         }
     }
 
@@ -62,11 +84,13 @@ impl<'a> Visitor<'a> {
 
         self.blocks.insert(block_id, this_block);
 
+        self.free_memory_start_of_block(func, block_id);
+
         for (_, instruction) in basic_block.ops.borrow().iter() {
             self.visit_instruction(instruction);
         }
 
-        self.free_memory_end_of_block(block_id, &func.successors(block_id));
+        self.free_memory_end_of_block(func, block_id);
 
         match basic_block.control_flow.borrow().deref() {
             ControlFlow::IfElse {

--- a/crates/cubecl-cpu/src/compiler/visitor/block.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/block.rs
@@ -3,7 +3,10 @@ use std::ops::Deref;
 use cubecl_core::ir::Id;
 use cubecl_opt::{ControlFlow, Function, NodeIndex};
 use tracel_llvm::mlir_rs::{
-    dialect::{cf, memref, ods::llvm},
+    dialect::{
+        cf,
+        ods::llvm::{self, intr_stackrestore},
+    },
     ir::{Block, BlockLike, BlockRef, RegionLike, Value},
 };
 
@@ -16,33 +19,49 @@ impl<'a> Visitor<'a> {
             .any(|succ| !self.liveness.is_dead(*succ, var))
     }
 
-    fn free_memory_start_of_block(&mut self, func: &Function, block_id: NodeIndex) {
-        let to_free = self.mutable_variables.iter().filter(|&&var| {
-            self.liveness.is_dead(block_id, var)
-                && func
-                    .predecessors(block_id)
-                    .iter()
-                    .any(|pred| self.is_live_out(func, *pred, var))
-        });
-        for var in to_free {
-            let alloc = self.values.get(&var).unwrap();
-            self.block
-                .append_operation(memref::dealloc(*alloc, self.location));
-        }
-    }
-
-    fn free_memory_end_of_block(&mut self, func: &Function, current_block: NodeIndex) {
-        if !func.successors(current_block).is_empty() {
-            return;
-        }
-        let to_free = self
+    fn free_memory_start_of_block(&mut self, func: &Function) {
+        let dying = self
             .mutable_variables
             .iter()
-            .filter(|&&var| !self.liveness.is_dead(current_block, var));
-        for var in to_free {
-            let alloc = self.values.get(&var).unwrap();
-            self.block
-                .append_operation(memref::dealloc(*alloc, self.location));
+            .copied()
+            .filter(|&var| {
+                self.liveness.is_dead(self.current_node, var)
+                    && func
+                        .predecessors(self.current_node)
+                        .iter()
+                        .any(|pred| self.is_live_out(func, *pred, var))
+            })
+            .collect::<Vec<_>>();
+        self.restore_stack_for(&dying);
+    }
+
+    fn free_memory_end_of_block(&mut self, func: &Function) {
+        let dying = self
+            .mutable_variables
+            .iter()
+            .copied()
+            .filter(|&var| {
+                let allocated_here =
+                    self.stack_saves.get(&var).map(|s| s.alloc_block) == Some(self.current_node);
+                let live_in = !self.liveness.is_dead(self.current_node, var);
+                (allocated_here || live_in) && !self.is_live_out(func, self.current_node, var)
+            })
+            .collect::<Vec<_>>();
+        self.restore_stack_for(&dying);
+    }
+
+    /// Emit a single `stackrestore` to the earliest stack pointer saved among `dying`
+    fn restore_stack_for(&self, dying: &[Id]) {
+        let earliest = dying
+            .iter()
+            .filter_map(|var| self.stack_saves.get(var).copied())
+            .min_by_key(|save| save.seq);
+        if let Some(save) = earliest {
+            self.block.append_operation(intr_stackrestore(
+                self.context,
+                save.stack_pointer,
+                self.location,
+            ));
         }
     }
 
@@ -83,14 +102,15 @@ impl<'a> Visitor<'a> {
         self.block = this_block;
 
         self.blocks.insert(block_id, this_block);
+        self.current_node = block_id;
 
-        self.free_memory_start_of_block(func, block_id);
+        self.free_memory_start_of_block(func);
 
         for (_, instruction) in basic_block.ops.borrow().iter() {
             self.visit_instruction(instruction);
         }
 
-        self.free_memory_end_of_block(func, block_id);
+        self.free_memory_end_of_block(func);
 
         match basic_block.control_flow.borrow().deref() {
             ControlFlow::IfElse {

--- a/crates/cubecl-cpu/src/compiler/visitor/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/mod.rs
@@ -61,6 +61,16 @@ pub struct Visitor<'a> {
     pub(self) args_manager: ArgsManager<'a>,
     pub liveness: Rc<MemoryLiveness>,
     pub mutable_variables: Vec<Id>,
+    pub(self) stack_saves: HashMap<Id, StackSave<'a>>,
+    pub(self) stack_save_counter: usize,
+    pub(self) current_node: NodeIndex,
+}
+
+#[derive(Clone, Copy)]
+pub(self) struct StackSave<'a> {
+    pub stack_pointer: Value<'a, 'a>,
+    pub seq: usize,
+    pub alloc_block: NodeIndex,
 }
 
 impl<'a> Visitor<'a> {
@@ -100,6 +110,9 @@ impl<'a> Visitor<'a> {
             values,
             liveness,
             mutable_variables,
+            stack_saves: HashMap::new(),
+            stack_save_counter: 0,
+            current_node: NodeIndex::new(0),
         }
     }
 

--- a/crates/cubecl-cpu/src/compiler/visitor/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/mod.rs
@@ -11,10 +11,11 @@ use std::collections::HashMap;
 
 use args_manager::{ArgsManager, ArgsManagerBuilder};
 use cubecl_core::{
-    ir::{self as cube, Builtin, StorageType},
+    ir::{self as cube, Builtin, Id, StorageType},
     prelude::KernelDefinition,
 };
-use cubecl_opt::{Function, NodeIndex};
+use cubecl_opt::{Function, GlobalState, Liveness, NodeIndex};
+use std::rc::Rc;
 use tracel_llvm::mlir_rs::{
     Context,
     dialect::{
@@ -58,6 +59,8 @@ pub struct Visitor<'a> {
 
     pub(self) values: Values<'a>,
     pub(self) args_manager: ArgsManager<'a>,
+    pub liveness: Rc<Liveness>,
+    pub mutable_variables: Vec<Id>,
 }
 
 impl<'a> Visitor<'a> {
@@ -70,11 +73,13 @@ impl<'a> Visitor<'a> {
         context: &'a Context,
         location: Location<'a>,
         args_manager: ArgsManager<'a>,
+        liveness: Rc<Liveness>,
     ) -> Self {
         let blocks = HashMap::new();
         let blocks_args = HashMap::new();
         let str_counter = 0;
         let mut values = Values::new();
+        let mutable_variables = Vec::new();
 
         for (&id, &buffer) in args_manager.buffers.iter() {
             values.insert(id, buffer);
@@ -93,6 +98,8 @@ impl<'a> Visitor<'a> {
             str_counter,
             args_manager,
             values,
+            liveness,
+            mutable_variables,
         }
     }
 
@@ -163,7 +170,8 @@ impl<'a> Visitor<'a> {
         location: Location<'a>,
         kernel: &'b KernelDefinition,
         module: &tracel_llvm::mlir_rs::ir::Module<'a>,
-        func: &Function,
+        func: &mut Function,
+        global_state: &GlobalState,
         shared_memories: &SharedMemories,
         addr_type: StorageType,
     ) {
@@ -180,6 +188,7 @@ impl<'a> Visitor<'a> {
 
         add_external_function_to_module(context, module);
         add_sync_cube_function(context, module).unwrap();
+        let liveness = func.analysis::<Liveness>(global_state);
         module.body().append_operation(func::func(
             context,
             name,
@@ -189,7 +198,8 @@ impl<'a> Visitor<'a> {
                 let args = args.create_top_block(&region, context, location);
                 let block = region.first_block().unwrap();
 
-                Self::insert_builtin_loop(block, module, func, context, location, args).unwrap();
+                Self::insert_builtin_loop(block, module, func, context, location, args, liveness)
+                    .unwrap();
 
                 block.append_operation(func::r#return(&[], location));
 
@@ -207,6 +217,7 @@ impl<'a> Visitor<'a> {
         context: &'a Context,
         location: Location<'a>,
         mut args: ArgsManager<'a>,
+        liveness: Rc<Liveness>,
     ) -> Result<(), Error> {
         let basic_block_id = func.root;
         let integer_type = IntegerType::new(context, 32).into();
@@ -370,6 +381,7 @@ impl<'a> Visitor<'a> {
                                     context,
                                     location,
                                     args,
+                                    liveness.clone(),
                                 );
                                 visitor.visit_basic_block(basic_block_id, func);
 

--- a/crates/cubecl-cpu/src/compiler/visitor/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/mod.rs
@@ -67,7 +67,7 @@ pub struct Visitor<'a> {
 }
 
 #[derive(Clone, Copy)]
-pub(self) struct StackSave<'a> {
+pub struct StackSave<'a> {
     pub stack_pointer: Value<'a, 'a>,
     pub seq: usize,
     pub alloc_block: NodeIndex,
@@ -75,7 +75,7 @@ pub(self) struct StackSave<'a> {
 
 impl<'a> Visitor<'a> {
     #[allow(clippy::too_many_arguments)]
-    pub(self) fn new(
+    pub fn new(
         current_block: BlockRef<'a, 'a>,
         last_block: BlockRef<'a, 'a>,
         module: &'a Module<'a>,
@@ -178,6 +178,7 @@ impl<'a> Visitor<'a> {
             .into()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn visit_kernel<'b: 'a>(
         context: &'a Context,
         location: Location<'a>,

--- a/crates/cubecl-cpu/src/compiler/visitor/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/mod.rs
@@ -14,7 +14,7 @@ use cubecl_core::{
     ir::{self as cube, Builtin, Id, StorageType},
     prelude::KernelDefinition,
 };
-use cubecl_opt::{Function, GlobalState, Liveness, NodeIndex};
+use cubecl_opt::{Function, GlobalState, MemoryLiveness, NodeIndex};
 use std::rc::Rc;
 use tracel_llvm::mlir_rs::{
     Context,
@@ -59,7 +59,7 @@ pub struct Visitor<'a> {
 
     pub(self) values: Values<'a>,
     pub(self) args_manager: ArgsManager<'a>,
-    pub liveness: Rc<Liveness>,
+    pub liveness: Rc<MemoryLiveness>,
     pub mutable_variables: Vec<Id>,
 }
 
@@ -73,7 +73,7 @@ impl<'a> Visitor<'a> {
         context: &'a Context,
         location: Location<'a>,
         args_manager: ArgsManager<'a>,
-        liveness: Rc<Liveness>,
+        liveness: Rc<MemoryLiveness>,
     ) -> Self {
         let blocks = HashMap::new();
         let blocks_args = HashMap::new();
@@ -188,7 +188,7 @@ impl<'a> Visitor<'a> {
 
         add_external_function_to_module(context, module);
         add_sync_cube_function(context, module).unwrap();
-        let liveness = func.analysis::<Liveness>(global_state);
+        let liveness = func.analysis::<MemoryLiveness>(global_state);
         module.body().append_operation(func::func(
             context,
             name,
@@ -217,7 +217,7 @@ impl<'a> Visitor<'a> {
         context: &'a Context,
         location: Location<'a>,
         mut args: ArgsManager<'a>,
-        liveness: Rc<Liveness>,
+        liveness: Rc<MemoryLiveness>,
     ) -> Result<(), Error> {
         let basic_block_id = func.root;
         let integer_type = IntegerType::new(context, 32).into();

--- a/crates/cubecl-cpu/src/compiler/visitor/values.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/values.rs
@@ -33,18 +33,15 @@ impl<'a> Visitor<'a> {
         let align_ty = IntegerType::new(self.context, 64);
         let alignment = IntegerAttribute::new(align_ty.into(), alignment as i64);
         let memref_type = MemRefType::new(r#type, &[length as i64], None, None);
-        let value = self
-            .first_block
-            .unwrap()
-            .append_op_result(memref::alloca(
-                self.context,
-                memref_type,
-                &[],
-                &[],
-                Some(alignment),
-                self.location,
-            ))
-            .unwrap();
+        let value = self.append_operation_with_result(memref::alloc(
+            self.context,
+            memref_type,
+            &[],
+            &[],
+            Some(alignment),
+            self.location,
+        ));
+        self.mutable_variables.push(cube_value.id());
         self.values.insert(cube_value.id(), value);
     }
 

--- a/crates/cubecl-cpu/src/compiler/visitor/values.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/values.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use cubecl_core::ir::{self as cube, Builtin, ConstantValue, FloatKind, Id, ValueKind};
 use tracel_llvm::mlir_rs::{
     dialect::{
-        index, memref,
-        ods::{arith, vector},
+        index, llvm, memref,
+        ods::{arith, llvm::intr_stacksave, vector},
     },
     ir::{
         Value,
@@ -33,7 +33,12 @@ impl<'a> Visitor<'a> {
         let align_ty = IntegerType::new(self.context, 64);
         let alignment = IntegerAttribute::new(align_ty.into(), alignment as i64);
         let memref_type = MemRefType::new(r#type, &[length as i64], None, None);
-        let value = self.append_operation_with_result(memref::alloc(
+
+        let ptr_ty = llvm::r#type::pointer(self.context, 0);
+        let stack_pointer =
+            self.append_operation_with_result(intr_stacksave(self.context, ptr_ty, self.location));
+
+        let value = self.append_operation_with_result(memref::alloca(
             self.context,
             memref_type,
             &[],
@@ -41,6 +46,16 @@ impl<'a> Visitor<'a> {
             Some(alignment),
             self.location,
         ));
+        let seq = self.stack_save_counter;
+        self.stack_save_counter += 1;
+        self.stack_saves.insert(
+            cube_value.id(),
+            super::StackSave {
+                stack_pointer,
+                seq,
+                alloc_block: self.current_node,
+            },
+        );
         self.mutable_variables.push(cube_value.id());
         self.values.insert(cube_value.id(), value);
     }

--- a/crates/cubecl-opt/src/analyses/liveness.rs
+++ b/crates/cubecl-opt/src/analyses/liveness.rs
@@ -1,5 +1,5 @@
 use alloc::collections::vec_deque::VecDeque;
-use cubecl_ir::{Id, Value, ValueKind};
+use cubecl_ir::{AddressSpace, Id, Value, ValueKind};
 use hashbrown::{HashMap, HashSet};
 use petgraph::graph::NodeIndex;
 
@@ -7,11 +7,13 @@ use crate::{Function, GlobalState, analyses::post_order::PostOrder};
 
 use super::Analysis;
 
+type LivePredicate = fn(&Function, &Value) -> Option<Id>;
+
 pub struct Liveness {
     live_vars: HashMap<NodeIndex, HashSet<Id>>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct BlockSets {
     generated: HashSet<Id>,
     kill: HashSet<Id>,
@@ -24,9 +26,9 @@ struct State {
 
 impl Analysis for Liveness {
     fn init(func: &mut Function, state: &GlobalState) -> Self {
-        let mut this = Self::empty(func);
-        this.analyze_liveness(func, state);
-        this
+        Self {
+            live_vars: compute_liveness(func, state, Function::local_variable_id),
+        }
     }
 }
 
@@ -47,38 +49,86 @@ impl Liveness {
     pub fn is_dead(&self, node: NodeIndex, var: Id) -> bool {
         !self.at_block(node).contains(&var)
     }
+}
 
-    /// Do a conservative block level liveness analysis
-    pub fn analyze_liveness(&mut self, func: &mut Function, global_state: &GlobalState) {
-        let mut state = State {
-            worklist: VecDeque::from(func.analysis::<PostOrder>(global_state).forward()),
-            block_sets: HashMap::new(),
-        };
-        while let Some(block) = state.worklist.pop_front() {
-            self.analyze_block(func, global_state, block, &mut state);
+/// Block level liveness over all non-atomic local memories, including non-destructurable ones such
+/// as arrays.
+///
+/// [`Liveness`] only tracks destructurable locals (those that get promoted to SSA registers and
+/// phi nodes). Backends that keep local memory as actual allocations and need to free it when it
+/// dies (e.g. the CPU backend) must also track non-destructurable locals, which this analysis does.
+pub struct MemoryLiveness {
+    live_vars: HashMap<NodeIndex, HashSet<Id>>,
+}
+
+impl Analysis for MemoryLiveness {
+    fn init(func: &mut Function, state: &GlobalState) -> Self {
+        Self {
+            live_vars: compute_liveness(func, state, Function::local_memory_id),
         }
     }
+}
 
-    fn analyze_block(
-        &mut self,
-        func: &mut Function,
-        global_state: &GlobalState,
-        block: NodeIndex,
-        state: &mut State,
-    ) {
-        let BlockSets { generated, kill } = block_sets(func, global_state, block, state);
+impl MemoryLiveness {
+    pub fn empty(func: &Function) -> Self {
+        let live_vars = func
+            .node_ids()
+            .iter()
+            .map(|it| (*it, HashSet::new()))
+            .collect();
+        Self { live_vars }
+    }
 
-        let mut live_vars = generated.clone();
+    pub fn at_block(&self, block: NodeIndex) -> &HashSet<Id> {
+        &self.live_vars[&block]
+    }
 
-        for successor in func.successors(block) {
-            let successor = &self.live_vars[&successor];
-            live_vars.extend(successor.difference(kill));
-        }
+    pub fn is_dead(&self, node: NodeIndex, var: Id) -> bool {
+        !self.at_block(node).contains(&var)
+    }
+}
 
-        if live_vars != self.live_vars[&block] {
-            state.worklist.extend(func.predecessors(block));
-            self.live_vars.insert(block, live_vars);
-        }
+/// Do a conservative block level liveness analysis, tracking the variables selected by `pred`.
+fn compute_liveness(
+    func: &mut Function,
+    global_state: &GlobalState,
+    pred: LivePredicate,
+) -> HashMap<NodeIndex, HashSet<Id>> {
+    let mut live_vars: HashMap<NodeIndex, HashSet<Id>> = func
+        .node_ids()
+        .iter()
+        .map(|it| (*it, HashSet::new()))
+        .collect();
+    let mut state = State {
+        worklist: VecDeque::from(func.analysis::<PostOrder>(global_state).forward()),
+        block_sets: HashMap::new(),
+    };
+    while let Some(block) = state.worklist.pop_front() {
+        analyze_block(func, global_state, block, &mut state, &mut live_vars, pred);
+    }
+    live_vars
+}
+
+fn analyze_block(
+    func: &mut Function,
+    global_state: &GlobalState,
+    block: NodeIndex,
+    state: &mut State,
+    live_vars: &mut HashMap<NodeIndex, HashSet<Id>>,
+    pred: LivePredicate,
+) {
+    let BlockSets { generated, kill } = block_sets(func, global_state, block, state, pred);
+
+    let mut block_live = generated.clone();
+
+    for successor in func.successors(block) {
+        let successor = &live_vars[&successor];
+        block_live.extend(successor.difference(kill));
+    }
+
+    if block_live != live_vars[&block] {
+        state.worklist.extend(func.predecessors(block));
+        live_vars.insert(block, block_live);
     }
 }
 
@@ -87,12 +137,18 @@ fn block_sets<'a>(
     global_state: &GlobalState,
     block: NodeIndex,
     state: &'a mut State,
+    pred: LivePredicate,
 ) -> &'a BlockSets {
     let block_sets = state.block_sets.entry(block);
-    block_sets.or_insert_with(|| calculate_block_sets(func, global_state, block))
+    block_sets.or_insert_with(|| calculate_block_sets(func, global_state, block, pred))
 }
 
-fn calculate_block_sets(func: &mut Function, state: &GlobalState, block: NodeIndex) -> BlockSets {
+fn calculate_block_sets(
+    func: &mut Function,
+    state: &GlobalState,
+    block: NodeIndex,
+    pred: LivePredicate,
+) -> BlockSets {
     let mut generated = HashSet::new();
     let mut kill = HashSet::new();
 
@@ -100,7 +156,7 @@ fn calculate_block_sets(func: &mut Function, state: &GlobalState, block: NodeInd
 
     let control_flow = func[block].control_flow.clone();
     func.visit_control_flow(&mut control_flow.borrow_mut(), |func, val| {
-        if let Some(id) = func.local_variable_id(val) {
+        if let Some(id) = pred(func, val) {
             generated.insert(id);
         }
     });
@@ -108,13 +164,13 @@ fn calculate_block_sets(func: &mut Function, state: &GlobalState, block: NodeInd
     for op in ops.values_mut().rev() {
         // Reads must be tracked after writes
         func.visit_out(&mut op.out, |func, val| {
-            if let Some(id) = func.local_variable_id(val) {
+            if let Some(id) = pred(func, val) {
                 kill.insert(id);
                 generated.remove(&id);
             }
         });
         func.visit_operation(state, &mut op.operation, |func, val| {
-            if let Some(id) = func.local_variable_id(val) {
+            if let Some(id) = pred(func, val) {
                 generated.insert(id);
             }
         });
@@ -124,12 +180,32 @@ fn calculate_block_sets(func: &mut Function, state: &GlobalState, block: NodeInd
 }
 
 impl Function {
-    /// Gets the `id` and `depth` of the variable if it's a `Local` and not atomic, `None` otherwise.
+    /// Gets the `id` of the variable if it's a destructurable `Local` and not atomic, `None`
+    /// otherwise.
     pub fn local_variable_id(&self, value: &Value) -> Option<Id> {
         match value.kind {
             ValueKind::Value { id } if self.destructurable_local_memories().contains_key(&id) => {
                 Some(id)
             }
+            _ => None,
+        }
+    }
+
+    /// Gets the `id` of the variable if it's a `Local` memory and not atomic, `None` otherwise.
+    ///
+    /// Unlike [`Function::local_variable_id`], this includes non-destructurable locals such as
+    /// arrays, so it can be used by backends that allocate and free those memories.
+    pub fn local_memory_id(&self, value: &Value) -> Option<Id> {
+        match value.kind {
+            ValueKind::Value { id } => match self.memories.get(&id) {
+                Some(mem)
+                    if matches!(mem.address_space, AddressSpace::Local)
+                        && !mem.value_ty.is_atomic() =>
+                {
+                    Some(id)
+                }
+                _ => None,
+            },
             _ => None,
         }
     }

--- a/crates/cubecl-opt/src/lib.rs
+++ b/crates/cubecl-opt/src/lib.rs
@@ -80,10 +80,14 @@ pub use petgraph::graph::{EdgeIndex, NodeIndex};
 pub use transformers::*;
 pub use version::PhiInstruction;
 
-pub use crate::analyses::liveness::Liveness;
+pub use crate::analyses::liveness::MemoryLiveness;
 pub use crate::analyses::liveness::shared::SharedLiveness;
 use crate::{
-    analyses::{dominance::Dominators, liveness::Captures, pointer_source::PointerSource},
+    analyses::{
+        dominance::Dominators,
+        liveness::{Captures, Liveness},
+        pointer_source::PointerSource,
+    },
     passes::{CopyTransform, DisaggregateArray},
 };
 

--- a/crates/cubecl-opt/src/lib.rs
+++ b/crates/cubecl-opt/src/lib.rs
@@ -37,7 +37,7 @@ use core::{
 };
 
 use alloc::{boxed::Box, collections::vec_deque::VecDeque, rc::Rc, vec, vec::Vec};
-use analyses::{AnalysisCache, dominance::DomFrontiers, liveness::Liveness, writes::LocalStores};
+use analyses::{AnalysisCache, dominance::DomFrontiers, writes::LocalStores};
 use cubecl_core::{
     CubeDim,
     post_processing::{
@@ -80,6 +80,7 @@ pub use petgraph::graph::{EdgeIndex, NodeIndex};
 pub use transformers::*;
 pub use version::PhiInstruction;
 
+pub use crate::analyses::liveness::Liveness;
 pub use crate::analyses::liveness::shared::SharedLiveness;
 use crate::{
     analyses::{dominance::Dominators, liveness::Captures, pointer_source::PointerSource},


### PR DESCRIPTION
This PR deallocate stack memory at the end of scope of a loop instead of keeping the allocation alive through the cube


## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
