### PR TITLE
fix(cpu): reserve shared memory from a dedicated pool

### DIFF
--- a/crates/cubecl-cpu/src/compute/stream.rs
+++ b/crates/cubecl-cpu/src/compute/stream.rs
@@ -25,6 +25,13 @@ use std::sync::{Arc, atomic::AtomicU64};
 pub struct CpuStream {
     pub(crate) max_units_per_cube: u32,
     pub(crate) memory_management: MemoryManagement<BytesStorage>,
+    /// Dedicated pool for per-launch shared memory.
+    ///
+    /// Shared memory MUST NOT be reserved from `memory_management`: kernel input/output
+    /// bindings keep their allocation alive through a `ManagedMemoryBinding`, which does
+    /// *not* hold the pool reservation. `reserve` would then hand a still-bound tensor's
+    /// slice to shared memory, aliasing an input and corrupting it in place.
+    pub(crate) shared_memory_management: MemoryManagement<BytesStorage>,
     pub(crate) timestamps: TimestampProfiler,
     errors: Vec<ServerError>,
     threadpool: &'static spin::Mutex<Threadpool>,
@@ -48,9 +55,16 @@ impl CpuStream {
         let memory_management = MemoryManagement::from_configuration(
             BytesStorage::default(),
             &memory_properties,
-            memory_config,
+            memory_config.clone(),
             logger.clone(),
             MemoryManagementOptions::new("Main CPU"),
+        );
+        let shared_memory_management = MemoryManagement::from_configuration(
+            BytesStorage::default(),
+            &memory_properties,
+            memory_config,
+            logger.clone(),
+            MemoryManagementOptions::new("Shared CPU"),
         );
         let threadpool = Threadpool::get();
         let next_counter_step = 0;
@@ -58,6 +72,7 @@ impl CpuStream {
         Self {
             max_units_per_cube,
             memory_management,
+            shared_memory_management,
             timestamps: TimestampProfiler::default(),
             errors: Vec::new(),
             threadpool,
@@ -96,7 +111,7 @@ impl CpuStream {
                     bindings,
                     cube_dim,
                     cube_count,
-                    &mut self.memory_management,
+                    &mut self.shared_memory_management,
                     self.next_counter_step,
                     &self.atomic_counter,
                 );

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -73,6 +73,25 @@ mod tests {
         out[idx] = sum;
     }
 
+    // Reads an input into shared memory at a computed (non-identity) index, then reads it
+    // back. If shared memory is reserved from the same pool as the input binding, the two
+    // alias and `mem[j] = input[i]` corrupts the input in place.
+    #[cube(launch)]
+    fn shared_scatter_gather(input: &[f32], output: &mut [f32], #[comptime] n: usize) {
+        let mut mem = Shared::new_slice(n);
+        let mut i = 0usize;
+        while i < n {
+            mem[(i + 2) % n] = input[i];
+            i += 1;
+        }
+        sync_cube();
+        let mut k = 0usize;
+        while k < n {
+            output[k] = mem[k];
+            k += 1;
+        }
+    }
+
     #[cube(launch_unchecked)]
     fn delayed_copy(input: &[u32], output: &mut [u32], num_loop: usize) {
         if UNIT_POS == 0 {
@@ -158,6 +177,33 @@ mod tests {
         let bytes = client.read_one_unchecked(out);
         let actual = u32::from_bytes(&bytes);
         assert_eq!(actual, &[28u32; 8]);
+    }
+
+    #[test]
+    fn shared_memory_does_not_alias_input_binding() {
+        let client = TestRuntime::client(&Default::default());
+        let n = 8usize;
+        let input = client.create_from_slice(f32::as_bytes(&[
+            10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0,
+        ]));
+        let out = client.empty(n * core::mem::size_of::<f32>());
+
+        unsafe {
+            shared_scatter_gather::launch::<TestRuntime>(
+                &client,
+                CubeCount::new_single(),
+                CubeDim::new_1d(1),
+                BufferArg::from_raw_parts(input, n),
+                BufferArg::from_raw_parts(out.clone(), n),
+                n,
+            )
+        }
+
+        let bytes = client.read_one_unchecked(out);
+        let actual = f32::from_bytes(&bytes);
+        // output[k] = input[(k + n - 2) % n]
+        let expected: Vec<f32> = (0..n).map(|k| (10 + (k + n - 2) % n) as f32).collect();
+        assert_eq!(actual, expected.as_slice());
     }
 
     #[test]


### PR DESCRIPTION
Shared memory was reserved from `CpuStream::memory_management`, the same pool that backs kernel input/output tensors. A kernel binding keeps its allocation valid through a `ManagedMemoryBinding`, but that binding does NOT hold the pool reservation (only `ManagedMemoryHandle` does). So `MemoryManagement::reserve` would hand a still-bound input tensor's slice back out for shared memory.

When a kernel then scattered a global load into shared memory at a non-identity index (e.g. the FFT bit-reversed load `mem[bit_reverse(i)] = input[i]`), it was writing over the input in place, corrupting subsequent reads. This produced silent wrong results on the CPU runtime while passing on every GPU backend. It was latent until #1400/#1411 enabled CPU execution on macOS.

`MlirData::new` already takes the pool as `memory_management_shared_memory`; the caller just wired in the wrong one. Give the stream a dedicated "Shared CPU" pool so shared memory can never alias a live tensor binding.