### PR TITLE
Cache metadata info uniforms in the wgpu runtime

### DIFF
--- a/crates/cubecl-wgpu/src/compute/mem_manager.rs
+++ b/crates/cubecl-wgpu/src/compute/mem_manager.rs
@@ -122,21 +122,28 @@ impl WgpuMemManager {
             .get_resource(binding.memory, binding.offset_start, binding.offset_end)
     }
 
-    pub(crate) fn reserve_uniform(&mut self, size: u64) -> WgpuResource {
+    /// Reserve a uniform slice and resolve its resource. The returned
+    /// [`ManagedMemoryHandle`] owns the slice: the uniform stays reserved as
+    /// long as a clone of it is held (the info cache holds one for cached
+    /// metadata buffers), on top of the per-flush retention in `self.uniforms`.
+    pub(crate) fn reserve_uniform(&mut self, size: u64) -> (ManagedMemoryHandle, WgpuResource) {
         let slice = self
             .memory_uniforms
             .reserve(size)
             .expect("Must have enough memory for a uniform");
         // Keep track of this uniform until it is released.
         self.uniforms.push(slice.clone());
+        let retained = slice.clone();
         let handle = self
             .memory_uniforms
             .get_storage(slice.binding())
             .expect("Failed to find storage!");
-        self.memory_uniforms
+        let resource = self
+            .memory_uniforms
             .storage()
             .get(&handle)
-            .expect("Failed to get the uniform's storage!")
+            .expect("Failed to get the uniform's storage!");
+        (retained, resource)
     }
 
     pub(crate) fn memory_usage(&self) -> cubecl_runtime::memory_management::MemoryUsage {
@@ -149,6 +156,13 @@ impl WgpuMemManager {
 
     pub(crate) fn memory_cleanup(&mut self, explicit: bool) {
         self.memory_pool.cleanup(explicit);
+        // An explicit cleanup also reclaims the uniforms pool: the info cache
+        // holds uniform slices across flushes, so this is where the pages of
+        // just-released entries (see `MetadataInfoCache::clear_unpinned`) are
+        // actually returned to the driver.
+        if explicit {
+            self.memory_uniforms.cleanup(explicit);
+        }
     }
 
     pub(crate) fn mode(&mut self, mode: MemoryAllocationMode) {

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -181,8 +181,7 @@ impl BindingsResource {
         mut self,
         stream: &mut WgpuStream,
     ) -> (Vec<WgpuResource>, Vec<WgpuResource>, Option<Addresses>) {
-        let info = (!self.info.data.is_empty())
-            .then(|| stream.create_uniform(bytemuck::cast_slice(&self.info.data)));
+        let info = (!self.info.data.is_empty()).then(|| stream.info_uniform(&self.info.data));
         match self.compiler_info {
             CompilerInfo::Vulkan { params_transfer } => {
                 let addresses = self

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -496,6 +496,11 @@ impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
     fn memory_cleanup(&mut self, stream_id: StreamId) {
         self.scheduler.execute_streams(vec![stream_id]);
         let stream = self.scheduler.stream(&stream_id);
+        // The info cache's buffers are live slices in the uniforms pool; an
+        // explicit cleanup exists to leave the pools empty, so every entry not
+        // pinned by a live graph goes too (entries are recreated on their next
+        // miss).
+        stream.info_cache.clear_unpinned();
         stream.mem_manage.memory_cleanup(true);
     }
 

--- a/crates/cubecl-wgpu/src/compute/storage.rs
+++ b/crates/cubecl-wgpu/src/compute/storage.rs
@@ -27,7 +27,7 @@ impl core::fmt::Debug for WgpuStorage {
 }
 
 /// The memory resource that can be allocated for wgpu.
-#[derive(new, Debug)]
+#[derive(new, Debug, Clone)]
 pub struct WgpuResource {
     /// The wgpu buffer.
     pub buffer: wgpu::Buffer,

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -28,6 +28,7 @@ use cubecl_ir::MemoryDeviceProperties;
 use cubecl_runtime::{
     logging::ServerLogger,
     memory_management::{ManagedMemoryHandle, SharedMemoryBindings},
+    metadata_cache::{MetadataCachePolicy, MetadataInfoCache},
     timestamp_profiler::TimestampProfiler,
 };
 #[cfg(renderdoc)]
@@ -69,6 +70,14 @@ pub struct WgpuStream {
     /// Kept alive here until the next `flush` ties their release to the submission's completion.
     /// See [`ScheduleTask::Execute::pins`](crate::schedule::ScheduleTask).
     shared_bindings: SharedMemoryBindings,
+    /// Reusable per-launch info uniforms (kernel shapes/strides/scalars), keyed
+    /// by the exact info words they were built from — same scheme as the CUDA
+    /// and HIP servers. A hit reuses the already-uploaded uniform buffer, so a
+    /// stable-shape launch costs no uniform reservation and no
+    /// `queue.write_buffer`. The cached [`ManagedMemoryHandle`] keeps the slice
+    /// reserved past the per-flush release in
+    /// [`WgpuMemManager::release_uniforms`].
+    pub(crate) info_cache: MetadataInfoCache<(ManagedMemoryHandle, WgpuResource)>,
 }
 
 impl WgpuStream {
@@ -138,6 +147,11 @@ impl WgpuStream {
             submission_load: SubmissionLoad::default(),
             pending_write_count: 0,
             shared_bindings: SharedMemoryBindings::default(),
+            // Tighter entry cap than the default policy: the uniforms pool is
+            // bucketed exclusive pages with a 32 KiB minimum, so every cached
+            // entry pins a whole page (512 × 32 KiB ≈ 16 MiB worst case) —
+            // unlike CUDA/HIP where an entry is a small dynamic-pool slice.
+            info_cache: MetadataInfoCache::new(MetadataCachePolicy::new(512, 2048)),
         }
     }
 
@@ -427,8 +441,33 @@ impl WgpuStream {
     }
 
     pub(crate) fn create_uniform(&mut self, data: &[u8]) -> WgpuResource {
-        let resource = self.mem_manage.reserve_uniform(data.len() as u64);
+        let (_handle, resource) = self.mem_manage.reserve_uniform(data.len() as u64);
         self.write_to_buffer(&resource, data);
+        resource
+    }
+
+    /// Stage the metadata info `words` into a uniform, reusing a cached one
+    /// when a launch has already staged these exact words. The info is
+    /// read-only metadata (no buffer bindings), so sharing it across launches —
+    /// even of different kernels — is sound; see
+    /// [`MetadataInfoCache`](cubecl_runtime::metadata_cache::MetadataInfoCache).
+    /// A hit's buffer bytes always equal the key bytes, so it is byte-identical
+    /// to what the miss path would have built and uploaded.
+    pub(crate) fn info_uniform(&mut self, words: &[u64]) -> WgpuResource {
+        let size = core::mem::size_of_val(words);
+        if !self.info_cache.should_cache(size) {
+            return self.create_uniform(bytemuck::cast_slice(words));
+        }
+        // Look up by the borrowed words — a hit clones nothing but the
+        // resource. On a miss we build the uniform and clone the words into
+        // the cache as the key.
+        if let Some((_handle, resource)) = self.info_cache.get(words) {
+            return resource;
+        }
+        let (handle, resource) = self.mem_manage.reserve_uniform(size as u64);
+        self.write_to_buffer(&resource, bytemuck::cast_slice(words));
+        self.info_cache
+            .insert(words.to_vec(), (handle, resource.clone()));
         resource
     }
 


### PR DESCRIPTION
Route the per-launch metadata info buffer (shapes/strides/scalars) through the shared MetadataInfoCache, as CUDA and HIP already do. A stable-shape launch now reuses the already-uploaded uniform instead of paying a uniform-pool reservation and a queue.write_buffer per launch. This is also the groundwork for wgpu graph capture: warm info buffers mean a capture window allocates and uploads nothing, and the cache's pinning lifecycle (capture_commit/graph_release) will keep recorded uniforms alive for a graph's lifetime.

The entry cap is tuned down to 512 (vs the 4096 default) because the wgpu uniforms pool is bucketed exclusive pages with a 32 KiB minimum, so each cached entry pins a whole page.