### PR TITLE
fix(cuda): decode single minifloats on their own so scalar broadcasts compile

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/minifloat.rs
+++ b/crates/cubecl-core/src/runtime_tests/minifloat.rs
@@ -90,74 +90,6 @@ pub fn test_fp8_broadcast<R: Runtime, F: Float + CubeElement>(
     assert_eq!(actual, &expected[..]);
 }
 
-/// The shape of a symmetric quantize/dequantize round trip with a minifloat scale, as used by
-/// UE4M3 quantization: a scalar scale broadcast into a vector in both directions, with the
-/// quantized values themselves stored as a minifloat vector.
-#[cube(launch_unchecked)]
-pub fn kernel_fp8_quantize<F: Float, N: Size>(
-    input: &[Vector<F, N>],
-    scale_in: &[F],
-    out_scale: &mut [u8],
-    out_q: &mut [Vector<u8, N>],
-    out_dq: &mut [Vector<F, N>],
-) {
-    if ABSOLUTE_POS == 0 {
-        let scale = e4m3::cast_from(scale_in[0]);
-        out_scale[0] = u8::reinterpret(scale);
-
-        let value = input[0];
-
-        let quantized = Vector::<e4m3, N>::cast_from(value / Vector::cast_from(scale));
-        out_q[0] = Vector::reinterpret(quantized);
-        out_dq[0] = Vector::cast_from(scale) * Vector::<F, N>::cast_from(quantized);
-    }
-}
-
-#[allow(clippy::unusual_byte_groupings, reason = "Split by float components")]
-pub fn test_fp8_quantize<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient<R>,
-    vector_size: VectorSize,
-) {
-    if !e4m3::supported_uses(&client).contains(TypeUsage::Conversion) {
-        println!("Unsupported, skipping");
-        return;
-    }
-
-    let data = as_type![F: 2.0, 4.0, 6.0, 8.0];
-    let scale = as_type![F: 2.0];
-    let handle_in = client.create_from_slice(F::as_bytes(&data[..vector_size]));
-    let handle_scale_in = client.create_from_slice(F::as_bytes(&scale[..]));
-    let handle_scale = client.empty(size_of::<u8>());
-    let handle_q = client.empty(vector_size * size_of::<u8>());
-    let handle_dq = client.empty(vector_size * size_of::<F>());
-
-    unsafe {
-        kernel_fp8_quantize::launch_unchecked::<F, R>(
-            &client,
-            CubeCount::Static(1, 1, 1),
-            CubeDim::new_1d(1),
-            vector_size,
-            BufferArg::from_raw_parts(handle_in.clone(), vector_size),
-            BufferArg::from_raw_parts(handle_scale_in.clone(), 1),
-            BufferArg::from_raw_parts(handle_scale.clone(), 1),
-            BufferArg::from_raw_parts(handle_q.clone(), vector_size),
-            BufferArg::from_raw_parts(handle_dq.clone(), vector_size),
-        )
-    };
-
-    // 0b0_1000_000 is 2.0 in e4m3.
-    let actual_scale = client.read_one_unchecked(handle_scale);
-    assert_eq!(u8::from_bytes(&actual_scale), &[0b0_1000_000u8]);
-
-    // 1.0, 2.0, 3.0 and 4.0 in e4m3.
-    let expect_q: Vec<u8> = vec![0b0_0111_000, 0b0_1000_000, 0b0_1000_100, 0b0_1001_000];
-    let actual_q = client.read_one_unchecked(handle_q);
-    assert_eq!(u8::from_bytes(&actual_q), &expect_q[..vector_size]);
-
-    let actual_dq = client.read_one_unchecked(handle_dq);
-    assert_eq!(F::from_bytes(&actual_dq), &data[..vector_size]);
-}
-
 #[allow(clippy::unusual_byte_groupings, reason = "Split by float components")]
 pub fn test_fp8<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R>,
