### PR TITLE
refactor(benchmark): make Benchmark::sync fallible

### DIFF
--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -206,8 +206,15 @@ pub trait Benchmark {
         vec![]
     }
 
-    /// Wait for computation to complete.
-    fn sync(&self);
+    /// Wait for all queued work to complete, surfacing any error left on the stream.
+    ///
+    /// On asynchronous backends, kernel launches are fire-and-forget: compilation and
+    /// validation errors recorded at launch time, as well as GPU execution faults, may
+    /// only become observable at synchronization. Implementations must return these as
+    /// `Err` — e.g. `block_on(client.sync()).map_err(|err| format!("{err}"))` — rather
+    /// than panic, so a failing benchmark fails its own [`Benchmark::run`] instead of
+    /// aborting the process.
+    fn sync(&self) -> Result<(), String>;
 
     /// Start measuring the computation duration.
     #[cfg(feature = "std")]
@@ -219,10 +226,13 @@ pub trait Benchmark {
     /// device duration is available or not.
     #[cfg(feature = "std")]
     fn profile_full(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        self.sync();
+        // Surfaces faults left queued by previous work before the timer starts.
+        self.sync()?;
         let start_time = Instant::now();
         let out = self.execute(args)?;
-        self.sync();
+        // Surfaces queued launch errors (compilation/validation) and execution
+        // faults belonging to this workload.
+        self.sync()?;
         core::mem::drop(out);
         Ok(ProfileDuration::new_system_time(start_time, Instant::now()))
     }
@@ -231,41 +241,58 @@ pub trait Benchmark {
     #[allow(unused_variables)]
     fn run(&self, timing_method: TimingMethod) -> Result<BenchmarkDurations, String> {
         #[cfg(not(feature = "std"))]
-        panic!("Attempting to run benchmark in a no-std environment");
+        {
+            Err(String::from(
+                "Running a benchmark is not supported in a no-std environment",
+            ))
+        }
 
         #[cfg(feature = "std")]
         {
-            let execute = |args: &Self::Input| {
-                let profile: Result<ProfileDuration, String> = match timing_method {
+            let execute = |args: &Self::Input| -> Result<crate::profile::ProfileTicks, String> {
+                let profile = match timing_method {
                     TimingMethod::System => self.profile_full(args.clone()),
                     TimingMethod::Device => self.profile(args.clone()),
-                };
-                let profile = match profile {
-                    Ok(val) => val,
-                    Err(err) => return Err(err),
-                };
+                }?;
                 Ok(crate::future::block_on(profile.resolve()))
             };
             let args = self.prepare();
 
-            // Triggers JIT-compilation and perform a Warmup
-            //
-            // We are using 5 iterations, where the first one probably triggers the JIT-compilation
-            // and it is then followed by 4 warmup executions.
-            for _ in 0..5 {
-                let _duration: Result<crate::profile::ProfileTicks, _> = execute(&args);
-            }
-
-            // Real execution.
-            let mut durations = Vec::with_capacity(self.num_samples());
-            for _ in 0..self.num_samples() {
-                match execute(&args) {
-                    Ok(val) => durations.push(val.duration()),
-                    Err(err) => {
-                        return Err(err);
-                    }
+            let collect = || -> Result<Vec<Duration>, String> {
+                // Triggers JIT-compilation and performs a warmup.
+                //
+                // We are using 5 iterations, where the first one probably triggers the
+                // JIT-compilation and it is then followed by 4 warmup executions.
+                //
+                // Errors are propagated: JIT compilation happens here, so queued
+                // compilation/launch errors and GPU faults surface at a warmup
+                // sync. Swallowing them would report timings for a strategy that
+                // never ran correctly.
+                for _ in 0..5 {
+                    execute(&args)?;
                 }
-            }
+
+                // Real execution.
+                let mut durations = Vec::with_capacity(self.num_samples());
+                for _ in 0..self.num_samples() {
+                    durations.push(execute(&args)?.duration());
+                }
+                Ok(durations)
+            };
+
+            let result = collect();
+
+            // Drain any failure still queued on the stream, regardless of outcome.
+            // Device-timing overrides of `profile()` bypass the trait's `sync()`
+            // entirely and `ProfileDuration::resolve()` has no error channel, so a
+            // fault from the final samples could otherwise go unreported — or worse,
+            // surface at the NEXT benchmark's leading sync and be misattributed.
+            let drained = self.sync();
+
+            // The in-run error wins; a drain error only surfaces when the run was
+            // otherwise clean.
+            let durations = result?;
+            drained?;
 
             Ok(BenchmarkDurations {
                 timing_method,
@@ -411,5 +438,121 @@ mod tests {
         let mean = durations.mean_duration();
         let variance = durations.variance_duration(mean);
         assert_eq!(variance, Duration::from_secs(200));
+    }
+
+    #[cfg(feature = "std")]
+    mod fallible_sync {
+        use super::super::*;
+        use core::cell::Cell;
+
+        /// A benchmark whose `sync` fails on a chosen call, counting calls so
+        /// tests can target the leading sync, the post-execute sync, or the
+        /// trailing drain in `run()`.
+        struct MockBench {
+            fail_sync_on_call: Option<usize>,
+            sync_calls: Cell<usize>,
+            samples: usize,
+        }
+
+        impl MockBench {
+            fn new(fail_sync_on_call: Option<usize>) -> Self {
+                Self {
+                    fail_sync_on_call,
+                    sync_calls: Cell::new(0),
+                    samples: 3,
+                }
+            }
+        }
+
+        impl Benchmark for MockBench {
+            type Input = ();
+            type Output = ();
+
+            fn prepare(&self) -> Self::Input {}
+
+            fn execute(&self, _input: Self::Input) -> Result<Self::Output, String> {
+                Ok(())
+            }
+
+            fn num_samples(&self) -> usize {
+                self.samples
+            }
+
+            fn name(&self) -> String {
+                String::from("mock")
+            }
+
+            fn sync(&self) -> Result<(), String> {
+                let call = self.sync_calls.get();
+                self.sync_calls.set(call + 1);
+                match self.fail_sync_on_call {
+                    Some(fail_on) if call == fail_on => Err(String::from("queued fault")),
+                    _ => Ok(()),
+                }
+            }
+        }
+
+        #[test_log::test]
+        fn clean_run_returns_num_samples_durations() {
+            let bench = MockBench::new(None);
+            let durations = bench.run(TimingMethod::System).unwrap();
+            assert_eq!(durations.durations.len(), bench.num_samples());
+        }
+
+        #[test_log::test]
+        fn sync_error_during_warmup_fails_the_run() {
+            // Call 1 is the post-execute sync of the first warmup iteration,
+            // where a queued JIT compilation error would surface.
+            let bench = MockBench::new(Some(1));
+            let result = bench.run(TimingMethod::System);
+            assert_eq!(result.unwrap_err(), "queued fault");
+        }
+
+        #[test_log::test]
+        fn sync_error_in_trailing_drain_fails_an_otherwise_clean_run() {
+            // (5 warmups + 3 samples) * 2 syncs in profile_full = 16 calls,
+            // so call 16 is the trailing drain in `run()`.
+            let bench = MockBench::new(Some(16));
+            let result = bench.run(TimingMethod::System);
+            assert_eq!(bench.sync_calls.get(), 17);
+            assert_eq!(result.unwrap_err(), "queued fault");
+        }
+
+        #[test_log::test]
+        fn loop_error_wins_over_drain_error() {
+            struct BothFail {
+                sync_calls: Cell<usize>,
+            }
+            impl Benchmark for BothFail {
+                type Input = ();
+                type Output = ();
+                fn prepare(&self) -> Self::Input {}
+                fn execute(&self, _input: Self::Input) -> Result<Self::Output, String> {
+                    Err(String::from("execute failed"))
+                }
+                fn num_samples(&self) -> usize {
+                    1
+                }
+                fn name(&self) -> String {
+                    String::from("both-fail")
+                }
+                fn sync(&self) -> Result<(), String> {
+                    let call = self.sync_calls.get();
+                    self.sync_calls.set(call + 1);
+                    match call {
+                        // Call 0 is the leading sync of the first warmup; call 1
+                        // is the trailing drain, reached because execute errored.
+                        0 => Ok(()),
+                        _ => Err(String::from("drain failed")),
+                    }
+                }
+            }
+            let bench = BothFail {
+                sync_calls: Cell::new(0),
+            };
+            let result = bench.run(TimingMethod::System);
+            assert_eq!(bench.sync_calls.get(), 2);
+            assert_eq!(result.unwrap_err(), "execute failed");
+        }
     }
 }

--- a/crates/cubecl-metal/src/compute/server.rs
+++ b/crates/cubecl-metal/src/compute/server.rs
@@ -529,9 +529,25 @@ impl ComputeServer for MetalServer {
             Ok(r) => r,
             Err(e) => return Box::pin(async move { Err(e) }),
         };
-        let fence = MetalStreamBackend::flush(resolved.current());
+        let stream = resolved.current();
+        let fence = MetalStreamBackend::flush(stream);
+        let error_sink = stream.errors.clone();
 
-        Box::pin(async move { MetalStreamBackend::wait_event_sync(fence) })
+        Box::pin(async move {
+            MetalStreamBackend::wait_event_sync(fence)?;
+            // Completion handlers may record faults between the pre-wait drain above
+            // and the fence resolving; surface them on this sync rather than leaving
+            // them to poison a later, unrelated call.
+            let errors = core::mem::take(&mut *error_sink.lock().unwrap());
+            if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(ServerError::ServerUnhealthy {
+                    errors,
+                    backtrace: cubecl_common::backtrace::BackTrace::capture(),
+                })
+            }
+        })
     }
 
     fn flush(&mut self, stream_id: StreamId) -> Result<(), ServerError> {
@@ -549,10 +565,11 @@ impl ComputeServer for MetalServer {
     }
 
     fn start_profile(&mut self, stream_id: StreamId) -> Result<ProfilingToken, ServerError> {
-        // Drain prior work so the window only contains command buffers committed from here on.
-        if let Err(err) = cubecl_common::future::block_on(self.sync(stream_id)) {
-            log::warn!("{err}");
-        }
+        // Drain prior work so the window only contains command buffers committed from
+        // here on. Errors are propagated, not swallowed: a fault left by previous work
+        // belongs to its own caller, and discarding it here would let the failure
+        // vanish while the profile reports a valid-looking measurement.
+        cubecl_common::future::block_on(self.sync(stream_id))?;
         // Begin collecting this window's work-bearing command buffers on the stream.
         if let Ok(mut resolved) = self.streams.resolve(stream_id, std::iter::empty(), false) {
             resolved.current().profiling = Some(Vec::new());
@@ -593,6 +610,17 @@ impl ComputeServer for MetalServer {
         // valid once completed, so wait explicitly before reading them.
         for buffer in &buffers {
             buffer.waitUntilCompleted();
+        }
+
+        // The completion handlers have now all run; surface any fault they recorded
+        // after the sync above drained the sink, so a mid-window GPU fault fails this
+        // profile instead of leaking into the next call on the stream.
+        let errors = self.flush_errors(stream_id);
+        if !errors.is_empty() {
+            return Err(ProfileError::Unknown {
+                reason: format!("{errors:?}"),
+                backtrace: cubecl_common::backtrace::BackTrace::capture(),
+            });
         }
 
         // GPU wall-time of the window: latest end minus earliest start across the

--- a/cubecl-book/src/getting-started/benchmark.md
+++ b/cubecl-book/src/getting-started/benchmark.md
@@ -29,14 +29,20 @@ pub trait Benchmark {
     ///
     /// It is important to return the output since otherwise deadcode optimization might optimize
     /// away code that should be benchmarked.
-    fn execute(&self, input: Self::Input) -> Self::Output;
+    fn execute(&self, input: Self::Input) -> Result<Self::Output, String>;
 
     /// Name of the benchmark, should be short and it should match the name
     /// defined in the crate Cargo.toml
     fn name(&self) -> String;
 
-    /// Wait for computation to complete.
-    fn sync(&self);
+    /// Wait for all queued work to complete, surfacing any error left on the stream.
+    ///
+    /// On asynchronous backends, kernel launches are fire-and-forget: compilation and
+    /// validation errors recorded at launch time, as well as GPU execution faults, may
+    /// only become observable at synchronization. Implementations must return these as
+    /// `Err` rather than panic, so a failing benchmark fails its own run instead of
+    /// aborting the process.
+    fn sync(&self) -> Result<(), String>;
 }
 
 ```
@@ -49,7 +55,7 @@ In the `prepare` method, we will create the input data and return a `GpuTensor` 
 ## Running the benchmark
 Now that we have implemented the `Benchmark` trait, we can run the benchmark using the `Benchmark::run` method. This method will execute the benchmark and return the time it took to complete it.
 ```rust,ignore
-{{#rustdoc_include src/bin/v3-gpu.rs:58:81}}
+{{#rustdoc_include src/bin/v3-gpu.rs:58:83}}
 ```
 
 ## The Results

--- a/cubecl-book/src/getting-started/src/bin/v3-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v3-gpu.rs
@@ -22,11 +22,11 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
         format!("{}-reduction-{:?}", R::name(&self.client), self.input_shape).to_lowercase()
     }
 
-    fn sync(&self) {
-        future::block_on(self.client.sync())
+    fn sync(&self) -> Result<(), String> {
+        future::block_on(self.client.sync()).map_err(|err| format!("{err}"))
     }
 
-    fn execute(&self, input: Self::Input) -> Self::Output {
+    fn execute(&self, input: Self::Input) -> Result<Self::Output, String> {
         let output_shape: Vec<usize> = vec![self.input_shape[0]];
         let output = GpuTensor::<R, F>::empty(output_shape, &self.client);
 
@@ -40,7 +40,7 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
             );
         }
 
-        output
+        Ok(output)
     }
 }
 
@@ -71,7 +71,10 @@ pub fn launch<R: Runtime, F: Float + CubeElement>(device: &R::Device) {
 
     for bench in [bench1, bench2] {
         println!("{}", bench.name());
-        println!("{}", bench.run(TimingMethod::System));
+        match bench.run(TimingMethod::System) {
+            Ok(durations) => println!("{durations}"),
+            Err(err) => eprintln!("error: {err}"),
+        }
     }
 }
 

--- a/cubecl-book/src/getting-started/src/bin/v4-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v4-gpu.rs
@@ -22,11 +22,11 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
         format!("{}-reduction-{:?}", R::name(&self.client), self.input_shape).to_lowercase()
     }
 
-    fn sync(&self) {
-        future::block_on(self.client.sync())
+    fn sync(&self) -> Result<(), String> {
+        future::block_on(self.client.sync()).map_err(|err| format!("{err}"))
     }
 
-    fn execute(&self, input: Self::Input) -> Self::Output {
+    fn execute(&self, input: Self::Input) -> Result<Self::Output, String> {
         let output_shape: Vec<usize> = vec![self.input_shape[0]];
         let output = GpuTensor::<R, F>::empty(output_shape, &self.client);
 
@@ -40,7 +40,7 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
             );
         }
 
-        output
+        Ok(output)
     }
 }
 
@@ -69,7 +69,10 @@ pub fn launch<R: Runtime, F: Float + CubeElement>(device: &R::Device) {
 
     for bench in [bench1, bench2] {
         println!("{}", bench.name());
-        println!("{}", bench.run(TimingMethod::System));
+        match bench.run(TimingMethod::System) {
+            Ok(durations) => println!("{durations}"),
+            Err(err) => eprintln!("error: {err}"),
+        }
     }
 }
 

--- a/cubecl-book/src/getting-started/src/bin/v5-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v5-gpu.rs
@@ -24,11 +24,11 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
         format!("{}-reduction-{:?}", R::name(&self.client), self.input_shape).to_lowercase()
     }
 
-    fn sync(&self) {
-        future::block_on(self.client.sync())
+    fn sync(&self) -> Result<(), String> {
+        future::block_on(self.client.sync()).map_err(|err| format!("{err}"))
     }
 
-    fn execute(&self, input: Self::Input) -> Self::Output {
+    fn execute(&self, input: Self::Input) -> Result<Self::Output, String> {
         let output_shape: Vec<usize> = vec![self.input_shape[0]];
         let output = GpuTensor::<R, F>::empty(output_shape, &self.client);
 
@@ -42,7 +42,7 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
             );
         }
 
-        output
+        Ok(output)
     }
 }
 
@@ -72,7 +72,10 @@ pub fn launch<R: Runtime, F: Float + CubeElement>(device: &R::Device) {
 
     for bench in [bench1, bench2] {
         println!("{}", bench.name());
-        println!("{}", bench.run(TimingMethod::System));
+        match bench.run(TimingMethod::System) {
+            Ok(durations) => println!("{durations}"),
+            Err(err) => eprintln!("error: {err}"),
+        }
     }
 }
 

--- a/cubecl-book/src/getting-started/src/bin/v6-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v6-gpu.rs
@@ -24,11 +24,11 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
         format!("{}-reduction-{:?}", R::name(&self.client), self.input_shape).to_lowercase()
     }
 
-    fn sync(&self) {
-        future::block_on(self.client.sync())
+    fn sync(&self) -> Result<(), String> {
+        future::block_on(self.client.sync()).map_err(|err| format!("{err}"))
     }
 
-    fn execute(&self, input: Self::Input) -> Self::Output {
+    fn execute(&self, input: Self::Input) -> Result<Self::Output, String> {
         let output_shape: Vec<usize> = vec![self.input_shape[0]];
         let output = GpuTensor::<R, F>::empty(output_shape, &self.client);
 
@@ -42,7 +42,7 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
             );
         }
 
-        output
+        Ok(output)
     }
 }
 
@@ -72,7 +72,10 @@ pub fn launch<R: Runtime, F: Float + CubeElement>(device: &R::Device) {
 
     for bench in [bench1, bench2] {
         println!("{}", bench.name());
-        println!("{}", bench.run(TimingMethod::System));
+        match bench.run(TimingMethod::System) {
+            Ok(durations) => println!("{durations}"),
+            Err(err) => eprintln!("error: {err}"),
+        }
     }
 }
 

--- a/cubecl-book/src/getting-started/src/bin/v7-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v7-gpu.rs
@@ -24,11 +24,11 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
         format!("{}-reduction-{:?}", R::name(&self.client), self.input_shape).to_lowercase()
     }
 
-    fn sync(&self) {
-        future::block_on(self.client.sync())
+    fn sync(&self) -> Result<(), String> {
+        future::block_on(self.client.sync()).map_err(|err| format!("{err}"))
     }
 
-    fn execute(&self, input: Self::Input) -> Self::Output {
+    fn execute(&self, input: Self::Input) -> Result<Self::Output, String> {
         let output_shape: Vec<usize> = vec![self.input_shape[0]];
         let output = GpuTensor::<R, F>::empty(output_shape, &self.client);
 
@@ -42,7 +42,7 @@ impl<R: Runtime, F: Float + CubeElement> Benchmark for ReductionBench<R, F> {
             );
         }
 
-        output
+        Ok(output)
     }
 }
 
@@ -72,7 +72,10 @@ pub fn launch<R: Runtime, F: Float + CubeElement>(device: &R::Device) {
 
     for bench in [bench1, bench2] {
         println!("{}", bench.name());
-        println!("{}", bench.run(TimingMethod::System));
+        match bench.run(TimingMethod::System) {
+            Ok(durations) => println!("{durations}"),
+            Err(err) => eprintln!("error: {err}"),
+        }
     }
 }
 


### PR DESCRIPTION
On asynchronous backends, kernel launches are fire-and-forget: compilation/validation errors and GPU faults often only become observable at synchronization. Since `sync()` returned `()`, an implementor's only option was `.unwrap()`. That means a single benchmark whose kernel legitimately can't run on the current device (e.g. requesting 40 KiB of shared memory against Apple's 32 KiB limit) aborts the entire benchmark binary instead of failing that one bench. In practice this made full cubek benchmark sweeps impossible to complete on macOS.

`sync` now returns `Result<(), String>`, propagated through `profile_full` and `run()`. Two `run()` changes close holes the signature alone wouldn't fix:
- warmup errors are propagated instead of discarded. Previously a queued JIT-compilation error was consumed invisibly by a warmup sync, and the benchmark reported timings for a kernel that never ran;
- the stream is drained after the samples. Previously, under device timing (where `profile()` overrides bypass the trait's `sync`), a fault from the final samples surfaced at the _next_ benchmark's leading sync and failed the wrong one.

The first commit fixes Metal fault recording during sync/profiling (faults recorded by completion handlers during the fence wait were dropped or misattributed). Standalone fixes, but without them the trait's guarantee wouldn't hold on Metal.

Migration is one line per impl: `block_on(client.sync()).unwrap() → block_on(client.sync()).map_err(|e| format!("{e}"))`. The getting-started examples are updated.