### PR TITLE
feat(tune): roofline bounds from a Work amount and per-resource thresholds

### DIFF
--- a/crates/cubecl-runtime/src/tune/bounds_generator.rs
+++ b/crates/cubecl-runtime/src/tune/bounds_generator.rs
@@ -57,26 +57,62 @@ pub struct AutotuneBound {
     pub ops_count: usize,
 }
 
+/// Work required by a problem, specified in minimum compute operations and byte transfers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(std_io, derive(serde::Serialize, serde::Deserialize))]
+pub struct Work {
+    /// Compute operations required.
+    pub compute_ops: usize,
+    /// Memory bytes transferred (reads and writes).
+    pub bytes: usize,
+}
+
+/// Target fractions of modeled peak compute and memory roofline throughput.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(std_io, derive(serde::Serialize, serde::Deserialize))]
+pub struct Thresholds {
+    /// Fraction of peak compute throughput expected.
+    pub compute: f32,
+    /// Fraction of peak memory bandwidth expected.
+    pub memory: f32,
+}
+
+impl Thresholds {
+    /// The same fraction for both bounds.
+    pub const fn uniform(fraction: f32) -> Self {
+        Self {
+            compute: fraction,
+            memory: fraction,
+        }
+    }
+}
+
+impl Default for Thresholds {
+    /// The roofline itself: a candidate is expected to reach 100% of the modeled peak, which
+    /// is the only fraction that needs no justification.
+    fn default() -> Self {
+        Self::uniform(1.0)
+    }
+}
+
 /// Standardizes the creation of compute and memory [`AutotuneBound`]s.
 pub fn calculate_bounds(
+    work: Work,
+    thresholds: Thresholds,
     compute_throughput: &ThroughputValue,
-    compute_ops: usize,
-    compute_threshold: f32,
     memory_throughput: &ThroughputValue,
     memory_key: &ThroughputKey,
-    memory_bytes: usize,
-    memory_threshold: f32,
 ) -> Vec<AutotuneBound> {
     alloc::vec![
         AutotuneBound {
-            ops_count: compute_ops,
+            ops_count: work.compute_ops,
             throughput: compute_throughput.ops_per_s(),
-            threshold: compute_threshold,
+            threshold: thresholds.compute,
         },
         AutotuneBound {
-            ops_count: memory_bytes,
+            ops_count: work.bytes,
             throughput: memory_throughput.bytes_per_s(memory_key),
-            threshold: memory_threshold,
+            threshold: thresholds.memory,
         },
     ]
 }
@@ -109,6 +145,8 @@ impl TimeBound for Bounds {
 
 #[cfg(test)]
 mod tests {
+    use crate::throughput::ThroughputMode;
+
     use super::*;
     use alloc::vec;
 
@@ -164,6 +202,40 @@ mod tests {
             launch_overhead: Duration::from_millis(500),
         };
         assert_eq!(bounds.time_limit(), Some(Duration::from_millis(2500)));
+    }
+
+    #[test]
+    fn calculate_bounds_applies_a_threshold_per_resource() {
+        let work = Work {
+            compute_ops: 8,
+            bytes: 16,
+        };
+        let thresholds = Thresholds {
+            compute: 0.5,
+            memory: 1.0,
+        };
+        let key = ThroughputKey {
+            mode: ThroughputMode::Memory,
+        };
+
+        let bounds = calculate_bounds(
+            work,
+            thresholds,
+            &ThroughputValue::ZERO,
+            &ThroughputValue::ZERO,
+            &key,
+        );
+
+        assert_eq!(bounds[0].ops_count, 8);
+        assert_eq!(bounds[0].threshold, 0.5);
+        assert_eq!(bounds[1].ops_count, 16);
+        assert_eq!(bounds[1].threshold, 1.0);
+    }
+
+    #[test]
+    fn the_default_threshold_is_the_roofline_itself() {
+        assert_eq!(Thresholds::default(), Thresholds::uniform(1.0));
+        assert_eq!(Thresholds::default().compute, 1.0);
     }
 
     #[test]

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -4,6 +4,7 @@ use cubecl_runtime::{
     runtime::Runtime,
     server::CubeDim,
     throughput::{ThroughputKey, ThroughputMode, ThroughputValue},
+    tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
 
 use crate::throughput::{compute_cmma, compute_direct, launch_overhead, memory_direct};
@@ -50,6 +51,34 @@ pub fn measure_peak_throughput<R: Runtime>(
     client.memory_cleanup();
 
     value
+}
+
+/// Calculates roofline autotune bounds for a given [`Work`] amount and compute throughput key.
+///
+/// Measures compute and memory peak throughputs along with launch overhead for the runtime client.
+pub fn roofline_bounds<R: Runtime>(
+    client: &ComputeClient<R>,
+    compute_key: ThroughputKey,
+    work: Work,
+    thresholds: Thresholds,
+) -> Bounds {
+    let memory_key = ThroughputKey {
+        mode: ThroughputMode::Memory,
+    };
+    let launch_key = ThroughputKey {
+        mode: ThroughputMode::Launch,
+    };
+
+    Bounds {
+        bounds: calculate_bounds(
+            work,
+            thresholds,
+            &measure_peak_throughput(client, compute_key),
+            &measure_peak_throughput(client, memory_key),
+            &memory_key,
+        ),
+        launch_overhead: measure_peak_throughput(client, launch_key).duration_per_op(),
+    }
 }
 
 /// Hardware execution parameters for launching a compute kernel.


### PR DESCRIPTION
Autotune bounds are currently assembled by each consumer: measure the peaks, pick thresholds, build the two `AutotuneBound`s by hand. This moves the shared half into cubecl.

`Work` holds what a problem costs, in compute operations and bytes. `Thresholds` holds the target fraction of peak, one per resource, so a caller can hold its memory bound at peak while giving compute slack. `calculate_bounds` takes both instead of seven positional arguments.

`roofline_bounds` in cubecl-std measures the compute and memory peaks plus the launch overhead and assembles the `Bounds`, so a kernel family only has to state what its problem costs and which instruction it computes with.

Per key or per group threshold policies need nothing further: a `BoundsGenerator` already receives the autotune key and the inputs, so the thresholds it passes can be any function of them.

Note that the counts in `Work` must be under-estimates. The tuner keeps the first candidate at or below the time limit, so overstating a count buys a mediocre kernel an early exit, while understating one only costs a full tuning round.

Two new unit tests: thresholds land on the matching bound, and the default is 1.0.