### PR TITLE
fix(publish): add missing cubecl-std requirement to cubecl-metal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -210,6 +210,7 @@ jobs:
   publish-cubecl-metal:
     needs:
       - publish-cubecl-common
+      - publish-cubecl-std
       - publish-cubecl-core
       - publish-cubecl-cpp
       - publish-cubecl-ir


### PR DESCRIPTION
cubecl-metal lists cubecl-std as a dependency but the publish workflow didn't. Sometimes the workflow worked because cubecl-std had already been published, otherwise it failed.