### PR TITLE
Disable persistent tune cache option

### DIFF
--- a/crates/cubecl-runtime/src/config/autotune.rs
+++ b/crates/cubecl-runtime/src/config/autotune.rs
@@ -17,6 +17,12 @@ pub struct AutotuneConfig {
     #[serde(default)]
     #[cfg(std_io)]
     pub cache: CacheConfig,
+
+    /// Whether to disable the persistent cache of autotune results.
+    ///
+    /// The in-memory cache is unaffected: a key is still tuned only once per process.
+    #[serde(default)]
+    pub disable_cache: bool,
 }
 
 /// Log levels for autotune logging in `CubeCL`.

--- a/crates/cubecl-runtime/src/config/base.rs
+++ b/crates/cubecl-runtime/src/config/base.rs
@@ -152,6 +152,18 @@ impl RuntimeConfig for CubeClRuntimeConfig {
             }
         }
 
+        if let Ok(val) = std::env::var("CUBECL_AUTOTUNE_CACHE") {
+            match val.as_str() {
+                "true" | "1" | "on" => {
+                    self.autotune.disable_cache = false;
+                }
+                "false" | "0" | "off" => {
+                    self.autotune.disable_cache = true;
+                }
+                _ => {}
+            }
+        }
+
         self
     }
 }

--- a/crates/cubecl-runtime/src/tune/tune_cache.rs
+++ b/crates/cubecl-runtime/src/tune/tune_cache.rs
@@ -82,8 +82,9 @@ impl PartialEq for AutotuneResult {
 #[derive(Debug)]
 pub(crate) struct TuneCache<K> {
     in_memory_cache: HashMap<K, CacheEntry>,
+    /// `None` when the persistent cache is disabled, so no cache file is ever touched.
     #[cfg(std_io)]
-    persistent_cache: Cache<PersistentCacheKey<K>, PersistentCacheValue>,
+    persistent_cache: Option<Cache<PersistentCacheKey<K>, PersistentCacheValue>>,
 }
 
 /// Result of the cache try
@@ -114,17 +115,23 @@ impl<K: AutotuneKey> TuneCache<K> {
             use crate::config::RuntimeConfig;
             use std::format;
 
-            let root = crate::config::CubeClRuntimeConfig::get()
-                .autotune
-                .cache
-                .root();
+            let config = crate::config::CubeClRuntimeConfig::get();
+
+            if config.autotune.disable_cache {
+                return TuneCache {
+                    in_memory_cache: HashMap::new(),
+                    persistent_cache: None,
+                };
+            }
+
+            let root = config.autotune.cache.root();
             let options = cubecl_common::cache::CacheOption::default();
             let mut cache = TuneCache {
                 in_memory_cache: HashMap::new(),
-                persistent_cache: Cache::new(
+                persistent_cache: Some(Cache::new(
                     format!("{device_id}/{name}"),
                     options.root(root).name("autotune"),
-                ),
+                )),
             };
             cache.load();
             cache
@@ -221,7 +228,11 @@ impl<K: AutotuneKey> TuneCache<K> {
         fastest_index: usize,
         results: Vec<AutotuneResult>,
     ) {
-        if let Err(err) = self.persistent_cache.insert(
+        let Some(persistent_cache) = self.persistent_cache.as_mut() else {
+            return;
+        };
+
+        if let Err(err) = persistent_cache.insert(
             PersistentCacheKey { key, checksum },
             PersistentCacheValue {
                 fastest_index,
@@ -248,9 +259,13 @@ impl<K: AutotuneKey> TuneCache<K> {
 
     /// Load the persistent cache data from disk
     pub(crate) fn load(&mut self) {
+        let Some(persistent_cache) = self.persistent_cache.as_mut() else {
+            return;
+        };
+
         log::info!("Load autotune cache ...");
         let mut loaded = 0;
-        self.persistent_cache.for_each(|key, value| {
+        persistent_cache.for_each(|key, value| {
             loaded += 1;
             self.in_memory_cache.insert(
                 key.key.clone(),


### PR DESCRIPTION
## Key Changes

- Added a `CUBECL_AUTOTUNE_CACHE` environment variable to explicitly bypass cache persistent reading and writing.
- Uses `in_memory_cache` per process.