### PR TITLE
fix(quant): map QuantParam::UE4M3 to FloatKind::E4M3

### DIFF
--- a/crates/cubecl-ir/src/type.rs
+++ b/crates/cubecl-ir/src/type.rs
@@ -122,7 +122,7 @@ impl ElemType {
             QuantParam::F16 => Self::Float(FloatKind::F16),
             QuantParam::BF16 => Self::Float(FloatKind::BF16),
             QuantParam::UE8M0 => Self::Float(FloatKind::UE8M0),
-            QuantParam::UE4M3 => Self::Float(FloatKind::UE8M0),
+            QuantParam::UE4M3 => Self::Float(FloatKind::E4M3),
         }
     }
 


### PR DESCRIPTION
Closes #1370.

`ElemType::from_quant_param` mapped `QuantParam::UE4M3` to `FloatKind::UE8M0`, which is a different format (e8m0 is exponent-only with no mantissa; e4m3 has 4 exponent and 3 mantissa bits).

The practical consequence is worse than a precision loss. `UE8M0` is only registered as a usable type on Blackwell (`arch_major` 10/11/12, `cubecl-cuda/src/runtime.rs`), so on anything older a `UE4M3` scheme resolves to a type the runtime does not support and fails there, rather than at the scheme.

`E4M3` is what the rest of the ecosystem already uses for this param, so this brings `from_quant_param` in line with two existing sites rather than introducing a new convention:

- `run_with_quant_type` in `cubecl-std/src/quant/view.rs` dispatches `QuantParam::UE4M3 => func.execute::<Q, e4m3>()`.
- burn's fusion codegen keeps its own copy of this table in `burn-cubecl-fusion/src/engine/codegen/kernel.rs` and maps `UE4M3 => FloatKind::E4M3`.

## Testing

`cargo check --workspace`, `cargo clippy -p cubecl-ir --all-targets`, and `cargo fmt --check` are clean.

No test is added. The change is a single arm of a five-arm lookup table with no logic; a test over it would restate the implementation and would have passed with the bug present, since the oracle is the two sites above rather than anything the test could assert independently.

## Validate your PR with burn

The template checklist is not applicable here, and I have not opened downstream PRs. Nothing in cubek or burn can change behaviour as a result of this commit:

- The only callers of `from_quant_param` are `cubek-quant`'s `quantize.rs` / `dequantize.rs` and `cubek-test-utils`.
- No test or benchmark in cubek or burn constructs a `UE4M3` scheme. Every `QuantParam::UE4M3` site in burn is either an independent table or an `unimplemented!()` arm, and cubek's tile path asserts `param == QuantParam::F32` outright.

So there is no downstream breakage to fix and no cubek/burn PR to link. Happy to run the full procedure anyway if you would rather have it on the record.

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.