### PR TITLE
fix(cpp): materialize constant bitcasts as lvalues

### DIFF
--- a/crates/cubecl-cpp/src/shared/instruction.rs
+++ b/crates/cubecl-cpp/src/shared/instruction.rs
@@ -602,6 +602,10 @@ for (*{i} = {start}; *{i} {cmp} {end}; {increment}) {{
                 } else {
                     let out = out.fmt_left();
                     let addr_space = D::address_space_for_value(input);
+                    let input = match input {
+                        Value::Constant(..) => input.ensure_lvalue(f)?,
+                        _ => *input,
+                    };
                     writeln!(
                         f,
                         "{out} = reinterpret_cast<{addr_space}{out_item}{qualifier}&>({input});"
@@ -1039,5 +1043,33 @@ impl<V: Display, D: Dialect> Display for EnsureBoolArg<'_, V, D> {
         } else {
             write!(f, "{}", self.val)
         }
+    }
+}
+
+#[cfg(all(test, feature = "metal"))]
+mod tests {
+    use cubecl_core::ir::ConstantValue;
+
+    use crate::metal::MslDialect;
+
+    use super::*;
+
+    #[test]
+    fn bitcast_constant_uses_lvalue() {
+        let instruction = Instruction::<MslDialect>::Bitcast(UnaryInstruction {
+            input: Value::Constant(ConstantValue::UInt(0x7f80_0000), Item::Scalar(Elem::U32)),
+            out: Value::Value {
+                id: 0,
+                item: Item::Scalar(Elem::F32),
+            },
+        });
+
+        let source = instruction.to_string();
+
+        assert!(source.contains("uint _tmp_"), "{source}");
+        assert!(
+            source.contains("reinterpret_cast<thread float const&>(_tmp_"),
+            "{source}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Materialize constant operands before emitting the reference-form `reinterpret_cast` used by C++ dialect bitcasts.

`Value::Constant` formats as a constructor expression, which is a prvalue. A reference-form `reinterpret_cast` requires a glvalue, so the generated CUDA, HIP, and Metal source is invalid when the bitcast input is a constant.

This code-generation limitation predates the current reduction work. tracel-ai/cubek#457 exposed it by constructing floating-point extrema identities through constant IEEE-754 bit reinterpretation.

Fixes #1476.
Related to tracel-ai/cubek#457.

## Changes

- Materialize `Value::Constant` bitcast inputs through the existing `Value::ensure_lvalue` path.
- Preserve the existing lowering for nonconstant and pointer inputs.
- Add a focused Metal source-generation regression test verifying that the cast consumes a named temporary.

This does not change the public API or add dependencies.

## Testing

- `cargo fmt --all -- --check` — passed.
- `cargo test -p cubecl-cpp --features metal --locked --lib shared::instruction::tests::bitcast_constant_uses_lvalue -- --exact` — 1 passed.
- `cargo clippy -p cubecl-cpp --locked --all-targets --features metal -- -D warnings` — passed.
- `cargo check -p cubecl-cpp --locked --no-default-features --features std,metal` — passed.
- `cargo check -p cubecl-cpp --locked --no-default-features --features std,cuda` — passed.
- `cargo check -p cubecl-cpp --locked --no-default-features --features std,hip` — passed.
- Cubek's `nan_extrema` suite using this CubeCL commit on an NVIDIA RTX 4070 SUPER with CUDA 13.2 — 10 passed, 0 failed.
- Cubek's `cargo xtask test --ci` — 8,413 passed and 24 pre-existing TopK-with-indices cases failed; an exact failure was reproduced on untouched Cubek `origin/main` at `de661419` with CubeCL `5d5af999`.

Cubek validation PR: tracel-ai/cubek#461.

Burn validation remains pending while this PR and the Cubek pin are in draft.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [x] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
