### PR TITLE
fix(cuda): reclaim and retry a failed device reserve

### DIFF
--- a/crates/cubecl-cuda/src/compute/command.rs
+++ b/crates/cubecl-cuda/src/compute/command.rs
@@ -123,9 +123,24 @@ impl<'a> Command<'a> {
     /// * `Err(IoError)` - If the allocation fails.
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip(self)))]
     pub fn reserve(&mut self, size: u64) -> Result<ManagedMemoryHandle, IoError> {
-        let handle = self.streams.current().memory_management_gpu.reserve(size)?;
-
-        Ok(handle)
+        match self.streams.current().memory_management_gpu.reserve(size) {
+            Ok(handle) => Ok(handle),
+            // The allocation can never fit; reclaiming would not change that.
+            Err(err @ IoError::BufferTooBig { .. }) => Err(err),
+            // Out of memory *right now* is not out of memory for good: pool
+            // pages whose slices have all been dropped are still resident, and
+            // the frees that would release them may sit in the deferred drop
+            // queue. Reclaim this stream's memory and retry once; only a
+            // failure after that is reported. Without the retry, a transient
+            // peak — a model build holding float weights while their quantized
+            // copies allocate, an autotune sample on a full device — becomes a
+            // never-initialized handle whose every downstream use fails.
+            Err(err) => {
+                log::warn!("device allocation of {size} B failed ({err}); reclaiming and retrying");
+                self.memory_cleanup();
+                self.streams.current().memory_management_gpu.reserve(size)
+            }
+        }
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip(self)))]

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -122,7 +122,9 @@ impl ComputeServer for CudaServer {
             Err(err) => unreachable!("{err}"),
         };
 
-        let reserved = command.reserve(size).unwrap();
+        let reserved = command
+            .reserve(size)
+            .unwrap_or_else(|err| panic!("failed to reserve {size} bytes of device memory: {err}"));
         command.bind(reserved, memory);
     }
 


### PR DESCRIPTION
## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.

Not done — I'd rather leave the boxes empty than tick them. `compute` is a private module in `cubecl-cuda`, so `Command::reserve` is not public API and no signature changed; there is nothing downstream can see. #1454 made the same change in `cubecl-hip` with no cubek or burn companion PR. Happy to run the downstream pass anyway if you want it.

## The change

CUDA counterpart of #1454. That PR added error handling and a reclaim fallback to `cubecl-hip`; `cubecl-cuda` still has the bare sites.

- `Command::reserve` reclaims the current stream's memory and retries once instead of returning the first `Err`. `BufferTooBig` still returns immediately, since reclaiming can't make room for an allocation that never fits.
- `initialize_memory` names the requested size and the underlying error instead of a bare `.unwrap()`.

The two files were identical before #1454, so both hunks are byte-identical to the ones it landed. The `IoError::Unknown` display change is in `cubecl-runtime`, so CUDA already has it.

## Why

Same reasoning as #1454: an allocation that fails now isn't out of memory for good, since pages whose slices have all been dropped are still resident and their frees may be sitting in the deferred drop queue.

I ran into the CUDA side of this from a LoRA trainer on a 4090 (#1401). To be clear about what this does and doesn't do: in my case the device really was full — 0.58 GB free of 25.2 GB at the failing allocation — so the retry wouldn't have saved the run. What changes is what you see afterwards. It's diagnosability hardening, not a fix for the race #1401 reports; I have no evidence for that race in my own runs, and said so there.

## What I ran

macOS/arm64, no CUDA device, so nothing was executed — only compiled:

- `cargo check -p cubecl-cuda` — clean. It does type-check without a CUDA install here, which surprised me, so I confirmed the crate is really being checked by inserting a deliberate type error and watching it fail.
- `cargo clippy -p cubecl-cuda -- -D warnings` — clean
- `cargo fmt -p cubecl-cuda -- --check` — clean
- `cargo test -p cubecl-cuda --no-run` — builds

`cargo xtask validate` doesn't finish on this machine: `cubecl-metal` fails to compile on macOS with 8 errors in `device.rs` (`registry().lock()` handled as a `Result`). I checked that against a clean tree — it's on `main` already, not from this PR.
