### PR TITLE
Lower cube.poison to OpUndef in the SPIR-V backend

### DIFF
--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -633,14 +633,22 @@ fn build_pools(
                 });
             }
 
-            // Add pools from big to small.
+            // Allocations bigger than the sliced ladder get exact-size
+            // exclusive pages. A sliced tail pool here would materialize a
+            // whole `max_page` page (a quarter of device memory) for the
+            // first allocation that lands in it — on unified-memory devices
+            // that alone can consume a large share of host RAM. Exclusive
+            // pages allocate exactly what is requested and are released once
+            // they sit unused for a full dealloc period.
+            let max_alloc = max_page / memory_alignment * memory_alignment;
+            let dealloc_period = (BASE_DEALLOC_PERIOD as f64
+                * (1.0 + max_alloc as f64 / (DEALLOC_SCALE_MB as f64)).round())
+                as u64;
             pools.push(MemoryPoolOptions {
-                pool_type: PoolType::SlicedPages {
-                    page_size: max_page / memory_alignment * memory_alignment,
-                    max_slice_size: max_page / memory_alignment * memory_alignment,
-                    max_pool_size: None,
+                pool_type: PoolType::ExclusivePages {
+                    max_alloc_size: max_alloc,
                 },
-                dealloc_period: None,
+                dealloc_period: Some(dealloc_period),
             });
             pools
         }
@@ -1077,6 +1085,13 @@ impl<Storage: ComputeStorage> MemoryManagement<Storage> {
         // If this happens every nanosecond, counts overflows after 585 years, so not worth thinking too
         // hard about overflow here.
         self.alloc_reserve_count += 1;
+
+        // Drive the pools' periodic deallocation. Each pool gates itself on
+        // its own `dealloc_period` (pools without one no-op), so this is a few
+        // comparisons per reservation — without it, pages freed long ago are
+        // never returned to the driver until an explicit cleanup, which on
+        // long-running processes lets every stream's pools grow monotonically.
+        self.cleanup(false);
 
         let mapping = PageMapping::current();
 

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/direct_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/direct_pool.rs
@@ -234,16 +234,24 @@ impl MemoryPool for DirectPool {
         }
     }
 
