### PR TITLE
fix(common): call ceil through num_traits so round_up builds on no_std

### DIFF
--- a/crates/cubecl-common/src/quant/scheme.rs
+++ b/crates/cubecl-common/src/quant/scheme.rs
@@ -239,7 +239,8 @@ impl QuantParam {
             && scale < subnormals.min_normal
         {
             // Below the minimum normal the spacing stops halving, so the answer is a count of steps.
-            return Some((scale / subnormals.spacing).ceil() * subnormals.spacing);
+            // Qualified call: the inherent `f32::ceil` lives in std, and this crate builds no_std.
+            return Some(num_traits::Float::ceil(scale / subnormals.spacing) * subnormals.spacing);
         }
 
         Some(f32::from_bits(


### PR DESCRIPTION
The inherent f32::ceil lives in std. Burn's no-std CI builds cubecl-common for bare-metal targets, where the subnormal branch of QuantParam::round_up failed to compile. num_traits::Float is already the crate's convention for this, via the libm feature.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
