### PR TITLE
feat(wgpu/msl): register bf16 when the device probe-compiles bfloat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,8 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "log",
+ "objc2-foundation",
+ "objc2-metal",
  "paste",
  "pliron",
  "pretty_assertions",

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -31,7 +31,7 @@ std = [
 ]
 # 'msl' and 'spirv' features are exclusive
 # TODO find a way to have wgpu runtime auto-compiler to support several compilers at the same time
-msl = ["cubecl-cpp/metal"]
+msl = ["cubecl-cpp/metal", "dep:objc2-metal", "dep:objc2-foundation"]
 profile-tracy = ["tracy-client"]
 spirv = ["cubecl-spirv", "ash", "tracel-ash", "cubecl-common/hash"]
 
@@ -104,6 +104,10 @@ wgpu = { workspace = true, features = ["fragile-send-sync-non-atomic-wasm"] }
 ## On macOS, the `vulkan-portability` feature is required due to the MoltenVK translation layer.
 # To install MoltenVK, install the VulkanSDK: https://vulkan.lunarg.com/sdk/home#mac
 [target.'cfg(target_os = "macos")'.dependencies]
+# bf16 probe gate for the msl passthrough (see backend/metal.rs). Versions
+# match wgpu-hal's own objc2 stack, so these add no new lockfile entries.
+objc2-metal = { version = "0.3", default-features = false, features = ["std", "MTLDevice", "MTLLibrary"], optional = true }
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSString", "NSError"], optional = true }
 wgpu = { workspace = true, features = [
     "vulkan-portability",
     "fragile-send-sync-non-atomic-wasm",

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -93,12 +93,15 @@ pub fn register_metal_features(
 }
 
 fn register_features(
-    _adapter: &metal::Adapter,
+    adapter: &metal::Adapter,
     props: &mut DeviceProperties,
     _features: Features,
     _comp_options: &mut WgpuCompilationOptions,
 ) {
     register_types(props);
+    if device_compiles_bfloat(adapter) {
+        register_bf16(props);
+    }
     register_cmma(props);
     props.features.alignment = true;
     props.features.plane.insert(Plane::Ops);
@@ -141,6 +144,43 @@ fn register_types(props: &mut DeviceProperties) {
         props
             .register_atomic_type_usage(Type::atomic(ty), AtomicUsage::Add | AtomicUsage::LoadStore)
     }
+}
+
+/// Registers `bf16` for the msl passthrough. Only called when
+/// [`device_compiles_bfloat`] proved the device+OS pair actually compiles
+/// `bfloat` MSL — the codegen for it already exists in `cubecl-cpp`'s metal
+/// dialect (reductions fall back through `float`, shuffles through `ushort`),
+/// so registration is the only missing link on capable systems.
+fn register_bf16(props: &mut DeviceProperties) {
+    use cubecl_core::ir::{ElemType, FloatKind};
+    props.register_type_usage(ElemType::Float(FloatKind::BF16), TypeUsage::all());
+}
+
+/// Probe-compiles a one-line `bfloat` kernel on the adapter's raw device.
+///
+/// `bfloat` needs MSL 3.1 (macOS 14+ / iOS 17+) AND an Apple6+ GPU family —
+/// rather than encoding that version/family table here (wgpu-hal keeps its
+/// resolved `msl_version` private), the probe tests the real condition
+/// directly: can THIS device on THIS OS compile a `bfloat` kernel? A few
+/// milliseconds, once per device init, and it fails closed on any error.
+fn device_compiles_bfloat(adapter: &metal::Adapter) -> bool {
+    use objc2_foundation::NSString;
+    use objc2_metal::MTLDevice;
+
+    let src = NSString::from_str(concat!(
+        "#include <metal_stdlib>\n",
+        "using namespace metal;\n",
+        "kernel void cubecl_bf16_probe(device bfloat* x [[buffer(0)]],\n",
+        "                              uint i [[thread_position_in_grid]]) {\n",
+        "    x[i] = bfloat(float(x[i]) + 1.0f);\n",
+        "}\n"
+    ));
+    // Default compile options resolve to the OS's newest supported MSL —
+    // the same ceiling wgpu-hal's private `msl_version` ladder tracks.
+    adapter
+        .raw_device()
+        .newLibraryWithSource_options_error(&src, None)
+        .is_ok()
 }
 
 fn register_cmma(props: &mut DeviceProperties) {


### PR DESCRIPTION
The msl passthrough's Metal backend registers f16/f32 but never bf16 — yet the bfloat MSL codegen already ships in `cubecl-cpp`'s metal dialect (reductions fall back through `float`, shuffles through `ushort`, float-returning intrinsics cast back). On macOS 14+, wgpu-hal compiles MSL at 3.1+, where `bfloat` is a native type, so on those systems the missing capability registration is the only gap.

## Approach

Rather than encoding the OS/family version table here (wgpu-hal keeps its resolved `msl_version` private), the gate **probe-compiles a one-line `bfloat` kernel on the adapter's raw device at init**: if the device+OS pair compiles it, bf16 is registered with full usage; any error fails closed to today's behavior. It costs a few milliseconds, once per device init. macOS 13 and earlier (MSL 3.0 — no `bfloat`) refuse the probe and are unchanged.

Happy to re-gate differently if you'd prefer another idiom (e.g., exposing `msl_version` via your wgpu fork).

## Measured

On an M1 Max (Apple7 family): a 10-step rank-8 LoRA training run over an 8B Llama-arch model in bf16 completes with finite loss through this path — load (16.5 GB, 4 shards), forward, backward, optimizer step.

Throughput, stated plainly: bf16 ran ~16× slower than the same run at f16 on this GPU family (5.3 vs 84.3 tok/s), consistent with per-op conversion and no native bf16 SIMD on Apple7. Newer families were not measured and are expected to fare better. The value on Apple7 is correctness (bf16's exponent range), not speed.

## Dependencies

`objc2-metal`/`objc2-foundation` are macOS-only, optional behind the `msl` feature, and version-matched to wgpu-hal's own objc2 stack — no new lockfile entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