-    /// Return **every** free slice, whatever the ceiling says: a cleanup is
-    /// the caller stating that reuse is worth less than the memory right now,
-    /// which is exactly the judgement [`reclaim_at`](Self::reclaim_at)
-    /// automates in the absence of one.
+    /// On an explicit cleanup, return **every** free slice, whatever the
+    /// ceiling says: the caller is stating that reuse is worth less than the
+    /// memory right now, which is exactly the judgement
+    /// [`reclaim_at`](Self::reclaim_at) automates in the absence of one.
+    ///
+    /// Periodic (non-explicit) cleanups are ignored — below the ceiling, free
+    /// slices are held for reuse by design, and crossing the ceiling (handled
+    /// in `alloc`) is what returns memory to the driver.
     fn cleanup<Storage: crate::storage::ComputeStorage>(
         &mut self,
         storage: &mut Storage,
         _alloc_nr: u64,
-        _explicit: bool,
+        explicit: bool,
     ) {
+        if !explicit {
+            return;
+        }
+
         for (index, entry) in self.slices.iter_mut().enumerate() {
             let Some(slice) = entry else { continue };
             if !slice.is_free() {

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -272,9 +272,7 @@ impl SpirvCompiler {
         // verify_operation(module_op, ctx).expect("Failed to verify after passes");
 
         let mut builder = PlironBuilder::default();
-        spirv_module
-            .to_spirv(ctx, &mut builder)
-            .expect("Failed to convert");
+        spirv_module.to_spirv(ctx, &mut builder)?;
         let module = builder.module();
 
         Ok((module, bindings, shared_size))

--- a/crates/cubecl-spirv/src/lib.rs
+++ b/crates/cubecl-spirv/src/lib.rs
@@ -14,6 +14,7 @@ pub mod lower;
 pub mod ops;
 pub mod target;
 pub mod types;
+pub mod validate;
 
 pub use compiler::*;
 use serde::{Deserialize, Serialize};

--- a/crates/cubecl-spirv/src/ops/general.rs
+++ b/crates/cubecl-spirv/src/ops/general.rs
@@ -52,6 +52,24 @@ impl ToSpirvDialectOp for general::SelectOp {
     }
 }
 
+#[op_interface_impl]
+impl ToSpirvDialectOp for general::PoisonOp {
+    fn to_spirv_dialect(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        let op = self.get_operation();
+        let out_ty = ty_to_spirv_dialect(ctx, self.get_result(ctx).get_type(ctx));
+        let new_op = ops::UndefOp::new(ctx, out_ty);
+        rewriter.append_op(ctx, &new_op);
+        rewriter.replace_operation(ctx, op, new_op.get_operation());
+
+        Ok(())
+    }
+}
+
 macro_rules! erase_op {
     ($ty: ty) => {
         #[op_interface_impl]

--- a/crates/cubecl-spirv/src/validate.rs
+++ b/crates/cubecl-spirv/src/validate.rs
@@ -1,0 +1,127 @@
+//! Device-capability validation of compiled SPIR-V modules.
+
+use std::collections::HashMap;
+
+use cubecl_ir::{DeviceProperties, ElemType, FloatKind, IntKind, UIntKind};
+use rspirv::{
+    dr::{Instruction, Module, Operand},
+    spirv::{CooperativeMatrixUse, FPEncoding, Op, Scope},
+};
+
+/// Checks that every subgroup-scope cooperative matrix type declared in the
+/// module matches a fragment shape the device advertises. Drivers only accept
+/// the exact (element type, rows, columns, use) combinations they report;
+/// anything else is undefined behavior at runtime — loads and stores silently
+/// produce garbage on at least RADV — so it must be rejected at compile time.
+pub fn check_cmma_types(module: &Module, props: &DeviceProperties) -> Result<(), String> {
+    let types: HashMap<u32, &Instruction> = module
+        .types_global_values
+        .iter()
+        .filter_map(|inst| inst.result_id.map(|id| (id, inst)))
+        .collect();
+
+    let const_u32 = |id: &u32| -> Option<u32> {
+        let inst = types.get(id)?;
+        if inst.class.opcode != Op::Constant {
+            return None;
+        }
+        match inst.operands.first()? {
+            Operand::LiteralBit32(v) => Some(*v),
+            _ => None,
+        }
+    };
+
+    for inst in &module.types_global_values {
+        if inst.class.opcode != Op::TypeCooperativeMatrixKHR {
+            continue;
+        }
+        let [
+            Operand::IdRef(component),
+            Operand::IdRef(scope) | Operand::IdScope(scope),
+            Operand::IdRef(rows),
+            Operand::IdRef(cols),
+            Operand::IdRef(usage),
+        ] = inst.operands.as_slice()
+        else {
+            continue;
+        };
+        // Workgroup-scope matrices (cooperative matrix 2) have flexible
+        // dimensions and are validated by their own feature set.
+        if const_u32(scope) != Some(Scope::Subgroup as u32) {
+            continue;
+        }
+        let (Some(rows), Some(cols), Some(usage)) =
+            (const_u32(rows), const_u32(cols), const_u32(usage))
+        else {
+            continue;
+        };
+        let Some(elem) = types.get(component).and_then(|it| elem_type(it)) else {
+            continue;
+        };
+        let Some(usage) = CooperativeMatrixUse::from_u32(usage) else {
+            continue;
+        };
+
+        let supported = props.features.matmul.cmma.iter().any(|cfg| match usage {
+            CooperativeMatrixUse::MatrixAKHR => cfg.a_type == elem && cfg.m == rows && cfg.k == cols,
+            CooperativeMatrixUse::MatrixBKHR => cfg.b_type == elem && cfg.k == rows && cfg.n == cols,
+            CooperativeMatrixUse::MatrixAccumulatorKHR => {
+                cfg.cd_type == elem && cfg.m == rows && cfg.n == cols
+            }
+        });
+        if !supported {
+            let usage = match usage {
+                CooperativeMatrixUse::MatrixAKHR => "A",
+                CooperativeMatrixUse::MatrixBKHR => "B",
+                CooperativeMatrixUse::MatrixAccumulatorKHR => "Accumulator",
+            };
+            return Err(format!(
+                "the device doesn't support a {rows}x{cols} {usage} cooperative matrix fragment \
+                 of {elem:?}; supported configurations: {:?}",
+                props.features.matmul.cmma
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn elem_type(inst: &Instruction) -> Option<ElemType> {
+    let width = match inst.operands.first()? {
+        Operand::LiteralBit32(w) => *w,
+        _ => return None,
+    };
+    let ty = match inst.class.opcode {
+        Op::TypeFloat => match inst.operands.get(1) {
+            None => match width {
+                16 => ElemType::Float(FloatKind::F16),
+                32 => ElemType::Float(FloatKind::F32),
+                64 => ElemType::Float(FloatKind::F64),
+                _ => return None,
+            },
+            Some(Operand::FPEncoding(enc)) => match enc {
+                FPEncoding::BFloat16KHR => ElemType::Float(FloatKind::BF16),
+                FPEncoding::Float8E4M3EXT => ElemType::Float(FloatKind::E4M3),
+                FPEncoding::Float8E5M2EXT => ElemType::Float(FloatKind::E5M2),
+                _ => return None,
+            },
+            Some(_) => return None,
+        },
+        Op::TypeInt => {
+            let signed = matches!(inst.operands.get(1)?, Operand::LiteralBit32(1));
+            match (width, signed) {
+                (8, true) => ElemType::Int(IntKind::I8),
+                (16, true) => ElemType::Int(IntKind::I16),
+                (32, true) => ElemType::Int(IntKind::I32),
+                (64, true) => ElemType::Int(IntKind::I64),
+                (8, false) => ElemType::UInt(UIntKind::U8),
+                (16, false) => ElemType::UInt(UIntKind::U16),
+                (32, false) => ElemType::UInt(UIntKind::U32),
+                (64, false) => ElemType::UInt(UIntKind::U64),
+                _ => return None,
+            }
+        }
+        _ => return None,
+    };
+    Some(ty)
+}

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -209,7 +209,22 @@ impl WgpuCompiler for AutoCompiler {
             #[cfg(feature = "spirv")]
             AutoRepresentation::SpirV(repr) => repr.shared_size,
         });
-        check_shared_memory(shared_bytes, props)
+        check_shared_memory(shared_bytes, props)?;
+
+        #[cfg(feature = "spirv")]
+        if let Some(module) = repr.as_ref().and_then(|repr| match repr {
+            AutoRepresentation::SpirV(repr) => repr.module.as_ref(),
+            _ => None,
+        }) {
+            cubecl_spirv::validate::check_cmma_types(module, props).map_err(|reason| {
+                LaunchError::CompilationError(CompilationError::Validation {
+                    reason,
+                    backtrace: BackTrace::capture(),
+                })
+            })?;
+        }
+
+        Ok(())
     }
 
     fn normalize_repr(
@@ -332,7 +347,18 @@ impl WgpuCompiler for cubecl_spirv::SpirvCompiler {
         props: &DeviceProperties,
     ) -> Result<(), LaunchError> {
         let shared_bytes = repr.as_ref().map(|repr| repr.shared_size);
-        check_shared_memory(shared_bytes, props)
+        check_shared_memory(shared_bytes, props)?;
+
+        if let Some(module) = repr.as_ref().and_then(|repr| repr.module.as_ref()) {
+            cubecl_spirv::validate::check_cmma_types(module, props).map_err(|reason| {
+                LaunchError::CompilationError(CompilationError::Validation {
+                    reason,
+                    backtrace: BackTrace::capture(),
+                })
+            })?;
+        }
+
+        Ok(())
     }
 
     fn normalize_repr(


### PR DESCRIPTION
The SROA pass can scalarize a local array into a plain variable, which mem2reg then promotes with a cube.poison initial value threaded through loops as an iter-arg. cube.poison had no SPIR-V lowering, so emission failed on any kernel where this happened (e.g. the plane vec-mat matmul), and the failure was an .expect() panic on the device thread: the launch silently produced uninitialized output instead of a compile error. Lower poison to spirv.Undef and propagate to_spirv failures as a CompilationError.