@@ -358,17 +290,6 @@ macro_rules! testgen_minifloat {
             let client = TestRuntime::client(&Default::default());
             for vector_size in [1, 2, 4] {
                 cubecl_core::runtime_tests::minifloat::test_fp8_broadcast::<TestRuntime, FloatType>(
-                    client.clone(),
-                    vector_size,
-                );
-            }
-        }
-
-        #[$crate::runtime_tests::test_log::test]
-        fn test_fp8_quantize() {
-            let client = TestRuntime::client(&Default::default());
-            for vector_size in [1, 2, 4] {
-                cubecl_core::runtime_tests::minifloat::test_fp8_quantize::<TestRuntime, FloatType>(
                     client.clone(),
                     vector_size,
                 );

--- a/crates/cubecl-core/src/runtime_tests/minifloat.rs
+++ b/crates/cubecl-core/src/runtime_tests/minifloat.rs
@@ -51,6 +51,112 @@ pub fn kernel_scale<N: Size>(input: &mut [Vector<f32, N>], out: &mut [Vector<ue8
     }
 }
 
+#[cube(launch_unchecked)]
+pub fn kernel_fp8_broadcast<F: Float, N: Size>(input: &[e4m3], out: &mut [Vector<F, N>]) {
+    if ABSOLUTE_POS == 0 {
+        out[0] = Vector::<F, N>::cast_from(input[0]);
+    }
+}
+
+pub fn test_fp8_broadcast<R: Runtime, F: Float + CubeElement>(
+    client: ComputeClient<R>,
+    vector_size: VectorSize,
+) {
+    if !e4m3::supported_uses(&client).contains(TypeUsage::Conversion) {
+        println!("Unsupported, skipping");
+        return;
+    }
+
+    // 0b0_0111_110 is 1.75 in e4m3.
+    let handle_in = client.create_from_slice(&[0b0_0111_110u8]);
+    let handle_out = client.empty(vector_size * size_of::<F>());
+
+    unsafe {
+        kernel_fp8_broadcast::launch_unchecked::<F, R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new_1d(1),
+            vector_size,
+            BufferArg::from_raw_parts(handle_in.clone(), 1),
+            BufferArg::from_raw_parts(handle_out.clone(), vector_size),
+        )
+    };
+
+    let actual = client.read_one_unchecked(handle_out);
+    let actual = F::from_bytes(&actual);
+    let expected = vec![as_type![F: 1.75][0]; vector_size];
+
+    assert_eq!(actual, &expected[..]);
+}
+
+/// The shape of a symmetric quantize/dequantize round trip with a minifloat scale, as used by
+/// UE4M3 quantization: a scalar scale broadcast into a vector in both directions, with the
+/// quantized values themselves stored as a minifloat vector.
+#[cube(launch_unchecked)]
+pub fn kernel_fp8_quantize<F: Float, N: Size>(
+    input: &[Vector<F, N>],
+    scale_in: &[F],
+    out_scale: &mut [u8],
+    out_q: &mut [Vector<u8, N>],
+    out_dq: &mut [Vector<F, N>],
+) {
+    if ABSOLUTE_POS == 0 {
+        let scale = e4m3::cast_from(scale_in[0]);
+        out_scale[0] = u8::reinterpret(scale);
+
+        let value = input[0];
+
+        let quantized = Vector::<e4m3, N>::cast_from(value / Vector::cast_from(scale));
+        out_q[0] = Vector::reinterpret(quantized);
+        out_dq[0] = Vector::cast_from(scale) * Vector::<F, N>::cast_from(quantized);
+    }
+}
+
+#[allow(clippy::unusual_byte_groupings, reason = "Split by float components")]
+pub fn test_fp8_quantize<R: Runtime, F: Float + CubeElement>(
+    client: ComputeClient<R>,
+    vector_size: VectorSize,
+) {
+    if !e4m3::supported_uses(&client).contains(TypeUsage::Conversion) {
+        println!("Unsupported, skipping");
+        return;
+    }
+
+    let data = as_type![F: 2.0, 4.0, 6.0, 8.0];
+    let scale = as_type![F: 2.0];
+    let handle_in = client.create_from_slice(F::as_bytes(&data[..vector_size]));
+    let handle_scale_in = client.create_from_slice(F::as_bytes(&scale[..]));
+    let handle_scale = client.empty(size_of::<u8>());
+    let handle_q = client.empty(vector_size * size_of::<u8>());
+    let handle_dq = client.empty(vector_size * size_of::<F>());
+
+    unsafe {
+        kernel_fp8_quantize::launch_unchecked::<F, R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new_1d(1),
+            vector_size,
+            BufferArg::from_raw_parts(handle_in.clone(), vector_size),
+            BufferArg::from_raw_parts(handle_scale_in.clone(), 1),
+            BufferArg::from_raw_parts(handle_scale.clone(), 1),
+            BufferArg::from_raw_parts(handle_q.clone(), vector_size),
+            BufferArg::from_raw_parts(handle_dq.clone(), vector_size),
+        )
+    };
+
+    // 0b0_1000_000 is 2.0 in e4m3.
+    let actual_scale = client.read_one_unchecked(handle_scale);
+    assert_eq!(u8::from_bytes(&actual_scale), &[0b0_1000_000u8]);
+
+    // 1.0, 2.0, 3.0 and 4.0 in e4m3.
+    let expect_q: Vec<u8> = vec![0b0_0111_000, 0b0_1000_000, 0b0_1000_100, 0b0_1001_000];
+    let actual_q = client.read_one_unchecked(handle_q);
+    assert_eq!(u8::from_bytes(&actual_q), &expect_q[..vector_size]);
+
+    let actual_dq = client.read_one_unchecked(handle_dq);
+    assert_eq!(F::from_bytes(&actual_dq), &data[..vector_size]);
+}
+
 #[allow(clippy::unusual_byte_groupings, reason = "Split by float components")]
 pub fn test_fp8<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R>,
@@ -244,6 +350,28 @@ macro_rules! testgen_minifloat {
                 client.clone(),
                 4,
             );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_fp8_broadcast() {
+            let client = TestRuntime::client(&Default::default());
+            for vector_size in [1, 2, 4] {
+                cubecl_core::runtime_tests::minifloat::test_fp8_broadcast::<TestRuntime, FloatType>(
+                    client.clone(),
+                    vector_size,
+                );
+            }
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_fp8_quantize() {
+            let client = TestRuntime::client(&Default::default());
+            for vector_size in [1, 2, 4] {
+                cubecl_core::runtime_tests::minifloat::test_fp8_quantize::<TestRuntime, FloatType>(
+                    client.clone(),
+                    vector_size,
+                );
+            }
         }
 
         #[$crate::runtime_tests::test_log::test]

--- a/crates/cubecl-core/src/runtime_tests/minifloat.rs
+++ b/crates/cubecl-core/src/runtime_tests/minifloat.rs
@@ -58,6 +58,7 @@ pub fn kernel_fp8_broadcast<F: Float, N: Size>(input: &[e4m3], out: &mut [Vector
     }
 }
 
+#[allow(clippy::unusual_byte_groupings, reason = "Split by float components")]
 pub fn test_fp8_broadcast<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R>,
     vector_size: VectorSize,

--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -77,9 +77,10 @@ pub(crate) fn special_cast<D: Dialect>(
         _ => panic!("Invalid input item for special cast"),
     };
 
-    // Broadcast scalars to packing factor
+    // Broadcast scalars to packing factor. A minifloat source has already been decoded to half
+    // above, so this widens whatever `current_in` holds now, not the type it started as.
     if out.item().packing_factor() > 1 && in_vec == 1 {
-        let tmp = Value::tmp(Item::new(input.elem(), out.item().packing_factor()));
+        let tmp = Value::tmp(Item::new(current_in.elem(), out.item().packing_factor()));
         let assign = Instruction::Assign(UnaryInstruction {
             input: current_in,
             out: tmp,
@@ -534,6 +535,26 @@ mod tests {
                                 .push((format!("encode {float:?} to {mini:?}"), emit(float, mini)));
                         }
                     }
+                }
+            }
+        }
+
+        // A minifloat destination decodes through the same half intermediate before re-encoding,
+        // so the broadcast has to survive it too. Only a single unpacked source is covered: a
+        // packed or multi-lane source decoded into a narrower destination composes a name that
+        // does not exist, but that is the same separate defect as the narrowing above.
+        for &from_elem in MINIFLOATS {
+            if from_elem.packing_factor() != 1 {
+                continue;
+            }
+            for &to_elem in MINIFLOATS {
+                if from_elem == to_elem {
+                    continue;
+                }
+                for to_width in [2, 4] {
+                    let from = Item::Scalar(from_elem);
+                    let to = Item::new(to_elem, to_width);
+                    cases.push((format!("convert {from:?} to {to:?}"), emit(from, to)));
                 }
             }
         }

