### PR TITLE
Clean up dead regions before lowering branches to avoid weird crash in DCE

### DIFF
--- a/crates/cubecl-cpp/src/shared/vector.rs
+++ b/crates/cubecl-cpp/src/shared/vector.rs
@@ -65,7 +65,7 @@ shared_op_with_out!(VectorExtractDynamicOp, |op, ctx| {
     let vector = op.vector(ctx).name(ctx);
     let index = op.index(ctx).name(ctx);
     let elem_ty = op.get_result(ctx).get_type(ctx).to_cpp(ctx);
-    format!("reinterpret_cast<{elem_ty}*>({vector})[{index}]")
+    format!("reinterpret_cast<const {elem_ty}*>(&{vector})[{index}]")
 });
 
 #[cube]

--- a/crates/cubecl-cpu/src/compiler/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/mod.rs
@@ -118,6 +118,7 @@ impl PlironCompiler {
         func_passes.add_pass(SimplifyOpsPass::default());
         func_passes.add_pass(PromoteBitwisePass);
         func_passes.add_pass(LowerComplexOpPass::default());
+        func_passes.add_pass(DCEPass);
         func_passes.add_pass(BranchToSCFPass::default());
         func_passes.add_pass(SCFToLlvmCf::default());
         func_passes.add_pass(LowerEntryAbiPass::new(


### PR DESCRIPTION
This may be an upstream bug but can be worked around for now. Also fixes dynamic extract for CUDA