### PR TITLE
Fall back to remaining candidates when an autotune cache-hit winner fails at launch

### DIFF
--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -118,6 +118,44 @@ where
         super::check_autotune_outputs(checks_outputs)
     }
 
+    /// Run the cache-hit winner; if its launch fails, fall back to the
+    /// remaining candidates instead of panicking.
+    ///
+    /// The autotune key does not capture everything launch-time validation
+    /// checks (and benchmark inputs are not always identical to the real
+    /// ones), so a winner tuned on one representative can be an invalid
+    /// config for a later cache hit. Panicking here is not a recoverable
+    /// position for the caller: on an async device runner the panic is
+    /// caught and warn-logged by the task loop while the op's registered
+    /// outputs stay unwritten, which surfaces as silent NaN corruption in
+    /// training. Falling back trades one slow launch for a correct result.
+    fn execute_hit<'a, I: TuneInputs, Out: AutotuneOutput>(
+        operations: &TunableSet<AK, I, Out>,
+        inputs: <I as TuneInputs>::At<'a>,
+        fastest_index: usize,
+    ) -> Out
+    where
+        <I as TuneInputs>::At<'a>: Clone + Send,
+    {
+        match operations.fastest(fastest_index).execute(inputs.clone()) {
+            Ok(out) => out,
+            Err(err) => {
+                log::warn!(
+                    "Autotune winner {fastest_index} failed at launch ({err:?}); falling back to remaining candidates."
+                );
+                for i in 0..operations.len() {
+                    if i == fastest_index {
+                        continue;
+                    }
+                    if let Ok(out) = operations.fastest(i).execute(inputs.clone()) {
+                        return out;
+                    }
+                }
+                panic!("All autotune operations failed after the selected winner failed: {err:?}");
+            }
+        }
+    }
+
     /// Execute the fastest operation in a [`TunableSet`], triggering a tuning pass on
     /// the first call for a given key.
     pub fn execute<'a, R: Runtime, I: TuneInputs, Out>(
