### PR TITLE
fix(runtime): classify driver out-of-memory apart from BufferTooBig

### DIFF
--- a/crates/cubecl-cuda/src/compute/storage/gpu.rs
+++ b/crates/cubecl-cuda/src/compute/storage/gpu.rs
@@ -177,8 +177,11 @@ impl ComputeStorage for GpuStorage {
             Err(_) => unsafe {
                 match cudarc::driver::result::malloc_sync(size as usize) {
                     Ok(ptr) => (ptr, AllocationKind::Sync),
+                    // Not `BufferTooBig`: that variant means the allocation can
+                    // never fit, and `Command::reserve` skips its reclaim-and-retry
+                    // when it sees it. A full device is a moment, not a verdict.
                     Err(DriverError(cudarc::driver::sys::CUresult::CUDA_ERROR_OUT_OF_MEMORY)) => {
-                        return Err(IoError::BufferTooBig {
+                        return Err(IoError::OutOfMemory {
                             size,
                             backtrace: BackTrace::capture(),
                         });

--- a/crates/cubecl-runtime/src/server/base.rs
+++ b/crates/cubecl-runtime/src/server/base.rs
@@ -844,6 +844,24 @@ pub enum IoError {
         backtrace: BackTrace,
     },
 
+    /// The device had no memory left for this allocation.
+    ///
+    /// Unlike [`IoError::BufferTooBig`] (the allocation can *never* fit), this
+    /// describes the device at one moment: pool pages whose slices have all
+    /// been dropped are still resident, and the frees that would release them
+    /// may not have reached the driver yet. Reclaiming and retrying is a
+    /// reasonable response, which is why a storage backend must not report a
+    /// driver out-of-memory as `BufferTooBig`: that tells every caller the
+    /// allocation is hopeless when it is merely untimely.
+    #[error("out of device memory allocating {size} bytes\n{backtrace}")]
+    OutOfMemory {
+        /// The size of the failed allocation in bytes.
+        size: u64,
+        /// The captured backtrace.
+        #[cfg_attr(std_io, serde(skip))]
+        backtrace: BackTrace,
+    },
+
     /// A memory pool with a fixed capacity cap is exhausted.
     ///
     /// Unlike [`IoError::BufferTooBig`] (the allocation can *never* fit), this

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -257,8 +257,12 @@ pub(crate) fn create_storage_buffer(
 
 fn as_io_error(result: vk::Result, size: u64) -> IoError {
     match result {
+        // Not `BufferTooBig`: Vulkan is reporting the heap it has right now, not
+        // a size it can never satisfy. Nothing on this backend reclaims and
+        // retries yet, but keeping the two apart is what would let it, and it
+        // stops the failure being reported as though the size were hopeless.
         vk::Result::ERROR_OUT_OF_HOST_MEMORY | vk::Result::ERROR_OUT_OF_DEVICE_MEMORY => {
-            IoError::BufferTooBig {
+            IoError::OutOfMemory {
                 size,
                 backtrace: BackTrace::capture(),
             }

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -294,7 +294,9 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
 
     fn initialize_memory(&mut self, memory: ManagedMemoryHandle, size: u64, stream_id: StreamId) {
         let stream = self.scheduler.stream(&stream_id);
-        let reserved = stream.empty(size).unwrap();
+        let reserved = stream
+            .empty(size)
+            .unwrap_or_else(|err| panic!("failed to reserve {size} bytes of device memory: {err}"));
         stream.mem_manage.bind(reserved, memory);
     }
 


### PR DESCRIPTION
## Problem

`IoError::BufferTooBig` has a documented meaning, stated in the `PoolCapacityExceeded` docs right below it: "the allocation can *never* fit".

`Command::reserve` on CUDA (#1468) and HIP (#1454) relies on that contract to decide whether reclaiming and retrying is worth attempting:

```rust
// The allocation can never fit; reclaiming would not change that.
Err(err @ IoError::BufferTooBig { .. }) => Err(err),
```

But the CUDA storage backend reports a driver out-of-memory as `BufferTooBig`:

```rust
Err(DriverError(CUresult::CUDA_ERROR_OUT_OF_MEMORY)) => {
    return Err(IoError::BufferTooBig { size, backtrace: BackTrace::capture() });
}
```

So on CUDA the retry added in #1468 is skipped for exactly the case it was written for: a device that is merely full is reported as permanently incapable.

HIP is the control. Its storage returns `IoError::Unknown` on `hipMalloc` failure, so it falls through to the retry arm, which is why #1454 has been working since it landed.

`cubecl-wgpu`'s Vulkan backend has the same mapping, sending both `ERROR_OUT_OF_DEVICE_MEMORY` and `ERROR_OUT_OF_HOST_MEMORY` to `BufferTooBig`.

## Change

Add `IoError::OutOfMemory` and report it from the CUDA and Vulkan storage backends. `BufferTooBig` keeps its documented meaning: a size no pool can ever serve, which is still what `MemoryManagement::reserve` returns when no pool accepts an allocation.

Also give the wgpu `initialize_memory` panic the size and the error. It unwraps before binding the handle, so an allocation failure currently surfaces downstream as `couldn't find resource for that handle: Memory location was never initialized` instead of as running out of memory. That cost me a while to trace back to its real cause.

## Testing

`cargo check` and `cargo clippy` clean on `cubecl-wgpu` (with `spirv,std`), `cubecl-cuda` and `cubecl-hip`. Exercised end to end on Vulkan, Intel Arc B390 with Mesa 26.1.6, loading and running Qwen3-4B through burn.

## Deliberately not included: a wgpu-side retry

I prototyped the wgpu equivalent of #1468 and measured that it would be inert, so it is not here.

`memory_cleanup` on wgpu does not return memory to the driver within the process. After a cleanup, cubecl's `bytes_reserved` goes from 2048 MiB to 0 while the kernel's `GPUActive` does not move at all. Everything is released a few seconds after process exit, so nothing leaks, but nothing comes back while the process runs either.

Neither `device.poll(PollType::Wait { .. })`, nor `PollType::Poll`, nor an explicit `wgpu::Buffer::destroy()` in `dealloc` changes this. Ownership is not the issue: `from_raw_managed` sets `BufferOwnership::Managed` and wgpu-hal's `destroy_buffer` calls `free_memory` on that arm. What does move the number is genuinely submitted work retiring, which advances wgpu's deferred destruction. One create plus read round trip released 220 MiB of the 2048.

So a working reclaim-and-retry on wgpu needs `WgpuStorage` to hold a `Queue` and submit rather than merely poll, and it needs measurements showing it recovers a useful fraction. That belongs in its own PR. Landing the retry on top of a flush that frees nothing would add the same latent gap this PR fixes on CUDA.
