### PR TITLE
Correct the e4m3 and e5m2 limits and exponent constants

### DIFF
--- a/crates/cubecl-common/src/float/fp8/fp8_e4m3.rs
+++ b/crates/cubecl-common/src/float/fp8/fp8_e4m3.rs
@@ -11,7 +11,16 @@ use num_traits::{Num, NumCast, One, ToPrimitive, Zero};
 
 /// A 8-bit floating point type with 4 exponent bits and 3 mantissa bits.
 ///
-/// [`Minifloat`]: https://en.wikipedia.org/wiki/Minifloat
+/// Follows table 1 of [FP8 Formats for Deep Learning](https://arxiv.org/abs/2209.05433). E4M3
+/// departs from IEEE 754 to widen its range: it has **no infinities**, and reserves only
+/// `S.1111.111` for NaN. Reclaiming the rest of the special-value patterns is what puts its
+/// maximum at 448 rather than the 240 an IEEE-style reservation would give.
+///
+/// `MAX`, `MIN`, `MAX_EXP` and `MANTISSA_DIGITS` are spelled out here rather than delegated to
+/// `float8`, each for the reason given on the constant itself. Every other constant delegates and
+/// agrees. No infinity constant is exposed, because the format has none.
+///
+/// See also the [minifloat overview](https://en.wikipedia.org/wiki/Minifloat).
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -19,22 +28,34 @@ use num_traits::{Num, NumCast, One, ToPrimitive, Zero};
 pub struct e4m3(u8);
 
 impl e4m3 {
-    /// Maximum representable value
-    pub const MAX: Self = Self::from_bits(F8E4M3::MAX.to_bits());
-    /// Minimum representable value
-    pub const MIN: Self = Self::from_bits(F8E4M3::MIN.to_bits());
+    /// Maximum representable value, `S.1111.110` = 1.75 * 2^8 = 448.
+    ///
+    /// Not taken from `F8E4M3::MAX`, which is 416 and one representable step low. E4M3 has no
+    /// infinities and reserves only `S.1111.111` for NaN, so `0x7E` is finite. See table 1 of
+    /// "FP8 Formats for Deep Learning" (arXiv:2209.05433), which also matches what `from_f32`
+    /// saturates to and what `QuantValue::E4M3` bounds against.
+    pub const MAX: Self = Self::from_bits(0x7E);
+    /// Minimum representable value, the negation of [`MAX`](Self::MAX).
+    pub const MIN: Self = Self::from_bits(0xFE);
     /// the difference between 1.0 and the next largest representable number.
     pub const EPSILON: Self = Self::from_bits(F8E4M3::EPSILON.to_bits());
     /// Minimum representable value
     pub const MIN_POSITIVE: Self = Self::from_bits(F8E4M3::MIN_POSITIVE.to_bits());
     ///Approximate number of significant digits in base 10
     pub const DIGITS: u32 = F8E4M3::DIGITS;
-    ///Number of mantissa digits
-    pub const MANTISSA_DIGITS: u32 = F8E4M3::MANTISSA_DIGITS;
+    /// Number of mantissa digits, the 3 stored bits plus the implicit leading one.
+    ///
+    /// `F8E4M3::MANTISSA_DIGITS` counts only the stored bits, where [`f32`] and [`half::f16`] both
+    /// count the implicit one.
+    pub const MANTISSA_DIGITS: u32 = 4;
     /// Maximum possible normal power of 10 exponent
     pub const MAX_10_EXP: i32 = F8E4M3::MAX_10_EXP;
-    /// Maximum possible normal power of 2 exponent
-    pub const MAX_EXP: i32 = F8E4M3::MAX_EXP;
+    /// One greater than the maximum possible normal power of 2 exponent, matching [`f32::MAX_EXP`].
+    ///
+    /// [`MAX`](Self::MAX) is 1.75 * 2^8, so this is 9. `F8E4M3::MAX_EXP` is 7: one lower because it
+    /// reserves an exponent for infinities this format does not have, and another because it does
+    /// not add the one that [`f32`] and [`half::f16`] do.
+    pub const MAX_EXP: i32 = 9;
     /// Minimum possible normal power of 10 exponent
     pub const MIN_10_EXP: i32 = F8E4M3::MIN_10_EXP;
     /// Minimum possible normal power of 2 exponent
@@ -59,8 +80,9 @@ impl e4m3 {
 
     /// Constructs a [`e4m3`] value from a 32-bit floating point value.
     ///
-    /// This operation is lossy. If the 32-bit value is too large to fit, ±∞ will result. NaN values
-    /// are preserved. Subnormal values that are too tiny to be represented will result in ±0. All
+    /// This operation is lossy. Values too large to fit, infinities included, saturate to
+    /// ±[`MAX`](Self::MAX), since the format has no infinities of its own. NaN values are
+    /// preserved. Subnormal values that are too tiny to be represented will result in ±0. All
     /// other values are truncated and rounded to the nearest representable value.
     #[inline]
     #[must_use]
@@ -70,8 +92,9 @@ impl e4m3 {
 
     /// Constructs a [`e4m3`] value from a 64-bit floating point value.
     ///
-    /// This operation is lossy. If the 64-bit value is to large to fit, ±∞ will result. NaN values
-    /// are preserved. 64-bit subnormal values are too tiny to be represented and result in ±0.
+    /// This operation is lossy. Values too large to fit, infinities included, saturate to
+    /// ±[`MAX`](Self::MAX), since the format has no infinities of its own. NaN values are
+    /// preserved. 64-bit subnormal values are too tiny to be represented and result in ±0.
     /// Exponents that underflow the minimum exponent will result in subnormals or ±0. All other
     /// values are truncated and rounded to the nearest representable value.
     #[inline]
@@ -274,5 +297,40 @@ impl Display for e4m3 {
 impl Debug for e4m3 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{self}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX_F32: f32 = 448.0;
+
+    /// `MAX` diverges from `F8E4M3::MAX`, so it needs checking against the encoding rather than
+    /// against the crate it would otherwise mirror.
+    ///
+    /// Round tripping alone would not pin it, since 416 round trips too. Saturating from above is
+    /// what rules out every smaller candidate, and the step past `MAX` being NaN is what rules out
+    /// any larger one.
+    #[test]
+    fn max_is_the_largest_finite_value() {
+        assert_eq!(e4m3::from_f32(MAX_F32).to_f32(), MAX_F32);
+        assert_eq!(e4m3::from_f32(f32::MAX).to_f32(), MAX_F32);
+        assert!(e4m3::from_bits(e4m3::MAX.to_bits() + 1).to_f32().is_nan());
+    }
+
+    #[test]
+    fn min_is_max_negated() {
+        assert_eq!(e4m3::MIN.to_f32(), -MAX_F32);
+    }
+
+    /// This one does delegate to `float8`, which gets E4M3's NaN set right. Pinned so that stays
+    /// true, given its neighbouring constants do not.
+    #[test]
+    fn is_nan_agrees_with_the_conversion_for_every_encoding() {
+        for bits in 0..=u8::MAX {
+            let v = e4m3::from_bits(bits);
+            assert_eq!(v.is_nan(), v.to_f32().is_nan(), "0x{bits:02X}");
+        }
     }
 }

--- a/crates/cubecl-common/src/float/fp8/fp8_e5m2.rs
+++ b/crates/cubecl-common/src/float/fp8/fp8_e5m2.rs
@@ -11,7 +11,15 @@ use num_traits::{Num, NumCast, One, ToPrimitive, Zero};
 
 /// A 8-bit floating point type with 5 exponent bits and 2 mantissa bits.
 ///
-/// [`Minifloat`]: https://en.wikipedia.org/wiki/Minifloat
+/// Follows table 1 of [FP8 Formats for Deep Learning](https://arxiv.org/abs/2209.05433). Unlike
+/// [`e4m3`](super::e4m3), E5M2 keeps IEEE 754 conventions: infinities at `S.11111.00` and NaN at
+/// `S.11111.{01,10,11}`, so six of its 256 encodings are NaN.
+///
+/// `MAX`, `MIN`, `is_nan`, `MAX_EXP` and `MANTISSA_DIGITS` are spelled out here rather than
+/// delegated to `float8`, each for the reason given on the item itself. Every other constant
+/// delegates and agrees.
+///
+/// See also the [minifloat overview](https://en.wikipedia.org/wiki/Minifloat).
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -19,22 +27,33 @@ use num_traits::{Num, NumCast, One, ToPrimitive, Zero};
 pub struct e5m2(u8);
 
 impl e5m2 {
-    /// Maximum representable value
-    pub const MAX: e5m2 = Self::from_bits(F8E5M2::MAX.to_bits());
-    /// Minimum representable value
-    pub const MIN: e5m2 = Self::from_bits(F8E5M2::MIN.to_bits());
+    /// Maximum representable value, `S.11110.11` = 1.75 * 2^15 = 57344.
+    ///
+    /// Not taken from `F8E5M2::MAX`, which is 49152 and one representable step low. E5M2 follows
+    /// IEEE conventions and puts its first infinity at `S.11111.00`, so `0x7B` is finite. See
+    /// table 1 of "FP8 Formats for Deep Learning" (arXiv:2209.05433), which also matches what
+    /// `from_f32` saturates to and what `QuantValue::E5M2` bounds against.
+    pub const MAX: e5m2 = Self::from_bits(0x7B);
+    /// Minimum representable value, the negation of [`MAX`](Self::MAX).
+    pub const MIN: e5m2 = Self::from_bits(0xFB);
     /// the difference between 1.0 and the next largest representable number.
     pub const EPSILON: Self = Self::from_bits(F8E5M2::EPSILON.to_bits());
     /// Minimum representable value
     pub const MIN_POSITIVE: Self = Self::from_bits(F8E5M2::MIN_POSITIVE.to_bits());
     ///Approximate number of significant digits in base 10
     pub const DIGITS: u32 = F8E5M2::DIGITS;
-    ///Number of mantissa digits
-    pub const MANTISSA_DIGITS: u32 = F8E5M2::MANTISSA_DIGITS;
+    /// Number of mantissa digits, the 2 stored bits plus the implicit leading one.
+    ///
+    /// `F8E5M2::MANTISSA_DIGITS` counts only the stored bits, where [`f32`] and [`half::f16`] both
+    /// count the implicit one.
+    pub const MANTISSA_DIGITS: u32 = 3;
     /// Maximum possible normal power of 10 exponent
     pub const MAX_10_EXP: i32 = F8E5M2::MAX_10_EXP;
-    /// Maximum possible normal power of 2 exponent
-    pub const MAX_EXP: i32 = F8E5M2::MAX_EXP;
+    /// One greater than the maximum possible normal power of 2 exponent, matching [`f32::MAX_EXP`].
+    ///
+    /// [`MAX`](Self::MAX) is 1.75 * 2^15, so this is 16. `F8E5M2::MAX_EXP` is 15, not adding the one
+    /// that [`f32`] and [`half::f16`] do.
+    pub const MAX_EXP: i32 = 16;
     /// Minimum possible normal power of 10 exponent
     pub const MIN_10_EXP: i32 = F8E5M2::MIN_10_EXP;
     /// Minimum possible normal power of 2 exponent
@@ -58,8 +77,9 @@ impl e5m2 {
 
     /// Constructs a [`e5m2`] value from a 32-bit floating point value.
     ///
-    /// This operation is lossy. If the 32-bit value is too large to fit, ±∞ will result. NaN values
-    /// are preserved. Subnormal values that are too tiny to be represented will result in ±0. All
+    /// This operation is lossy. Values too large to fit, infinities included, saturate to
+    /// ±[`MAX`](Self::MAX) rather than reaching this format's own infinity. NaN values are
+    /// preserved. Subnormal values that are too tiny to be represented will result in ±0. All
     /// other values are truncated and rounded to the nearest representable value.
     #[inline]
     #[must_use]
@@ -69,8 +89,9 @@ impl e5m2 {
 
     /// Constructs a [`e5m2`] value from a 64-bit floating point value.
     ///
-    /// This operation is lossy. If the 64-bit value is to large to fit, ±∞ will result. NaN values
-    /// are preserved. 64-bit subnormal values are too tiny to be represented and result in ±0.
+    /// This operation is lossy. Values too large to fit, infinities included, saturate to
+    /// ±[`MAX`](Self::MAX) rather than reaching this format's own infinity. NaN values are
+    /// preserved. 64-bit subnormal values are too tiny to be represented and result in ±0.
     /// Exponents that underflow the minimum exponent will result in subnormals or ±0. All other
     /// values are truncated and rounded to the nearest representable value.
     #[inline]
@@ -87,6 +108,8 @@ impl e5m2 {
     }
 
     /// check if an [`e5m2`] value is Nan
+    ///
+    /// All six `S.11111.{01,10,11}` encodings, rather than `float8`'s two.
     #[inline]
     pub fn is_nan(self) -> bool {
         [0x7D, 0x7E, 0x7F, 0xFD, 0xFE, 0xFF].contains(&self.0)
@@ -272,5 +295,41 @@ impl Display for e5m2 {
 impl Debug for e5m2 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{self}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX_F32: f32 = 57344.0;
+
+    /// `MAX` diverges from `F8E5M2::MAX`, so it needs checking against the encoding. This format
+    /// has infinities, so the step past `MAX` is one rather than NaN.
+    #[test]
+    fn max_is_the_largest_finite_value() {
+        assert_eq!(e5m2::from_f32(MAX_F32).to_f32(), MAX_F32);
+        assert_eq!(e5m2::from_f32(f32::MAX).to_f32(), MAX_F32);
+        assert!(
+            e5m2::from_bits(e5m2::MAX.to_bits() + 1)
+                .to_f32()
+                .is_infinite()
+        );
+    }
+
+    #[test]
+    fn min_is_max_negated() {
+        assert_eq!(e5m2::MIN.to_f32(), -MAX_F32);
+    }
+
+    /// Every encoding, checked against the conversion table rather than against the rule this
+    /// restates. `float8`'s own `is_nan` recognises two of the six, which is why this does not
+    /// delegate.
+    #[test]
+    fn is_nan_agrees_with_the_conversion_for_every_encoding() {
+        for bits in 0..=u8::MAX {
+            let v = e5m2::from_bits(bits);
+            assert_eq!(v.is_nan(), v.to_f32().is_nan(), "0x{bits:02X}");
+        }
     }
 }


### PR DESCRIPTION
`e4m3` and `e5m2` took `MAX`, `MIN`, `MAX_EXP` and `MANTISSA_DIGITS` from `float8`, which does not model either format the way the FP8 spec defines it.

## What was wrong

**`MAX` / `MIN`.** `float8` models both formats as though they reserved the IEEE special-value patterns. E4M3 has no infinities and reserves only `S.1111.111` for NaN, so its maximum is 448, not the 416 `float8` reports. E5M2 does keep the IEEE conventions, but `float8` places its first infinity one step low, putting the maximum at 57344 rather than 49152. Both now follow table 1 of [FP8 Formats for Deep Learning](https://arxiv.org/abs/2209.05433), and both now agree with what `from_f32` already saturated to.

**`MAX_EXP` / `MANTISSA_DIGITS`.** These followed `float8`'s convention rather than the one `f32` and `half::f16` use: `float8` counts only the stored mantissa bits, and does not add one to the exponent. They now count the implicit leading bit and match the primitive float types.

## Why it matters beyond the types

These feed `FloatKind`'s `min`, `max` and `range` in `cubecl-ir`, and the `Pod` bounds in `cubecl-core`. The IR's idea of what these formats can hold was short at the top by one representable step.

## Tests

`MAX` is pinned against the encoding rather than against `float8`. Round tripping alone would not pin it, since the old value round trips too, so the tests saturate from above and check the step past `MAX` (NaN for e4m3, infinity for e5m2). `e5m2::is_nan` already spelled out all six `S.11111.{01,10,11}` encodings where `float8` recognises two, and that is now pinned across every encoding.

## Stack

This is the base of a two-part stack. [#1453](https://github.com/tracel-ai/cubecl/pull/1453) builds on it and depends on `e4m3::MAX` being 448.