### PR TITLE
feat(common): add ComptimeFloat and Ratio for hashable comptime kernel params

### DIFF
--- a/crates/cubecl-common/src/float/comptime_float.rs
+++ b/crates/cubecl-common/src/float/comptime_float.rs
@@ -5,8 +5,7 @@ use core::hash::{Hash, Hasher};
 ///
 /// Implemented for the IEEE-754 types that need to be used as comptime kernel
 /// parameters: two values are equal iff their bit patterns are equal, so `-0.0`
-/// is normalized to `0.0` (they are numerically equal) but distinct NaN payloads
-/// are not conflated with each other.
+/// is normalized to `0.0` since they are numerically equal.
 pub trait FloatBits: Copy + PartialEq + Debug + Display {
     /// The unsigned integer type with the same width as `Self`.
     type Bits: Copy + Eq + Hash;
@@ -64,15 +63,11 @@ pub struct ComptimeFloat<F: FloatBits>(F);
 /// A float value that cannot be used as a [`ComptimeFloat`] because it is
 /// infinite or NaN.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct InvalidComptimeFloat<F: Debug>(pub F);
+pub struct InvalidComptimeFloat<F>(pub F);
 
 impl<F: FloatBits> Display for InvalidComptimeFloat<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "invalid comptime float: {} is not finite",
-            self.0
-        )
+        write!(f, "invalid comptime float: {} is not finite", self.0)
     }
 }
 

