### PR TITLE
Expose an ordered CUDA stream for scoped external writes

### DIFF
--- a/crates/cubecl-cuda/src/compute/command.rs
+++ b/crates/cubecl-cuda/src/compute/command.rs
@@ -43,6 +43,10 @@ pub struct Command<'a> {
 }
 
 impl<'a> Command<'a> {
+    pub(super) fn external_write_stream(&mut self) -> u64 {
+        self.streams.current().sys as usize as u64
+    }
+
     /// Retrieves a GPU resource associated with the provided binding.
     ///
     /// # Parameters

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -30,7 +30,7 @@ use cubecl_runtime::{
     config::{CubeClRuntimeConfig, RuntimeConfig},
     logging::ServerLogger,
     memory_management::{ManagedMemoryHandle, MemoryAllocationMode, MemoryUsage},
-    server::ComputeServer,
+    server::{ComputeServer, ExternalWriteServer},
     storage::{ComputeStorage, ManagedResource},
     stream::MultiStream,
 };
@@ -61,6 +61,24 @@ pub struct CudaServer {
 // which serializes all server access. The CUDA context, streams, and NCCL communicators
 // it manages are never shared across threads without synchronization.
 unsafe impl Send for CudaServer {}
+
+impl ExternalWriteServer for CudaServer {
+    fn external_write_stream(
+        &mut self,
+        binding: Binding,
+        stream_id: StreamId,
+    ) -> Result<u64, ServerError> {
+        let mut command = self.command(
+            stream_id,
+            core::iter::once(&binding),
+            StreamErrorMode {
+                ignore: false,
+                flush: false,
+            },
+        )?;
+        Ok(command.external_write_stream())
+    }
+}
 
 impl ComputeServer for CudaServer {
     type Kernel = Box<dyn CubeTask<CudaCompiler>>;

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -5,10 +5,10 @@ use crate::{
     memory_management::{MemoryAllocationMode, MemoryUsage},
     runtime::Runtime,
     server::{
-        CommunicationId, ComputeServer, CopyDescriptor, CubeCount, ExecutionMode, Handle, IoError,
-        KernelArguments, MemoryLayout, MemoryLayoutDescriptor, MemoryLayoutPolicy,
-        MemoryLayoutStrategy, ProfileError, ReduceOperation, ServerCommunication, ServerError,
-        ServerUtilities,
+        CommunicationId, ComputeServer, CopyDescriptor, CubeCount, ExecutionMode,
+        ExternalWriteServer, Handle, IoError, KernelArguments, MemoryLayout,
+        MemoryLayoutDescriptor, MemoryLayoutPolicy, MemoryLayoutStrategy, ProfileError,
+        ReduceOperation, ServerCommunication, ServerError, ServerUtilities,
     },
     storage::{ComputeStorage, ManagedResource},
 };
@@ -206,6 +206,25 @@ impl<R: Runtime> ComputeClient<R> {
 
         self.device
             .submit_blocking(move |state| state.get_resource(binding, stream_id))
+            .unwrap()
+    }
+
+    /// Resolve the backend-native stream owning `handle` for an external write.
+    ///
+    /// # Safety
+    ///
+    /// The returned token must remain inside an audited backend bridge. The
+    /// caller must retain this client, the managed allocation, and every
+    /// external resource until dependencies have been registered in both
+    /// directions. The caller must not destroy or expose the stream.
+    pub unsafe fn external_write_stream(&self, handle: &Handle) -> Result<u64, ServerError>
+    where
+        R::Server: ExternalWriteServer,
+    {
+        let stream_id = self.stream_id();
+        let binding = handle.clone().binding();
+        self.device
+            .submit_blocking(move |server| server.external_write_stream(binding, stream_id))
             .unwrap()
     }
 

--- a/crates/cubecl-runtime/src/server/base.rs
+++ b/crates/cubecl-runtime/src/server/base.rs
@@ -308,6 +308,17 @@ pub struct StreamErrorMode {
     pub flush: bool,
 }
 
+/// Backend hook for ordering an audited external write on the server's native stream.
+pub trait ExternalWriteServer: ComputeServer {
+    /// Return the native stream associated with `binding` after resolving the
+    /// server's normal cross-stream dependencies.
+    fn external_write_stream(
+        &mut self,
+        binding: Binding,
+        stream_id: StreamId,
+    ) -> Result<u64, ServerError>;
+}
+
 /// The compute server is responsible for handling resources and computations over resources.
 ///
 /// Everything in the server is mutable, therefore it should be solely accessed through the

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -13,9 +13,9 @@ use cubecl_runtime::{
     logging::ServerLogger,
     memory_management::{ManagedMemoryHandle, MemoryAllocationMode, MemoryManagement, MemoryUsage},
     server::{
-        Binding, ComputeServer, CopyDescriptor, CubeCount, CubeDim, ExecutionMode, Handle,
-        KernelArguments, ProfileError, ProfilingToken, ServerCommunication, ServerError,
-        ServerUtilities,
+        Binding, ComputeServer, CopyDescriptor, CubeCount, CubeDim, ExecutionMode,
+        ExternalWriteServer, Handle, KernelArguments, ProfileError, ProfilingToken,
+        ServerCommunication, ServerError, ServerUtilities,
     },
     storage::{BytesResource, BytesStorage, ComputeStorage, ManagedResource},
     timestamp_profiler::TimestampProfiler,
@@ -90,6 +90,17 @@ impl KernelTask {
 
 impl ServerCommunication for DummyServer {
     const SERVER_COMM_ENABLED: bool = false;
+}
+
+impl ExternalWriteServer for DummyServer {
+    fn external_write_stream(
+        &mut self,
+        binding: Binding,
+        stream_id: StreamId,
+    ) -> Result<u64, ServerError> {
+        let _resource = self.get_resource(binding, stream_id)?;
+        Ok(stream_id.value)
+    }
 }
 
 impl ComputeServer for DummyServer {

--- a/crates/cubecl-runtime/tests/integration_test.rs
+++ b/crates/cubecl-runtime/tests/integration_test.rs
@@ -29,6 +29,27 @@ fn empty_allocates_memory() {
 }
 
 #[test_log::test]
+fn external_write_stream_resolves_a_cross_stream_handle_on_the_target_stream() {
+    use cubecl_common::stream_id::StreamId;
+
+    let mut producer = test_client(&DummyDevice);
+    let mut consumer = producer.clone();
+    let producer_stream = StreamId { value: 7 };
+    let consumer_stream = StreamId { value: 11 };
+    unsafe {
+        producer.set_stream(producer_stream);
+        consumer.set_stream(consumer_stream);
+    }
+    let handle = producer.empty(4);
+
+    assert_eq!(handle.stream, producer_stream);
+
+    let stream = unsafe { consumer.external_write_stream(&handle) }.unwrap();
+
+    assert_eq!(stream, consumer_stream.value);
+}
+
+#[test_log::test]
 fn execute_elementwise_addition() {
     let client = test_client(&DummyDevice);
     let lhs = client.create_from_slice(&[0, 1, 2]);


### PR DESCRIPTION
## Summary

- add a narrow `ExternalWriteServer` hook for backends that can expose an external-write stream
- add unsafe `ComputeClient::external_write_stream` access after resolving the managed binding on the caller stream
- implement the contract for CUDA through the existing `CudaServer::command` dependency path
- cover a handle produced on one CubeCL stream and resolved for an external write on another

## Motivation

An external GPU producer such as a decoder needs to fill a CubeCL-owned allocation directly without a decoded-pixel host round trip. Returning the native CUDA stream only after the normal binding dependency path lets the producer enqueue its write in the correct order while retaining CubeCL allocation ownership.

The unsafe contract requires the bridge to retain the client, managed allocation, and submitted external resources; keep the native token internal; and register ordering back into CubeCL before later use. This API does not synchronize the CPU.

## Validation

- `cargo test -p cubecl-runtime --test integration_test external_write_stream_resolves_a_cross_stream_handle_on_the_target_stream`
- `cargo check -p cubecl-cuda`
- `cargo clippy -p cubecl-runtime -p cubecl-cuda --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo xtask validate` passed audit, format, and workspace Clippy, then hit existing `cpy` typo findings in `cubecl-cuda/src/compute/command.rs`
- `cargo xtask validate --ignore-typos` continued through the workspace build, then stopped because the macOS host does not have the Vulkan SDK required by the SPIR-V build

This is intentionally backend-specific and small; equivalent naming or a scoped token type would also satisfy the interop need.