### PR TITLE
fix(msl): compile scalar reductions and atomic refs

### DIFF
--- a/crates/cubecl-cpp/src/metal/address_space.rs
+++ b/crates/cubecl-cpp/src/metal/address_space.rs
@@ -88,6 +88,11 @@ impl<D: Dialect> From<&Variable<D>> for AddressSpace {
             | Variable::UnitPosPlane => AddressSpace::None,
             Variable::GlobalInputArray(..) => AddressSpace::ConstDevice,
             Variable::GlobalOutputArray(..) => AddressSpace::Device,
+            Variable::LocalConst { item, .. }
+                if matches!(item.elem, crate::shared::Elem::Atomic(_)) =>
+            {
+                AddressSpace::Device
+            }
             Variable::GlobalScalar { .. } => {
                 if value.is_const() {
                     AddressSpace::ConstDevice

--- a/crates/cubecl-cpp/src/metal/dialect.rs
+++ b/crates/cubecl-cpp/src/metal/dialect.rs
@@ -38,14 +38,14 @@ impl MslDialect {
         let out = out.fmt_left();
         let vectorization = input.item().vectorization;
 
+        if vectorization == 1 {
+            return writeln!(f, "{out} = {simd_op_prefix}{input}{simd_op_suffix};");
+        }
+
         f.write_fmt(format_args!("{out} = {} {{", input.item()))?;
 
         for k in 0..vectorization {
-            let index = if vectorization > 1 {
-                format!(".i_{k}")
-            } else {
-                String::new()
-            };
+            let index = format!(".i_{k}");
             let comma = if k + 1 < vectorization { "," } else { "" };
 
             writeln!(f, "{simd_op_prefix}{input}{index}{simd_op_suffix}{comma}")?;
@@ -1310,5 +1310,45 @@ impl DialectWmmaCompiler<Self> for MslDialect {
 impl DialectProcessors<Self> for MslDialect {
     fn processors() -> Vec<Box<dyn gpu::Processor>> {
         Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct WarpReduceSum<'a> {
+        input: &'a Variable<MslDialect>,
+        out: &'a Variable<MslDialect>,
+    }
+
+    impl Display for WarpReduceSum<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            MslDialect::warp_reduce_sum(f, self.input, self.out)
+        }
+    }
+
+    #[test]
+    fn scalar_warp_reduction_does_not_use_aggregate_initialization() {
+        let item = Item::scalar(Elem::F32, false);
+        let input = Variable::LocalConst { id: 1, item };
+        let out = Variable::LocalConst { id: 2, item };
+
+        assert_eq!(
+            WarpReduceSum {
+                input: &input,
+                out: &out
+            }
+            .to_string(),
+            "const float l_2 = simd_sum(l_1);\n"
+        );
+    }
+
+    #[test]
+    fn atomic_local_reference_keeps_device_address_space() {
+        let item = Item::scalar(Elem::Atomic(AtomicKind::F32), false);
+        let atomic_ref = Variable::<MslDialect>::LocalConst { id: 1, item };
+
+        assert_eq!(atomic_ref.fmt_left(), "device atomic_float* l_1");
     }
 }

--- a/crates/cubecl-cpp/src/shared/variable.rs
+++ b/crates/cubecl-cpp/src/shared/variable.rs
@@ -585,7 +585,8 @@ impl<D: Dialect> FmtLeft for Variable<D> {
         match self {
             Self::LocalConst { item, .. } => match item.elem {
                 Elem::Atomic(_) => {
-                    format!("{item}* {self}")
+                    let addr_space = D::address_space_for_variable(self);
+                    format!("{addr_space}{item}* {self}")
                 }
                 _ => {
                     format!("const {item} {self}")


### PR DESCRIPTION
## Summary

- emit scalar Metal SIMD reductions as direct scalar assignments instead of aggregate initialization
- preserve the `device` address space when assigning an indexed atomic buffer reference to a local
- add focused regression tests for both generated MSL forms

## Failure mode

A scalar plane reduction generated invalid MSL such as:

```metal
const float result = float {simd_sum(value)};
```

An indexed global atomic could also lose its address space when copied:

```metal
device atomic_float* indexed = &buffer[index];
atomic_float* local = indexed;
```

The patch emits a direct scalar `simd_sum` assignment and keeps `device atomic_float*` on the local declaration.

## Validation

- `cargo test -p cubecl-cpp`
- downstream Burn/CubeCL selective-scan forward and autodiff backward kernels compile and match an NdArray reference on Metal
