### PR TITLE
Fix Pliron timer panic on WebAssembly

### DIFF
--- a/crates/cubecl-core/Cargo.toml
+++ b/crates/cubecl-core/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 browser-cache = ["cubecl-runtime/browser-cache"]
 default = ["cubecl-runtime/default", "cubecl-ir/default"]
 export_tests = ["tempfile", "test-log/trace", "test-log/log", "std"]
-std = ["cubecl-runtime/std", "pliron/std", "cubecl-environment/std"]
+std = ["cubecl-runtime/std", "cubecl-environment/std"]
 template = []
 tokio = ["cubecl-runtime/tokio"]
 
@@ -69,6 +69,9 @@ tempfile = { version = "3.20", optional = true }
 variadics_please = { workspace = true }
 
 pliron = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+pliron = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/cubecl-cpp/Cargo.toml
+++ b/crates/cubecl-cpp/Cargo.toml
@@ -31,7 +31,6 @@ std = [
     "cubecl-common/std",
     "cubecl-core/std",
     "cubecl-opt/std",
-    "pliron/std",
 ]
 
 tracing = [
@@ -62,3 +61,6 @@ paste = { workspace = true }
 pliron = { workspace = true }
 sanitize-filename = { workspace = true }
 thiserror = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+pliron = { workspace = true, features = ["std"] }

--- a/crates/cubecl-spirv/Cargo.toml
+++ b/crates/cubecl-spirv/Cargo.toml
@@ -27,7 +27,6 @@ std = [
     "cubecl-common/std",
     "cubecl-core/std",
     "cubecl-runtime/std",
-    "pliron/std",
     "dep:sanitize-filename",
 ]
 
@@ -63,3 +62,6 @@ rspirv = { workspace = true, features = ["serialize", "deserialize"] }
 
 # Optimizer
 cubecl-opt = { path = "../cubecl-opt", version = "=0.11.0-pre.2" }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+pliron = { workspace = true, features = ["std"] }

--- a/crates/cubecl-wgpu/Cargo.toml
+++ b/crates/cubecl-wgpu/Cargo.toml
@@ -26,7 +26,6 @@ std = [
     "cubecl-core/std",
     "cubecl-cpp/std",
     "cubecl-opt/std",
-    "pliron/std",
     "sanitize-filename",
 ]
 # 'msl' and 'spirv' features are exclusive
@@ -93,6 +92,9 @@ derive-new = { workspace = true }
 hashbrown = { workspace = true }
 
 cfg-if = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+pliron = { workspace = true, features = ["std"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen-futures = { workspace = true }


### PR DESCRIPTION
## Summary

Keep Pliron in `no_std` mode on WebAssembly while preserving its existing
`std` configuration on native targets.

## Problem

CubeCL's `std` features currently forward `pliron/std` from several compiler
crates.

On `wasm32-unknown-unknown`, Pliron's `std` timer uses
`std::time::Instant`. Pliron's pass manager starts this timer when running
compiler passes, causing browser inference to panic with:

```text
time not implemented on this platform
```

This happens even when pass timing output is not enabled because the timer is
constructed before the timing result is conditionally recorded.

## Solution

Stop forwarding `pliron/std` through the target-independent `std` features of:

- `cubecl-core`
- `cubecl-cpp`
- `cubecl-spirv`
- `cubecl-wgpu`

Re-enable `pliron/std` through target-specific native dependencies:

```toml
[target.'cfg(not(target_family = "wasm"))'.dependencies]
pliron = { workspace = true, features = ["std"] }
```

Pliron's existing `no_std` implementation provides the programmatic IR and
pass infrastructure used by CubeCL without calling the unsupported browser
clock. Native builds retain their previous Pliron functionality.

## Validation

- [x] `cargo fmt --all --check`
- [x] WASM feature resolution: `pliron v0.17.0 []`
- [x] Native feature resolution: `pliron v0.17.0 [std]`
- [x] `cargo check -p cubecl-wgpu --features std`
- [x] Built the downstream Metabolic local-compute WASM worker with this
      change and the runtime dependency fix applied

The full downstream WASM validation uses the separate
`wasm-bindgen-futures` dependency fix as well.

## Downstream validation

- [ ] Cubek validation PR: not done :-)
- [ ] Burn validation PR: not done :-)