--- a/crates/cubecl-common/src/float/comptime_float.rs
+++ b/crates/cubecl-common/src/float/comptime_float.rs
@@ -1,0 +1,177 @@
+use core::fmt::{Debug, Display, Formatter};
+use core::hash::{Hash, Hasher};
+
+/// A float type whose bit representation can stand in for [`PartialEq`]/[`Eq`]/[`Hash`].
+///
+/// Implemented for the IEEE-754 types that need to be used as comptime kernel
+/// parameters: two values are equal iff their bit patterns are equal, so `-0.0`
+/// is normalized to `0.0` (they are numerically equal) but distinct NaN payloads
+/// are not conflated with each other.
+pub trait FloatBits: Copy + PartialEq + Debug + Display {
+    /// The unsigned integer type with the same width as `Self`.
+    type Bits: Copy + Eq + Hash;
+
+    /// The bit pattern of this value.
+    fn to_bits(self) -> Self::Bits;
+
+    /// Whether this value is neither infinite nor NaN.
+    fn is_finite(self) -> bool;
+
+    /// Positive zero, used to normalize away the sign of zero.
+    fn zero() -> Self;
+}
+
+macro_rules! impl_float_bits {
+    ($ty:ty, $bits:ty) => {
+        impl FloatBits for $ty {
+            type Bits = $bits;
+
+            fn to_bits(self) -> $bits {
+                <$ty>::to_bits(self)
+            }
+
+            fn is_finite(self) -> bool {
+                <$ty>::is_finite(self)
+            }
+
+            fn zero() -> Self {
+                <$ty>::from_bits(0)
+            }
+        }
+    };
+}
+
+impl_float_bits!(f32, u32);
+impl_float_bits!(f64, u64);
+impl_float_bits!(half::f16, u16);
+impl_float_bits!(half::bf16, u16);
+
+/// A finite float usable as a comptime kernel parameter.
+///
+/// Plain floats can't back a [`Hash`]/[`Eq`] key because NaN breaks reflexivity,
+/// which is required for anything used as a kernel cache key (e.g. through
+/// `KernelId::info`). `ComptimeFloat` closes that gap by comparing and hashing
+/// bit patterns instead, after rejecting non-finite input and normalizing `-0.0`
+/// to `0.0` so numerically equal values always compare equal.
+///
+/// This is only appropriate for values that are genuinely arbitrary floats. If
+/// a value is always an exact ratio of two integers (e.g. derived from tensor
+/// shapes), prefer [`Ratio`](crate::Ratio): it is exact and avoids bit-pattern
+/// comparisons entirely.
+#[derive(Clone, Copy, Debug)]
+pub struct ComptimeFloat<F: FloatBits>(F);
+
+/// A float value that cannot be used as a [`ComptimeFloat`] because it is
+/// infinite or NaN.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InvalidComptimeFloat<F: Debug>(pub F);
+
+impl<F: FloatBits> Display for InvalidComptimeFloat<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "invalid comptime float: {} is not finite",
+            self.0
+        )
+    }
+}
+
+impl<F: FloatBits> core::error::Error for InvalidComptimeFloat<F> {}
+
+impl<F: FloatBits> ComptimeFloat<F> {
+    /// Wrap `val`, rejecting non-finite input.
+    pub fn new(val: F) -> Result<Self, InvalidComptimeFloat<F>> {
+        if !val.is_finite() {
+            return Err(InvalidComptimeFloat(val));
+        }
+        // IEEE-754 equality treats -0.0 == 0.0, so this also normalizes -0.0.
+        let val = if val == F::zero() { F::zero() } else { val };
+        Ok(Self(val))
+    }
+
+    /// The wrapped value.
+    pub fn get(self) -> F {
+        self.0
+    }
+}
+
+impl<F: FloatBits> PartialEq for ComptimeFloat<F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_bits() == other.0.to_bits()
+    }
+}
+
+impl<F: FloatBits> Eq for ComptimeFloat<F> {}
+
+impl<F: FloatBits> Hash for ComptimeFloat<F> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_bits().hash(state);
+    }
+}
+
+impl<F: FloatBits> Display for ComptimeFloat<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    #[test]
+    fn rejects_non_finite() {
+        assert!(ComptimeFloat::new(f32::NAN).is_err());
+        assert!(ComptimeFloat::new(f32::INFINITY).is_err());
+        assert!(ComptimeFloat::new(f32::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn accepts_finite() {
+        assert!(ComptimeFloat::new(1.5f32).is_ok());
+    }
+
+    /// A trivial FNV-1a hasher so hash-equality can be tested without `std`.
+    #[derive(Default)]
+    struct TestHasher(u64);
+
+    impl Hasher for TestHasher {
+        fn finish(&self) -> u64 {
+            self.0
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            self.0 = bytes.iter().fold(self.0, |hash, byte| {
+                (hash ^ *byte as u64).wrapping_mul(0x100000001b3)
+            });
+        }
+    }
+
+    fn hash_of<T: Hash>(val: &T) -> u64 {
+        let mut hasher = TestHasher::default();
+        val.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn negative_zero_equals_positive_zero() {
+        let neg = ComptimeFloat::new(-0.0f32).unwrap();
+        let pos = ComptimeFloat::new(0.0f32).unwrap();
+        assert_eq!(neg, pos);
+        assert_eq!(hash_of(&neg), hash_of(&pos));
+    }
+
+    #[test]
+    fn distinct_values_are_not_equal() {
+        let a = ComptimeFloat::new(1.0f32).unwrap();
+        let b = ComptimeFloat::new(2.0f32).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn display_matches_inner_value() {
+        let val = ComptimeFloat::new(3.25f32).unwrap();
+        assert_eq!(format!("{}", val), "3.25");
+    }
+}

--- a/crates/cubecl-common/src/float/mod.rs
+++ b/crates/cubecl-common/src/float/mod.rs
@@ -1,3 +1,4 @@
+mod comptime_float;
 #[cfg(feature = "fp4")]
 mod fp4;
 mod fp6;
@@ -6,6 +7,7 @@ mod fp8;
 mod relaxed;
 mod tensor_float;
 
+pub use comptime_float::*;
 #[cfg(feature = "fp4")]
 pub use fp4::*;
 pub use fp6::*;

--- a/crates/cubecl-common/src/lib.rs
+++ b/crates/cubecl-common/src/lib.rs
@@ -60,3 +60,8 @@ pub mod hash;
 mod float;
 
 pub use float::*;
+
+/// An exact ratio of two integers.
+mod ratio;
+
+pub use ratio::*;

--- a/crates/cubecl-common/src/ratio.rs
+++ b/crates/cubecl-common/src/ratio.rs
@@ -1,0 +1,118 @@
+use core::fmt::{Display, Formatter};
+
+/// An exact ratio of two integers, reduced to lowest terms on construction.
+///
+/// Unlike a float, a `Ratio` compares and hashes exactly: two ratios built
+/// from different numerator/denominator pairs are equal whenever they denote
+/// the same fraction (`Ratio::new(1, 2) == Ratio::new(2, 4)`), with no
+/// rounding or bit-pattern comparison involved. This makes it a good fit for
+/// comptime kernel parameters that are always derived from integers (tensor
+/// shapes, tile sizes, and the like).
+///
+/// For a value that is not exactly the ratio of two integers, use
+/// [`ComptimeFloat`](crate::ComptimeFloat) instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Ratio {
+    numerator: usize,
+    denominator: usize,
+}
+
+impl Ratio {
+    /// Create a new [`Ratio`], reduced to lowest terms.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `denominator` is zero.
+    pub fn new(numerator: usize, denominator: usize) -> Self {
+        assert!(denominator != 0, "ratio denominator must not be zero");
+        let divisor = gcd(numerator, denominator);
+        Self {
+            numerator: numerator / divisor,
+            denominator: denominator / divisor,
+        }
+    }
+
+    /// The reduced numerator.
+    pub fn numerator(self) -> usize {
+        self.numerator
+    }
+
+    /// The reduced denominator.
+    pub fn denominator(self) -> usize {
+        self.denominator
+    }
+
+    /// Convert to an [`f32`].
+    pub fn as_f32(self) -> f32 {
+        self.numerator as f32 / self.denominator as f32
+    }
+
+    /// Convert to an [`f64`].
+    pub fn as_f64(self) -> f64 {
+        self.numerator as f64 / self.denominator as f64
+    }
+}
+
+impl Display for Ratio {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}/{}", self.numerator, self.denominator)
+    }
+}
+
+fn gcd(a: usize, b: usize) -> usize {
+    if a == 0 || b == 0 {
+        // A zero numerator still reduces to 0/1; a zero denominator is
+        // rejected by `Ratio::new` before `gcd` is reached.
+        return a.max(b).max(1);
+    }
+    let (mut a, mut b) = (a, b);
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    #[test]
+    fn reduces_to_lowest_terms() {
+        let r = Ratio::new(2, 4);
+        assert_eq!(r.numerator(), 1);
+        assert_eq!(r.denominator(), 2);
+    }
+
+    #[test]
+    fn equal_fractions_are_equal() {
+        assert_eq!(Ratio::new(1, 2), Ratio::new(2, 4));
+        assert_eq!(Ratio::new(3, 9), Ratio::new(1, 3));
+    }
+
+    #[test]
+    fn zero_numerator_reduces_to_zero_over_one() {
+        let r = Ratio::new(0, 5);
+        assert_eq!(r.numerator(), 0);
+        assert_eq!(r.denominator(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "denominator must not be zero")]
+    fn zero_denominator_panics() {
+        Ratio::new(1, 0);
+    }
+
+    #[test]
+    fn conversions_are_accurate() {
+        let r = Ratio::new(1, 4);
+        assert_eq!(r.as_f32(), 0.25);
+        assert_eq!(r.as_f64(), 0.25);
+    }
+
+    #[test]
+    fn display_shows_reduced_form() {
+        let r = Ratio::new(6, 8);
+        assert_eq!(format!("{}", r), "3/4");
+    }
+}

--- a/crates/cubecl-common/src/ratio.rs
+++ b/crates/cubecl-common/src/ratio.rs
@@ -11,7 +11,7 @@ use core::fmt::{Display, Formatter};
 ///
 /// For a value that is not exactly the ratio of two integers, use
 /// [`ComptimeFloat`](crate::ComptimeFloat) instead.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Ratio {
     numerator: usize,
     denominator: usize,
@@ -60,11 +60,6 @@ impl Display for Ratio {
 }
 
 fn gcd(a: usize, b: usize) -> usize {
-    if a == 0 || b == 0 {
-        // A zero numerator still reduces to 0/1; a zero denominator is
-        // rejected by `Ratio::new` before `gcd` is reached.
-        return a.max(b).max(1);
-    }
     let (mut a, mut b) = (a, b);
     while b != 0 {
         (a, b) = (b, a % b);


### PR DESCRIPTION
## Summary
- Add `ComptimeFloat<F>`: wraps a finite `f32`/`f64`/`f16`/`bf16`, comparing and hashing by bit pattern (with `-0.0` normalized to `0.0`), so it can back `Eq + Hash` bounds like `KernelId::info` where a raw float cannot.
- Add `Ratio`: an exact `numerator/denominator` pair reduced to lowest terms on construction, for comptime values that are always integer ratios rather than arbitrary floats.

## Test plan
- [x] `cargo test -p cubecl-common` (new unit tests for both types)
- [x] `cargo check -p cubecl-common --no-default-features --features hash` (no_std)
- [x] `cargo clippy -p cubecl-common --all-features`
- [x] `cargo check --workspace`