### PR TITLE
fix(metal): validate shared memory limit before pipeline creation

### DIFF
--- a/crates/cubecl-metal/src/compute/context.rs
+++ b/crates/cubecl-metal/src/compute/context.rs
@@ -1,6 +1,7 @@
 use crate::MetalCompiler;
 use cubecl_common::backtrace::BackTrace;
 use cubecl_core::prelude::*;
+use cubecl_core::server::{LaunchError, ResourceLimitError};
 use cubecl_runtime::{compiler::CubeTask, logging::ServerLogger};
 use hashbrown::HashMap;
 use objc2::rc::Retained;
@@ -81,8 +82,9 @@ impl MetalContext {
         kernel_id: &KernelId,
         kernel: Box<dyn CubeTask<MetalCompiler>>,
         mode: ExecutionMode,
+        max_shared_memory_size: usize,
         logger: Arc<ServerLogger>,
-    ) -> Result<CompiledKernel, cubecl_runtime::compiler::CompilationError> {
+    ) -> Result<CompiledKernel, LaunchError> {
         if let Some(compiled) = self.compiled_kernels.get(kernel_id) {
             return Ok(compiled.clone());
         }
@@ -131,6 +133,18 @@ impl MetalContext {
             .as_ref()
             .map(|r| r.shared_memory_size())
             .unwrap_or(0);
+
+        // Check before creating the pipeline: Metal would reject the kernel there anyway,
+        // but with an opaque compilation error instead of a resource limit error.
+        if shared_memory_bytes > max_shared_memory_size {
+            return Err(LaunchError::TooManyResources(
+                ResourceLimitError::SharedMemory {
+                    requested: shared_memory_bytes,
+                    max: max_shared_memory_size,
+                    backtrace: BackTrace::capture(),
+                },
+            ));
+        }
 
         let mut compiled = self.create_pipeline_from_source(&source, &entrypoint_name, cube_dim)?;
         compiled.shared_memory_bytes = shared_memory_bytes;

--- a/crates/cubecl-metal/src/compute/server.rs
+++ b/crates/cubecl-metal/src/compute/server.rs
@@ -365,34 +365,15 @@ impl ComputeServer for MetalServer {
             &kernel_id,
             kernel,
             mode,
+            self.utilities.properties.hardware.max_shared_memory_size,
             self.utilities.logger.clone(),
         ) {
             Ok(c) => c,
             Err(err) => {
-                self.push_launch_error(
-                    stream_id,
-                    cubecl_core::prelude::LaunchError::CompilationError(err),
-                );
+                self.push_launch_error(stream_id, err);
                 return;
             }
         };
-
-        // Validate shared memory usage
-        let max_smem = self.utilities.properties.hardware.max_shared_memory_size;
-        if compiled.shared_memory_bytes > max_smem {
-            use cubecl_core::server::ResourceLimitError;
-            self.push_launch_error(
-                stream_id,
-                cubecl_core::prelude::LaunchError::TooManyResources(
-                    ResourceLimitError::SharedMemory {
-                        requested: compiled.shared_memory_bytes,
-                        max: max_smem,
-                        backtrace: cubecl_common::backtrace::BackTrace::capture(),
-                    },
-                ),
-            );
-            return;
-        }
 
         let dispatch_info = match count {
             CubeCount::Static(x, y, z) => DispatchInfo::Static(x, y, z),

--- a/crates/cubecl-metal/src/lib.rs
+++ b/crates/cubecl-metal/src/lib.rs
@@ -11,6 +11,8 @@ pub(crate) type MetalCompiler = cubecl_cpp::shared::CppCompiler<cubecl_cpp::meta
 #[cfg(test)]
 mod tests_expm1;
 #[cfg(test)]
+mod tests_launch_errors;
+#[cfg(test)]
 mod tests_multistream;
 #[cfg(test)]
 mod tests_profiling;

--- a/crates/cubecl-metal/src/tests_launch_errors.rs
+++ b/crates/cubecl-metal/src/tests_launch_errors.rs
@@ -1,0 +1,58 @@
+//! Launch-validation tests for the Metal backend.
+//!
+//! Resource-limit violations must surface as `LaunchError::TooManyResources`, not as the
+//! opaque `CompilationError` Metal's pipeline creation produces when a kernel genuinely
+//! uses more threadgroup memory than the device allows.
+
+use cubecl_core::{self as cubecl, prelude::*};
+use cubecl_core::{
+    Runtime,
+    server::{LaunchError, ResourceLimitError, ServerError},
+};
+
+type R = crate::MetalRuntime;
+
+#[cube(launch)]
+fn oversized_smem_kernel(output: &mut [u32], #[comptime] shared_size: usize) {
+    let mut shared = Shared::new_slice(shared_size);
+    // Runtime-dependent indices so the MSL compiler can't shrink the allocation.
+    let idx = output[0] as usize;
+    shared[idx] = output[0];
+    sync_cube();
+    output[0] = shared[idx + 1];
+}
+
+#[test]
+fn oversized_shared_memory_is_a_resource_limit_error() {
+    let client = R::client(&Default::default());
+    let max = client.properties().hardware.max_shared_memory_size;
+    let shared_size = (max + 1).div_ceil(size_of::<u32>());
+    let requested_bytes = shared_size * size_of::<u32>();
+
+    let handle = client.create_from_slice(u32::as_bytes(&[0]));
+    oversized_smem_kernel::launch::<R>(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_1d(1),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), 1) },
+        shared_size,
+    );
+
+    let err = client
+        .flush()
+        .expect_err("a launch requesting more shared memory than the device limit must fail");
+    let ServerError::ServerUnhealthy { errors, .. } = err else {
+        panic!("expected ServerUnhealthy, got: {err}");
+    };
+    match &errors[0] {
+        ServerError::Launch(LaunchError::TooManyResources(ResourceLimitError::SharedMemory {
+            requested,
+            max: reported_max,
+            ..
+        })) => {
+            assert_eq!(*requested, requested_bytes);
+            assert_eq!(*reported_max, max);
+        }
+        other => panic!("expected a shared memory resource limit error, got: {other}"),
+    }
+}


### PR DESCRIPTION
Validates shared memory limit before pipeline creation for better errors when failure is due to that