### PR TITLE
Invalidate the kernel cache when a kernel changes

### DIFF
--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -143,7 +143,9 @@ impl CpuServer {
         let kernel = if let Some(kernel) = self.compilation_cache.get(&kernel_id) {
             kernel
         } else {
+            let definition = kernel.define();
             let kernel = kernel.compile(
+                definition,
                 &mut Default::default(),
                 &MlirCompilerOptions::default(),
                 kind,

--- a/crates/cubecl-cuda/src/compute/context.rs
+++ b/crates/cubecl-cuda/src/compute/context.rs
@@ -14,13 +14,15 @@ use crate::{
     install::{cccl_include_path, include_path},
 };
 use cubecl_core::{
-    hash::StableHash,
     server::ResourceLimitError,
     {ir::DeviceProperties, prelude::*},
 };
 use cubecl_environment::persistence::Store;
 use cubecl_runtime::timestamp_profiler::TimestampProfiler;
-use cubecl_runtime::{compiler::CubeTask, logging::ServerLogger};
+use cubecl_runtime::{
+    compiler::{CubeTask, KernelCacheKey},
+    logging::ServerLogger,
+};
 use cudarc::driver::DriverError;
 use cudarc::driver::sys::CUfunc_st;
 use cudarc::driver::sys::{CUctx_st, CUfunction_attribute, CUtensorMap};
@@ -36,7 +38,7 @@ use cubecl_runtime::compiler::{compilation_store, store_compiled};
 pub(crate) struct CudaContext {
     pub context: *mut CUctx_st,
     pub module_names: HashMap<KernelId, CompiledKernel>,
-    ptx_cache: Option<Store<StableHash, PtxCacheEntry>>,
+    ptx_cache: Option<Store<KernelCacheKey, PtxCacheEntry>>,
     pub timestamps: TimestampProfiler,
     pub arch: CudaArchitecture,
     pub compilation_options: CompilationOptions,
@@ -89,10 +91,12 @@ impl CudaContext {
         mode: ExecutionMode,
         logger: Arc<ServerLogger>,
     ) -> Result<(), LaunchError> {
-        let hash = if let Some(cache) = self.ptx_cache.as_mut() {
-            let hash = kernel_id.stable_hash();
+        let definition = kernel.define();
 
-            if let Some(entry) = cache.remove(&hash) {
+        let key = if let Some(cache) = self.ptx_cache.as_mut() {
+            let key = KernelCacheKey::new(kernel_id, &definition);
+
+            if let Some(entry) = cache.remove(&key) {
                 log::trace!("Using PTX cache");
 
                 self.load_ptx(
@@ -104,7 +108,7 @@ impl CudaContext {
                 )?;
                 return Ok(());
             }
-            Some(hash)
+            Some(key)
         } else {
             None
         };
@@ -115,6 +119,7 @@ impl CudaContext {
         validate_units(&self.properties, kernel_id)?;
 
         let mut kernel_compiled = kernel.compile(
+            definition,
             &mut Default::default(),
             &self.compilation_options,
             mode,
@@ -179,16 +184,8 @@ impl CudaContext {
                         message += format!("\n    {line}").as_str();
                     }
                 }
-                let source = kernel
-                    .compile(
-                        &mut Default::default(),
-                        &self.compilation_options,
-                        mode,
-                        kernel.address_type(),
-                    )?
-                    .source;
                 Err(CompilationError::Generic {
-                    reason: format!("{message}\n[Source]  \n{source}"),
+                    reason: format!("{message}\n[Source]  \n{}", kernel_compiled.source),
                     backtrace: BackTrace::capture(),
                 })?;
             };
@@ -203,7 +200,7 @@ impl CudaContext {
         if let Some(cache) = &mut self.ptx_cache {
             store_compiled(
                 cache,
-                hash.unwrap(),
+                key.unwrap(),
                 PtxCacheEntry {
                     entrypoint_name: kernel_compiled.entrypoint_name.clone(),
                     shared_mem_bytes: repr.shared_memory_size(),

--- a/crates/cubecl-hip/src/compute/context.rs
+++ b/crates/cubecl-hip/src/compute/context.rs
@@ -1,7 +1,6 @@
 use super::storage::gpu::GpuResource;
 use crate::runtime::HipCompiler;
 use crate::{compute::stream::Stream, runtime::HipComputeKernel};
-use cubecl_common::hash::StableHash;
 use cubecl_core::{
     server::ResourceLimitError,
     {ir::DeviceProperties, prelude::*},
@@ -18,7 +17,10 @@ use cubecl_runtime::{
     compiler::CompilationError,
     validation::{validate_cube_dim, validate_units},
 };
-use cubecl_runtime::{compiler::CubeTask, logging::ServerLogger};
+use cubecl_runtime::{
+    compiler::{CubeTask, KernelCacheKey},
+    logging::ServerLogger,
+};
 use serde::Deserialize;
 use serde::Serialize;
 use std::ffi::CStr;
@@ -31,7 +33,7 @@ pub(crate) struct HipContext {
     pub timestamps: TimestampProfiler,
     pub compilation_options: CompilationOptions,
     pub properties: DeviceProperties,
-    pub compilation_cache: Option<Store<StableHash, CompilationCacheEntry>>,
+    pub compilation_cache: Option<Store<KernelCacheKey, CompilationCacheEntry>>,
 }
 
 #[derive(Debug)]
@@ -74,9 +76,11 @@ impl HipContext {
         mode: ExecutionMode,
         logger: Arc<ServerLogger>,
     ) -> Result<(), LaunchError> {
-        let hash = if let Some(cache) = self.compilation_cache.as_mut() {
-            let hash = kernel_id.stable_hash();
-            if let Some(entry) = cache.remove(&hash) {
+        let definition = cube_kernel.define();
+
+        let key = if let Some(cache) = self.compilation_cache.as_mut() {
+            let key = KernelCacheKey::new(kernel_id, &definition);
+            if let Some(entry) = cache.remove(&key) {
                 log::trace!("Using compilation cache");
                 self.load_compiled_binary(
                     entry.binary,
@@ -87,7 +91,7 @@ impl HipContext {
                 )?;
                 return Ok(());
             }
-            Some(hash)
+            Some(key)
         } else {
             None
         };
@@ -98,6 +102,7 @@ impl HipContext {
         // CubeCL compilation
         // jitc = just-in-time compiled
         let mut jitc_kernel = cube_kernel.compile(
+            definition,
             &mut Default::default(),
             &self.compilation_options,
             mode,
@@ -241,7 +246,7 @@ impl HipContext {
         if let Some(cache) = self.compilation_cache.as_mut() {
             store_compiled(
                 cache,
-                hash.unwrap(),
+                key.unwrap(),
                 CompilationCacheEntry {
                     entrypoint_name: jitc_kernel.entrypoint_name.clone(),
                     shared_mem_bytes: repr.shared_memory_size(),

--- a/crates/cubecl-ir/src/type.rs
+++ b/crates/cubecl-ir/src/type.rs
@@ -481,7 +481,10 @@ impl core::hash::Hash for Type {
         match self {
             Type::Scalar(storage_type) => storage_type.hash(state),
             Type::Opaque(opaque) => opaque.hash(state),
-            Type::Vector(intern, _) => intern.as_ref().hash(state),
+            Type::Vector(intern, size) => {
+                intern.as_ref().hash(state);
+                size.hash(state);
+            }
             Type::Semantic(semantic_type) => semantic_type.hash(state),
             Type::Atomic(intern) => intern.as_ref().hash(state),
             Type::Pointer(intern, addr_space) => {
@@ -961,13 +964,27 @@ impl Display for AddressSpace {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TypeHash, PartialOrd, Ord, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TypeHash, PartialOrd, Ord, Display)]
 pub enum AggregateKind {
     #[display("ptr<{meta}, {inner_ty}>")]
     Ptr {
         inner_ty: Intern<Type>,
         meta: MetadataKind,
     },
+}
+
+/// Hashed by value rather than derived, for the same reason as [`Type`]: an [`Intern`] hashes the
+/// pointer it holds, which moves between runs.
+impl core::hash::Hash for AggregateKind {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
+        match self {
+            AggregateKind::Ptr { inner_ty, meta } => {
+                inner_ty.as_ref().hash(state);
+                meta.hash(state);
+            }
+        }
+    }
 }
 
 impl AggregateKind {
@@ -1162,3 +1179,53 @@ impl_into_value!(
     usize => UIntKind::U32,
     isize => IntKind::I32,
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::hash::{Hash, Hasher};
+
+    fn hash(ty: Type) -> u64 {
+        let mut hasher = fnv::FnvHasher::default();
+        ty.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// `Intern` hashes the pointer it holds, which moves between runs. Every arm that holds one
+    /// has to reach through it, or a persistent cache keyed on the IR never hits.
+    #[test]
+    fn interned_types_hash_by_value() {
+        let f32_ty = Type::scalar(ElemType::Float(FloatKind::F32));
+
+        // Distinct `Intern` allocations of an equal type must agree.
+        assert_eq!(
+            hash(Type::Pointer(f32_ty.intern(), AddressSpace::Local)),
+            hash(Type::Pointer(f32_ty.intern(), AddressSpace::Local))
+        );
+        assert_eq!(
+            hash(Type::Aggregate(AggregateKind::ptr(f32_ty, MetadataKind::Slice))),
+            hash(Type::Aggregate(AggregateKind::ptr(f32_ty, MetadataKind::Slice)))
+        );
+    }
+
+    #[test]
+    fn vector_size_is_part_of_the_hash() {
+        let f32_ty = Type::scalar(ElemType::Float(FloatKind::F32));
+
+        assert_ne!(
+            hash(Type::Vector(f32_ty.intern(), 2)),
+            hash(Type::Vector(f32_ty.intern(), 4))
+        );
+    }
+
+    #[test]
+    fn aggregate_inner_type_is_part_of_the_hash() {
+        let f32_ty = Type::scalar(ElemType::Float(FloatKind::F32));
+        let u32_ty = Type::scalar(ElemType::UInt(UIntKind::U32));
+
+        assert_ne!(
+            hash(Type::Aggregate(AggregateKind::ptr(f32_ty, MetadataKind::Slice))),
+            hash(Type::Aggregate(AggregateKind::ptr(u32_ty, MetadataKind::Slice)))
+        );
+    }
+}

--- a/crates/cubecl-ir/src/type.rs
+++ b/crates/cubecl-ir/src/type.rs
@@ -1203,8 +1203,14 @@ mod tests {
             hash(Type::Pointer(f32_ty.intern(), AddressSpace::Local))
         );
         assert_eq!(
-            hash(Type::Aggregate(AggregateKind::ptr(f32_ty, MetadataKind::Slice))),
-            hash(Type::Aggregate(AggregateKind::ptr(f32_ty, MetadataKind::Slice)))
+            hash(Type::Aggregate(AggregateKind::ptr(
+                f32_ty,
+                MetadataKind::Slice
+            ))),
+            hash(Type::Aggregate(AggregateKind::ptr(
+                f32_ty,
+                MetadataKind::Slice
+            )))
         );
     }
 
@@ -1224,8 +1230,14 @@ mod tests {
         let u32_ty = Type::scalar(ElemType::UInt(UIntKind::U32));
 
         assert_ne!(
-            hash(Type::Aggregate(AggregateKind::ptr(f32_ty, MetadataKind::Slice))),
-            hash(Type::Aggregate(AggregateKind::ptr(u32_ty, MetadataKind::Slice)))
+            hash(Type::Aggregate(AggregateKind::ptr(
+                f32_ty,
+                MetadataKind::Slice
+            ))),
+            hash(Type::Aggregate(AggregateKind::ptr(
+                u32_ty,
+                MetadataKind::Slice
+            )))
         );
     }
 }

--- a/crates/cubecl-metal/src/compute/context.rs
+++ b/crates/cubecl-metal/src/compute/context.rs
@@ -3,7 +3,10 @@ use cubecl_core::prelude::*;
 use cubecl_core::server::{LaunchError, ResourceLimitError};
 use cubecl_environment::backtrace::BackTrace;
 use cubecl_environment::collections::HashMap;
-use cubecl_runtime::{compiler::CubeTask, logging::ServerLogger};
+use cubecl_runtime::{
+    compiler::{CubeTask, KernelCacheKey},
+    logging::ServerLogger,
+};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSString;
@@ -37,7 +40,7 @@ pub struct MetalContext {
     device: Retained<ProtocolObject<dyn MTLDevice>>,
     compiled_kernels: HashMap<KernelId, CompiledKernel>,
     /// On-disk MSL source cache for faster recompilation across runs.
-    msl_cache: Option<Store<String, MslCacheEntry>>,
+    msl_cache: Option<Store<KernelCacheKey, MslCacheEntry>>,
     compilation_options: cubecl_cpp::shared::CompilationOptions,
     msl_compile_options: Retained<MTLCompileOptions>,
 }
@@ -84,8 +87,10 @@ impl MetalContext {
             return Ok(compiled.clone());
         }
 
+        let definition = kernel.define();
+        let cache_key = KernelCacheKey::new(kernel_id, &definition);
+
         if let Some(cache) = self.msl_cache.as_mut() {
-            let cache_key = kernel_id.stable_format();
             if let Some(entry) = cache.remove(&cache_key) {
                 log::trace!("Using MSL cache");
 
@@ -108,6 +113,7 @@ impl MetalContext {
         log::trace!("Compiling kernel to MSL");
 
         let mut kernel_compiled = kernel.compile(
+            definition,
             &mut Default::default(),
             &self.compilation_options,
             mode,
@@ -147,7 +153,7 @@ impl MetalContext {
         if let Some(cache) = &mut self.msl_cache {
             store_compiled(
                 cache,
-                kernel_id.stable_format(),
+                cache_key,
                 MslCacheEntry {
                     entrypoint_name,
                     cube_dim: (cube_dim.x, cube_dim.y, cube_dim.z),

--- a/crates/cubecl-runtime/src/compiler.rs
+++ b/crates/cubecl-runtime/src/compiler.rs
@@ -1,8 +1,10 @@
 use crate::{
+    id::KernelId,
     kernel::{CompiledKernel, KernelDefinition, KernelMetadata},
     server::ExecutionMode,
 };
 use alloc::string::String;
+use cubecl_common::hash::StableHash;
 use cubecl_environment::backtrace::BackTrace;
 use cubecl_environment::persistence::{
     CacheOption, Namespace, Store, StoreKey, StoreOptions, StoreValue,
@@ -60,14 +62,45 @@ pub fn store_compiled<K: StoreKey, V: StoreValue>(store: &mut Store<K, V>, key: 
 /// Kernel trait with the `ComputeShader` that will be compiled and cached based on the
 /// provided id.
 pub trait CubeTask<C: Compiler>: KernelMetadata + Send + Sync {
-    /// Compile a kernel and return the compiled form with an optional non-text representation
+    /// Expand the kernel into its [definition](KernelDefinition).
+    ///
+    /// Kept separate from [`CubeTask::compile`] so a server can hash the definition to key the
+    /// compilation cache, then hand the same definition back on a miss instead of expanding twice.
+    fn define(&self) -> KernelDefinition;
+
+    /// Compile a kernel definition and return the compiled form with an optional non-text
+    /// representation.
     fn compile(
         &self,
+        definition: KernelDefinition,
         compiler: &mut C,
         compilation_options: &C::CompilationOptions,
         mode: ExecutionMode,
         address_type: StorageType,
     ) -> Result<CompiledKernel<C>, CompilationError>;
+}
+
+/// Key for an entry in the persistent compilation cache.
+///
+/// The [id](KernelId) alone doesn't describe what a kernel does: it covers the kernel type, its
+/// comptime arguments and its launch settings, but nothing of the body. Pairing it with a hash of
+/// the expanded IR is what lets a cached artifact be invalidated when the code behind it changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct KernelCacheKey {
+    /// Hash of the [kernel id](KernelId).
+    pub id: StableHash,
+    /// Hash of the [kernel definition](KernelDefinition).
+    pub ir: StableHash,
+}
+
+impl KernelCacheKey {
+    /// Create a key from a kernel id and its expanded definition.
+    pub fn new(id: &KernelId, definition: &KernelDefinition) -> Self {
+        Self {
+            id: id.stable_hash(),
+            ir: definition.stable_hash(),
+        }
+    }
 }
 
 /// JIT compilation error.

--- a/crates/cubecl-runtime/src/kernel.rs
+++ b/crates/cubecl-runtime/src/kernel.rs
@@ -5,11 +5,15 @@ use alloc::{
 };
 use core::{
     fmt::Display,
+    hash::Hash,
     marker::PhantomData,
     sync::atomic::{AtomicI8, Ordering},
 };
 
-use cubecl_common::format::format_str;
+use cubecl_common::{
+    format::format_str,
+    hash::{StableHash, StableHasher},
+};
 use cubecl_ir::{Id, Scope, StorageType, Value};
 use serde::{Deserialize, Serialize};
 
@@ -50,6 +54,39 @@ impl KernelDefinition {
     pub fn num_global_buffers(&self) -> usize {
         self.buffers.len() + self.tensor_maps.len()
     }
+
+    /// Hash the content of the kernel in a stable way that can be used between runs.
+    ///
+    /// Two kernels with the same hash expand to the same IR, so a compiled artifact keyed on it
+    /// stays valid exactly as long as the code producing it is unchanged. This is what makes the
+    /// persistent compilation cache pick up edits to a kernel body, or to any `#[cube]` function it
+    /// reaches, without relying on a version bump.
+    ///
+    /// Debug information is deliberately left out: it holds absolute source paths, which would make
+    /// the hash differ between machines and checkouts, and it never changes what the compiler emits
+    /// beyond [`KernelOptions::debug_symbols`], which is hashed.
+    pub fn stable_hash(&self) -> StableHash {
+        let mut hasher = StableHasher::new();
+
+        self.buffers.hash(&mut hasher);
+        self.tensor_maps.hash(&mut hasher);
+        self.scalars.hash(&mut hasher);
+        self.cube_dim.hash(&mut hasher);
+        self.options.hash(&mut hasher);
+        self.body.hash(&mut hasher);
+
+        // `Scope` skips the global state when hashing, so outlined functions have to be hashed
+        // here. They aren't reachable from the body instructions, which only reference them by id,
+        // meaning a change confined to one of them would otherwise go unnoticed. The map is ordered
+        // by id, so the traversal is deterministic.
+        let state = self.body.state();
+        for (id, function) in state.functions.iter() {
+            id.hash(&mut hasher);
+            function.hash(&mut hasher);
+        }
+
+        hasher.finalize()
+    }
 }
 
 #[derive(Default, Clone, Debug, Hash, PartialEq, Eq)]
@@ -63,7 +100,7 @@ pub struct KernelOptions {
     pub cluster_dim: Option<CubeDim>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 /// Global argument of a kernel.
 pub struct KernelArg {
     /// The kernel id.
@@ -74,7 +111,7 @@ pub struct KernelArg {
     pub has_extended_meta: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct ScalarKernelArg {
     pub ty: StorageType,
@@ -169,14 +206,18 @@ impl<C: Compiler, K: CubeKernel> KernelTask<C, K> {
 }
 
 impl<C: Compiler, K: CubeKernel> CubeTask<C> for KernelTask<C, K> {
+    fn define(&self) -> KernelDefinition {
+        self.kernel_definition.define()
+    }
+
     fn compile(
         &self,
+        gpu_ir: KernelDefinition,
         compiler: &mut C,
         compilation_options: &C::CompilationOptions,
         mode: ExecutionMode,
         addr_type: StorageType,
     ) -> Result<CompiledKernel<C>, CompilationError> {
-        let gpu_ir = self.kernel_definition.define();
         let entrypoint_name = gpu_ir.options.kernel_name.clone();
         let cube_dim = gpu_ir.cube_dim;
         let lower_level_ir = compiler.compile(gpu_ir, compilation_options, mode, addr_type)?;
@@ -295,5 +336,104 @@ source:
                 .unwrap_or(""),
             self.source
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cubecl_ir::{ElemType, Instruction, Operation, Type};
+
+    fn definition(body: Scope) -> KernelDefinition {
+        KernelDefinition {
+            buffers: Vec::new(),
+            tensor_maps: Vec::new(),
+            scalars: Vec::new(),
+            cube_dim: CubeDim::new_single(),
+            body,
+            options: KernelOptions::default(),
+        }
+    }
+
+    /// A scope holding a single `Copy` on a freshly declared local.
+    fn scope_with_copy() -> Scope {
+        let scope = Scope::root(false);
+        let local = scope.create_local_mut(Type::scalar(ElemType::Bool));
+        scope.register(Instruction::new(Operation::Copy(local), local));
+        scope
+    }
+
+    #[test]
+    fn hash_is_stable_across_calls() {
+        let definition = definition(scope_with_copy());
+
+        assert_eq!(definition.stable_hash(), definition.stable_hash());
+    }
+
+    #[test]
+    fn equivalent_definitions_hash_equal() {
+        let lhs = definition(scope_with_copy());
+        let rhs = definition(scope_with_copy());
+
+        assert_eq!(lhs.stable_hash(), rhs.stable_hash());
+    }
+
+    #[test]
+    fn body_change_changes_hash() {
+        let lhs = definition(scope_with_copy());
+
+        let scope = Scope::root(false);
+        let local = scope.create_local_mut(Type::scalar(ElemType::Bool));
+        // Same shape as `scope_with_copy`, different operation.
+        scope.register(Instruction::new(
+            Operation::ConstructAggregate(alloc::vec![local]),
+            local,
+        ));
+        let rhs = definition(scope);
+
+        assert_ne!(lhs.stable_hash(), rhs.stable_hash());
+    }
+
+    #[test]
+    fn cube_dim_change_changes_hash() {
+        let lhs = definition(scope_with_copy());
+        let mut rhs = definition(scope_with_copy());
+        rhs.cube_dim = CubeDim::new_2d(2, 2);
+
+        assert_ne!(lhs.stable_hash(), rhs.stable_hash());
+    }
+
+    /// The body only references an outlined function by id, and `Scope`'s own `Hash` skips the
+    /// global state holding it. Without hashing that map, editing a `#[cube]` helper that got
+    /// outlined would leave the key untouched and the stale artifact would be served.
+    #[test]
+    fn outlined_function_change_changes_hash() {
+        // The kernel body is empty either way; only the outlined function differs.
+        fn with_function(extra_instruction: bool) -> KernelDefinition {
+            let outlined = Scope::root(false);
+            let local = outlined.create_local_mut(Type::scalar(ElemType::Bool));
+            outlined.register(Instruction::new(Operation::Copy(local), local));
+            if extra_instruction {
+                outlined.register(Instruction::new(
+                    Operation::ConstructAggregate(alloc::vec![local]),
+                    local,
+                ));
+            }
+
+            let definition = definition(Scope::root(false));
+            definition.body.create_function(Vec::new(), outlined);
+            definition
+        }
+
+        let lhs = with_function(false);
+        let rhs = with_function(true);
+
+        // The bodies are indistinguishable on their own; only hashing the outlined function
+        // separates the two definitions.
+        assert_eq!(
+            StableHasher::hash_one(&lhs.body),
+            StableHasher::hash_one(&rhs.body)
+        );
+        assert_ne!(lhs.stable_hash(), rhs.stable_hash());
     }
 }

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -60,8 +60,21 @@ impl core::fmt::Display for KernelTask {
 }
 
 impl CubeTask<DummyCompiler> for KernelTask {
+    fn define(&self) -> cubecl_runtime::kernel::KernelDefinition {
+        // The dummy server compiles directly and never keys a cache, so nothing here is observed.
+        cubecl_runtime::kernel::KernelDefinition {
+            buffers: Vec::new(),
+            tensor_maps: Vec::new(),
+            scalars: Vec::new(),
+            cube_dim: CubeDim::new_single(),
+            body: cubecl_ir::Scope::root(false),
+            options: Default::default(),
+        }
+    }
+
     fn compile(
         &self,
+        _definition: cubecl_runtime::kernel::KernelDefinition,
         _compiler: &mut DummyCompiler,
         _compilation_options: &<DummyCompiler as cubecl_runtime::compiler::Compiler>::CompilationOptions,
         _mode: ExecutionMode,
@@ -210,7 +223,13 @@ impl ComputeServer for DummyServer {
 
         let mut resources: Vec<_> = resources.iter_mut().collect();
         let kernel = kernel
-            .compile(&mut DummyCompiler, &(), mode, kernel.address_type())
+            .compile(
+                kernel.define(),
+                &mut DummyCompiler,
+                &(),
+                mode,
+                kernel.address_type(),
+            )
             .unwrap();
         kernel.repr.unwrap().compute(resources.as_mut_slice());
     }

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -2,11 +2,15 @@ use super::wgsl;
 use crate::WgpuServer;
 use crate::{AutoRepresentationRef, CompilerInfo, WgpuCompiler};
 use cubecl_core::{
-    CubeDim, ExecutionMode, WgpuCompilationOptions, hash::StableHash, server::KernelArguments,
+    CubeDim, ExecutionMode, WgpuCompilationOptions, prelude::KernelDefinition,
+    server::KernelArguments,
 };
 use cubecl_core::{MemoryConfiguration, prelude::Visibility};
 use cubecl_ir::DeviceProperties;
-use cubecl_runtime::{compiler::CompilationError, id::KernelId};
+use cubecl_runtime::{
+    compiler::{CompilationError, KernelCacheKey},
+    id::KernelId,
+};
 use std::{borrow::Cow, sync::Arc};
 use wgpu::{
     Adapter, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BufferBindingType,
@@ -32,17 +36,21 @@ impl<C: WgpuCompiler> WgpuServer<C> {
     pub fn load_cached_pipeline(
         &mut self,
         kernel_id: &KernelId,
+        definition: &KernelDefinition,
         bindings: &KernelArguments,
         mode: ExecutionMode,
     ) -> Result<
-        Option<Result<(Arc<ComputePipeline>, CompilerInfo), (u64, StableHash)>>,
+        Option<Result<(Arc<ComputePipeline>, CompilerInfo), (u64, KernelCacheKey)>>,
         CompilationError,
     > {
         #[cfg(not(feature = "spirv"))]
         let res = Ok(None);
         #[cfg(feature = "spirv")]
         let res = if let Some(cache) = self.spirv_cache.as_mut() {
-            let key = (self.utilities.properties_hash, kernel_id.stable_hash());
+            let key = (
+                self.utilities.properties_hash,
+                KernelCacheKey::new(kernel_id, definition),
+            );
             if let Some(entry) = cache.remove(&key) {
                 use crate::ParamsTransfer;
 

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -9,7 +9,7 @@ use ash::vk::{
 use cubecl_core::{
     ExecutionMode, MemoryConfiguration, WgpuCompilationOptions,
     ir::{AddressType, ElemType, FloatKind, IntKind, UIntKind},
-    prelude::{CompiledKernel, Visibility},
+    prelude::{CompiledKernel, KernelDefinition, Visibility},
     server::{ComputeServer, IoError, KernelArguments},
 };
 use cubecl_environment::backtrace::BackTrace;
@@ -741,6 +741,7 @@ pub(crate) fn compile<C>(
     dyn_comp: &mut C,
     server: &mut WgpuServer<C>,
     kernel: <WgpuServer<C> as ComputeServer>::Kernel,
+    definition: KernelDefinition,
     mode: ExecutionMode,
 ) -> Result<CompiledKernel<C>, CompilationError>
 where
@@ -748,6 +749,7 @@ where
 {
     log::debug!("Compiling {}", kernel.name());
     let compiled = kernel.compile(
+        definition,
         dyn_comp,
         &server.compilation_options,
         mode,

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -192,10 +192,12 @@ impl WgpuCompiler for AutoCompiler {
         &mut self,
         server: &mut WgpuServer<AutoCompiler>,
         kernel: <WgpuServer<AutoCompiler> as ComputeServer>::Kernel,
+        definition: KernelDefinition,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError> {
         match self {
             AutoCompiler::Wgsl(_) => kernel.compile(
+                definition,
                 self,
                 &server.compilation_options,
                 mode,
@@ -205,7 +207,7 @@ impl WgpuCompiler for AutoCompiler {
             AutoCompiler::SpirV(_) => {
                 #[cfg(feature = "spirv-dump")]
                 let (name, id) = (kernel.name().to_string(), kernel.id());
-                let compiled = crate::vulkan::compile(self, server, kernel, mode)?;
+                let compiled = crate::vulkan::compile(self, server, kernel, definition, mode)?;
                 #[cfg(feature = "spirv-dump")]
                 if let Some(spirv) = compiled.repr.as_ref().and_then(|r| r.as_spirv()) {
                     crate::vulkan::dump_spirv(spirv, &name, id);
@@ -214,6 +216,7 @@ impl WgpuCompiler for AutoCompiler {
             }
             #[cfg(feature = "msl")]
             AutoCompiler::Msl(_) => kernel.compile(
+                definition,
                 self,
                 &server.compilation_options,
                 mode,
@@ -278,9 +281,11 @@ impl WgpuCompiler for WgslCompiler {
         &mut self,
         server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
+        definition: KernelDefinition,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError> {
         kernel.compile(
+            definition,
             self,
             &server.compilation_options,
             mode,
@@ -319,11 +324,18 @@ impl WgpuCompiler for MslCompiler {
         &mut self,
         _server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
+        definition: KernelDefinition,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError> {
         // The MSL compiler uses its own CompilationOptions, not WgpuCompilationOptions.
         let compilation_options = cubecl_cpp::shared::CompilationOptions::default();
-        kernel.compile(self, &compilation_options, mode, kernel.address_type())
+        kernel.compile(
+            definition,
+            self,
+            &compilation_options,
+            mode,
+            kernel.address_type(),
+        )
     }
 
     fn lang_tag(&self) -> &'static str {
@@ -357,11 +369,12 @@ impl<T: cubecl_spirv::SpirvTarget> WgpuCompiler for cubecl_spirv::SpirvCompiler<
         &mut self,
         server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
+        definition: KernelDefinition,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError> {
         #[cfg(feature = "spirv-dump")]
         let (name, id) = (kernel.name().to_string(), kernel.id());
-        let compiled = crate::vulkan::compile(self, server, kernel, mode)?;
+        let compiled = crate::vulkan::compile(self, server, kernel, definition, mode)?;
         #[cfg(feature = "spirv-dump")]
         if let Some(spirv) = compiled.repr.as_ref() {
             crate::vulkan::dump_spirv(spirv, &name, id);
@@ -450,6 +463,7 @@ pub trait WgpuCompiler: Compiler {
         &mut self,
         server: &mut WgpuServer<Self>,
         kernel: <WgpuServer<Self> as ComputeServer>::Kernel,
+        definition: KernelDefinition,
         mode: ExecutionMode,
     ) -> Result<CompiledKernel<Self>, CompilationError>;
 

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -9,8 +9,6 @@ use cubecl_common::{
     bytes::Bytes,
     profile::{ProfileDuration, TimingMethod},
 };
-#[cfg(feature = "spirv")]
-use cubecl_core::hash::StableHash;
 use cubecl_core::server::{Binding, StreamErrorMode};
 use cubecl_core::zspace::Shape;
 use cubecl_core::{
@@ -31,7 +29,7 @@ use cubecl_environment::stream::StreamId;
 use cubecl_ir::MemoryDeviceProperties;
 use cubecl_runtime::allocator::ContiguousMemoryLayoutPolicy;
 #[cfg(feature = "spirv")]
-use cubecl_runtime::compiler::{compilation_store, store_compiled};
+use cubecl_runtime::compiler::{KernelCacheKey, compilation_store, store_compiled};
 use cubecl_runtime::memory_management::{ManagedMemoryHandle, MemoryUsage, SharedMemoryBindings};
 use cubecl_runtime::{
     compiler::CubeTask,
@@ -72,7 +70,7 @@ pub struct WgpuServer<C: WgpuCompiler> {
     pipelines: HashMap<KernelId, (Arc<ComputePipeline>, CompilerInfo)>,
     scheduler: SchedulerMultiStream<ScheduledWgpuBackend>,
     #[cfg(feature = "spirv")]
-    pub(crate) spirv_cache: Option<Store<(u64, StableHash), cubecl_spirv::SpirvCacheEntry>>,
+    pub(crate) spirv_cache: Option<Store<(u64, KernelCacheKey), cubecl_spirv::SpirvCacheEntry>>,
     pub compilation_options: WgpuCompilationOptions,
     pub(crate) backend: wgpu::Backend,
     pub(crate) utilities: Arc<ServerUtilities<Self>>,
@@ -177,7 +175,8 @@ impl<C: WgpuCompiler> WgpuServer<C> {
             return Ok(pipeline.clone());
         }
 
-        let cached = self.load_cached_pipeline(&kernel_id, bindings, mode)?;
+        let definition = kernel.define();
+        let cached = self.load_cached_pipeline(&kernel_id, &definition, bindings, mode)?;
 
         if let Some(Ok(pipeline)) = cached {
             self.pipelines.insert(kernel_id, pipeline.clone());
@@ -188,7 +187,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
         validate_units(&self.utilities.properties, &kernel_id)?;
 
         let mut compiler = C::init(self.backend, &self.compilation_options);
-        let mut compiled = compiler.compile_kernel(self, kernel, mode)?;
+        let mut compiled = compiler.compile_kernel(self, kernel, definition, mode)?;
 
         if self.scheduler.logger.compilation_source_activated() {
             compiled.debug_info = Some(DebugInformation::new(


### PR DESCRIPTION
The on-disk cache is keyed on KernelId, which says nothing about the kernel body, so editing a #[cube] kernel or a helper it calls serves the stale artifact until you clear the cache by hand.
This keys it on a hash of the expanded CubeCL IR instead, which also required fixing two Hash bugs in cubecl-ir that were latent while hashes only fed in-process maps: AggregateKind hashed an Intern pointer that moves between runs, and Type::Vector dropped the vector size.
Cost is one define() per kernel per process, bounded by the in-memory kernel map.
