### PR TITLE
fix(opt): keep the switch merge on the block its cases converge to

### DIFF
--- a/crates/cubecl-opt/src/control_flow.rs
+++ b/crates/cubecl-opt/src/control_flow.rs
@@ -194,23 +194,23 @@ impl Function {
                 self.add_edge(current_block, case_id, 0);
                 self.current_block = Some(case_id);
                 let is_break = self.parse_scope(state, case);
-                let is_ret = if let Some(current_block) = self.current_block {
+                let falls_through = if let Some(current_block) = self.current_block {
                     self.add_edge(current_block, next, 0);
-                    false
+                    true
                 } else {
-                    !is_break
+                    false
                 };
                 let val = match val.as_const().expect("Switch value must be constant") {
                     ConstantValue::Int(val) => unsafe { transmute::<i32, u32>(val as i32) },
                     ConstantValue::UInt(val) => val as u32,
                     _ => unreachable!("Switch cases must be integer"),
                 };
-                (val, case_id, is_break, is_ret)
+                (val, case_id, is_break, falls_through)
             })
             .collect::<Vec<_>>();
 
         let is_break_branch = branches.iter().any(|it| it.2);
-        let mut is_ret = branches.iter().any(|it| it.3);
+        let mut falls_through = branches.iter().any(|it| it.3);
         let branches = branches
             .into_iter()
             .map(|it| (it.0, it.1))
@@ -223,17 +223,17 @@ impl Function {
 
         if let Some(current_block) = self.current_block {
             self.add_edge(current_block, next, 0);
-        } else {
-            is_ret = !is_break_def;
+            falls_through = true;
         }
 
+        // A case may only branch to the merge the switch declares, so any case reaching `next`
+        // forces it to be that merge. Returning cases end in their own terminator and need none.
         let merge = if is_break_def || is_break_branch {
             None
-        } else if is_ret {
-            Some(self.ret)
-        } else {
-            self[next].block_use.push(BlockUse::Merge);
+        } else if falls_through {
             Some(next)
+        } else {
+            Some(self.ret)
         };
 
         *self[current_block].control_flow.borrow_mut() = ControlFlow::Switch {


### PR DESCRIPTION
A switch whose default or any case diverged took the function return block as its merge, while the remaining cases still branched to the block after the switch. That block is the real convergence point, so the module named one merge and branched to another:

```
%23 = OpLabel
      OpSelectionMerge %39 None          <- declares %39
      OpSwitch %32 %35 1 %36 0 %37 2 %38
%36 =   OpBranch %40                     <- every case goes to %40
%37 =   OpBranch %40
%38 =   OpBranch %40
%35 =   OpUnreachable                    <- default diverges, which triggered the bad merge
%40 = OpLabel                            <- the actual convergence point
```

`spirv-val` rejects this, Mesa then fails `spirv_to_nir` with `VK_ERROR_UNKNOWN`, and wgpu treats the validation error as fatal, so a single bad shader took down **517 of 658 tests** on Intel. NVIDIA accepts the invalid module, which is why CI and NVIDIA developers never saw it.

`is_ret` was computed with `.any()`, so one diverging path was enough to redirect the merge. It now tracks fall-through instead: `next` is the merge whenever anything reaches it, and the return block is used only when nothing does. A case that returns ends in its own terminator and needs no branch to the merge, so mixing the two is fine.

## Verification

Every run below is against a baseline on the same hardware.

| Backend / GPU | main | this PR |
|---|---|---|
| SPIR-V, Arc B390 (validation layers on) | 122 passed / 517 failed | **621 passed / 18 failed** |
| SPIR-V, RTX 4070 Ti SUPER | 639 / 0 | 639 / 0 |
| CUDA, RTX 4070 Ti SUPER | 774 / 0 | 774 / 0 |
| WGSL, Arc B390 | 12/12 on the shuffle subset | 417 / 12 |

Rather than trust one driver, I dumped every shader with `CUBECL_DEBUG_SPIRV` and ran `spirv-val` over all of them: **1 invalid of 476 before, 0 invalid of 685 after**. The offender was `KernelRuntimeVariantsValue`, from `tests_spirv::enums::runtime_enum_value`.

The remaining 18 (SPIR-V) and 12 (WGSL) failures are `plane_shuffle_up`/`plane_shuffle_down` numeric mismatches at the boundary lane. They reproduce with a byte-identical failing set on unmodified main, so they are pre-existing and unrelated.

Two notes for reviewers:

- Under the default parallel test runner the suite now reaches a SIGSEGV in the Intel driver. Single-threaded it completes cleanly. That is a Mesa concurrency issue that was simply unreachable before, since the suite used to die in the first two seconds.
- There is a latent sibling defect this PR does not touch: when a case contains a `break`, `merge` becomes `None` and `compile_switch` emits `OpSwitch` with no preceding `OpSelectionMerge`, which is also invalid. No test covers that path, so I had no way to verify a fix for it.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.

Not run. This changes no API, only which block a switch names as its merge, and it strictly increases the set of shaders that validate. The CUDA and NVIDIA Vulkan suites above are unchanged from main, which covers the backends a downstream build would exercise.
