### PR TITLE
fix(runtime): saturate FlushingPolicyState counters to prevent add-overflow panic (#1359)

### DIFF
--- a/crates/cubecl-runtime/src/memory_management/drop_queue/policy.rs
+++ b/crates/cubecl-runtime/src/memory_management/drop_queue/policy.rs
@@ -32,8 +32,10 @@ pub(crate) struct FlushingPolicyState {
 impl FlushingPolicyState {
     /// Record a newly staged [`Bytes`] allocation.
     pub(crate) fn register(&mut self, bytes: &Bytes) {
-        self.bytes_count += 1;
-        self.bytes_size += bytes.len() as u32;
+        self.bytes_count = self.bytes_count.saturating_add(1);
+        self.bytes_size = self
+            .bytes_size
+            .saturating_add(u32::try_from(bytes.len()).unwrap_or(u32::MAX));
     }
 
     /// Reset all counters, typically called after a flush.
@@ -96,6 +98,20 @@ mod policy_tests {
         // Only 2 allocations but already over the size limit.
         s.register(&Bytes::from_elems(vec![0u8; 60]));
         s.register(&Bytes::from_elems(vec![0u8; 60]));
+        assert!(s.should_flush(&policy()));
+    }
+
+    #[test]
+    fn register_saturates_instead_of_overflowing() {
+        // Regression test for #1359: staging allocations without an intervening
+        // reset must not panic with "attempt to add with overflow".
+        let mut s = FlushingPolicyState {
+            bytes_count: u32::MAX,
+            bytes_size: u32::MAX - 1,
+        };
+        s.register(&Bytes::from_elems(vec![0u8; 8]));
+        assert_eq!(s.bytes_count, u32::MAX);
+        assert_eq!(s.bytes_size, u32::MAX);
         assert!(s.should_flush(&policy()));
     }
 


### PR DESCRIPTION
## What

`FlushingPolicyState::register` now accumulates its `bytes_count` and `bytes_size` counters with `saturating_add` instead of `+=`, and converts the allocation length with `u32::try_from(bytes.len()).unwrap_or(u32::MAX)` instead of `as u32`.

## Why

`PendingDropQueue::push()` calls `register()` on every staged `Bytes` allocation, growing the two `u32` counters. Flushing is advisory — the consumer decides when to call `flush()`/`reset()` based on `should_flush()` — so between flushes the counters can grow without bound. On a large workload (reported in #1359 while training a resnet model on a 24 GB GPU; more data-loader workers reproduce it faster) `self.bytes_size += bytes.len() as u32` eventually exceeds `u32::MAX`:

- in debug (overflow-checks on) it panics with `attempt to add with overflow` at `policy.rs`, the site reported in the issue;
- in release it silently wraps, corrupting the flush decision.

`saturating_add` can never panic or wrap. Because `should_flush()` compares with `>=`, saturating at `u32::MAX` never changes the flush decision — once at/over threshold a flush+reset follows. The saturating `usize -> u32` conversion also fixes a latent truncation bug: a single allocation `>= 4 GiB` previously truncated to a small wrong value and could suppress a needed flush; it now counts as `u32::MAX`, guaranteeing a flush.

No public API change (the `u32` fields on `FlushingPolicy` are untouched), the default `max_bytes_size` of 64 MiB means normal configs are unaffected, and no-std/alloc compatibility is preserved.

## Testing

Added `register_saturates_instead_of_overflowing` to the existing `policy_tests` module. It stages an 8-byte allocation on a state whose counters are already at/near `u32::MAX`. On the current code this panics with `attempt to add with overflow` (debug overflow-checks); with the fix the counters saturate and `should_flush` returns `true`.

```
cargo test -p cubecl-runtime -- memory_management::drop_queue::policy
```

All 6 policy tests pass. `cargo fmt --check` and `cargo clippy -p cubecl-runtime --all-targets -- -D warnings` are clean.

Fixes #1359
