### PR TITLE
fix(common): release the caller's borrows before waking it in run_scoped

### DIFF
--- a/crates/cubecl-common/src/device/handle/channel.rs
+++ b/crates/cubecl-common/src/device/handle/channel.rs
@@ -144,14 +144,30 @@ impl<S: DeviceService + 'static> ChannelDeviceHandle<S> {
         &self,
         task: T,
     ) -> Result<R, CallError> {
+        /// What the runner sends back: the task's value, or the payload of the
+        /// panic it died on.
+        type Outcome<R> = Result<R, Box<dyn Any + Send>>;
+
         /// Builds a `'static` shim that consumes `*slot` on the device
         /// thread. The caller has to keep `*slot` alive until the shim has run,
         /// `run_scoped` does this by blocking on `recv.recv()`.
-        fn create_shim<W: FnOnce() + Send>(slot: &mut Option<W>) -> impl FnOnce() + Send + 'static {
+        ///
+        /// The shim runs the task and sends the outcome in two separate steps,
+        /// which is what keeps the second half of that contract honest. `task`
+        /// holds references into the caller's frame, and a reference passed by
+        /// value into a call is protected for as long as that call is running,
+        /// so the frame it points into may not be freed before the call
+        /// returns. Sending from inside the call would hand that frame back to
+        /// the caller to pop while the protector is still live. Running the
+        /// task under its own `catch_unwind` frame releases the protectors
+        /// first, leaving nothing caller-derived alive when the send wakes it.
+        fn create_shim<R: Send, F: FnOnce() -> R + Send>(
+            slot: &mut Option<(F, oneshot::Sender<Outcome<R>>)>,
+        ) -> impl FnOnce() + Send + 'static {
             // `*mut ()` so the shim is `'static`.
             struct Ptr(*mut ());
-            // SAFETY: pointee is `Send` by the bound on `W`; uniqueness of
-            // access is upheld by the deref below.
+            // SAFETY: pointee is `Send` by the bounds on `F` and `R`;
+            // uniqueness of access is upheld by the deref below.
             unsafe impl Send for Ptr {}
 
             let ptr = Ptr(slot as *mut _ as *mut ());
@@ -163,17 +179,21 @@ impl<S: DeviceService + 'static> ChannelDeviceHandle<S> {
                 //   once, so `*slot` is always `Some` on entry.
                 // `Option::take` flips `*slot` to `None`, keeping drop
                 // correct if the shim ran, panicked, or was never enqueued.
-                let f = unsafe { (*(ptr.0 as *mut Option<W>)).take().unwrap_unchecked() };
-                f()
+                let (task, sender) = unsafe {
+                    (*(ptr.0 as *mut Option<(F, oneshot::Sender<Outcome<R>>)>))
+                        .take()
+                        .unwrap_unchecked()
+                };
+                // Both moved out of the caller's slot and owned by this frame,
+                // so the caller's stack is only reachable through `task`, and
+                // only until `catch_unwind` returns.
+                let outcome = catch_unwind(AssertUnwindSafe(task));
+                let _ = sender.send(outcome);
             }
         }
 
         let (sender, recv) = oneshot::channel();
-        // Run `task` under `catch_unwind` inside the slot so a panic on the
-        // runner thread is captured and sent back here through the channel.
-        let mut slot = Some(move || {
-            let _ = sender.send(catch_unwind(AssertUnwindSafe(task)));
-        });
+        let mut slot = Some((task, sender));
         // Send the erased shim to the device thread.
         self.send::<_, SEND_FLUSH>(create_shim(&mut slot))?;
         match recv.recv() {

--- a/crates/cubecl-common/src/device/handle/channel.rs
+++ b/crates/cubecl-common/src/device/handle/channel.rs
@@ -144,23 +144,16 @@ impl<S: DeviceService + 'static> ChannelDeviceHandle<S> {
         &self,
         task: T,
     ) -> Result<R, CallError> {
-        /// What the runner sends back: the task's value, or the payload of the
-        /// panic it died on.
         type Outcome<R> = Result<R, Box<dyn Any + Send>>;
 
         /// Builds a `'static` shim that consumes `*slot` on the device
         /// thread. The caller has to keep `*slot` alive until the shim has run,
         /// `run_scoped` does this by blocking on `recv.recv()`.
         ///
-        /// The shim runs the task and sends the outcome in two separate steps,
-        /// which is what keeps the second half of that contract honest. `task`
-        /// holds references into the caller's frame, and a reference passed by
-        /// value into a call is protected for as long as that call is running,
-        /// so the frame it points into may not be freed before the call
-        /// returns. Sending from inside the call would hand that frame back to
-        /// the caller to pop while the protector is still live. Running the
-        /// task under its own `catch_unwind` frame releases the protectors
-        /// first, leaving nothing caller-derived alive when the send wakes it.
+        /// The task runs in its own frame and the outcome is sent from the one
+        /// above: references into the caller's frame stay protected for as long
+        /// as the call holding them runs, so sending any earlier would let the
+        /// caller pop that frame while a protector is still live.
         fn create_shim<R: Send, F: FnOnce() -> R + Send>(
             slot: &mut Option<(F, oneshot::Sender<Outcome<R>>)>,
         ) -> impl FnOnce() + Send + 'static {
@@ -184,9 +177,6 @@ impl<S: DeviceService + 'static> ChannelDeviceHandle<S> {
                         .take()
                         .unwrap_unchecked()
                 };
-                // Both moved out of the caller's slot and owned by this frame,
-                // so the caller's stack is only reachable through `task`, and
-                // only until `catch_unwind` returns.
                 let outcome = catch_unwind(AssertUnwindSafe(task));
                 let _ = sender.send(outcome);
             }


### PR DESCRIPTION
Should fix the `linux-miri-tests` flakiness on `main`.

A scoped task holds references into the caller's frame, and a reference passed by value into a call is protected for as long as that call runs, so the frame it points into may not be freed before the call returns. The task and the oneshot sender lived in the same closure, so the send happened from inside that call: the caller woke on `recv`, returned, and popped the frame while the protector was still live. Miri reports it as deallocating a strongly protected `SharedReadOnly`.

The shim now takes both out of the slot and runs the task in its own `catch_unwind` frame, so every caller-derived reference is released before the send wakes anyone.

No load from the freed frame happens today, but a `&T` argument carries `dereferenceable`, which licenses a speculative load anywhere in the function, and anything added between the send and the end of that closure would touch a frame the caller is free to reuse.

## Verification

Whether the window is hit depends on the interleaving left by preceding tests, not on the miri seed, which is why CI flipped between green and red on identical code. The discriminating config is the test on its own:

```
MIRIFLAGS="-Zmiri-ignore-leaks" cargo +nightly miri test -p cubecl-common --lib \
  device::handle::channel::tests::test_scoped_tasks_and_lifetimes -- --test-threads=1
```

- `main`: fails, `deallocating while item [SharedReadOnly for <326267>] is strongly protected`
- this branch: passes

Also clean with `-Zmiri-many-seeds=0..8` (`main` aborts on the first seed), and under the exact CI command: `cubecl-common` 81 passed, `cubecl-environment` 51 passed.