### PR TITLE
fix(cpu): enforce max_units_per_cube loudly and fix sync_cube scheduling

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/saturating.rs
+++ b/crates/cubecl-core/src/runtime_tests/saturating.rs
@@ -8,9 +8,12 @@ pub fn kernel_saturating_add<I: Int, N: Size>(
     rhs: &[Vector<I, N>],
     output: &mut [Vector<I, N>],
 ) {
-    if (UNIT_POS as usize) < output.len() {
-        output[UNIT_POS as usize] =
-            Vector::<I, N>::saturating_add(lhs[UNIT_POS as usize], rhs[UNIT_POS as usize]);
+    // Unit-strided so the test can clamp the cube dim to the device's
+    // `max_units_per_cube` (e.g. on CPU) while still covering every element.
+    let mut i = UNIT_POS as usize;
+    while i < output.len() {
+        output[i] = Vector::<I, N>::saturating_add(lhs[i], rhs[i]);
+        i += CUBE_DIM as usize;
     }
 }
 
@@ -20,9 +23,10 @@ pub fn kernel_saturating_sub<I: Int, N: Size>(
     rhs: &[Vector<I, N>],
     output: &mut [Vector<I, N>],
 ) {
-    if (UNIT_POS as usize) < output.len() {
-        output[UNIT_POS as usize] =
-            Vector::<I, N>::saturating_sub(lhs[UNIT_POS as usize], rhs[UNIT_POS as usize]);
+    let mut i = UNIT_POS as usize;
+    while i < output.len() {
+        output[i] = Vector::<I, N>::saturating_sub(lhs[i], rhs[i]);
+        i += CUBE_DIM as usize;
     }
 }
 
@@ -59,7 +63,10 @@ pub fn test_saturating_add_unsigned<R: Runtime, I: Int + CubeElement>(
         kernel_saturating_add::launch_unchecked::<I, R>(
             &client,
             CubeCount::new_single(),
-            CubeDim::new_1d(out.len() as u32),
+            CubeDim::new_1d(core::cmp::min(
+                out.len() as u32,
+                client.properties().hardware.max_units_per_cube,
+            )),
             vector_size,
             BufferArg::from_raw_parts(lhs_handle, 4),
             BufferArg::from_raw_parts(rhs_handle, 4),
@@ -100,7 +107,10 @@ pub fn test_saturating_sub_unsigned<R: Runtime, I: Int + CubeElement>(
         kernel_saturating_sub::launch_unchecked::<I, R>(
             &client,
             CubeCount::new_single(),
-            CubeDim::new_1d(out.len() as u32),
+            CubeDim::new_1d(core::cmp::min(
+                out.len() as u32,
+                client.properties().hardware.max_units_per_cube,
+            )),
             vector_size,
             BufferArg::from_raw_parts(lhs_handle, 4),
             BufferArg::from_raw_parts(rhs_handle, 4),
@@ -182,7 +192,10 @@ pub fn test_saturating_add_signed<R: Runtime, I: Int + CubeElement>(
         kernel_saturating_add::launch_unchecked::<I, R>(
             &client,
             CubeCount::new_single(),
-            CubeDim::new_1d(out.len() as u32),
+            CubeDim::new_1d(core::cmp::min(
+                out.len() as u32,
+                client.properties().hardware.max_units_per_cube,
+            )),
             vector_size,
             BufferArg::from_raw_parts(lhs_handle, 16),
             BufferArg::from_raw_parts(rhs_handle, 16),
@@ -264,7 +277,10 @@ pub fn test_saturating_sub_signed<R: Runtime, I: Int + CubeElement>(
         kernel_saturating_sub::launch_unchecked::<I, R>(
             &client,
             CubeCount::new_single(),
-            CubeDim::new_1d(out.len() as u32),
+            CubeDim::new_1d(core::cmp::min(
+                out.len() as u32,
+                client.properties().hardware.max_units_per_cube,
+            )),
             vector_size,
             BufferArg::from_raw_parts(lhs_handle, 16),
             BufferArg::from_raw_parts(rhs_handle, 16),

--- a/crates/cubecl-core/src/runtime_tests/synchronization.rs
+++ b/crates/cubecl-core/src/runtime_tests/synchronization.rs
@@ -16,13 +16,18 @@ fn kernel_test_sync_cube(buffer: &mut [u32], out: &mut [u32]) {
 }
 
 pub fn test_sync_cube<R: Runtime>(client: ComputeClient<R>) {
+    // Clamp the cube dim to the device's limit (e.g. the core count on CPU).
+    let max_units = client.properties().hardware.max_units_per_cube;
+    let dim_x = core::cmp::min(8, (max_units / 2).max(1));
+    let units = (dim_x * 2) as usize;
+
     let handle = client.empty(32 * core::mem::size_of::<u32>());
     let test = client.empty(32 * core::mem::size_of::<u32>());
 
     kernel_test_sync_cube::launch(
         &client,
         CubeCount::Static(1, 1, 1),
-        CubeDim::new_2d(8, 2),
+        CubeDim::new_2d(dim_x, 2),
         unsafe { BufferArg::from_raw_parts(test, 32) },
         unsafe { BufferArg::from_raw_parts(handle.clone(), 32) },
     );
@@ -30,11 +35,11 @@ pub fn test_sync_cube<R: Runtime>(client: ComputeClient<R>) {
     let actual = client.read_one_unchecked(handle);
     let actual = u32::from_bytes(&actual);
 
-    let expected: Vec<u32> = (0..16)
+    let expected: Vec<u32> = (0..units as i32)
         .map(|i| core::cmp::max(2 * i - 1, 0) as u32)
         .collect();
 
-    assert_eq!(&actual[1..16], &expected[1..16]);
+    assert_eq!(&actual[1..units], &expected[1..units]);
 }
 
 #[cube(launch)]
@@ -54,13 +59,18 @@ fn kernel_test_finished_sync_cube(buffer: &mut [u32], out: &mut [u32]) {
 }
 
 pub fn test_finished_sync_cube<R: Runtime>(client: ComputeClient<R>) {
+    // Clamp the cube dim to the device's limit (e.g. the core count on CPU).
+    let max_units = client.properties().hardware.max_units_per_cube;
+    let dim_x = core::cmp::min(8, (max_units / 2).max(1));
+    let checked = core::cmp::min(8, (dim_x * 2) as usize);
+
     let handle = client.empty(32 * core::mem::size_of::<u32>());
     let test = client.empty(32 * core::mem::size_of::<u32>());
 
     kernel_test_finished_sync_cube::launch(
         &client,
         CubeCount::Static(2, 1, 1),
-        CubeDim::new_2d(8, 2),
+        CubeDim::new_2d(dim_x, 2),
         unsafe { BufferArg::from_raw_parts(test, 32) },
         unsafe { BufferArg::from_raw_parts(handle.clone(), 32) },
     );
@@ -68,11 +78,11 @@ pub fn test_finished_sync_cube<R: Runtime>(client: ComputeClient<R>) {
     let actual = client.read_one_unchecked(handle);
     let actual = u32::from_bytes(&actual);
 
-    let expected: Vec<u32> = (0..8)
+    let expected: Vec<u32> = (0..checked as i32)
         .map(|i| core::cmp::max(2 * i - 1, 0) as u32)
         .collect();
 
-    assert_eq!(&actual[1..8], &expected[1..8]);
+    assert_eq!(&actual[1..checked], &expected[1..checked]);
 }
 
 #[cube(launch)]

--- a/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
+++ b/crates/cubecl-cpu/src/compiler/visitor/operation/synchronization.rs
@@ -425,6 +425,9 @@ impl<'a> Visitor<'a> {
     pub fn visit_synchronization(&mut self, synchronization: &Synchronization) {
         match synchronization {
             Synchronization::SyncCube => {
+                // The spin barrier only completes when every unit of the cube runs on its
+                // own thread; the scheduler must not queue two units behind each other.
+                *self.needs_parallelism = true;
                 let func_name = FlatSymbolRefAttribute::new(self.context, "sync_cube");
                 self.block.append_operation(func::call(
                     self.context,


### PR DESCRIPTION
The CPU runtime caps max_units_per_cube at the machine's core count (units are pinned one per worker thread so the sync_cube spin barrier can make progress). Three bugs surrounded that contract:

- Launches exceeding the cap were rejected into the stream error sink and never surfaced: reads returned the stale (usually zeroed) buffer, so downstream tests failed with silent wrong results instead of an error (misdiagnosed in cubek as a wgpu/Vulkan atomics regression). The server now validates cube dims at launch like every other backend, logs the refusal, and read drains the stream and returns any recorded error.

- sync_cube did not set needs_parallelism, so barrier kernels went through the load-balancing scheduler and two units of the same cube could queue behind each other on one worker, deadlocking the barrier whenever the pool wasn't idle.

- The shared runtime tests hardcoded 16-unit cube dims, which violates the (machine-dependent) cap on hosts with fewer than 16 cores; they now clamp to max_units_per_cube. The barrier wait loops also yield between iterations (only when actually waiting) so waiting units don't starve the rest of the process.
