### PR TITLE
Reorder passes to avoid `CondBrOp` panic

### DIFF
--- a/crates/cubecl-cpu/src/compiler/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/mod.rs
@@ -120,13 +120,13 @@ impl PlironCompiler {
         func_passes.add_pass(LowerComplexOpPass::default());
         func_passes.add_pass(BranchToSCFPass::default());
         func_passes.add_pass(SCFToLlvmCf::default());
-        func_passes.add_pass(SimplifyCFGPass);
-        func_passes.add_pass(DCEPass);
         func_passes.add_pass(LowerEntryAbiPass::new(
             kernel.info.clone(),
             shared_memories.clone(),
         ));
         func_passes.add_pass(CubeToLLVMPass::default());
+        func_passes.add_pass(SimplifyCFGPass);
+        func_passes.add_pass(DCEPass);
         func_passes.add_pass(Mem2RegPass);
 
         passes.add_pass(NestedOpsPass::new(func_passes));


### PR DESCRIPTION
`SimplifyCFGPass` panics if the branch cond is constant and the attribute is not an `IntegerAttr`, but the pass ordering meant that constant conditions were still `BoolAttr` attributes. This moves the SimplifyCFG and DCE passes after the conversion to avoid this panic. Fixes the CI failures in cubek.