### PR TITLE
Add address_type=auto

### DIFF
--- a/crates/cubecl-core/src/compute/launcher.rs
+++ b/crates/cubecl-core/src/compute/launcher.rs
@@ -6,7 +6,7 @@ use crate::prelude::{BufferArg, TensorArg, TensorMapArg, TensorMapKind};
 use crate::{InfoBuilder, KernelSettings, ScalarArgType};
 #[cfg(feature = "std")]
 use core::cell::RefCell;
-use cubecl_ir::{AddressType, Scope, StorageType, Type};
+use cubecl_ir::{Scope, StorageType, Type};
 use cubecl_runtime::server::{Binding, CubeCount, TensorMapBinding};
 use cubecl_runtime::{
     client::ComputeClient,
@@ -21,11 +21,44 @@ std::thread_local! {
     static SCOPE: RefCell<Scope> = RefCell::new(Scope::root(false));
 }
 
+/// Context used to resolve launch argument types before creating a [`KernelLauncher`].
+///
+/// Keeping type resolution separate allows launch settings, including the address type, to be
+/// finalized before the launcher starts registering arguments.
+pub struct LaunchContext {
+    #[cfg(not(feature = "std"))]
+    pub scope: Scope,
+}
+
+impl LaunchContext {
+    pub fn new() -> Self {
+        Self {
+            #[cfg(not(feature = "std"))]
+            scope: Scope::root(false),
+        }
+    }
+
+    #[cfg(feature = "std")]
+    pub fn with_scope<T>(&self, fun: impl FnOnce(&Scope) -> T) -> T {
+        SCOPE.with_borrow(fun)
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn with_scope<T>(&self, fun: impl FnOnce(&Scope) -> T) -> T {
+        fun(&self.scope)
+    }
+}
+
+impl Default for LaunchContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Prepare a kernel for [launch](KernelLauncher::launch).
 pub struct KernelLauncher<R: Runtime> {
     buffers: Vec<Binding>,
     tensor_maps: Vec<TensorMapBinding>,
-    address_type: AddressType,
     pub settings: KernelSettings,
     #[cfg(not(feature = "std"))]
     info: InfoBuilder,
@@ -36,12 +69,12 @@ pub struct KernelLauncher<R: Runtime> {
 
 impl<R: Runtime> KernelLauncher<R> {
     #[cfg(feature = "std")]
-    pub fn with_scope<T>(&mut self, fun: impl FnMut(&Scope) -> T) -> T {
+    pub fn with_scope<T>(&self, fun: impl FnOnce(&Scope) -> T) -> T {
         SCOPE.with_borrow(fun)
     }
 
     #[cfg(not(feature = "std"))]
-    pub fn with_scope<T>(&mut self, mut fun: impl FnMut(&Scope) -> T) -> T {
+    pub fn with_scope<T>(&self, fun: impl FnOnce(&Scope) -> T) -> T {
         fun(&self.scope)
     }
 
@@ -113,7 +146,7 @@ impl<R: Runtime> KernelLauncher<R> {
     /// is up to the runtime.
     fn into_bindings(mut self) -> KernelArguments {
         let mut bindings = KernelArguments::new();
-        let address_type = self.address_type;
+        let address_type = self.settings.address_type;
         let info = self.with_info(|info| info.finish(address_type));
 
         bindings.buffers = self.buffers;
@@ -141,7 +174,7 @@ impl<R: Runtime> KernelLauncher<R> {
 
         let elem_size = ty.size();
         let buffer_len = tensor.handle.size_in_used() / elem_size as u64;
-        let address_type = self.address_type;
+        let address_type = self.settings.address_type;
 
         self.with_info(|info| {
             info.metadata.register_tensor(
@@ -169,7 +202,7 @@ impl<R: Runtime> KernelLauncher<R> {
 
         let elem_size = ty.size();
         let buffer_len = array.handle.size_in_used() / elem_size as u64;
-        let address_type = self.address_type;
+        let address_type = self.settings.address_type;
         self.with_info(|info| info.metadata.register_buffer(buffer_len, address_type));
         Some(array.handle)
     }
@@ -187,8 +220,14 @@ impl<R: Runtime> KernelLauncher<R> {
 
 impl<R: Runtime> KernelLauncher<R> {
     pub fn new(settings: KernelSettings) -> Self {
+        Self::new_with_context(settings, LaunchContext::new())
+    }
+
+    /// Create a launcher from a context that has already resolved its argument types.
+    pub fn new_with_context(settings: KernelSettings, context: LaunchContext) -> Self {
+        context.with_scope(|scope| settings.address_type.register(scope));
+
         Self {
-            address_type: settings.address_type,
             settings,
             buffers: Vec::new(),
             tensor_maps: Vec::new(),
@@ -196,7 +235,7 @@ impl<R: Runtime> KernelLauncher<R> {
             #[cfg(not(feature = "std"))]
             info: InfoBuilder::default(),
             #[cfg(not(feature = "std"))]
-            scope: Scope::root(false),
+            scope: context.scope,
         }
     }
 }

--- a/crates/cubecl-core/src/frontend/comptime_option.rs
+++ b/crates/cubecl-core/src/frontend/comptime_option.rs
@@ -89,6 +89,13 @@ impl<T: LaunchArg + 'static + CubeType> LaunchArg for ComptimeOption<T> {
         }
     }
 
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        match arg {
+            ComptimeOptionArgs::Some(arg) => T::required_address_type::<R>(arg, scope),
+            ComptimeOptionArgs::None => AddressType::U32,
+        }
+    }
+
     fn expand(
         arg: &Self::CompilationArg,
         builder: &mut KernelBuilder,

--- a/crates/cubecl-core/src/frontend/container/sequence/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/sequence/launch.rs
@@ -5,7 +5,7 @@ use cubecl_zspace::SmallVec;
 
 use crate::{
     compute::{KernelBuilder, KernelLauncher},
-    prelude::{CubeType, LaunchArg},
+    prelude::{AddressType, CubeType, LaunchArg, Scope},
 };
 
 use super::{Sequence, SequenceExpand};
@@ -75,6 +75,14 @@ impl<C: LaunchArg + CubeType + 'static> LaunchArg for Sequence<C> {
             .into_iter()
             .map(|arg| C::register(arg, launcher))
             .collect()
+    }
+
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        arg.values
+            .iter()
+            .fold(AddressType::U32, |address_type, arg| {
+                address_type.max(C::required_address_type::<R>(arg, scope))
+            })
     }
 
     fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> SequenceExpand<C> {

--- a/crates/cubecl-core/src/frontend/container/slice/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/slice/launch.rs
@@ -82,6 +82,15 @@ impl<R: Runtime> BufferArg<R> {
             BufferArg::Alias { length, .. } => length,
         }
     }
+
+    /// Address type required to fully index the underlying buffer.
+    pub fn required_address_type(&self, elem_size: usize) -> AddressType {
+        let len = match self {
+            BufferArg::Handle { handle } => handle.handle.size_in_used() / elem_size as u64,
+            BufferArg::Alias { length, .. } => length[0] as u64,
+        };
+        AddressType::from_len_u64(len)
+    }
 }
 
 impl<R: Runtime> BufferBinding<R> {
@@ -134,6 +143,10 @@ impl<C: CubePrimitive> LaunchArg for Box<[C]> {
         <[C]>::register(arg, launcher)
     }
 
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        <[C]>::required_address_type::<R>(arg, scope)
+    }
+
     fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> NativeExpand<Box<[C]>> {
         <[C]>::expand(arg, builder).expand.into()
     }
@@ -155,6 +168,10 @@ impl<C: CubePrimitive> LaunchArg for [C] {
         launcher.register_buffer(arg, ty);
 
         BufferCompilationArg { inplace }
+    }
+
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        arg.required_address_type(C::__expand_type_size(scope))
     }
 
     fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> NativeExpand<[C]> {

--- a/crates/cubecl-core/src/frontend/container/tensor/launch.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/launch.rs
@@ -64,7 +64,7 @@ impl<R: Runtime> TensorBinding<R> {
 
     /// Address type required to fully index this tensor handle, assuming scalar access.
     pub fn required_address_type(&self, elem_size: usize) -> AddressType {
-        AddressType::from_len(self.handle.size() as usize / elem_size)
+        AddressType::from_len_u64(self.handle.size_in_used() / elem_size as u64)
     }
 }
 
@@ -107,6 +107,10 @@ impl<C: CubePrimitive> LaunchArg for Tensor<C> {
         TensorCompilationArg { meta, buffer }
     }
 
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        arg.required_address_type(C::__expand_type_size(scope))
+    }
+
     fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> TensorExpand<C> {
         let buffer = match arg.buffer.inplace {
             Some(id) => builder.inplace(id),
@@ -130,6 +134,10 @@ impl<C: CubePrimitive> LaunchArg for OwnedTensor<C> {
         launcher: &mut KernelLauncher<R>,
     ) -> Self::CompilationArg {
         Tensor::<C>::register(arg, launcher)
+    }
+
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        Tensor::<C>::required_address_type::<R>(arg, scope)
     }
 
     fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> OwnedTensorExpand<C> {
@@ -194,6 +202,21 @@ impl<R: Runtime> TensorArg<R> {
         match self {
             TensorArg::Handle { handle } => &handle.strides,
             TensorArg::Alias { strides, .. } => strides,
+        }
+    }
+
+    /// Address type required to fully index the underlying buffer.
+    pub fn required_address_type(&self, elem_size: usize) -> AddressType {
+        match self {
+            TensorArg::Handle { handle } => handle.required_address_type(elem_size),
+            TensorArg::Alias { shape, .. } => {
+                let len = shape
+                    .iter()
+                    .copied()
+                    .try_fold(1usize, usize::checked_mul)
+                    .unwrap_or(usize::MAX);
+                AddressType::from_len(len)
+            }
         }
     }
 }

--- a/crates/cubecl-core/src/frontend/container/tensor/tensormap.rs
+++ b/crates/cubecl-core/src/frontend/container/tensor/tensormap.rs
@@ -164,6 +164,11 @@ impl<E: CubePrimitive, K: TensorMapKind> LaunchArg for TensorMap<E, K> {
         launcher.register_tensor_map(arg, ty);
     }
 
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        arg.tensor
+            .required_address_type(E::__expand_type_size(scope))
+    }
+
     fn expand(
         _arg: &Self::CompilationArg,
         builder: &mut KernelBuilder,

--- a/crates/cubecl-core/src/frontend/element/base.rs
+++ b/crates/cubecl-core/src/frontend/element/base.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloc::{boxed::Box, vec::Vec};
 use core::{fmt::Debug, marker::PhantomData};
 use cubecl_common::{e2m1, e2m1x2, e2m3, e3m2, e4m3, e5m2, flex32, tf32, ue8m0};
-use cubecl_ir::{AddressSpace, Type, VectorSize};
+use cubecl_ir::{AddressSpace, AddressType, Type, VectorSize};
 use cubecl_runtime::runtime::Runtime;
 use half::{bf16, f16};
 use variadics_please::{all_tuples, all_tuples_enumerated};
@@ -456,6 +456,18 @@ pub trait LaunchArg: CubeType + 'static {
         launcher: &mut KernelLauncher<R>,
     ) -> Self::CompilationArg;
 
+    /// Return the address type required by this runtime argument.
+    ///
+    /// Implementations containing buffers should return the type required to index their largest
+    /// buffer. Composite implementations should return the maximum required by their fields. The
+    /// default is suitable only for arguments that don't contain buffers.
+    fn required_address_type<R: Runtime>(
+        _arg: &Self::RuntimeArg<R>,
+        _scope: &Scope,
+    ) -> AddressType {
+        AddressType::U32
+    }
+
     /// Register a variable during compilation that fill the [`KernelBuilder`].
     fn expand(
         arg: &Self::CompilationArg,
@@ -474,6 +486,13 @@ macro_rules! impl_launch_arg_ref {
                 launcher: &mut KernelLauncher<R>,
             ) -> Self::CompilationArg {
                 T::register(arg, launcher)
+            }
+
+            fn required_address_type<R: Runtime>(
+                arg: &Self::RuntimeArg<R>,
+                scope: &Scope,
+            ) -> AddressType {
+                T::required_address_type::<R>(arg, scope)
             }
 
             fn expand(
@@ -501,6 +520,11 @@ macro_rules! launch_tuple {
             fn register<R: Runtime>(runtime_arg: Self::RuntimeArg<R>, launcher: &mut KernelLauncher<R>) -> Self::CompilationArg {
                 let ($($t,)*) = runtime_arg;
                 ($($T::register($t, launcher),)*)
+            }
+
+            fn required_address_type<R: Runtime>(runtime_arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+                let ($($t,)*) = runtime_arg;
+                AddressType::U32$(.max($T::required_address_type::<R>($t, scope)))*
             }
 
             fn expand(arg: &Self::CompilationArg, builder: &mut KernelBuilder) -> ($(<$T as CubeType>::ExpandType,)*) {

--- a/crates/cubecl-core/src/frontend/runtime_option.rs
+++ b/crates/cubecl-core/src/frontend/runtime_option.rs
@@ -44,6 +44,13 @@ impl<T: LaunchArg + CubeType + Default + IntoRuntime + 'static> LaunchArg for Op
         }
     }
 
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        match arg {
+            OptionArgs::Some(arg) => T::required_address_type::<R>(arg, scope),
+            OptionArgs::None => AddressType::U32,
+        }
+    }
+
     fn expand(
         arg: &Self::CompilationArg,
         builder: &mut KernelBuilder,

--- a/crates/cubecl-core/src/frontend/tensor_layout.rs
+++ b/crates/cubecl-core/src/frontend/tensor_layout.rs
@@ -251,6 +251,10 @@ impl<T: CubePrimitive> LaunchArg for TensorView<T> {
         TensorViewBuilder::<T>::register(arg, launcher)
     }
 
+    fn required_address_type<R: Runtime>(arg: &Self::RuntimeArg<R>, scope: &Scope) -> AddressType {
+        TensorViewBuilder::<T>::required_address_type::<R>(arg, scope)
+    }
+
     fn expand(
         arg: &Self::CompilationArg,
         builder: &mut KernelBuilder,

--- a/crates/cubecl-core/src/prelude.rs
+++ b/crates/cubecl-core/src/prelude.rs
@@ -2,7 +2,7 @@ pub use crate::{
     CubeLaunch, CubeType, RuntimeArg,
     codegen::{KernelExpansion, KernelIntegrator, KernelSettings},
     comment, comptime, comptime_type,
-    compute::{KernelBuilder, KernelLauncher},
+    compute::{KernelBuilder, KernelLauncher, LaunchContext},
     cube, derive_cube_comptime,
     frontend::*,
     pod::CubeElement,

--- a/crates/cubecl-core/src/runtime_tests/launch.rs
+++ b/crates/cubecl-core/src/runtime_tests/launch.rs
@@ -13,6 +13,15 @@ pub struct ComptimeTag {
     tag: String,
 }
 
+#[derive(CubeLaunch, CubeType)]
+#[allow(dead_code)]
+pub struct AutoAddressingArgs {
+    input: Box<[f32]>,
+    alias: Box<[f32]>,
+    output: Box<[f32]>,
+    max: usize,
+}
+
 #[cube(launch)]
 pub fn kernel_with_comptime_tag(mut output: ComptimeTag) {
     if UNIT_POS == 0 {
@@ -42,6 +51,13 @@ pub fn kernel_without_generics(output: &mut [f32]) {
 pub fn kernel_dynamic_addressing(output: &mut [f32]) {
     if UNIT_POS == 0 {
         output[0] = 5.0;
+    }
+}
+
+#[cube(launch, address_type = "auto")]
+pub fn kernel_auto_addressing(mut args: AutoAddressingArgs) {
+    if UNIT_POS == 0 {
+        args.output[0] = if args.max + 1 == 0 { 32.0f32 } else { 64.0f32 };
     }
 }
 
@@ -371,6 +387,44 @@ pub fn test_kernel_dynamic_addressing<R: Runtime>(
     assert_eq!(actual[0], 5.0);
 }
 
+pub fn test_kernel_auto_addressing<R: Runtime>(client: ComputeClient<R>, expected: AddressType) {
+    if !client.properties().supports_address(expected) {
+        println!("Skipping automatic addressing kernel, no type support");
+        return;
+    }
+
+    let alias_len = match expected {
+        AddressType::U32 => 2,
+        AddressType::U64 => match usize::try_from(u32::MAX as u64 + 1) {
+            Ok(len) => len,
+            Err(_) => return,
+        },
+    };
+    let input = client.create_from_slice(f32::as_bytes(&[1.0, 0.0]));
+    let output = client.create_from_slice(f32::as_bytes(&[0.0, 0.0]));
+
+    kernel_auto_addressing::launch(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_1d(1),
+        AutoAddressingArgsLaunch::new(
+            unsafe { BufferArg::from_raw_parts(input, 2) },
+            BufferArg::alias(0, alias_len),
+            unsafe { BufferArg::from_raw_parts(output.clone(), 2) },
+            u32::MAX as usize,
+        ),
+    );
+
+    let actual = client.read_one_unchecked(output);
+    let actual = f32::from_bytes(&actual);
+
+    let expected = match expected {
+        AddressType::U32 => 32.0,
+        AddressType::U64 => 64.0,
+    };
+    assert_eq!(actual[0], expected);
+}
+
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! testgen_launch {
@@ -449,6 +503,24 @@ macro_rules! testgen_launch_untyped {
         fn test_launch_dynamic_addressing_64() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::launch::test_kernel_dynamic_addressing::<TestRuntime>(
+                client,
+                AddressType::U64,
+            );
+        }
+
+        #[test]
+        fn test_launch_auto_addressing_32() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::launch::test_kernel_auto_addressing::<TestRuntime>(
+                client,
+                AddressType::U32,
+            );
+        }
+
+        #[test]
+        fn test_launch_auto_addressing_64() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::launch::test_kernel_auto_addressing::<TestRuntime>(
                 client,
                 AddressType::U64,
             );

--- a/crates/cubecl-ir/src/address.rs
+++ b/crates/cubecl-ir/src/address.rs
@@ -24,7 +24,12 @@ impl core::fmt::Display for AddressType {
 impl AddressType {
     /// Pick an address type based on the number of elements in a buffer.
     pub fn from_len(num_elems: usize) -> Self {
-        if num_elems > u32::MAX as usize {
+        Self::from_len_u64(num_elems as u64)
+    }
+
+    /// Pick an address type based on the number of elements in a buffer.
+    pub fn from_len_u64(num_elems: u64) -> Self {
+        if num_elems > u32::MAX as u64 {
             AddressType::U64
         } else {
             AddressType::U32
@@ -65,5 +70,19 @@ impl AddressType {
             AddressType::U32 => size_of::<u32>(),
             AddressType::U64 => size_of::<u64>(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AddressType;
+
+    #[test]
+    fn address_type_from_u64_len() {
+        assert_eq!(AddressType::from_len_u64(u32::MAX as u64), AddressType::U32);
+        assert_eq!(
+            AddressType::from_len_u64(u32::MAX as u64 + 1),
+            AddressType::U64
+        );
     }
 }

--- a/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_enum.rs
@@ -332,6 +332,64 @@ impl CubeTypeEnum {
         }
     }
 
+    pub(crate) fn required_address_type_impl(&self) -> proc_macro2::TokenStream {
+        let launch_arg = prelude_type("LaunchArg");
+        let address_type = prelude_type("AddressType");
+        let scope = prelude_type("Scope");
+        let name = Ident::new(&format!("{}Args", self.ident), Span::call_site());
+
+        let body = self.match_impl(
+            quote! {arg},
+            self.variants
+                .iter()
+                .map(|variant| {
+                    let variant_name = &variant.ident;
+                    match variant.kind {
+                        VariantKind::Named => {
+                            let args = &variant.field_names;
+                            let required = args.iter().zip(&variant.fields).map(|(name, field)| {
+                                let ty = &field.ty;
+                                quote![.max(<#ty as #launch_arg>::required_address_type::<R>(#name, scope))]
+                            });
+                            quote! {
+                                #name::#variant_name { #(#args),* } => {
+                                    #address_type::U32 #(#required)*
+                                }
+                            }
+                        }
+                        VariantKind::Unnamed => {
+                            let args = variant
+                                .fields
+                                .iter()
+                                .enumerate()
+                                .map(|(i, _)| Ident::new(&format!("_{i}"), Span::call_site()))
+                                .collect::<Vec<_>>();
+                            let required = args.iter().zip(&variant.fields).map(|(name, field)| {
+                                let ty = &field.ty;
+                                quote![.max(<#ty as #launch_arg>::required_address_type::<R>(#name, scope))]
+                            });
+                            quote! {
+                                #name::#variant_name(#(#args),*) => {
+                                    #address_type::U32 #(#required)*
+                                }
+                            }
+                        }
+                        VariantKind::Empty => quote![#name::#variant_name => #address_type::U32],
+                    }
+                })
+                .collect(),
+        );
+
+        quote! {
+            fn required_address_type<R: Runtime>(
+                arg: &Self::RuntimeArg<R>,
+                scope: &#scope,
+            ) -> #address_type {
+                #body
+            }
+        }
+    }
+
     fn launch_arg_impl(&self) -> proc_macro2::TokenStream {
         let launch_arg = prelude_type("LaunchArg");
         let cube_type = prelude_type("CubeType");
@@ -350,6 +408,7 @@ impl CubeTypeEnum {
         let (_, all_generic_names, _) = all.split_for_impl();
 
         let register_impl = self.register_impl();
+        let required_address_type_impl = self.required_address_type_impl();
 
         let body_expand = self.launch_arg_expand_body();
 
@@ -359,6 +418,7 @@ impl CubeTypeEnum {
                 type CompilationArg = #compilation_arg #generic_names;
 
                 #register_impl
+                #required_address_type_impl
 
                 fn expand(arg: &Self::CompilationArg, builder: &mut #kernel_builder) -> <Self as #cube_type>::ExpandType {
                     #body_expand

--- a/crates/cubecl-macros/src/generate/cube_type/generate_runtime_enum.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_runtime_enum.rs
@@ -433,6 +433,53 @@ impl CubeTypeEnum {
         }
     }
 
+    fn required_address_type_impl_runtime(&self) -> proc_macro2::TokenStream {
+        let launch_arg = prelude_type("LaunchArg");
+        let address_type = prelude_type("AddressType");
+        let scope = prelude_type("Scope");
+        let args_name = Ident::new(&format!("{}Args", self.ident), Span::call_site());
+        let launch_name = Ident::new(&format!("{}Launch", self.ident), Span::call_site());
+        let value_ty = self.value_ty();
+
+        let body = self.match_impl(
+            quote! {value},
+            self.variants
+                .iter()
+                .map(|variant| {
+                    let name = &variant.ident;
+                    match variant.kind {
+                        VariantKind::Named => unimplemented!(),
+                        VariantKind::Unnamed => quote! {
+                            #args_name::#name(value) => {
+                                <#value_ty as #launch_arg>::required_address_type::<R>(value, scope)
+                            }
+                        },
+                        VariantKind::Empty => quote! {
+                            #args_name::#name => {
+                                <#value_ty as #launch_arg>::required_address_type::<R>(
+                                    &Default::default(),
+                                    scope,
+                                )
+                            }
+                        },
+                    }
+                })
+                .collect(),
+        );
+
+        quote! {
+            fn required_address_type<R: Runtime>(
+                arg: &Self::RuntimeArg<R>,
+                scope: &#scope,
+            ) -> #address_type {
+                let value = match arg {
+                    #launch_name::Comptime(value) | #launch_name::Runtime(value) => value,
+                };
+                #body
+            }
+        }
+    }
+
     fn launch_arg_impl_runtime(&self) -> proc_macro2::TokenStream {
         let launch_arg = prelude_type("LaunchArg");
         let cube_type = prelude_type("CubeType");
@@ -451,6 +498,7 @@ impl CubeTypeEnum {
         let (_, all_generic_names, _) = all.split_for_impl();
 
         let register_impl_runtime = self.register_impl_runtime();
+        let required_address_type_impl_runtime = self.required_address_type_impl_runtime();
 
         let value_ty = self.value_ty();
 
@@ -460,6 +508,7 @@ impl CubeTypeEnum {
                 type CompilationArg = #compilation_arg #generic_names;
 
                 #register_impl_runtime
+                #required_address_type_impl_runtime
 
                 fn expand(arg: &Self::CompilationArg, builder: &mut #kernel_builder) -> <Self as #cube_type>::ExpandType {
                     match arg {

--- a/crates/cubecl-macros/src/generate/cube_type/generate_struct.rs
+++ b/crates/cubecl-macros/src/generate/cube_type/generate_struct.rs
@@ -222,6 +222,8 @@ impl CubeTypeStruct {
     fn launch_arg_impl(&self) -> proc_macro2::TokenStream {
         let launch_arg = prelude_type("LaunchArg");
         let cube_type = prelude_type("CubeType");
+        let address_type = prelude_type("AddressType");
+        let scope = prelude_type("Scope");
         let body_input =
             self.fields
                 .iter()
@@ -242,6 +244,16 @@ impl CubeTypeStruct {
         let where_clause = self.launch_arg_where();
 
         let register_impl = self.register_impl();
+        let required_address_types = self
+            .fields
+            .iter()
+            .map(TypeField::split)
+            .filter(|field| !field.3)
+            .map(|(_, name, ty, _)| {
+                quote! {
+                    .max(<#ty as #launch_arg>::required_address_type::<R>(&arg.#name, scope))
+                }
+            });
 
         let (_, compilation_generics, _) = self.generics.split_for_impl();
         let assoc_generics = self.assoc_generics();
@@ -259,6 +271,13 @@ impl CubeTypeStruct {
                 type CompilationArg = #compilation_ident #compilation_generics;
 
                 #register_impl
+
+                fn required_address_type<R: Runtime>(
+                    arg: &Self::RuntimeArg<R>,
+                    scope: &#scope,
+                ) -> #address_type {
+                    #address_type::U32 #(#required_address_types)*
+                }
 
                 fn expand(
                     arg: &Self::CompilationArg,

--- a/crates/cubecl-macros/src/generate/launch.rs
+++ b/crates/cubecl-macros/src/generate/launch.rs
@@ -136,6 +136,7 @@ impl Launch {
 
     fn launch_body(&self) -> TokenStream {
         let kernel_launcher = prelude_type("KernelLauncher");
+        let launch_context = prelude_type("LaunchContext");
 
         let mappings = self.func.sig.define_mappings();
         let generic_registers =
@@ -143,7 +144,8 @@ impl Launch {
                 .analysis
                 .register_types(mappings, quote![scope], false, true);
 
-        let settings = self.configure_settings();
+        let settings = self.configure_settings(true);
+        let auto_address_type = self.configure_auto_address_type();
         let kernel_name = self.kernel_name();
         let kernel_generics = self.kernel_call_generics();
         let kernel_generics = kernel_generics.split_for_impl();
@@ -152,31 +154,70 @@ impl Launch {
         let (registers, args) = self.arg_registers();
 
         quote! {
-            #settings
-
-            let mut launcher = #kernel_launcher::<__R>::new(__settings.clone());
-            launcher.with_scope(|scope| {
+            let __launch_context = #launch_context::new();
+            __launch_context.with_scope(|scope| {
                 scope.device_properties(__client.properties());
                 #generic_registers
             });
 
+            #auto_address_type
+            #settings
+
+            let mut launcher = #kernel_launcher::<__R>::new_with_context(
+                __settings.clone(),
+                __launch_context,
+            );
             #registers
             let __kernel = #kernel_name #kernel_generics::new(__settings, __client.clone(), #args #(#comptime_args),*);
         }
     }
 
-    fn configure_settings(&self) -> TokenStream {
+    fn configure_settings(&self, auto_resolved: bool) -> TokenStream {
         let kernel_settings = prelude_type("KernelSettings");
         let addr_ty = prelude_type("AddressType");
         let address_type = match self.args.address_type {
             AddressType::U32 => quote![#addr_ty::U32],
             AddressType::U64 => quote![#addr_ty::U64],
             AddressType::Dynamic => quote![__address_type],
+            AddressType::Auto if auto_resolved => quote![__address_type],
+            AddressType::Auto => quote![#addr_ty::U32],
         };
 
         quote! {
-            let mut __settings = #kernel_settings::default()
+            let __settings = #kernel_settings::default()
                 .cube_dim(__cube_dim).address_type(#address_type);
+        }
+    }
+
+    fn configure_auto_address_type(&self) -> TokenStream {
+        if self.args.address_type != AddressType::Auto {
+            return TokenStream::new();
+        }
+
+        let launch_arg = prelude_type("LaunchArg");
+        let address_type = prelude_type("AddressType");
+        let required_address_types = self.runtime_params().map(|input| {
+            let ty = strip_ref(input.ty.clone());
+            let ty = anon_lifetime_to_static(ty);
+            let name = &input.name;
+            quote! {
+                __address_type = __address_type.max(
+                    <#ty as #launch_arg>::required_address_type::<__R>(&#name, scope)
+                );
+            }
+        });
+
+        quote! {
+            let __address_type = __launch_context.with_scope(|scope| {
+                let mut __address_type = #address_type::U32;
+                #(#required_address_types)*
+                __address_type
+            });
+            assert!(
+                __client.properties().supports_address(__address_type),
+                "The automatically selected address type `{}` isn't supported by this device",
+                __address_type,
+            );
         }
     }
 
@@ -215,7 +256,7 @@ impl Launch {
             let generics = &self.kernel_generics;
             let (_, generic_names, _) = self.kernel_generics.split_for_impl();
 
-            let settings = self.configure_settings();
+            let settings = self.configure_settings(false);
             let kernel_name = self.kernel_name();
             let comptime_args = self.launch_args();
             let comptime_names = self.comptime_params().map(|it| &it.name);

--- a/crates/cubecl-macros/src/lib.rs
+++ b/crates/cubecl-macros/src/lib.rs
@@ -36,6 +36,9 @@ mod statement;
 /// # Arguments
 /// * `launch` - generates a function to launch the kernel
 /// * `launch_unchecked` - generates a launch function without checks
+/// * `address_type` - controls the kernel address width. Supported values are `"u32"`, `"u64"`,
+///   `"dynamic"`, and `"auto"`. The automatic mode selects the width from launch buffer lengths;
+///   it doesn't inspect the kernel's index arithmetic.
 /// * `debug` - panics after generation to print the output to console
 /// * `create_dummy_kernel` - Generates a function to create a kernel without launching it. Used for
 ///   testing.

--- a/crates/cubecl-macros/src/parse/kernel.rs
+++ b/crates/cubecl-macros/src/parse/kernel.rs
@@ -46,6 +46,7 @@ pub(crate) enum AddressType {
     U32,
     U64,
     Dynamic,
+    Auto,
 }
 
 pub fn from_tokens<T: FromMeta>(tokens: TokenStream) -> syn::Result<T> {

--- a/crates/cubecl-std/src/tensor/handle.rs
+++ b/crates/cubecl-std/src/tensor/handle.rs
@@ -125,7 +125,7 @@ where
 
     pub fn required_address_type(&self) -> AddressType {
         let len = self.handle.size() / self.dtype.size() as u64;
-        AddressType::from_len(len as usize)
+        AddressType::from_len_u64(len)
     }
 
     pub fn shape(&self) -> &Shape {

--- a/crates/cubecl-std/src/tensor/view/launch.rs
+++ b/crates/cubecl-std/src/tensor/view/launch.rs
@@ -484,6 +484,24 @@ mod dynamic {
                 scheme,
             }
         }
+
+        fn required_address_type(&self, elem_size: usize) -> AddressType {
+            match self {
+                ViewArg::Array(buffer, _) => buffer.required_address_type(elem_size),
+                ViewArg::Tensor(buffer, _) => buffer.required_address_type(elem_size),
+                ViewArg::TensorMapTiled(buffer, _) => {
+                    buffer.tensor.required_address_type(elem_size)
+                }
+                ViewArg::TensorMapIm2col(buffer, _) => {
+                    buffer.tensor.required_address_type(elem_size)
+                }
+                // The storage and scale types are selected dynamically from the quantization
+                // scheme. Counting bytes is conservative for both buffers.
+                ViewArg::Quantized { values, scales, .. } => values
+                    .required_address_type(1)
+                    .max(scales.required_address_type(1)),
+            }
+        }
     }
     #[derive(Clone)]
     pub enum ViewCompilationArg<C: Coordinates> {
@@ -648,6 +666,14 @@ mod dynamic {
                 }
             }
         }
+
+        fn required_address_type<R: Runtime>(
+            arg: &Self::RuntimeArg<R>,
+            scope: &Scope,
+        ) -> AddressType {
+            arg.required_address_type(E::__expand_type_size(scope))
+        }
+
         fn expand(
             arg: &Self::CompilationArg,
             builder: &mut KernelBuilder,
@@ -699,6 +725,13 @@ mod dynamic {
             launcher: &mut KernelLauncher<R>,
         ) -> Self::CompilationArg {
             <View<'static, E, C> as LaunchArg>::register(arg, launcher)
+        }
+
+        fn required_address_type<R: Runtime>(
+            arg: &Self::RuntimeArg<R>,
+            scope: &Scope,
+        ) -> AddressType {
+            <View<'static, E, C> as LaunchArg>::required_address_type::<R>(arg, scope)
         }
 
         fn expand(


### PR DESCRIPTION
Add support for `#[cube(..., address_type = "auto")]`.

Automatic mode selects the concrete `AddressType` at launch time from the
largest indexable buffer length used by the kernel:

- `U32` when every buffer length fits in `u32`
- `U64` when at least one buffer exceeds `u32::MAX`

The resolved concrete address type is included in the existing kernel settings
and cache key.
