### PR TITLE
Fix ue8m0 display

### DIFF
--- a/crates/cubecl-common/src/float/fp8/fp8_e8m0.rs
+++ b/crates/cubecl-common/src/float/fp8/fp8_e8m0.rs
@@ -80,7 +80,7 @@ impl ue8m0 {
 
 impl Display for ue8m0 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", ue8m0::to_f64(*self))
+        write!(f, "ue8m0({:x})", self.0)
     }
 }
 


### PR DESCRIPTION
Breaks all the way downstream because burn enables fp8 but not fp4 and this case is never tested