@@ -155,10 +193,7 @@ where
         // `fastest` also resets the tuner cache if the environment switched, so
         // a miss here falls through to `check_tune`, which re-hydrates.
         if let TuneCacheResult::Hit { fastest_index } = tuner.fastest(&key) {
-            return operations
-                .fastest(fastest_index)
-                .execute(inputs)
-                .expect("Should run when selected by autotune.");
+            return Self::execute_hit(&operations, inputs, fastest_index);
         }
 
         let fastest = tuner.check_tune::<R, I, Out>(
@@ -172,10 +207,9 @@ where
 
         // Run the execution depending on the cache state.
         match fastest {
-            TuneCacheResult::Hit { fastest_index } => operations
-                .fastest(fastest_index)
-                .execute(inputs)
-                .expect("Should run when selected by autotune."),
+            TuneCacheResult::Hit { fastest_index } => {
+                Self::execute_hit(&operations, inputs, fastest_index)
+            }
             TuneCacheResult::Unchecked | TuneCacheResult::Miss => {
                 panic!(
                     "Somehow we STILL didn't check a tuning checksum or start tuning, something has gone wrong."
@@ -191,5 +225,80 @@ where
                 panic!("All autotune operations failed, no viable operation found.");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tune::{Tunable, TunableSet};
+    use alloc::string::{String, ToString};
+    use alloc::sync::Arc;
+    use alloc::vec::Vec;
+    use core::fmt::Display;
+    use cubecl_environment::sync::Mutex;
+
+    #[derive(Hash, Eq, PartialEq, Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct FakeKey;
+
+    impl Display for FakeKey {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.write_str("FakeKey")
+        }
+    }
+
+    impl AutotuneKey for FakeKey {}
+
+    /// The autotune key does not capture everything launch-time validation
+    /// checks, so a cached winner can fail on a later cache hit even though
+    /// it benchmarked fine. That failure must fall back to the remaining
+    /// candidates (in order, skipping the winner) instead of panicking.
+    #[test_log::test]
+    fn cache_hit_winner_failure_falls_back() {
+        let ran: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let log = |name: &'static str, ok: bool| {
+            let ran = ran.clone();
+            move |_: u32| {
+                ran.lock().push(name.to_string());
+                if ok { Ok(()) } else { Err("invalid config") }
+            }
+        };
+
+        let set: TunableSet<FakeKey, u32, ()> = TunableSet::new_cloning_inputs(|_: &u32| FakeKey)
+            .with(Tunable::new(
+                "winner_now_invalid",
+                log("winner_now_invalid", false),
+            ))
+            .with(Tunable::new("also_broken", log("also_broken", false)))
+            .with(Tunable::new("works", log("works", true)));
+
+        LocalTuner::<FakeKey, String>::execute_hit(&set, 7u32, 0);
+
+        assert_eq!(
+            ran.lock().as_slice(),
+            ["winner_now_invalid", "also_broken", "works"]
+        );
+    }
+
+    /// A winner that keeps working takes the fast path untouched.
+    #[test_log::test]
+    fn cache_hit_winner_success_runs_alone() {
+        let ran: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let ran2 = ran.clone();
+        let ran3 = ran.clone();
+
+        let set: TunableSet<FakeKey, u32, ()> = TunableSet::new_cloning_inputs(|_: &u32| FakeKey)
+            .with(Tunable::new("winner", move |_: u32| {
+                ran2.lock().push("winner".to_string());
+                Ok::<(), String>(())
+            }))
+            .with(Tunable::new("unused", move |_: u32| {
+                ran3.lock().push("unused".to_string());
+                Ok::<(), String>(())
+            }));
+
+        LocalTuner::<FakeKey, String>::execute_hit(&set, 7u32, 0);
+
+        assert_eq!(ran.lock().as_slice(), ["winner"]);
     }
 }


### PR DESCRIPTION
Addresses https://github.com/tracel-ai/burn/issues/5352 (the layer that recovers the failure; the companion cubek key-soundness PR is linked below).

## Problem

`LocalTuner::execute` runs a cache-hit winner with `.expect("Should run when selected by autotune.")`. The autotune key does not capture everything launch-time validation checks (and benchmark inputs are not always byte-identical to the real call's), so a cached winner can fail setup validation on a later cache hit even though it benchmarked Ok.

We hit this in burn training on CUDA (RTX 4080 SUPER, cubecl 0.11.0-pre.2): a ~60-line MLP training loop deterministically selects `matmul_specialized_cyclic_mma` from the cache on the step after the first optimizer update and dies with

```
Should run when selected by autotune.: matmul_specialized_cyclic_mma: An unknown error happened.
Unable to launch matmul because the config is invalid: "Async copy requires strides to be aligned to 16 bytes"
```

for the forward head matmul `[512,128] @ [128,7]` (rhs strides `[7,1]` → 28-byte canonical stride, under the async-copy reader's 16-byte threshold) — a problem for which the same bucket recorded a successful benchmark.

The `.expect` makes this unrecoverable in the worst possible way: on an async device runner the panic unwinds into the task loop's `catch_unwind`, is warn-logged, and execution continues — the op's registered outputs stay unwritten, so downstream either trains on uninitialized buffers (silent NaN weights, which cost us six multi-hour training campaigns on 0.22.0-pre.1) or corrupts the fusion stream's handle state (`Should have handle for tensor`, `ordering.rs` index out of bounds, propagated `CallError`) on 0.22.0-pre.2.

## Fix

On a cache-hit launch failure, warn-log and try the remaining candidates in order (skipping the failed winner) instead of panicking; panic only if every candidate fails. Both hit paths (fast path and post-`check_tune`) route through the new `execute_hit`.

Verified on the failing training repro against the published `0.11.0-pre.2` crates: unpatched, 3/3 fresh-cache runs die on step 1; with this change, 3/3 runs train to completion with finite, decreasing losses, logging the winner failure and recovering each time. (On current main the same repro is masked on sm_89: the offending kernel now fails *compilation* at tune time with `UnsupportedOp("plane.elect")` — a swallowed device-thread panic — so it never becomes the cached winner. The unrecoverable `.expect` path this PR fixes is unchanged.)

A possible follow-up (not in this PR): demote or re-tune a winner that fails at launch, so the fallback path isn't taken on every subsequent hit.

## Tests

- `cache_hit_winner_failure_falls_back` — the winner errors; the remaining candidates run in order and the first success is returned.
- `cache_hit_winner_success_runs_alone` — a healthy winner keeps the fast path: nothing else executes.

Related: companion cubek PR https://github.com/tracel-ai/cubek/pull/488 fixing `MatmulAutotuneKey`'s stride factors being derived from anchored dims rather than real strides (which lets problems that fail the async-copy/TMA validators share buckets with problems that pass them).

## Validate your PR with burn

- [x] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [x] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here — none needed beyond the companion fix above: no compatibility changes were required.
- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here — none needed: no burn changes were required.

Validation details: burn main does not currently compile against cubecl main (pre-existing quant API drift from #1479, unrelated to this change), so validation ran on burn's pinned revs, mirroring the maintainers' rev-bump flow. This fix cherry-picked onto burn's pinned cubecl (`f0721ea`) — branch [`validate/fallback-on-burn-pin`](https://github.com/RAV64/cubecl/tree/validate/fallback-on-burn-pin) — with cubek's cubecl rev bumped to it ([`validate/keyfix-on-burn-pin`](https://github.com/RAV64/cubek/tree/validate/keyfix-on-burn-pin)): burn compiles cleanly with `std,autodiff,optim,cuda,fusion,autotune`, cubek-matmul's unit tests pass (16/16), and the training reproduction from the linked issue trains to completion (3/3 fresh-cache runs, finite decreasing losses). A cubek-main-based bump branch also builds: [`validate/cubecl-fallback-revbump`](https://github.com/RAV64/cubek/tree/validate/cubecl-fallback-revbump). The change is additive and API-neutral (a private fallback helper inside `LocalTuner::execute`; no public signatures change). All 42 `cubecl-runtime` tune tests pass on both cubecl main and the pinned base.
