### PR TITLE
Zero-init arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
+checksum = "804764d10e844da09765a7b2ca9641a0851523d1702efb0d7299d73e31b86e80"
 dependencies = [
  "libloading 0.9.0",
 ]
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2957,9 +2957,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -3402,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "pliron-spirv"
-version = "0.14.0+sdk-1.4.357.0"
+version = "0.14.1+sdk-1.4.357.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e775b2401a6ca1c46ac3e749ca3c6b44329c156f42fb263eb52499099543182d"
+checksum = "2919774bd35911798e824286a15c2c3c6fedbfd56d06a33e071dc1af5d5e7030"
 dependencies = [
  "derive-new",
  "derive_more",
@@ -4942,9 +4942,9 @@ dependencies = [
 
 [[package]]
 name = "tracel-rspirv"
-version = "0.14.0+sdk-1.4.357.0"
+version = "0.14.1+sdk-1.4.357.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18ed0062c1f1236d9c51523b310974352778b0dd3b8598f70eac580afbed27b"
+checksum = "d1f062140c2875c072de7ab05019970906105a9a2c971af922b8d16bd3b5cbea"
 dependencies = [
  "bitflags 2.13.1",
  "pliron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,8 +179,8 @@ cudarc = { version = "0.19.6", features = [
 ], default-features = false } # CubeCL-CUDA
 
 # CubeCL-SPIR-V
-pliron-spirv = "0.14.0"
-rspirv = { version = "0.14.0", package = "tracel-rspirv" }
+pliron-spirv = "0.14.1"
+rspirv = { version = "0.14.1", package = "tracel-rspirv" }
 # pliron-spirv = { package = "pliron-spirv", path = "../tracel-rspirv/pliron-spirv" }
 # rspirv = { package = "tracel-rspirv", path = "../tracel-rspirv/rspirv" }
 # pliron-spirv = { git = "https://github.com/tracel-ai/tracel-rspirv.git", rev = "7c59c46f4248ba92e3b06d411c0a2e8cce379025" }

--- a/crates/cubecl-core/src/frontend/cmma.rs
+++ b/crates/cubecl-core/src/frontend/cmma.rs
@@ -54,6 +54,7 @@ use cubecl_macros::{comptime_type, cube, intrinsic};
 
 use cubecl_ir::{
     ExpandValue, Scope, VectorSize,
+    attributes::ZeroAttr,
     dialect::matrix::{
         ColIndexOp, LdMatrixOp, MmaManualOp, MmaManualScaledOp, RowIndexOp, StMatrixOp,
     },
@@ -250,7 +251,8 @@ impl<C: CubePrimitive, S: MatrixScope> Matrix<C, S> {
             let elem = C::Scalar::__expand_as_type(scope);
             let matrix_ty =
                 MatrixType::get(scope.ctx(), ident, (m, n, k).into(), elem, layout, S::SCOPE);
-            let elem = scope.create_local_mut(matrix_ty, None);
+            let null = ZeroAttr::new(matrix_ty);
+            let elem = scope.create_local_mut(matrix_ty, Some(null.into()));
             MatrixExpand {
                 elem,
                 ident,

--- a/crates/cubecl-core/src/frontend/container/array/base.rs
+++ b/crates/cubecl-core/src/frontend/container/array/base.rs
@@ -33,7 +33,7 @@ impl<E> AsMutExpand for ArrayExpand<E> {
 
 /// Module that contains the implementation details of the new function.
 mod new {
-    use cubecl_ir::types::ArrayType;
+    use cubecl_ir::{attributes::ZeroAttr, types::ArrayType};
     use cubecl_macros::intrinsic;
 
     use super::*;
@@ -49,7 +49,8 @@ mod new {
                 // so it needs to be prepared in advance.
                 let elem = T::__expand_as_type(scope);
                 let ty = ArrayType::get(scope.ctx(), elem, length);
-                let buffer = scope.create_local_mut(ty, None);
+                let null = ZeroAttr::new(ty);
+                let buffer = scope.create_local_mut(ty, Some(null.into()));
                 let slice = slice::from_raw_parts::<T>(
                     scope,
                     buffer,

--- a/crates/cubecl-cpp/src/shared/value.rs
+++ b/crates/cubecl-cpp/src/shared/value.rs
@@ -1,5 +1,5 @@
 use cubecl_core::ir::{
-    attributes::{BoolAttr, FloatAttr, IndexAttr},
+    attributes::{BoolAttr, FloatAttr, IndexAttr, ZeroAttr},
     types::barrier::BarrierTokenType,
     verify_attr_succ,
 };
@@ -90,6 +90,16 @@ impl CppConstantAttr for BoolAttr {
     }
     fn to_cpp(&self, _ctx: &Context) -> String {
         self.0.to_string()
+    }
+}
+
+#[attr_interface_impl]
+impl CppConstantAttr for ZeroAttr {
+    fn as_f64(&self, _ctx: &Context) -> f64 {
+        0.0
+    }
+    fn to_cpp(&self, _ctx: &Context) -> String {
+        "{}".to_string()
     }
 }
 

--- a/crates/cubecl-cpu/src/compiler/to_llvm/constant.rs
+++ b/crates/cubecl-cpu/src/compiler/to_llvm/constant.rs
@@ -1,10 +1,11 @@
 use super::prelude::*;
-use cubecl_core::ir::attributes::{BoolAttr, FloatAttr, IndexAttr};
+use cubecl_core::ir::attributes::{BoolAttr, FloatAttr, IndexAttr, ZeroAttr};
 use half::f16;
 use pliron::{
     builtin::ops::ConstantOp,
     utils::apfloat::{self, Float},
 };
+use pliron_llvm::ops::ZeroOp;
 
 /// Width LLVM expects for vector lane indices, intrinsic flags and `alloca` sizes.
 pub const I32_WIDTH: u32 = 32;
@@ -73,6 +74,17 @@ pub fn convert_attr(ctx: &mut Context, value: AttrObj) -> AttrObj {
     }
 }
 
+pub fn constant_op(ctx: &mut Context, value: AttrObj) -> Ptr<Operation> {
+    // Upstream doesn't want to add `ZeroAttr` support to `ConstantOp`
+    if let Some(zero) = value.downcast_ref::<ZeroAttr>() {
+        let ty = cube_type_to_llvm(ctx, zero.ty);
+        ZeroOp::new(ctx, ty).get_operation()
+    } else {
+        let attr = convert_attr(ctx, value);
+        llvm::ConstantOp::new(ctx, attr).get_operation()
+    }
+}
+
 #[op_interface_impl]
 impl ToLLVMDialect for ConstantOp {
     fn rewrite(
@@ -82,13 +94,12 @@ impl ToLLVMDialect for ConstantOp {
         _operands_info: &OperandsInfo,
     ) -> Result<()> {
         let value = self.get_value(ctx);
-        let const_value = convert_attr(ctx, value);
 
-        let llvm_const = llvm::ConstantOp::new(ctx, const_value);
-        rewriter.insert_operation(ctx, llvm_const.get_operation());
+        let llvm_const = constant_op(ctx, value);
+        rewriter.insert_operation(ctx, llvm_const);
 
         let old_op = self.get_operation();
-        rewriter.replace_operation(ctx, old_op, llvm_const.get_operation());
+        rewriter.replace_operation(ctx, old_op, llvm_const);
 
         Ok(())
     }

--- a/crates/cubecl-cpu/src/compiler/to_llvm/memory.rs
+++ b/crates/cubecl-cpu/src/compiler/to_llvm/memory.rs
@@ -1,4 +1,4 @@
-use crate::compiler::to_llvm::ty::scalar_alignment;
+use crate::compiler::to_llvm::{constant::constant_op, ty::scalar_alignment};
 
 use super::prelude::*;
 use cubecl_core::ir::{
@@ -24,20 +24,13 @@ impl ToLLVMDialect for DeclareVariableOp {
             return Ok(());
         }
 
-        let (elem_ty, count) = {
-            let value_ty = value_ty.deref(ctx);
-            match value_ty.downcast_ref::<CubeArrayType>() {
-                Some(array) => (array.inner, array.length),
-                None => (self.value_ty(ctx).get_type(ctx), 1),
-            }
-        };
-        let elem_ty = cube_type_to_llvm(ctx, elem_ty);
+        let elem_ty = cube_type_to_llvm(ctx, value_ty);
 
         let entry_block = enclosing_entry_block(ctx, self.get_operation());
         let insertion_point = rewriter.get_insertion_point();
         rewriter.set_insertion_point(OpInsertionPoint::AtBlockStart(entry_block));
 
-        let size = insert_i32_const(ctx, rewriter, count as i32);
+        let size = insert_i32_const(ctx, rewriter, 1);
 
         let alloca = llvm::AllocaOp::new(ctx, elem_ty, size);
         let size_op = size.defining_op().expect("constant defines its result");
@@ -48,11 +41,10 @@ impl ToLLVMDialect for DeclareVariableOp {
 
         let initializer = self.initializer(ctx).map(|initializer| initializer.clone());
         if let Some(initializer) = initializer {
-            let initializer = convert_attr(ctx, initializer);
-            let constant = llvm::ConstantOp::new(ctx, initializer);
-            rewriter.insert_op(ctx, &constant);
+            let constant = constant_op(ctx, initializer);
+            rewriter.insert_operation(ctx, constant);
 
-            let store = llvm::StoreOp::new(ctx, constant.get_result(ctx), alloca.get_result(ctx));
+            let store = llvm::StoreOp::new(ctx, constant.result(ctx), alloca.get_result(ctx));
             store.set_alignment(ctx, self.alignment(ctx).0 as u32);
             rewriter.insert_op(ctx, &store);
         }

--- a/crates/cubecl-cpu/src/compiler/to_llvm/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/to_llvm/mod.rs
@@ -41,7 +41,8 @@ pub mod prelude {
     };
     pub use pliron_llvm::ops as llvm;
     pub use pliron_llvm::types::{
-        FuncType, PointerType as LlvmPointerType, VectorType as LlvmVectorType, VectorTypeKind,
+        ArrayType as LlvmArrayType, FuncType, PointerType as LlvmPointerType,
+        VectorType as LlvmVectorType, VectorTypeKind,
     };
 }
 

--- a/crates/cubecl-cpu/src/compiler/to_llvm/ty.rs
+++ b/crates/cubecl-cpu/src/compiler/to_llvm/ty.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 use cubecl_core::ir::types::{
-    AtomicType,
+    ArrayType, AtomicType,
     scalar::{Float16Type, Float32Type, Float64Type, FloatFlex32Type},
 };
 use pliron::printable::Printable;
@@ -29,6 +29,10 @@ impl_cube_to_llvm_type!(Float16Type, self, ctx => FP16Type::get(ctx));
 impl_cube_to_llvm_type!(CubePointerType, self, ctx => LlvmPointerType::get(ctx, 0));
 impl_cube_to_llvm_type!(CubeVectorType, self, ctx => LlvmVectorType::get(ctx, cube_type_to_llvm(ctx, self.inner), self.vectorization as u32, VectorTypeKind::Fixed));
 impl_cube_to_llvm_type!(AtomicType, self, ctx => cube_type_to_llvm(ctx, self.inner));
+impl_cube_to_llvm_type!(ArrayType, self, ctx => {
+    let inner = cube_type_to_llvm(ctx, self.inner);
+    LlvmArrayType::get(ctx, inner, self.length as u64)
+});
 
 /// Convert a cubecl type to its LLVM-dialect equivalent, or return it unchanged when no
 /// conversion applies.

--- a/crates/cubecl-ir/src/attributes/mod.rs
+++ b/crates/cubecl-ir/src/attributes/mod.rs
@@ -20,14 +20,14 @@ use pliron::{
     operation::Operation,
     parsable::{IntoParseResult, Parsable, ParseResult, StateStream},
     printable::{self, Printable},
-    r#type::TypeHandle,
+    r#type::{TypeHandle, type_impls},
     utils::apint::{APInt, bw},
 };
 
 use crate::{
     ConstantValue,
     apfloat::{APFloat, APFloatType},
-    interfaces::ConstantAttr,
+    interfaces::{ConstantAttr, TypedExt},
     settings::Dim3,
     try_cast_ty,
     types::scalar::*,
@@ -80,6 +80,55 @@ macro_rules! ext_attribute {
             }
         }
     };
+}
+
+/// A zero-value attribute, used for zero-initializing arbitrary types with whatever "zero" means
+/// for it. Arrays get all fields zero-initialized, floats and ints initialize to zero, booleans
+/// to false, etc.
+#[pliron_attr(name = "cube.zero", format = "`[zero: ` $ty `]`", verifier = "succ")]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+pub struct ZeroAttr {
+    pub ty: TypeHandle,
+}
+materialize_const!(ZeroAttr);
+
+impl ZeroAttr {
+    pub fn new(ty: impl Into<TypeHandle>) -> Self {
+        Self { ty: ty.into() }
+    }
+}
+
+#[attr_interface_impl]
+impl TypedAttrInterface for ZeroAttr {
+    fn get_type(&self, _ctx: &Context) -> TypeHandle {
+        self.ty
+    }
+}
+
+#[attr_interface_impl]
+impl ConstantAttr for ZeroAttr {
+    fn as_const_val(&self, ctx: &Context) -> ConstantValue {
+        let ty = self.ty.deref(ctx);
+        if type_impls::<dyn APFloatType>(&*ty) {
+            ConstantValue::Float(0.0)
+        } else if self.ty.is_unsigned_int(ctx) || self.ty.is_index(ctx) {
+            ConstantValue::UInt(0)
+        } else if self.ty.is_signed_int(ctx) {
+            ConstantValue::Int(0)
+        } else if self.ty.is_bool(ctx) {
+            ConstantValue::Bool(false)
+        } else {
+            panic!("Invalid value type for `as_const_val`")
+        }
+    }
+    fn float_as_f64(&self, ctx: &Context) -> Option<f64> {
+        let ty = self.ty.deref(ctx);
+        if type_impls::<dyn APFloatType>(&*ty) {
+            Some(0.0)
+        } else {
+            None
+        }
+    }
 }
 
 #[pliron_attr(name = "cube.index", format = "$0", verifier = "succ")]

--- a/crates/cubecl-ir/src/dialect/branch.rs
+++ b/crates/cubecl-ir/src/dialect/branch.rs
@@ -12,7 +12,10 @@ use pliron::{
 use thiserror::Error;
 
 use crate::{
-    CanMaterialize, NoMemoryEffect, Pure, attributes::BoolAttr, prelude::*, types::scalar::BoolType,
+    CanMaterialize, NoMemoryEffect, Pure,
+    attributes::{BoolAttr, ZeroAttr},
+    prelude::*,
+    types::scalar::BoolType,
 };
 
 /// Marker for terminators that do not return, i.e. `UnreachableOp`. In Rust terms, they return `!`.
@@ -281,10 +284,12 @@ impl ConstFoldInterface for IfOp {
         let Some(attr) = operand_attrs[0].as_ref() else {
             return IRStatus::Unchanged;
         };
-        let Some(attr) = attr.downcast_ref::<BoolAttr>() else {
+        let zero = attr.downcast_ref::<ZeroAttr>().map(|_| false);
+        let bool = attr.downcast_ref::<BoolAttr>().map(|it| it.0);
+        let Some(const_cond) = zero.or(bool) else {
             return IRStatus::Unchanged;
         };
-        let (taken, not_taken) = match attr.0 {
+        let (taken, not_taken) = match const_cond {
             true => (self.then_block(ctx), self.else_block(ctx)),
             false => (self.else_block(ctx), self.then_block(ctx)),
         };

--- a/crates/cubecl-ir/src/dialect/general.rs
+++ b/crates/cubecl-ir/src/dialect/general.rs
@@ -18,7 +18,7 @@ use crate::{
         math::{index_attr, int_attr},
         pure_binop, pure_unop,
     },
-    interfaces::{ScalarType, TypedExt, aliasing::AliasingOp},
+    interfaces::{ScalarType, TriviallyUnrollable, TypedExt, aliasing::AliasingOp},
     prelude::*,
     types::scalar::IndexType,
 };
@@ -182,6 +182,7 @@ impl AliasingOp for ReinterpretCastOp {
 
 #[cube_op(name = "cube.select")]
 #[result_ty(same_as = true_value)]
+#[op_interfaces(TriviallyUnrollable)]
 #[op_traits(Pure, CanMaterialize)]
 pub struct SelectOp {
     pub condition: Value,

--- a/crates/cubecl-ir/src/dialect/memory.rs
+++ b/crates/cubecl-ir/src/dialect/memory.rs
@@ -36,7 +36,7 @@ use thiserror::Error;
 
 use crate::{
     AddressSpace, CanMaterialize, NoSideEffects, Pure,
-    attributes::IndexAttr,
+    attributes::{IndexAttr, ZeroAttr},
     dialect::{general::PoisonOp, math::index_attr, ptr_value_ty},
     interfaces::{
         IndexableType, TriviallyUnrollable, TypedExt,
@@ -174,7 +174,12 @@ impl PromotableAllocationInterface for DeclareVariableOp {
 #[op_interface_impl]
 impl DestructurableConstructorOpInterface for DeclareVariableOp {
     fn destructurable_values(&self, ctx: &Context) -> Vec<DestructurableValueSlot> {
-        if self.addr_space(ctx).0 != AddressSpace::Local || self.initializer(ctx).is_some() {
+        if self.addr_space(ctx).0 != AddressSpace::Local {
+            return vec![];
+        }
+        if let Some(init) = self.initializer(ctx)
+            && !init.is::<ZeroAttr>()
+        {
             return vec![];
         }
         let value_ty = self.value_ty(ctx).get_type(ctx);
@@ -201,6 +206,9 @@ impl DestructurableConstructorOpInterface for DeclareVariableOp {
         new_constructors: &mut Vec<TraitOp<dyn DestructurableConstructorOpInterface>>,
     ) -> HMap<AttrObj, ValueSlot> {
         let addr_space = self.addr_space(ctx).0;
+        let init = self.initializer(ctx).map(|it| {
+            assert!(it.is::<ZeroAttr>());
+        });
         let destructured_type = {
             let ty = self.value_ty(ctx).get_type(ctx).deref(ctx);
             let destructurable = try_cast_ty!(ty, ctx, dyn DestructurableTypeInterface);
@@ -210,8 +218,9 @@ impl DestructurableConstructorOpInterface for DeclareVariableOp {
         let mut slot_map = HMap::new();
         for used_index in used_indices {
             let value_ty = destructured_type[used_index];
+            let init = init.map(|_| ZeroAttr::new(value_ty).into());
             let align = value_ty.align(ctx);
-            let suballoc = DeclareVariableOp::new(ctx, value_ty, addr_space, align, None);
+            let suballoc = DeclareVariableOp::new(ctx, value_ty, addr_space, align, init);
             rewriter.append_op(ctx, &suballoc);
 
             let slot = ValueSlot::new(suballoc.get_result(ctx), value_ty);

--- a/crates/cubecl-ir/src/dialect/scf.rs
+++ b/crates/cubecl-ir/src/dialect/scf.rs
@@ -18,7 +18,7 @@ use pliron::{
 };
 
 use crate::{
-    attributes::BoolAttr,
+    attributes::{BoolAttr, ZeroAttr},
     dialect::branch::{self, ConditionOp, DeadRegionOp, YieldOp, block_side_effects},
     interfaces::memory_slot::PromotableRegionOpInterface,
     prelude::*,
@@ -108,10 +108,12 @@ impl ConstFoldInterface for IfOp {
         let Some(attr) = operand_attrs[0].as_ref() else {
             return IRStatus::Unchanged;
         };
-        let Some(attr) = attr.downcast_ref::<BoolAttr>() else {
+        let zero = attr.downcast_ref::<ZeroAttr>().map(|_| false);
+        let bool = attr.downcast_ref::<BoolAttr>().map(|it| it.0);
+        let Some(const_cond) = zero.or(bool) else {
             return IRStatus::Unchanged;
         };
-        let (taken, not_taken) = match attr.0 {
+        let (taken, not_taken) = match const_cond {
             true => (self.then_block(ctx), self.else_block(ctx)),
             false => (self.else_block(ctx), self.then_block(ctx)),
         };

--- a/crates/cubecl-ir/src/spirv.rs
+++ b/crates/cubecl-ir/src/spirv.rs
@@ -24,7 +24,7 @@ use pliron::{
 use pliron_spirv::{
     ops::{AccessChainOp, InBoundsAccessChainOp, LoadOp, LoopOp, SelectionOp},
     spirv::StorageClass,
-    types::{FloatType, PointerType, VectorType},
+    types::{ArrayType, FloatType, PointerType, VectorType, khr::CooperativeMatrixType},
 };
 
 NoMemoryEffect!(InBoundsAccessChainOp);
@@ -65,6 +65,20 @@ impl AlignedType for FloatType {
 impl AlignedType for VectorType {
     fn align(&self, ctx: &Context) -> usize {
         self.count as usize * self.element_type.align(ctx)
+    }
+}
+
+#[type_interface_impl]
+impl AlignedType for ArrayType {
+    fn align(&self, ctx: &Context) -> usize {
+        self.element_type.align(ctx)
+    }
+}
+
+#[type_interface_impl]
+impl AlignedType for CooperativeMatrixType {
+    fn align(&self, ctx: &Context) -> usize {
+        self.component_type.align(ctx)
     }
 }
 

--- a/crates/cubecl-runtime/src/compiler.rs
+++ b/crates/cubecl-runtime/src/compiler.rs
@@ -7,9 +7,9 @@ use core::hash::Hash;
 use cubecl_common::hash::StableHash;
 use cubecl_environment::backtrace::BackTrace;
 use cubecl_environment::collections::HashMap;
-use cubecl_environment::persistence::{
-    CacheOption, Namespace, Store, StoreKey, StoreOptions, StoreValue,
-};
+#[cfg(std_io)]
+use cubecl_environment::persistence::{CacheOption, Namespace, StoreOptions};
+use cubecl_environment::persistence::{Store, StoreKey, StoreValue};
 use thiserror::Error;
 
 /// A store for `backend`'s compiled artifacts, or `None` when compilation

--- a/crates/cubecl-spirv/src/attributes.rs
+++ b/crates/cubecl-spirv/src/attributes.rs
@@ -1,11 +1,15 @@
-use cubecl_ir::{attributes::IndexAttr, prelude::*, verify_attr_succ};
+use cubecl_ir::{
+    attributes::{BoolAttr, IndexAttr, ZeroAttr},
+    prelude::*,
+    verify_attr_succ,
+};
 
 use pliron::{
     attribute::{AttrObj, attr_cast},
     builtin::{attr_interfaces::TypedAttrInterface, attributes::IntegerAttr},
     utils::apint::{APInt, bw},
 };
-use pliron_spirv::attrs::FloatAttr;
+use pliron_spirv::attrs::{FloatAttr, NullAttr};
 
 use crate::types::ty_to_spirv_dialect;
 
@@ -52,11 +56,19 @@ impl ToSpirvDialectAttr for cubecl_ir::attributes::FloatAttr {
 }
 
 #[attr_interface_impl]
-impl ToSpirvDialectAttr for cubecl_ir::attributes::BoolAttr {
+impl ToSpirvDialectAttr for BoolAttr {
     fn to_spirv_dialect(&self, ctx: &Context) -> AttrObj {
         let ty = ty_to_spirv_dialect(ctx, self.get_type(ctx));
         let value = if self.0 { 1 } else { 0 };
         let value = APInt::from_u8(value, bw(1));
         IntegerAttr::new(TypedHandle::from_handle(ty, ctx).unwrap(), value).into()
+    }
+}
+
+#[attr_interface_impl]
+impl ToSpirvDialectAttr for ZeroAttr {
+    fn to_spirv_dialect(&self, ctx: &Context) -> AttrObj {
+        let ty = ty_to_spirv_dialect(ctx, self.get_type(ctx));
+        NullAttr::new(ty).into()
     }
 }

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/general.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/general.rs
@@ -1,6 +1,6 @@
 use cubecl_core::{self as cubecl, prelude::*};
 use cubecl_ir::{
-    attributes::{BoolAttr, FloatAttr, IndexAttr},
+    attributes::{BoolAttr, FloatAttr, IndexAttr, ZeroAttr},
     dialect::general::*,
     interfaces::TypedExt,
     prelude::*,
@@ -106,6 +106,13 @@ impl AttrToWgsl for FloatAttr {
 impl AttrToWgsl for BoolAttr {
     fn to_wgsl(&self, _ctx: &Context) -> String {
         format!("{}", self.0)
+    }
+}
+
+#[attr_interface_impl]
+impl AttrToWgsl for ZeroAttr {
+    fn to_wgsl(&self, ctx: &Context) -> String {
+        format!("{}()", self.ty.to_wgsl(ctx))
     }
 }
 


### PR DESCRIPTION
Rust semantics require all locals to be initialized in all divergent paths, but `Array::new` currently returns an uninitialized local which can cause undefined values to be read from it. This adds a new `ZeroAttr` for easily defining type-agnostic zeroed values, and uses it to initialize the two kinds of locals that are not enforced by Rust. `let x;` is *not* initialized because Rust already ensures it's assigned in every path. We may want to change `Array::new` to `Array::zeroed` at some point and add a new way to construct it with a value, but the fix comes first.

`ZeroAttr` maps to `ZeroOp` for CPU, `{}` for C++, `NullAttr`/`OpConstantNull` for SPIR-V and `{type}()` for WGSL. These all have the same behavior of zeroing the whole array in a single constant instruction.