### PR TITLE
Fix missing wasm-bindgen-futures dependency in cubecl-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,7 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracy-client",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/crates/cubecl-runtime/Cargo.toml
+++ b/crates/cubecl-runtime/Cargo.toml
@@ -66,6 +66,9 @@ thiserror = { workspace = true }
 
 futures-util = { workspace = true, default-features = false }
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasm-bindgen-futures = { workspace = true }
+
 # Persistent cache deps - has to match the cfg(std_io) cfg.
 [target.'cfg(any(target_os = "windows", target_os = "linux", target_os = "macos", target_os = "android"))'.dependencies]
 cubecl-common = { path = "../cubecl-common", version = "=0.11.0-pre.2", default-features = false, features = [


### PR DESCRIPTION
## Summary

Declare `wasm-bindgen-futures` as a WASM-specific dependency of
`cubecl-runtime`.

## Problem

`cubecl-runtime` calls `wasm_bindgen_futures::spawn_local` from its WASM
autotuning path, but it does not declare `wasm-bindgen-futures` as a direct
dependency.

Some downstream dependency graphs happen to include the crate transitively,
but Rust packages cannot rely on transitive dependencies being available in
their extern prelude. This causes WASM builds to fail when the dependency is
not otherwise introduced with the required configuration.

## Solution

Add `wasm-bindgen-futures` under:

```toml
[target.'cfg(target_family = "wasm")'.dependencies]
wasm-bindgen-futures = { workspace = true }
```

Keeping it target-specific avoids adding it to native CubeCL builds.

## Validation

- [x] `cargo fmt --all --check`
- [x] Confirmed that the WASM dependency graph resolves
      `wasm-bindgen-futures` for `cubecl-runtime`
- [x] Built the downstream Metabolic local-compute WASM worker with this
      dependency correction applied

A direct default-feature `cubecl-runtime` WASM check on current `main` is
currently blocked later by the existing `getrandom 0.4` `wasm_js`
configuration. That failure is unrelated to this dependency declaration.

## Downstream validation

- [ ] Cubek validation PR: not done :-)
- [ ] Burn validation PR: not done :-)
