### PR TITLE
fix(spirv): name the FPEncoding variants added in tracel-rspirv 0.13.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ cudarc = { version = "0.19.6", features = [
 ], default-features = false } # CubeCL-CUDA
 
 # CubeCL-SPIR-V
-rspirv = { package = "tracel-rspirv", version = "0.13.0" }
+rspirv = { package = "tracel-rspirv", version = "0.13.3" }
 
 # CubeCL-WGPU
 ash = "0.38"

--- a/crates/cubecl-spirv/src/item.rs
+++ b/crates/cubecl-spirv/src/item.rs
@@ -628,6 +628,11 @@ impl std::fmt::Display for Elem {
             Elem::Float(_, Some(FPEncoding::BFloat16KHR)) => write!(f, "bf16"),
             Elem::Float(_, Some(FPEncoding::Float8E4M3EXT)) => write!(f, "e4m3"),
             Elem::Float(_, Some(FPEncoding::Float8E5M2EXT)) => write!(f, "e5m2"),
+            Elem::Float(_, Some(FPEncoding::Float6E2M3EXT)) => write!(f, "e2m3"),
+            Elem::Float(_, Some(FPEncoding::Float6E3M2EXT)) => write!(f, "e3m2"),
+            Elem::Float(_, Some(FPEncoding::Float4E2M1EXT)) => write!(f, "e2m1"),
+            Elem::Float(_, Some(FPEncoding::Float8UnsignedE8M0EXT)) => write!(f, "ue8m0"),
+            Elem::Float(_, Some(FPEncoding::MXInt8EXT)) => write!(f, "mxint8"),
             Elem::Relaxed => write!(f, "flex32"),
         }
     }


### PR DESCRIPTION
`tracel-rspirv 0.13.3` adds five variants to `FPEncoding`, so the `Display` impl for `Elem` stopped being exhaustive and `cubecl-spirv` no longer builds:

```
error[E0004]: non-exhaustive patterns
  --> crates/cubecl-spirv/src/item.rs:622:15
```

`Cargo.lock` is not tracked, so CI resolves the newest `0.13.x` on every run and hits this. It fails on `main` too, independently of any PR.

The requirement moves to `0.13.3` rather than taking a wildcard arm: `0.13.1` has only the three encodings already matched, where a wildcard would be an unreachable pattern. Keeping the match exhaustive means the next upstream addition fails at compile time instead of silently printing a wrong debug name.

The names follow the existing `FloatKind` vocabulary. `MXInt8EXT` has no cubecl equivalent, so it gets `mxint8`. All five arms are unreachable today, since `compile_elem` panics with "Minifloat not supported in SPIR-V" for those kinds; this only affects debug symbol names.

Verified with `cargo check -p cubecl-wgpu --features spirv`, the exact check that fails ("std with SPIR-V compiler", `xtask/src/commands/check.rs:56`), and `cargo clippy -p cubecl-spirv -p cubecl-wgpu --features spirv --all-targets -- -D warnings`.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.

Not run: this adds match arms to a debug-name `Display` impl and raises a patch-level floor on an existing dependency. No API surface changes, so there is nothing downstream to fix.
