### PR TITLE
Suffixes the `llvm.is.fpclass` intrinsic with the type to fix crash in `cubek-reduce`

### DIFF
--- a/crates/cubecl-cpu/src/compiler/to_llvm/math.rs
+++ b/crates/cubecl-cpu/src/compiler/to_llvm/math.rs
@@ -181,9 +181,13 @@ macro_rules! lower_float_fpclass {
                 let intrinsic_type =
                     FuncType::get(ctx, bool_ty, vec![elem_ty, int_ty.into()], false);
 
+                let mut llvm_op = "llvm.is.fpclass".to_string();
+                llvm_op.push('.');
+                llvm_op.push_str(llvm_mangled_ty(ctx, elem_ty).as_str());
+
                 let op = llvm::CallIntrinsicOp::new(
                     ctx,
-                    "llvm.is.fpclass".into(),
+                    llvm_op.into(),
                     intrinsic_type,
                     vec![input, val],
                 );


### PR DESCRIPTION
Fix for CI failures in https://github.com/tracel-ai/cubek/pull/471