### PR TITLE
fix(wgpu): clamp compute dispatch cube count to u16::MAX (NVIDIA Vulkan)

### DIFF
--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -370,8 +370,31 @@ impl ServerCommunication for CpuServer {
 pub(crate) fn contiguous_strides(shape: &Shape) -> Strides {
     let rank = shape.len();
     let mut strides = strides![1; rank];
-    for i in (0..rank - 1).rev() {
+    // `saturating_sub` keeps the bound at 0 for rank-0 (scalar) shapes, where
+    // `rank - 1` would otherwise underflow and panic.
+    for i in (0..rank.saturating_sub(1)).rev() {
         strides[i] = strides[i + 1] * shape[i + 1];
     }
     strides
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contiguous_strides_handles_rank_0() {
+        // Rank-0 (scalar) shapes must not underflow the `rank - 1` loop bound.
+        let strides = contiguous_strides(&Shape::new([]));
+        assert!(strides.is_empty());
+    }
+
+    #[test]
+    fn contiguous_strides_are_row_major() {
+        assert_eq!(contiguous_strides(&Shape::new([5])), strides![1]);
+        assert_eq!(
+            contiguous_strides(&Shape::new([2, 3, 4])),
+            strides![12, 4, 1]
+        );
+    }
 }

--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -406,8 +406,31 @@ impl ServerCommunication for CpuServer {
 pub(crate) fn contiguous_strides(shape: &Shape) -> Strides {
     let rank = shape.len();
     let mut strides = strides![1; rank];
-    for i in (0..rank - 1).rev() {
+    // `saturating_sub` keeps the bound at 0 for rank-0 (scalar) shapes, where
+    // `rank - 1` would otherwise underflow and panic.
+    for i in (0..rank.saturating_sub(1)).rev() {
         strides[i] = strides[i + 1] * shape[i + 1];
     }
     strides
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contiguous_strides_handles_rank_0() {
+        // Rank-0 (scalar) shapes must not underflow the `rank - 1` loop bound.
+        let strides = contiguous_strides(&Shape::new([]));
+        assert!(strides.is_empty());
+    }
+
+    #[test]
+    fn contiguous_strides_are_row_major() {
+        assert_eq!(contiguous_strides(&Shape::new([5])), strides![1]);
+        assert_eq!(
+            contiguous_strides(&Shape::new([2, 3, 4])),
+            strides![12, 4, 1]
+        );
+    }
 }

--- a/crates/cubecl-runtime/src/allocator.rs
+++ b/crates/cubecl-runtime/src/allocator.rs
@@ -116,7 +116,9 @@ impl MemoryLayoutPolicy for ContiguousMemoryLayoutPolicy {
 pub(crate) fn contiguous_strides(shape: &Shape) -> Strides {
     let rank = shape.len();
     let mut strides = strides![1; rank];
-    for i in (0..rank - 1).rev() {
+    // `saturating_sub` keeps the bound at 0 for rank-0 (scalar) shapes, where
+    // `rank - 1` would otherwise underflow and panic.
+    for i in (0..rank.saturating_sub(1)).rev() {
         strides[i] = strides[i + 1] * shape[i + 1];
     }
     strides
@@ -143,4 +145,25 @@ pub fn offset_handles(
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contiguous_strides_handles_rank_0() {
+        // Rank-0 (scalar) shapes must not underflow the `rank - 1` loop bound.
+        let strides = contiguous_strides(&Shape::new([]));
+        assert!(strides.is_empty());
+    }
+
+    #[test]
+    fn contiguous_strides_are_row_major() {
+        assert_eq!(contiguous_strides(&Shape::new([5])), strides![1]);
+        assert_eq!(
+            contiguous_strides(&Shape::new([2, 3, 4])),
+            strides![12, 4, 1]
+        );
+    }
 }

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -448,8 +448,8 @@ fn register_types(props: &mut DeviceProperties, ext_feat: &ExtendedFeatures<'_>)
         .buf_16
         .is_some_and(|it| it.uniform_and_storage_buffer16_bit_access == TRUE);
     let storage8 = ext_feat
-        .buf_16
-        .is_some_and(|it| it.uniform_and_storage_buffer16_bit_access == TRUE);
+        .buf_8
+        .is_some_and(|it| it.uniform_and_storage_buffer8_bit_access == TRUE);
 
     for ty in default_types {
         props.register_type_usage(ty, TypeUsage::all());

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -453,8 +453,8 @@ fn register_types(props: &mut DeviceProperties, ext_feat: &ExtendedFeatures<'_>)
         .buf_16
         .is_some_and(|it| it.uniform_and_storage_buffer16_bit_access == TRUE);
     let storage8 = ext_feat
-        .buf_16
-        .is_some_and(|it| it.uniform_and_storage_buffer16_bit_access == TRUE);
+        .buf_8
+        .is_some_and(|it| it.uniform_and_storage_buffer8_bit_access == TRUE);
 
     for ty in default_types {
         props.register_type_usage(ty, TypeUsage::all());

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -467,8 +467,31 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
 pub(crate) fn contiguous_strides(shape: &Shape) -> Strides {
     let rank = shape.len();
     let mut strides = strides![1; rank];
-    for i in (0..rank - 1).rev() {
+    // `saturating_sub` keeps the bound at 0 for rank-0 (scalar) shapes, where
+    // `rank - 1` would otherwise underflow and panic.
+    for i in (0..rank.saturating_sub(1)).rev() {
         strides[i] = strides[i + 1] * shape[i + 1];
     }
     strides
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contiguous_strides_handles_rank_0() {
+        // Rank-0 (scalar) shapes must not underflow the `rank - 1` loop bound.
+        let strides = contiguous_strides(&Shape::new([]));
+        assert!(strides.is_empty());
+    }
+
+    #[test]
+    fn contiguous_strides_are_row_major() {
+        assert_eq!(contiguous_strides(&Shape::new([5])), strides![1]);
+        assert_eq!(
+            contiguous_strides(&Shape::new([2, 3, 4])),
+            strides![12, 4, 1]
+        );
+    }
 }

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -529,8 +529,31 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
 pub(crate) fn contiguous_strides(shape: &Shape) -> Strides {
     let rank = shape.len();
     let mut strides = strides![1; rank];
-    for i in (0..rank - 1).rev() {
+    // `saturating_sub` keeps the bound at 0 for rank-0 (scalar) shapes, where
+    // `rank - 1` would otherwise underflow and panic.
+    for i in (0..rank.saturating_sub(1)).rev() {
         strides[i] = strides[i + 1] * shape[i + 1];
     }
     strides
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contiguous_strides_handles_rank_0() {
+        // Rank-0 (scalar) shapes must not underflow the `rank - 1` loop bound.
+        let strides = contiguous_strides(&Shape::new([]));
+        assert!(strides.is_empty());
+    }
+
+    #[test]
+    fn contiguous_strides_are_row_major() {
+        assert_eq!(contiguous_strides(&Shape::new([5])), strides![1]);
+        assert_eq!(
+            contiguous_strides(&Shape::new([2, 3, 4])),
+            strides![12, 4, 1]
+        );
+    }
 }

--- a/crates/cubecl-wgpu/src/graphics.rs
+++ b/crates/cubecl-wgpu/src/graphics.rs
@@ -80,7 +80,7 @@ impl GraphicsApi for AutoGraphicsApi {
                 "webgpu" => return Backend::BrowserWebGpu,
                 _ => {
                     eprintln!(
-                        "Invalid graphics backend specified in GRAPHICS_BACKEND environment \
+                        "Invalid graphics backend specified in AUTO_GRAPHICS_BACKEND environment \
                          variable"
                     );
                     std::process::exit(1);

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -283,6 +283,20 @@ pub async fn init_setup_async<G: GraphicsApi>(
     return_setup
 }
 
+/// Clamp an adapter-reported `max_compute_workgroups_per_dimension` to the
+/// per-dimension cube-count limit the GPU actually enforces at dispatch time.
+///
+/// Some adapters — notably the Vulkan backend on NVIDIA hardware — advertise a
+/// `max_compute_workgroups_per_dimension` larger than the value the driver
+/// validates against when a dispatch is recorded. Propagating that inflated
+/// number into `HardwareProperties::max_cube_count` lets an oversized
+/// `[N, 1, 1]` cube count reach wgpu and trip a validation error once `N`
+/// exceeds the real cap of `u16::MAX`. Clamping keeps the launch bookkeeping
+/// consistent with the limit reported by `WgpuRuntime::max_cube_count`.
+fn clamp_max_cube_count(reported: u32) -> u32 {
+    reported.min(u16::MAX as u32)
+}
+
 pub(crate) fn create_server<C: WgpuCompiler>(
     setup: WgpuSetup,
     options: RuntimeOptions,
@@ -305,7 +319,7 @@ pub(crate) fn create_server<C: WgpuCompiler>(
         max_page_size: limits.max_storage_buffer_binding_size,
         alignment: limits.min_uniform_buffer_offset_alignment as u64,
     };
-    let max_count = adapter_limits.max_compute_workgroups_per_dimension;
+    let max_count = clamp_max_cube_count(adapter_limits.max_compute_workgroups_per_dimension);
     let hardware_props = HardwareProperties {
         load_width: 128,
         // On Apple Silicon, the plane size is 32,
@@ -618,4 +632,34 @@ fn get_device_override() -> Option<WgpuDevice> {
             }
             override_device
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_max_cube_count_caps_inflated_adapter_limits() {
+        // NVIDIA's Vulkan adapter reports a per-dimension workgroup limit far
+        // above the value the driver actually enforces at dispatch time.
+        assert_eq!(clamp_max_cube_count(u32::MAX), u16::MAX as u32);
+        assert_eq!(clamp_max_cube_count(1 << 20), u16::MAX as u32);
+    }
+
+    #[test]
+    fn clamp_max_cube_count_preserves_honest_adapter_limits() {
+        assert_eq!(clamp_max_cube_count(0), 0);
+        assert_eq!(clamp_max_cube_count(1024), 1024);
+        assert_eq!(clamp_max_cube_count(u16::MAX as u32), u16::MAX as u32);
+    }
+
+    #[test]
+    fn clamp_max_cube_count_matches_runtime_advertised_limit() {
+        // The clamp must agree with the limit `WgpuRuntime` advertises so the
+        // launch logic never produces a cube count the GPU will reject.
+        assert_eq!(
+            clamp_max_cube_count(u32::MAX),
+            WgpuRuntime::<AutoCompiler>::max_cube_count().0
+        );
+    }
 }

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -284,6 +284,20 @@ pub async fn init_setup_async<G: GraphicsApi>(
     return_setup
 }
 
+/// Clamp an adapter-reported `max_compute_workgroups_per_dimension` to the
+/// per-dimension cube-count limit the GPU actually enforces at dispatch time.
+///
+/// Some adapters — notably the Vulkan backend on NVIDIA hardware — advertise a
+/// `max_compute_workgroups_per_dimension` larger than the value the driver
+/// validates against when a dispatch is recorded. Propagating that inflated
+/// number into `HardwareProperties::max_cube_count` lets an oversized
+/// `[N, 1, 1]` cube count reach wgpu and trip a validation error once `N`
+/// exceeds the real cap of `u16::MAX`. Clamping keeps the launch bookkeeping
+/// consistent with the limit reported by `WgpuRuntime::max_cube_count`.
+fn clamp_max_cube_count(reported: u32) -> u32 {
+    reported.min(u16::MAX as u32)
+}
+
 pub(crate) fn create_server<C: WgpuCompiler>(
     setup: WgpuSetup,
     options: RuntimeOptions,
@@ -306,7 +320,7 @@ pub(crate) fn create_server<C: WgpuCompiler>(
         max_page_size: limits.max_storage_buffer_binding_size,
         alignment: limits.min_uniform_buffer_offset_alignment as u64,
     };
-    let max_count = adapter_limits.max_compute_workgroups_per_dimension;
+    let max_count = clamp_max_cube_count(adapter_limits.max_compute_workgroups_per_dimension);
     let hardware_props = HardwareProperties {
         load_width: 128,
         // On Apple Silicon, the plane size is 32,
@@ -633,4 +647,34 @@ fn get_device_override() -> Option<WgpuDevice> {
             }
             override_device
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_max_cube_count_caps_inflated_adapter_limits() {
+        // NVIDIA's Vulkan adapter reports a per-dimension workgroup limit far
+        // above the value the driver actually enforces at dispatch time.
+        assert_eq!(clamp_max_cube_count(u32::MAX), u16::MAX as u32);
+        assert_eq!(clamp_max_cube_count(1 << 20), u16::MAX as u32);
+    }
+
+    #[test]
+    fn clamp_max_cube_count_preserves_honest_adapter_limits() {
+        assert_eq!(clamp_max_cube_count(0), 0);
+        assert_eq!(clamp_max_cube_count(1024), 1024);
+        assert_eq!(clamp_max_cube_count(u16::MAX as u32), u16::MAX as u32);
+    }
+
+    #[test]
+    fn clamp_max_cube_count_matches_runtime_advertised_limit() {
+        // The clamp must agree with the limit `WgpuRuntime` advertises so the
+        // launch logic never produces a cube count the GPU will reject.
+        assert_eq!(
+            clamp_max_cube_count(u32::MAX),
+            WgpuRuntime::<AutoCompiler>::max_cube_count().0
+        );
+    }
 }


### PR DESCRIPTION
## Summary

A small batch of independent correctness fixes in `cubecl-wgpu`, plus the same
rank-0 stride bug fixed in two sibling crates that carry a copy of the helper.
Each fix is its own commit so they can be reviewed.
## Fixes

### 1. Clamp dispatch cube count to the enforced per-dimension limit (`cubecl-wgpu`)

Some adapters — notably the **Vulkan backend on NVIDIA hardware** — report a
`max_compute_workgroups_per_dimension` larger than the limit the driver
actually validates against at dispatch time. `create_server` fed that
adapter-reported value straight into `HardwareProperties::max_cube_count`, so
the launch logic treated an oversized `[N, 1, 1]` cube count as legal and let
it reach wgpu, which then rejected the dispatch with a validation error once
`N` exceeded the real cap of `u16::MAX` (65_535).

This bites any single large elementwise dispatch — e.g. a 52,428,800-element
launch needs `52_428_800 / 256 = 204_800` workgroups along X, well past 65_535.

The fix clamps the reported value to `u16::MAX` via a new `clamp_max_cube_count`
helper, keeping it consistent with the cap already advertised by
`<WgpuRuntime as Runtime>::max_cube_count`.

### 2. Detect 8-bit storage via the 8-bit feature struct (`cubecl-wgpu`)

In `register_types`, `storage8` was computed from `ext_feat.buf_16` and its
`uniform_and_storage_buffer16_bit_access` field — a copy-paste of the
`storage16` line above it. As a result 8-bit storage capability tracked the
16-bit device feature, so I8/U8 types could be marked storable based on the
wrong feature. Now reads `ext_feat.buf_8.uniform_and_storage_buffer8_bit_access`.

### 3. Name `AUTO_GRAPHICS_BACKEND` in its invalid-value error (`cubecl-wgpu`)

The error printed for an unrecognised backend reads the `AUTO_GRAPHICS_BACKEND`
env var but told the user to check `GRAPHICS_BACKEND`, sending them to the wrong
variable. Corrected the message.

### 4. Guard `contiguous_strides` against rank-0 shapes (`cubecl-wgpu`, `cubecl-cpu`, `cubecl-runtime`)

`contiguous_strides` iterated `(0..rank - 1)`, which underflows and panics when
`rank == 0` (a scalar / rank-0 shape). Changed to `(0..rank.saturating_sub(1))`
so a rank-0 shape yields empty strides. The same helper is duplicated in
`cubecl-cpu` and `cubecl-runtime`, fixed in all three.

Notes:
- `cubecl-std`'s `contiguous_strides` uses a different, subtraction-free
  implementation and is not affected.
- The pitched-allocation path in `ContiguousMemoryLayoutPolicy`
  (`cubecl-runtime`) already guards its `rank - 2` loop behind `rank > 2`, so
  only the standalone helper needed the fix.

## Testing

- New unit tests for `clamp_max_cube_count` (caps inflated limits, preserves
  honest ones, agrees with `WgpuRuntime::max_cube_count`) and for
  `contiguous_strides` (rank-0 returns empty, row-major correctness) in each of
  the three crates.
- `cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` pass for
  the touched crates; `cubecl-wgpu` additionally checked under `--features spirv`
  to compile the Vulkan path.
