### PR TITLE
Add version check to ensure required features are supported in MSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "log",
+ "objc2",
  "objc2-foundation",
  "objc2-metal",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,8 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
  "log",
+ "objc2-foundation",
+ "objc2-metal",
  "paste",
  "pliron",
  "pretty_assertions",

--- a/crates/cubecl-core/src/codegen/compiler.rs
+++ b/crates/cubecl-core/src/codegen/compiler.rs
@@ -4,6 +4,7 @@ pub struct WgpuCompilationOptions {
     pub supports_u64: bool,
     /// Whether the Vulkan compiler is supported or we need to fall back to WGSL
     pub supports_vulkan_compiler: bool,
+    pub supports_msl_compiler: bool,
 
     pub vulkan: VulkanCompilationOptions,
 }

--- a/crates/cubecl-metal/src/compute/context.rs
+++ b/crates/cubecl-metal/src/compute/context.rs
@@ -52,7 +52,7 @@ impl MetalContext {
     ) -> Self {
         let msl_compile_options = MTLCompileOptions::new();
         // MSL 3.1 for native `bfloat`.
-        msl_compile_options.setLanguageVersion(MTLLanguageVersion::Version3_1);
+        msl_compile_options.setLanguageVersion(MTLLanguageVersion::Version3_2);
         // Compile with IEEE-safe math by default; per-op fast math is opted into separately.
         // `mathMode` disables FP reassociation/contraction, `mathFloatingPointFunctions`
         // keeps math functions precise.
@@ -91,20 +91,20 @@ impl MetalContext {
         let definition = kernel.define();
         let cache_key = KernelCacheKey::new(kernel_id, &definition);
 
-        if let Some(cache) = self.msl_cache.as_mut() {
-            if let Some(entry) = cache.remove(&cache_key) {
-                log::trace!("Using MSL cache");
+        if let Some(cache) = self.msl_cache.as_mut()
+            && let Some(entry) = cache.remove(&cache_key)
+        {
+            log::trace!("Using MSL cache");
 
-                let compiled = self.create_pipeline_from_source(
-                    &entry.source,
-                    &entry.entrypoint_name,
-                    entry.cube_dim.into(),
-                )?;
+            let compiled = self.create_pipeline_from_source(
+                &entry.source,
+                &entry.entrypoint_name,
+                entry.cube_dim.into(),
+            )?;
 
-                self.compiled_kernels
-                    .insert(kernel_id.clone(), compiled.clone());
-                return Ok(compiled);
-            }
+            self.compiled_kernels
+                .insert(kernel_id.clone(), compiled.clone());
+            return Ok(compiled);
         }
 
         log::trace!("Compiling kernel to MSL");

--- a/crates/cubecl-metal/src/compute/context.rs
+++ b/crates/cubecl-metal/src/compute/context.rs
@@ -51,7 +51,7 @@ impl MetalContext {
         compilation_options: cubecl_cpp::shared::CompilationOptions,
     ) -> Self {
         let msl_compile_options = MTLCompileOptions::new();
-        // MSL 3.1 for native `bfloat`.
+        // MSL 3.2 for lambdas.
         msl_compile_options.setLanguageVersion(MTLLanguageVersion::Version3_2);
         // Compile with IEEE-safe math by default; per-op fast math is opted into separately.
         // `mathMode` disables FP reassociation/contraction, `mathFloatingPointFunctions`

--- a/crates/cubecl-metal/src/compute/server.rs
+++ b/crates/cubecl-metal/src/compute/server.rs
@@ -102,7 +102,7 @@ fn resolve_origin_resource(
     }
 
     let offset = storage_handle.offset();
-    let resource = stream.memory_management.storage().get(&storage_handle);
+    let resource = stream.memory_management.storage().get(&storage_handle)?;
 
     Ok((resource, offset))
 }

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -31,7 +31,7 @@ std = [
 ]
 # 'msl' and 'spirv' features are exclusive
 # TODO find a way to have wgpu runtime auto-compiler to support several compilers at the same time
-msl = ["cubecl-cpp/metal"]
+msl = ["cubecl-cpp/metal", "dep:objc2-foundation", "dep:objc2-metal"]
 profile-tracy = ["tracy-client"]
 spirv = ["cubecl-spirv", "ash", "tracel-ash", "cubecl-common/hash"]
 
@@ -78,6 +78,14 @@ tracel-ash = { workspace = true, optional = true }
 cubecl-cpp = { path = "../cubecl-cpp", version = "=0.11.0-pre.2", features = [
     "metal",
 ], optional = true }
+
+# Metal bindings only exist on Apple platforms. Keeping them in a target table
+# means other platforms never even download them, so workspace-wide builds and
+# clippy work everywhere (the crate itself is empty off-Apple, see lib.rs).
+# They are only used for checking device compatibility.
+[target.'cfg(target_vendor = "apple")'.dependencies]
+objc2-foundation = { version = "0.3", optional = true }
+objc2-metal = { version = "0.3", features = ["MTLLibrary"], optional = true }
 
 # Validation
 wgpu-hal = { workspace = true, optional = true }

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -104,12 +104,14 @@ wgpu = { workspace = true, features = ["fragile-send-sync-non-atomic-wasm"] }
 ## On macOS, the `vulkan-portability` feature is required due to the MoltenVK translation layer.
 # To install MoltenVK, install the VulkanSDK: https://vulkan.lunarg.com/sdk/home#mac
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-foundation = { version = "0.3", optional = true }
-objc2-metal = { version = "0.3", features = ["MTLLibrary"], optional = true }
 wgpu = { workspace = true, features = [
     "vulkan-portability",
     "fragile-send-sync-non-atomic-wasm",
 ] }
+
+[target.'cfg(target_vendor = "apple")'.dependencies]
+objc2-foundation = { version = "0.3", optional = true }
+objc2-metal = { version = "0.3", features = ["MTLLibrary"], optional = true }
 
 
 ## Uncomment if targeting metal through msl feature

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -31,7 +31,12 @@ std = [
 ]
 # 'msl' and 'spirv' features are exclusive
 # TODO find a way to have wgpu runtime auto-compiler to support several compilers at the same time
-msl = ["cubecl-cpp/metal", "dep:objc2-foundation", "dep:objc2-metal"]
+msl = [
+    "cubecl-cpp/metal",
+    "dep:objc2",
+    "dep:objc2-foundation",
+    "dep:objc2-metal",
+]
 profile-tracy = ["tracy-client"]
 spirv = ["cubecl-spirv", "ash", "tracel-ash", "cubecl-common/hash"]
 
@@ -110,6 +115,7 @@ wgpu = { workspace = true, features = [
 ] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
+objc2 = { version = "0.6", optional = true }
 objc2-foundation = { version = "0.3", optional = true }
 objc2-metal = { version = "0.3", features = ["MTLLibrary"], optional = true }
 

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -79,14 +79,6 @@ cubecl-cpp = { path = "../cubecl-cpp", version = "=0.11.0-pre.2", features = [
     "metal",
 ], optional = true }
 
-# Metal bindings only exist on Apple platforms. Keeping them in a target table
-# means other platforms never even download them, so workspace-wide builds and
-# clippy work everywhere (the crate itself is empty off-Apple, see lib.rs).
-# They are only used for checking device compatibility.
-[target.'cfg(target_vendor = "apple")'.dependencies]
-objc2-foundation = { version = "0.3", optional = true }
-objc2-metal = { version = "0.3", features = ["MTLLibrary"], optional = true }
-
 # Validation
 wgpu-hal = { workspace = true, optional = true }
 
@@ -112,10 +104,14 @@ wgpu = { workspace = true, features = ["fragile-send-sync-non-atomic-wasm"] }
 ## On macOS, the `vulkan-portability` feature is required due to the MoltenVK translation layer.
 # To install MoltenVK, install the VulkanSDK: https://vulkan.lunarg.com/sdk/home#mac
 [target.'cfg(target_os = "macos")'.dependencies]
+objc2-foundation = { version = "0.3", optional = true }
+objc2-metal = { version = "0.3", features = ["MTLLibrary"], optional = true }
 wgpu = { workspace = true, features = [
     "vulkan-portability",
     "fragile-send-sync-non-atomic-wasm",
 ] }
+
+
 ## Uncomment if targeting metal through msl feature
 # wgpu = { git = "https://github.com/tracel-ai/wgpu", features = ["vulkan-portability", "fragile-send-sync-non-atomic-wasm"], rev = "624db2ae762b83446693020ae637e2c5879b3af9" }
 ## For development on wgpu uncomment this one and make it point to your local wgpu repo

--- a/crates/cubecl-wgpu/src/backend/base.rs
+++ b/crates/cubecl-wgpu/src/backend/base.rs
@@ -350,8 +350,7 @@ pub fn register_metal_features(
     _memory_config: &MemoryConfiguration,
 ) -> bool {
     if is_metal(adapter) {
-        metal::register_metal_features(adapter, props, comp_options);
-        true
+        metal::register_metal_features(adapter, props, comp_options)
     } else {
         false
     }

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -79,17 +79,58 @@ fn request_device(
     }
 }
 
+#[cfg(target_vendor = "apple")]
 pub fn register_metal_features(
     adapter: &wgpu::Adapter,
     props: &mut DeviceProperties,
     comp_options: &mut WgpuCompilationOptions,
-) {
+) -> bool {
+    // Canary for ensuring the current Metal language version is 3.2+.
+    const LAMBDA_CANARY: &str = r#"
+        #include <metal_stdlib>
+        using namespace metal;
+
+        kernel void __canary__(device float* out [[buffer(0)]]) {
+            auto f = [](float x) -> float { return x * 2.0; };
+            out[0] = f(1.0);
+        }
+    "#;
+
     let features = adapter.features();
     unsafe {
-        if let Some(adapter) = adapter.as_hal::<hal::api::Metal>() {
-            register_features(&adapter, props, features, comp_options);
+        use objc2_foundation::NSString;
+        use objc2_metal::{MTLDevice, MTLGPUFamily};
+
+        let Some(adapter) = adapter.as_hal::<hal::api::Metal>() else {
+            return false;
+        };
+        let raw = adapter.raw_device();
+        if !raw.supportsFamily(MTLGPUFamily::Apple7) {
+            return false;
+        };
+        let canary = NSString::from_str(LAMBDA_CANARY);
+        if raw
+            .newLibraryWithSource_options_error(&canary, None)
+            .is_err()
+        {
+            // This is a fixable issue, so we should warn users.
+            log::warn!(
+                "Device can support native MSL, but Metal compiler version is too old. Upgrading to 3.2 or higher is recommended."
+            );
+            return false;
         }
+        register_features(&adapter, props, features, comp_options);
     }
+    true
+}
+
+#[cfg(not(target_vendor = "apple"))]
+pub fn register_metal_features(
+    _: &wgpu::Adapter,
+    _: &mut DeviceProperties,
+    _: &mut WgpuCompilationOptions,
+) -> bool {
+    false
 }
 
 fn register_features(

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -98,6 +98,7 @@ pub fn register_metal_features(
 
     let features = adapter.features();
     unsafe {
+        use objc2::rc::autoreleasepool;
         use objc2_foundation::NSString;
         use objc2_metal::{MTLDevice, MTLGPUFamily};
 
@@ -108,17 +109,19 @@ pub fn register_metal_features(
         if !raw.supportsFamily(MTLGPUFamily::Apple7) {
             return false;
         };
-        let canary = NSString::from_str(LAMBDA_CANARY);
-        if raw
-            .newLibraryWithSource_options_error(&canary, None)
-            .is_err()
-        {
+        let supports_lambdas = autoreleasepool(|_| {
+            let canary = NSString::from_str(LAMBDA_CANARY);
+            raw.newLibraryWithSource_options_error(&canary, None)
+                .is_ok()
+        });
+        if !supports_lambdas {
             // This is a fixable issue, so we should warn users.
             log::warn!(
                 "Device can support native MSL, but Metal compiler version is too old. Upgrading to 3.2 or higher is recommended."
             );
             return false;
         }
+
         register_features(&adapter, props, features, comp_options);
     }
     true

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -121,7 +121,7 @@ pub fn register_metal_features(
             );
             return false;
         }
-
+        comp_options.supports_msl_compiler = true;
         register_features(&adapter, props, features, comp_options);
     }
     true

--- a/crates/cubecl-wgpu/src/compiler/base.rs
+++ b/crates/cubecl-wgpu/src/compiler/base.rs
@@ -167,7 +167,9 @@ impl WgpuCompiler for AutoCompiler {
                 AutoCompiler::SpirV(Default::default())
             }
             #[cfg(feature = "msl")]
-            wgpu::Backend::Metal => AutoCompiler::Msl(Default::default()),
+            wgpu::Backend::Metal if options.supports_msl_compiler => {
+                AutoCompiler::Msl(Default::default())
+            }
             _ => AutoCompiler::Wgsl(Default::default()),
         }
     }


### PR DESCRIPTION
Disables the MSL compiler if either the device is too old (simply disable), or the MSL compiler version is too old (warn and disable). Metal has no way to query for specific versions, so I used a canary shader to detect it. I can confirm it succeeds on my M1 with Metal 3.2, but don't have a 3.1 M-series mac or older Intel Mac to test the failure case.