### PR TITLE
fixed `cargo xtask validate` failure on Linux

### DIFF
--- a/xtask/src/commands/check.rs
+++ b/xtask/src/commands/check.rs
@@ -78,7 +78,7 @@ pub(crate) fn handle_command(
 }
 
 /// Run workspace lint, excluding platform-specific crates.
-fn run_ci_lint() -> anyhow::Result<()> {
+pub(crate) fn run_ci_lint() -> anyhow::Result<()> {
     let mut cmd_args: Vec<&str> = vec!["clippy", "--workspace", "--no-deps", "--color=always"];
     for crate_name in CI_EXCLUDED_CRATES {
         cmd_args.push("--exclude");

--- a/xtask/src/commands/validate.rs
+++ b/xtask/src/commands/validate.rs
@@ -11,11 +11,10 @@ pub fn handle_command(
     let exclude = vec![];
     let only = vec![];
 
-    // checks
+    // checks (lint is handled separately below)
     [
         CheckSubCommand::Audit,
         CheckSubCommand::Format,
-        CheckSubCommand::Lint,
         CheckSubCommand::Typos,
     ]
     .iter()
@@ -35,6 +34,28 @@ pub fn handle_command(
             context.clone(),
         )
     })?;
+
+    // Lint. The base check command silently ignores `--exclude` for `--target workspace`,
+    // so the Apple-only `cubecl-metal` (which pulls in `objc2`) can't be dropped that way.
+    // On non-Apple hosts, reuse check.rs's `run_ci_lint`, which builds the clippy command
+    // by hand with `--exclude`; on macOS, lint the full workspace as before.
+    #[cfg(target_os = "macos")]
+    base_commands::check::handle_command(
+        CheckCmdArgs {
+            command: Some(CheckSubCommand::Lint),
+            exclude: exclude.clone(),
+            ignore_audit: args.ignore_audit,
+            only: only.clone(),
+            target: target.clone(),
+            ignore_typos: args.ignore_typos,
+            features: args.features.clone(),
+            no_default_features: args.no_default_features,
+        },
+        env.clone(),
+        context.clone(),
+    )?;
+    #[cfg(not(target_os = "macos"))]
+    crate::commands::check::run_ci_lint()?;
 
     // build
     super::build::handle_command(


### PR DESCRIPTION
# `cargo xtask validate` fails on Linux

Fixed #1398 

## Symptom

Running `cargo xtask validate` on Linux fails with:

```
error: `objc2` only works on Apple platforms. Pass `--target aarch64-apple-darwin`
or similar to compile for macOS.
   --> .../objc2-0.6.4/src/lib.rs:219:1
    | compile_error!("`objc2` only works on Apple platforms. ...");
error: could not compile `objc2` (lib) due to 1 previous error
Error: Workspace lint failed (exit status: 101)
```

## Root cause

`objc2` is an **Apple-only** crate. It is added in PR #1175.

- `cubecl-metal` is a normal workspace member (`members = ["crates/*", ...]` in the
  root `Cargo.toml`).
- Its Apple bindings are **not** target-gated — `crates/cubecl-metal/Cargo.toml:29-32`
  declares `objc2`, `objc2-metal`, `objc2-foundation`, `block2` unconditionally.

So when I run `cargo xtask validate`, `cargo clippy` tries to compile `cubecl-metal` (and thus
`objc2`) on Linux, where it cannot build. 

## How CI avoids this

CI runs lint on Linux (`ubuntu-22.04`) but uses the **`--ci` flag**, which excludes the
Apple-only crate.

`--ci` exclusion is implemented per-command in `build.rs:15-19`, `test.rs:22-27`,
`doc.rs:17-18`, and `check.rs:5,21-24`.

## Gap: `cargo xtask validate` is inconsistent on using the `ci` flag.

- Its build / test / doc phases pass `ci: true`, and those custom handlers DO exclude
  `cubecl-metal` (`build.rs:15-19`, `test.rs:22-27`, `doc.rs:17-18`). OK.
https://github.com/tracel-ai/cubecl/blob/4993b24c3bb3a82283633b63356a7400b03bbcd3/xtask/src/commands/build.rs#L15-L21
https://github.com/tracel-ai/cubecl/blob/4993b24c3bb3a82283633b63356a7400b03bbcd3/xtask/src/commands/test.rs#L22-L29
https://github.com/tracel-ai/cubecl/blob/4993b24c3bb3a82283633b63356a7400b03bbcd3/xtask/src/commands/doc.rs#L17-L19
- Its **check / lint phase does NOT**. `validate.rs:23-33` calls
  `base_commands::check::handle_command` directly with `exclude: vec![]`, bypassing the
  repo's CI-aware check wrapper in `check.rs`. The base `CheckCmdArgs` has no `ci`
  field, so the exclusion is never applied.
https://github.com/tracel-ai/cubecl/blob/4993b24c3bb3a82283633b63356a7400b03bbcd3/xtask/src/commands/validate.rs#L23-L33

**Net effect:** `cargo xtask validate` on Linux passes build/test/doc but **fails at the
lint step** with the same `objc2` error.

Today, to mirror the full CI suite locally on Linux:

```bash
cargo xtask check audit
cargo xtask check format
cargo xtask check --ci lint
cargo xtask doc  --ci build
cargo xtask doc  --ci tests
cargo xtask test --ci
```

Fixing `validate` turns that six-command checklist back into one `cargo xtask validate`.

### Why a plain `--exclude` does not work

The obvious fix — passing `exclude: vec!["cubecl-metal"]` to the check phase — is silently
dropped. The base check command **ignores `--exclude` (and `--only`) when the target is
`workspace`**:

```
WARN tracel_xtask::commands::check] '--target workspace' ignores the arguments
'--exclude' and '--only'. Use '--target crates' instead.
```

### Fix

Split `validate`'s check phase: keep audit / format / typos on the base handler (they pass
fine on Linux), and route **only the lint step** through `check.rs`'s existing
`run_ci_lint` on non-Apple hosts, matching the `#[cfg(not(target_os = "macos"))]` pattern
already used in `check.rs:54`. On macOS the lint runs over the full workspace as before.

```rust
// xtask/src/commands/validate.rs
#[cfg(target_os = "macos")]
base_commands::check::handle_command(
    CheckCmdArgs { command: Some(CheckSubCommand::Lint), /* ... */ },
    env.clone(),
    context.clone(),
)?;
#[cfg(not(target_os = "macos"))]
crate::commands::check::run_ci_lint()?;
```

`run_ci_lint` was made `pub(crate)` in `check.rs` so `validate.rs` can reuse it.

### Why not route `validate` through the full `--ci` check wrapper (`check.rs`)?

An alternative was to have `validate` call the repo's own
`crate::commands::check::handle_command` with `ci: true` instead of
`base_commands::check::handle_command`, reusing the whole CI-aware path. We did not do this
because **the local wrapper always runs the `custom_crates_check` block at
`check.rs:54-75`** (the SPIR-V, `exclusive-memory-only`, and `no-default-features`
feature-specific checks). Today `validate` skips those, so routing through the wrapper would
silently expand `validate`'s scope beyond fixing this bug.
