### PR TITLE
Enable min, max, bitwise, and compare-exchange atomics for i32 and u32

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/atomic.rs
+++ b/crates/cubecl-core/src/runtime_tests/atomic.rs
@@ -257,6 +257,40 @@ pub fn test_kernel_atomic_int<R: Runtime, I: Int + CubeElement>(
     }
 }
 
+#[cube(launch)]
+pub fn kernel_atomic_max_contention<I: Numeric>(atomics: &[Atomic<I>]) {
+    atomics[0].fetch_max(I::cast_from(ABSOLUTE_POS));
+}
+
+/// Many threads race `fetch_max` into one cell. The result must be the largest contribution.
+pub fn test_kernel_atomic_max_contention<R: Runtime, I: Numeric + CubeElement>(
+    client: ComputeClient<R>,
+) {
+    if !require_feature::<R, I>(&client, AtomicUsage::MinMax, 1, "Max contention") {
+        return;
+    }
+
+    // Keep the highest contributed value within reach of the smallest integer type this
+    // test runs against (i8, max 127), so 4 blocks of 32 threads contribute 0..=127.
+    let cube_dim = 32u32;
+    let cube_count = 4u32;
+    let n = cube_dim * cube_count;
+
+    let handle = client.create_from_slice(I::as_bytes(&[I::from_int(0)]));
+
+    kernel_atomic_max_contention::launch::<I, R>(
+        &client,
+        CubeCount::new_1d(cube_count),
+        CubeDim::new_1d(cube_dim),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+    );
+
+    let actual = client.read_one_unchecked(handle);
+    let actual = I::from_bytes(&actual);
+
+    assert_eq!(actual, &[I::from_int((n - 1) as i64)]);
+}
+
 #[macro_export]
 macro_rules! testgen_atomic_int {
     () => {
@@ -333,6 +367,15 @@ macro_rules! testgen_atomic_int {
             test_atomic_compare_exchange_int,
             cubecl_core::runtime_tests::atomic::IntAtomicOp::CompareExchange
         );
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_atomic_max_contention_int() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::atomic::test_kernel_atomic_max_contention::<
+                TestRuntime,
+                IntType,
+            >(client);
+        }
     };
 }
 
@@ -413,6 +456,15 @@ macro_rules! testgen_atomic_uint {
             test_atomic_compare_exchange_uint,
             cubecl_core::runtime_tests::atomic::IntAtomicOp::CompareExchange
         );
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_atomic_max_contention_uint() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::atomic::test_kernel_atomic_max_contention::<
+                TestRuntime,
+                UintType,
+            >(client);
+        }
     };
 }
 

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -2061,9 +2061,14 @@ pub fn register_supported_types(props: &mut DeviceProperties) {
     }
 
     for ty in supported_atomic_types {
-        props.register_atomic_type_usage(
-            Type::atomic(ty),
-            AtomicUsage::Add | AtomicUsage::LoadStore,
-        );
+        // Restricted to 32-bit integers because not every min/max/bitwise/CAS overload
+        // exists for 64-bit and float atomics across the C++ dialects (CUDA, HIP, Metal).
+        let usage = match ty {
+            ir::ElemType::Int(ir::IntKind::I32) | ir::ElemType::UInt(ir::UIntKind::U32) => {
+                AtomicUsage::all()
+            }
+            _ => AtomicUsage::Add | AtomicUsage::LoadStore,
+        };
+        props.register_atomic_type_usage(Type::atomic(ty), usage);
     }
 }

--- a/crates/cubecl-wgpu/src/backend/wgsl.rs
+++ b/crates/cubecl-wgpu/src/backend/wgsl.rs
@@ -91,10 +91,7 @@ pub fn register_types(props: &mut DeviceProperties, adapter: &wgpu::Adapter) {
     }
 
     for ty in supported_atomic_types {
-        props.register_atomic_type_usage(
-            Type::atomic(ty),
-            AtomicUsage::LoadStore | AtomicUsage::Add,
-        );
+        props.register_atomic_type_usage(Type::atomic(ty), AtomicUsage::all());
     }
 
     let feats = adapter.features();


### PR DESCRIPTION
cubecl gates each atomic operation behind a per-backend list of what that backend allows. For integers, the WebGPU (`wgsl`) and shared C++ backends only listed loads, stores, and addition, so calling `min`, `max`, a bitwise op, or compare-and-exchange on a `u32` failed at compile time. The backends could already generate that code and the hardware already runs it, so the only thing missing was the entry in the list.

This adds those operations for the 32-bit integer types `i32` and `u32` on both backends. The WebGPU side needs no device feature for it, and the single C++ change covers both `cubecl-cuda` and `cubecl-hip`.

The known-answer tests for these operations already existed but were being skipped on both backends, so they now run and pass. I also added a test where many threads race a `max` into the same cell.