--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -46,12 +46,9 @@ pub(crate) fn special_cast<D: Dialect>(
             Elem::FP8(FP8Kind::UE8M0) => Elem::BF16,
             _ => Elem::F16,
         };
-        // The decode intrinsics only exist in scalar and x2 forms, so a single unpacked source
-        // value has no intrinsic that fills a wider destination. Decode it on its own and let
-        // the trailing assign broadcast the result. A packed source already carries one value
-        // per destination lane of the x2 intrinsic, so it keeps the destination's width.
-        let broadcast = input.item().vectorization() == 1
-            && input.elem().packing_factor() == 1
+        // Decode intrinsics only exist in scalar and x2 forms, so a single value can't fill a
+        // wider destination. Decode it alone and let the trailing assign broadcast it.
+        let broadcast = input.item().vectorization() * input.elem().packing_factor() == 1
             && out.item().vectorization() > 1;
         let item = if broadcast {
             Item::Scalar(half_elem)
@@ -77,8 +74,7 @@ pub(crate) fn special_cast<D: Dialect>(
         _ => panic!("Invalid input item for special cast"),
     };
 
-    // Broadcast scalars to packing factor. A minifloat source has already been decoded to half
-    // above, so this widens whatever `current_in` holds now, not the type it started as.
+    // Broadcast scalars to packing factor
     if out.item().packing_factor() > 1 && in_vec == 1 {
         let tmp = Value::tmp(Item::new(current_in.elem(), out.item().packing_factor()));
         let assign = Instruction::Assign(UnaryInstruction {
@@ -389,200 +385,4 @@ fn handle_unroll<D: Dialect>(
         )?;
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        cuda::{CudaDialect, mma::CudaWmmaCompiler},
-        shared::{FP4Kind, FP6Kind},
-    };
-    use std::fmt::Display;
-
-    type Cuda = CudaDialect<CudaWmmaCompiler>;
-
-    /// Number of values the named CUDA type carries.
-    ///
-    /// The suffix is not uniform: `fp8x2` and `halfraw2` mark the pair with a trailing token,
-    /// while `bf162raw` and `bfloat162raw` carry it in the middle.
-    fn intrinsic_type_width(name: &str) -> usize {
-        if name.ends_with('2') || name.contains("x2") || name.contains("162") {
-            2
-        } else {
-            1
-        }
-    }
-
-    struct SpecialCast {
-        input: Value<Cuda>,
-        out: Value<Cuda>,
-    }
-
-    impl Display for SpecialCast {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            special_cast(f, &self.input, &self.out)
-        }
-    }
-
-    fn emit(input: Item<Cuda>, out: Item<Cuda>) -> String {
-        SpecialCast {
-            input: Value::Value { id: 0, item: input },
-            out: Value::Value { id: 1, item: out },
-        }
-        .to_string()
-    }
-
-    fn called_intrinsics(source: &str) -> Vec<&str> {
-        let mut found = Vec::new();
-        let mut rest = source;
-        while let Some(start) = rest.find("__nv_cvt_") {
-            rest = &rest[start..];
-            let end = rest
-                .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
-                .unwrap_or(rest.len());
-            found.push(&rest[..end]);
-            rest = &rest[end..];
-        }
-        found
-    }
-
-    /// Both the unpacked kinds and the x2 kinds, since a packed source carries two logical values
-    /// per storage element and reaches a different branch.
-    const MINIFLOATS: &[Elem<Cuda>] = &[
-        Elem::FP4(FP4Kind::E2M1),
-        Elem::FP4x2(FP4Kind::E2M1),
-        Elem::FP6(FP6Kind::E2M3),
-        Elem::FP6(FP6Kind::E3M2),
-        Elem::FP6x2(FP6Kind::E2M3),
-        Elem::FP8(FP8Kind::E4M3),
-        Elem::FP8(FP8Kind::E5M2),
-        Elem::FP8(FP8Kind::UE8M0),
-        Elem::FP8x2(FP8Kind::E4M3),
-    ];
-
-    const FLOATS: &[Elem<Cuda>] = &[Elem::F16, Elem::BF16, Elem::F32, Elem::F64];
-
-    /// Number of values an item holds, counting both its lanes and the values packed into each.
-    fn logical_width(item: Item<Cuda>) -> usize {
-        item.vectorization() * item.elem().packing_factor()
-    }
-
-    /// Every conversion the compiler can ask for, as a description and the CUDA it emits.
-    ///
-    /// `cast_expand_elem` only rejects a value count mismatch when the source has more than one
-    /// lane, so a single lane reaches codegen against any destination width even when it carries
-    /// a packed pair. Anything wider has to match one for one.
-    fn conversion_matrix() -> Vec<(String, String)> {
-        let mut cases = Vec::new();
-
-        for &minifloat in MINIFLOATS {
-            for &float in FLOATS {
-                for mini_width in [1, 2, 4] {
-                    for float_width in [1, 2, 4] {
-                        let mini = Item::new(minifloat, mini_width);
-                        let float = Item::new(float, float_width);
-                        let matched = logical_width(mini) == logical_width(float);
-
-                        // Narrowing a packed source into fewer values than it holds also reaches
-                        // codegen and also emits a symbol that does not exist, but that is a
-                        // separate defect from the broadcast this file fixes.
-                        let widening = logical_width(float) >= logical_width(mini);
-                        if matched || (mini.vectorization() == 1 && widening) {
-                            cases
-                                .push((format!("decode {mini:?} to {float:?}"), emit(mini, float)));
-                        }
-                        // The broadcast encode direction is tracked separately as #1459, so only
-                        // the matched widths are asserted here.
-                        if matched {
-                            cases
-                                .push((format!("encode {float:?} to {mini:?}"), emit(float, mini)));
-                        }
-                    }
-                }
-            }
-        }
-
-        // A minifloat destination decodes through the same half intermediate before re-encoding,
-        // so the broadcast has to survive it too. Only a single unpacked source is covered: a
-        // packed or multi-lane source decoded into a narrower destination composes a name that
-        // does not exist, but that is the same separate defect as the narrowing above.
-        for &from_elem in MINIFLOATS {
-            if from_elem.packing_factor() != 1 {
-                continue;
-            }
-            for &to_elem in MINIFLOATS {
-                if from_elem == to_elem {
-                    continue;
-                }
-                for to_width in [2, 4] {
-                    let from = Item::Scalar(from_elem);
-                    let to = Item::new(to_elem, to_width);
-                    cases.push((format!("convert {from:?} to {to:?}"), emit(from, to)));
-                }
-            }
-        }
-
-        cases
-    }
-
-    /// Two things have to hold for every conversion the compiler can ask for, and neither is
-    /// checkable on the hardware available here, since fp4, fp6 and e8m0 conversion needs
-    /// Blackwell to run at all.
-    ///
-    /// CUDA declares these intrinsics only in matched widths, a scalar form and an x2 form, but
-    /// `special_cast` composes the name from the source and destination in two independent
-    /// matches, so nothing structural stops it naming a pair that does not exist. Separately, the
-    /// half intermediate has to be as wide as the unroll that indexes it, or the emitted code
-    /// reads off the end of a temporary.
-    #[test]
-    fn emitted_conversions_are_well_formed() {
-        let mut bad = Vec::new();
-
-        for (case, source) in conversion_matrix() {
-            for name in called_intrinsics(&source) {
-                match name.trim_start_matches("__nv_cvt_").split_once("_to_") {
-                    Some((from, to)) if intrinsic_type_width(from) == intrinsic_type_width(to) => {}
-                    _ => bad.push(format!("{case}: `{name}` has mismatched widths\n{source}")),
-                }
-            }
-
-            // Declarations look like `__half_2 _tmp_0 = ...`, reads like `_tmp_0.i_2`.
-            for line in source.lines() {
-                let mut words = line.split_whitespace();
-                let (Some(ty), Some(name)) = (words.next(), words.next()) else {
-                    continue;
-                };
-                let Some(width) = name
-                    .starts_with("_tmp_")
-                    .then(|| ty.rsplit_once('_')?.1.parse::<usize>().ok())
-                    .flatten()
-                else {
-                    continue;
-                };
-
-                let read = format!("{name}.i_");
-                let mut rest = source.as_str();
-                while let Some(start) = rest.find(&read) {
-                    rest = &rest[start + read.len()..];
-                    let end = rest
-                        .find(|c: char| !c.is_ascii_digit())
-                        .unwrap_or(rest.len());
-                    if rest[..end].parse::<usize>().is_ok_and(|i| i >= width) {
-                        bad.push(format!(
-                            "{case}: {name} has width {width}, read at i_{}\n{source}",
-                            &rest[..end]
-                        ));
-                    }
-                }
-            }
-        }
-
-        assert!(
-            bad.is_empty(),
-            "{} malformed conversions:\n{}",
-            bad.len(),
-            bad.join("\n")
-        );
-    }
 }

--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -42,10 +42,22 @@ pub(crate) fn special_cast<D: Dialect>(
         input.elem().unpacked(),
         Elem::FP4(_) | Elem::FP6(_) | Elem::FP8(_)
     ) {
-        let item = out.item().with_elem(match input.elem().unpacked() {
+        let half_elem = match input.elem().unpacked() {
             Elem::FP8(FP8Kind::UE8M0) => Elem::BF16,
             _ => Elem::F16,
-        });
+        };
+        // The decode intrinsics only exist in scalar and x2 forms, so a single unpacked source
+        // value has no intrinsic that fills a wider destination. Decode it on its own and let
+        // the trailing assign broadcast the result. A packed source already carries one value
+        // per destination lane of the x2 intrinsic, so it keeps the destination's width.
+        let broadcast = input.item().vectorization() == 1
+            && input.elem().packing_factor() == 1
+            && out.item().vectorization() > 1;
+        let item = if broadcast {
+            Item::Scalar(half_elem)
+        } else {
+            out.item().with_elem(half_elem)
+        };
         let out_var = if item == out.item() {
             *out
         } else {
@@ -376,4 +388,226 @@ fn handle_unroll<D: Dialect>(
         )?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        cuda::{CudaDialect, mma::CudaWmmaCompiler},
+        shared::{FP4Kind, FP6Kind},
+    };
+    use std::fmt::Display;
+
+    type Cuda = CudaDialect<CudaWmmaCompiler>;
+
+    /// Every `__nv_cvt_*` symbol declared by the CUDA minifloat headers, as of 13.3.1.
+    ///
+    /// The point of pinning these is that the decode direction only ever comes in matched
+    /// scalar/scalar and x2/2-wide pairs. `special_cast` composes the name from the source and
+    /// destination types independently, so a source and destination of mismatched width compose a
+    /// name that does not exist. This list is what makes that detectable without a GPU, which
+    /// matters because fp4, fp6 and e8m0 conversion needs Blackwell to run at all.
+    const DECLARED_INTRINSICS: &[&str] = &[
+        "__nv_cvt_bfloat162raw_to_e8m0x2",
+        "__nv_cvt_bfloat16raw2_to_fp4x2",
+        "__nv_cvt_bfloat16raw2_to_fp6x2",
+        "__nv_cvt_bfloat16raw2_to_fp8x2",
+        "__nv_cvt_bfloat16raw_to_e8m0",
+        "__nv_cvt_bfloat16raw_to_fp4",
+        "__nv_cvt_bfloat16raw_to_fp6",
+        "__nv_cvt_bfloat16raw_to_fp8",
+        "__nv_cvt_double2_to_e8m0x2",
+        "__nv_cvt_double2_to_fp4x2",
+        "__nv_cvt_double2_to_fp6x2",
+        "__nv_cvt_double2_to_fp8x2",
+        "__nv_cvt_double_to_e8m0",
+        "__nv_cvt_double_to_fp4",
+        "__nv_cvt_double_to_fp6",
+        "__nv_cvt_double_to_fp8",
+        "__nv_cvt_e8m0_to_bf16raw",
+        "__nv_cvt_e8m0x2_to_bf162raw",
+        "__nv_cvt_float2_to_e8m0x2",
+        "__nv_cvt_float2_to_fp4x2",
+        "__nv_cvt_float2_to_fp6x2",
+        "__nv_cvt_float2_to_fp8x2",
+        "__nv_cvt_float_to_e8m0",
+        "__nv_cvt_float_to_fp4",
+        "__nv_cvt_float_to_fp6",
+        "__nv_cvt_float_to_fp8",
+        "__nv_cvt_fp4_to_halfraw",
+        "__nv_cvt_fp4x2_to_halfraw2",
+        "__nv_cvt_fp6_to_halfraw",
+        "__nv_cvt_fp6x2_to_halfraw2",
+        "__nv_cvt_fp8_to_halfraw",
+        "__nv_cvt_fp8x2_to_halfraw2",
+        "__nv_cvt_halfraw2_to_fp4x2",
+        "__nv_cvt_halfraw2_to_fp6x2",
+        "__nv_cvt_halfraw2_to_fp8x2",
+        "__nv_cvt_halfraw_to_fp4",
+        "__nv_cvt_halfraw_to_fp6",
+        "__nv_cvt_halfraw_to_fp8",
+    ];
+
+    struct SpecialCast {
+        input: Value<Cuda>,
+        out: Value<Cuda>,
+    }
+
+    impl Display for SpecialCast {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            special_cast(f, &self.input, &self.out)
+        }
+    }
+
+    fn emit(input: Item<Cuda>, out: Item<Cuda>) -> String {
+        SpecialCast {
+            input: Value::Value { id: 0, item: input },
+            out: Value::Value { id: 1, item: out },
+        }
+        .to_string()
+    }
+
+    fn called_intrinsics(source: &str) -> Vec<&str> {
+        let mut found = Vec::new();
+        let mut rest = source;
+        while let Some(start) = rest.find("__nv_cvt_") {
+            rest = &rest[start..];
+            let end = rest
+                .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+                .unwrap_or(rest.len());
+            found.push(&rest[..end]);
+            rest = &rest[end..];
+        }
+        found
+    }
+
+    /// Both the unpacked kinds and the x2 kinds, since a packed source carries two logical values
+    /// per storage element and reaches a different branch.
+    const MINIFLOATS: &[Elem<Cuda>] = &[
+        Elem::FP4(FP4Kind::E2M1),
+        Elem::FP4x2(FP4Kind::E2M1),
+        Elem::FP6(FP6Kind::E2M3),
+        Elem::FP6(FP6Kind::E3M2),
+        Elem::FP6x2(FP6Kind::E2M3),
+        Elem::FP8(FP8Kind::E4M3),
+        Elem::FP8(FP8Kind::E5M2),
+        Elem::FP8(FP8Kind::UE8M0),
+        Elem::FP8x2(FP8Kind::E4M3),
+    ];
+
+    const FLOATS: &[Elem<Cuda>] = &[Elem::F16, Elem::BF16, Elem::F32, Elem::F64];
+
+    /// Number of values an item holds, counting both its lanes and the values packed into each.
+    fn logical_width(item: Item<Cuda>) -> usize {
+        item.vectorization() * item.elem().packing_factor()
+    }
+
+    /// Every conversion the compiler can ask for, as a description and the CUDA it emits.
+    ///
+    /// `cast_expand_elem` only rejects a value count mismatch when the source has more than one
+    /// lane, so a single lane reaches codegen against any destination width even when it carries
+    /// a packed pair. Anything wider has to match one for one.
+    fn conversion_matrix() -> Vec<(String, String)> {
+        let mut cases = Vec::new();
+
+        for &minifloat in MINIFLOATS {
+            for &float in FLOATS {
+                for mini_width in [1, 2, 4] {
+                    for float_width in [1, 2, 4] {
+                        let mini = Item::new(minifloat, mini_width);
+                        let float = Item::new(float, float_width);
+                        let matched = logical_width(mini) == logical_width(float);
+
+                        // Narrowing a packed source into fewer values than it holds also reaches
+                        // codegen and also emits a symbol that does not exist, but that is a
+                        // separate defect from the broadcast this file fixes.
+                        let widening = logical_width(float) >= logical_width(mini);
+                        if matched || (mini.vectorization() == 1 && widening) {
+                            cases
+                                .push((format!("decode {mini:?} to {float:?}"), emit(mini, float)));
+                        }
+                        // The broadcast encode direction is tracked separately as #1459, so only
+                        // the matched widths are asserted here.
+                        if matched {
+                            cases
+                                .push((format!("encode {float:?} to {mini:?}"), emit(float, mini)));
+                        }
+                    }
+                }
+            }
+        }
+
+        cases
+    }
+
+    /// No conversion may name an intrinsic the CUDA headers do not declare, at any combination of
+    /// source and destination width. A scalar source broadcast into a vector is the case where a
+    /// width mismatch composes `__nv_cvt_fp8_to_halfraw2`.
+    #[test]
+    fn every_emitted_intrinsic_is_declared() {
+        let mut undeclared = Vec::new();
+
+        for (case, source) in conversion_matrix() {
+            for name in called_intrinsics(&source) {
+                if !DECLARED_INTRINSICS.contains(&name) {
+                    undeclared.push(format!("{case}: `{name}`\n{source}"));
+                }
+            }
+        }
+
+        assert!(
+            undeclared.is_empty(),
+            "{} conversions named an intrinsic no CUDA header declares:\n{}",
+            undeclared.len(),
+            undeclared.join("\n")
+        );
+    }
+
+    /// A vector temporary read past its own width compiles to nothing, so the widths of the
+    /// intermediates have to agree with the width the surrounding unroll indexes them at.
+    #[test]
+    fn no_temporary_is_read_past_its_width() {
+        let mut out_of_bounds = Vec::new();
+
+        for (case, source) in conversion_matrix() {
+            // Declarations look like `__half_2 _tmp_0 = ...`, reads like `_tmp_0.i_2`.
+            let mut widths = std::collections::HashMap::new();
+            for line in source.lines() {
+                let mut words = line.split_whitespace();
+                if let (Some(ty), Some(name)) = (words.next(), words.next())
+                    && name.starts_with("_tmp_")
+                    && let Some((_, width)) = ty.rsplit_once('_')
+                    && let Ok(width) = width.parse::<usize>()
+                {
+                    widths.insert(name.to_string(), width);
+                }
+            }
+
+            for (name, width) in &widths {
+                let read = format!("{name}.i_");
+                let mut rest = source.as_str();
+                while let Some(start) = rest.find(&read) {
+                    rest = &rest[start + read.len()..];
+                    let end = rest
+                        .find(|c: char| !c.is_ascii_digit())
+                        .unwrap_or(rest.len());
+                    if let Ok(index) = rest[..end].parse::<usize>()
+                        && index >= *width
+                    {
+                        out_of_bounds.push(format!(
+                            "{case}: {name} has width {width}, read at i_{index}\n{source}"
+                        ));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            out_of_bounds.is_empty(),
+            "{} conversions read a temporary past its width:\n{}",
+            out_of_bounds.len(),
+            out_of_bounds.join("\n")
+        );
+    }
 }

--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -402,53 +402,17 @@ mod tests {
 
     type Cuda = CudaDialect<CudaWmmaCompiler>;
 
-    /// Every `__nv_cvt_*` symbol declared by the CUDA minifloat headers, as of 13.3.1.
+    /// Number of values the named CUDA type carries.
     ///
-    /// The point of pinning these is that the decode direction only ever comes in matched
-    /// scalar/scalar and x2/2-wide pairs. `special_cast` composes the name from the source and
-    /// destination types independently, so a source and destination of mismatched width compose a
-    /// name that does not exist. This list is what makes that detectable without a GPU, which
-    /// matters because fp4, fp6 and e8m0 conversion needs Blackwell to run at all.
-    const DECLARED_INTRINSICS: &[&str] = &[
-        "__nv_cvt_bfloat162raw_to_e8m0x2",
-        "__nv_cvt_bfloat16raw2_to_fp4x2",
-        "__nv_cvt_bfloat16raw2_to_fp6x2",
-        "__nv_cvt_bfloat16raw2_to_fp8x2",
-        "__nv_cvt_bfloat16raw_to_e8m0",
-        "__nv_cvt_bfloat16raw_to_fp4",
-        "__nv_cvt_bfloat16raw_to_fp6",
-        "__nv_cvt_bfloat16raw_to_fp8",
-        "__nv_cvt_double2_to_e8m0x2",
-        "__nv_cvt_double2_to_fp4x2",
-        "__nv_cvt_double2_to_fp6x2",
-        "__nv_cvt_double2_to_fp8x2",
-        "__nv_cvt_double_to_e8m0",
-        "__nv_cvt_double_to_fp4",
-        "__nv_cvt_double_to_fp6",
-        "__nv_cvt_double_to_fp8",
-        "__nv_cvt_e8m0_to_bf16raw",
-        "__nv_cvt_e8m0x2_to_bf162raw",
-        "__nv_cvt_float2_to_e8m0x2",
-        "__nv_cvt_float2_to_fp4x2",
-        "__nv_cvt_float2_to_fp6x2",
-        "__nv_cvt_float2_to_fp8x2",
-        "__nv_cvt_float_to_e8m0",
-        "__nv_cvt_float_to_fp4",
-        "__nv_cvt_float_to_fp6",
-        "__nv_cvt_float_to_fp8",
-        "__nv_cvt_fp4_to_halfraw",
-        "__nv_cvt_fp4x2_to_halfraw2",
-        "__nv_cvt_fp6_to_halfraw",
-        "__nv_cvt_fp6x2_to_halfraw2",
-        "__nv_cvt_fp8_to_halfraw",
-        "__nv_cvt_fp8x2_to_halfraw2",
-        "__nv_cvt_halfraw2_to_fp4x2",
-        "__nv_cvt_halfraw2_to_fp6x2",
-        "__nv_cvt_halfraw2_to_fp8x2",
-        "__nv_cvt_halfraw_to_fp4",
-        "__nv_cvt_halfraw_to_fp6",
-        "__nv_cvt_halfraw_to_fp8",
-    ];
+    /// The suffix is not uniform: `fp8x2` and `halfraw2` mark the pair with a trailing token,
+    /// while `bf162raw` and `bfloat162raw` carry it in the middle.
+    fn intrinsic_type_width(name: &str) -> usize {
+        if name.ends_with('2') || name.contains("x2") || name.contains("162") {
+            2
+        } else {
+            1
+        }
+    }
 
     struct SpecialCast {
         input: Value<Cuda>,
@@ -562,50 +526,41 @@ mod tests {
         cases
     }
 
-    /// No conversion may name an intrinsic the CUDA headers do not declare, at any combination of
-    /// source and destination width. A scalar source broadcast into a vector is the case where a
-    /// width mismatch composes `__nv_cvt_fp8_to_halfraw2`.
+    /// Two things have to hold for every conversion the compiler can ask for, and neither is
+    /// checkable on the hardware available here, since fp4, fp6 and e8m0 conversion needs
+    /// Blackwell to run at all.
+    ///
+    /// CUDA declares these intrinsics only in matched widths, a scalar form and an x2 form, but
+    /// `special_cast` composes the name from the source and destination in two independent
+    /// matches, so nothing structural stops it naming a pair that does not exist. Separately, the
+    /// half intermediate has to be as wide as the unroll that indexes it, or the emitted code
+    /// reads off the end of a temporary.
     #[test]
-    fn every_emitted_intrinsic_is_declared() {
-        let mut undeclared = Vec::new();
+    fn emitted_conversions_are_well_formed() {
+        let mut bad = Vec::new();
 
         for (case, source) in conversion_matrix() {
             for name in called_intrinsics(&source) {
-                if !DECLARED_INTRINSICS.contains(&name) {
-                    undeclared.push(format!("{case}: `{name}`\n{source}"));
+                match name.trim_start_matches("__nv_cvt_").split_once("_to_") {
+                    Some((from, to)) if intrinsic_type_width(from) == intrinsic_type_width(to) => {}
+                    _ => bad.push(format!("{case}: `{name}` has mismatched widths\n{source}")),
                 }
             }
-        }
 
-        assert!(
-            undeclared.is_empty(),
-            "{} conversions named an intrinsic no CUDA header declares:\n{}",
-            undeclared.len(),
-            undeclared.join("\n")
-        );
-    }
-
-    /// A vector temporary read past its own width compiles to nothing, so the widths of the
-    /// intermediates have to agree with the width the surrounding unroll indexes them at.
-    #[test]
-    fn no_temporary_is_read_past_its_width() {
-        let mut out_of_bounds = Vec::new();
-
-        for (case, source) in conversion_matrix() {
             // Declarations look like `__half_2 _tmp_0 = ...`, reads like `_tmp_0.i_2`.
-            let mut widths = std::collections::HashMap::new();
             for line in source.lines() {
                 let mut words = line.split_whitespace();
-                if let (Some(ty), Some(name)) = (words.next(), words.next())
-                    && name.starts_with("_tmp_")
-                    && let Some((_, width)) = ty.rsplit_once('_')
-                    && let Ok(width) = width.parse::<usize>()
-                {
-                    widths.insert(name.to_string(), width);
-                }
-            }
+                let (Some(ty), Some(name)) = (words.next(), words.next()) else {
+                    continue;
+                };
+                let Some(width) = name
+                    .starts_with("_tmp_")
+                    .then(|| ty.rsplit_once('_')?.1.parse::<usize>().ok())
+                    .flatten()
+                else {
+                    continue;
+                };
 
-            for (name, width) in &widths {
                 let read = format!("{name}.i_");
                 let mut rest = source.as_str();
                 while let Some(start) = rest.find(&read) {
@@ -613,11 +568,10 @@ mod tests {
                     let end = rest
                         .find(|c: char| !c.is_ascii_digit())
                         .unwrap_or(rest.len());
-                    if let Ok(index) = rest[..end].parse::<usize>()
-                        && index >= *width
-                    {
-                        out_of_bounds.push(format!(
-                            "{case}: {name} has width {width}, read at i_{index}\n{source}"
+                    if rest[..end].parse::<usize>().is_ok_and(|i| i >= width) {
+                        bad.push(format!(
+                            "{case}: {name} has width {width}, read at i_{}\n{source}",
+                            &rest[..end]
                         ));
                     }
                 }
@@ -625,10 +579,10 @@ mod tests {
         }
 
         assert!(
-            out_of_bounds.is_empty(),
-            "{} conversions read a temporary past its width:\n{}",
-            out_of_bounds.len(),
-            out_of_bounds.join("\n")
+            bad.is_empty(),
+            "{} malformed conversions:\n{}",
+            bad.len(),
+            bad.join("\n")
         );
     }
 }

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -1566,17 +1566,27 @@ impl<D: Dialect> CppCompiler<D> {
                 let vec_out = out.ty.vector_size();
                 let packing = out.storage_type().packing_factor();
                 self.compile_type(op.input.ty.with_vector_size(packing));
-                // `special_cast` builds its half intermediates while formatting, long after the
-                // declared type set is frozen, so they have to be registered here instead. Its
-                // width follows the source, the destination or the packing factor depending on
-                // the direction of the conversion, so declare all three.
-                for width in [vec_in, vec_out, packing] {
-                    for kind in [FloatKind::F16, FloatKind::BF16] {
-                        self.compile_type(
-                            ir::Type::scalar(ir::ElemType::Float(kind)).with_vector_size(width),
-                        );
-                    }
-                }
+                self.compile_type(
+                    ir::Type::scalar(ir::ElemType::Float(FloatKind::F16)).with_vector_size(vec_in),
+                );
+                self.compile_type(
+                    ir::Type::scalar(ir::ElemType::Float(FloatKind::BF16)).with_vector_size(vec_in),
+                );
+                // A scalar source decodes into a half as wide as the destination
+                self.compile_type(
+                    ir::Type::scalar(ir::ElemType::Float(FloatKind::F16)).with_vector_size(vec_out),
+                );
+                self.compile_type(
+                    ir::Type::scalar(ir::ElemType::Float(FloatKind::BF16))
+                        .with_vector_size(vec_out),
+                );
+                self.compile_type(
+                    ir::Type::scalar(ir::ElemType::Float(FloatKind::F16)).with_vector_size(packing),
+                );
+                self.compile_type(
+                    ir::Type::scalar(ir::ElemType::Float(FloatKind::BF16))
+                        .with_vector_size(packing),
+                );
 
                 let inst = self.compile_unary(op, out);
 

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -1563,21 +1563,20 @@ impl<D: Dialect> CppCompiler<D> {
                 self.flags.elem_f16 = true;
                 self.flags.elem_bf16 = true;
                 let vec_in = op.input.ty.vector_size();
+                let vec_out = out.ty.vector_size();
                 let packing = out.storage_type().packing_factor();
                 self.compile_type(op.input.ty.with_vector_size(packing));
-                self.compile_type(
-                    ir::Type::scalar(ir::ElemType::Float(FloatKind::F16)).with_vector_size(vec_in),
-                );
-                self.compile_type(
-                    ir::Type::scalar(ir::ElemType::Float(FloatKind::BF16)).with_vector_size(vec_in),
-                );
-                self.compile_type(
-                    ir::Type::scalar(ir::ElemType::Float(FloatKind::F16)).with_vector_size(packing),
-                );
-                self.compile_type(
-                    ir::Type::scalar(ir::ElemType::Float(FloatKind::BF16))
-                        .with_vector_size(packing),
-                );
+                // `special_cast` builds its half intermediates while formatting, long after the
+                // declared type set is frozen, so they have to be registered here instead. Its
+                // width follows the source, the destination or the packing factor depending on
+                // the direction of the conversion, so declare all three.
+                for width in [vec_in, vec_out, packing] {
+                    for kind in [FloatKind::F16, FloatKind::BF16] {
+                        self.compile_type(
+                            ir::Type::scalar(ir::ElemType::Float(kind)).with_vector_size(width),
+                        );
+                    }
+                }
 
                 let inst = self.compile_unary(op, out);
 


### PR DESCRIPTION
Closes #1458.

## The bug

`Vector::<F, N>::cast_from(scalar_e4m3)` does not compile. `special_cast` built the f16/bf16 intermediate at the destination's width regardless of the source's, so a scalar source with a wider destination composed `__nv_cvt_fp8_to_halfraw2`. CUDA declares the decode direction only in matched pairs, scalar to scalar and x2 to x2, so that symbol does not exist. The temporary vector type it decoded into was never declared either.

The practical effect is that UE4M3 quantization cannot compile on CUDA, since `quantize_symmetric` divides by `Vector::cast_from(scale)` with a scalar minifloat scale. The same asymmetry reaches fp4, fp6 and e8m0 through the same line.

## The fix

`cuda/convert.rs` decodes a single unpacked source on its own and lets the existing trailing assign broadcast it, one intrinsic call instead of N where every lane holds the same value:

```cuda
__half _tmp_0 = __half(__nv_cvt_fp8_to_halfraw(val_13, __NV_E4M3));
const float_4 val_14 = float_4{ float(_tmp_0), float(_tmp_0), float(_tmp_0), float(_tmp_0) };
```

A packed source already supplies one value per lane of the x2 intrinsic, so it keeps the destination's width and its emitted code is unchanged.

`shared/base.rs` also registers f16 and bf16 at the destination width. `special_cast` synthesizes `Item`s inside a `Display` impl, after the declared type set is frozen, so they cannot be registered where they are created.

## Tests

`test_fp8_broadcast`, the issue's repro, at vector sizes 1, 2, 4 across f16, bf16, f32, f64.

Verified on an RTX 4070 Ti SUPER (sm_89). With the fix, `cubecl-cuda` is 774 passed, 0 failed, 24 ignored. Reverting only the two source files and keeping the test gives 4 failures naming both defects:

```
error: identifier "__nv_cvt_fp8_to_halfraw2" is undefined
error: identifier "__half_2" is undefined
```

sm_89 is the only CUDA hardware available here, so fp4, fp6 and e8m0 conversion is unsupported and `test_fp4`, `test_fp6` and `test_scale` skip. Those paths get no hardware coverage. If you have Blackwell access, checking values there is the useful thing to do.

## Known gaps

#1459 covers two further shapes with the same root cause, a scalar float into a packed minifloat vector and a packed minifloat scalar into a narrower destination. Both are present on main and independent of this change.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [x] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.

The two unchecked boxes have nothing to submit: neither repo needs a source change. Both already pin cubecl at `05cac673`, this branch's base, so the only edit either needs is the routine rev bump after merge. `cubek-quant` on CUDA is 25 passed, 0 failed, identical to its own pin, and `burn-cuda` builds clean.

Worth stating plainly: a green cubek does not validate this fix. Its quant tests cover `q2f`, `q2s`, `q4f`, `q4s`, `q8f`, `q8s` only, every scheme built `.with_param(QuantParam::F32)`, with no `E4M3`, `E5M2`, `UE4M3` or `E2M1` in the test tree, so it cannot reach this code. `test_fp8_broadcast` is the meaningful check.
