### PR TITLE
Sync before the load in workgroup_uniform_load

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/synchronization.rs
+++ b/crates/cubecl-core/src/runtime_tests/synchronization.rs
@@ -259,6 +259,98 @@ pub fn test_workgroup_uniform_load_vec<R: Runtime>(client: ComputeClient<R>) {
 }
 
 #[allow(missing_docs)]
+
+/// `workgroup_uniform_load` has to synchronise on its own: one unit publishes a
+/// value and the rest read it back through the uniform load, with no explicit
+/// `sync_cube` in between. The value is used as a loop bound, so a stale read
+/// changes how much work the reader does rather than just its output.
+#[cube(launch)]
+fn kernel_test_workgroup_uniform_load_synchronizes(out: &mut [u32]) {
+    let mut bound = Shared::new_slice(1usize);
+    if UNIT_POS == 0 {
+        // Derive the bound from real work so it cannot be constant-folded and
+        // the store cannot be hoisted above the readers.
+        let mut acc = 0u32;
+        let mut i = 0u32;
+        while i < 1024u32 {
+            acc += i % 3u32;
+            i += 1u32;
+        }
+        bound[0] = acc;
+    }
+    let n = workgroup_uniform_load(&bound[0]);
+    let capped = min(n, 4096u32);
+    let mut sum = 0u32;
+    let mut k = 0u32;
+    while k < capped {
+        sum += k;
+        k += 1u32;
+    }
+    out[UNIT_POS as usize] = sum;
+}
+
+fn expected_uniform_load_sum() -> u32 {
+    let acc: u32 = (0..1024u32).map(|i| i % 3).sum();
+    let capped = acc.min(4096);
+    (0..capped).sum()
+}
+
+pub fn test_workgroup_uniform_load_synchronizes<R: Runtime>(client: ComputeClient<R>) {
+    let units = std::cmp::min(256, client.properties().hardware.max_units_per_cube);
+    let handle = client.empty(units as usize * core::mem::size_of::<u32>());
+
+    kernel_test_workgroup_uniform_load_synchronizes::launch(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_2d(units / 2, 2),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), units as usize) },
+    );
+
+    let actual = client.read_one_unchecked(handle);
+    let expected = vec![expected_uniform_load_sum(); units as usize];
+    assert_eq!(u32::from_bytes(&actual), &expected);
+}
+
+/// Atomic counterpart of [`test_workgroup_uniform_load_synchronizes`].
+#[cube(launch)]
+fn kernel_test_workgroup_uniform_load_atomic_synchronizes(out: &mut [u32]) {
+    let bound = Shared::<[Atomic<u32>]>::new_slice(1usize);
+    if UNIT_POS == 0 {
+        let mut acc = 0u32;
+        let mut i = 0u32;
+        while i < 1024u32 {
+            acc += i % 3u32;
+            i += 1u32;
+        }
+        Atomic::store(&bound[0], acc);
+    }
+    let n = workgroup_uniform_load_atomic(&bound[0]);
+    let capped = min(n, 4096u32);
+    let mut sum = 0u32;
+    let mut k = 0u32;
+    while k < capped {
+        sum += k;
+        k += 1u32;
+    }
+    out[UNIT_POS as usize] = sum;
+}
+
+pub fn test_workgroup_uniform_load_atomic_synchronizes<R: Runtime>(client: ComputeClient<R>) {
+    let units = std::cmp::min(256, client.properties().hardware.max_units_per_cube);
+    let handle = client.empty(units as usize * core::mem::size_of::<u32>());
+
+    kernel_test_workgroup_uniform_load_atomic_synchronizes::launch(
+        &client,
+        CubeCount::Static(1, 1, 1),
+        CubeDim::new_2d(units / 2, 2),
+        unsafe { BufferArg::from_raw_parts(handle.clone(), units as usize) },
+    );
+
+    let actual = client.read_one_unchecked(handle);
+    let expected = vec![expected_uniform_load_sum(); units as usize];
+    assert_eq!(u32::from_bytes(&actual), &expected);
+}
+
 #[macro_export]
 macro_rules! testgen_sync_plane {
     () => {
@@ -290,6 +382,22 @@ macro_rules! testgen_sync_plane {
             cubecl_core::runtime_tests::synchronization::test_sync_cube_shared::<TestRuntime>(
                 client,
             );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_workgroup_uniform_load_synchronizes() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::synchronization::test_workgroup_uniform_load_synchronizes::<
+                TestRuntime,
+            >(client);
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_workgroup_uniform_load_atomic_synchronizes() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::synchronization::test_workgroup_uniform_load_atomic_synchronizes::<
+                TestRuntime,
+            >(client);
         }
 
         #[$crate::runtime_tests::test_log::test]

--- a/crates/cubecl-cpp/src/shared/unary.rs
+++ b/crates/cubecl-cpp/src/shared/unary.rs
@@ -12,6 +12,7 @@ use cubecl_core::{
             math::*,
             memory::{LoadOp, StoreOp},
             plane::{AtomicUniformLoadOp, UniformLoadOp},
+            synchronization::{SyncOp, SyncScope, SyncScopeAttr},
         },
         interfaces::TypedExt,
         prelude::*,
@@ -334,6 +335,10 @@ unrolling!(IsInfOp);
 #[op_interface_impl]
 impl LowerOp for UniformLoadOp {
     fn lower(&self, scope: &Scope) -> Vec<Value> {
+        scope.register(&SyncOp::new(
+            scope.ctx_mut(),
+            SyncScopeAttr::new(SyncScope::Cube),
+        ));
         let ptr = self.ptr(scope.ctx());
         vec![scope.register_with_result(&LoadOp::new(scope.ctx_mut(), ptr))]
     }
@@ -342,6 +347,10 @@ impl LowerOp for UniformLoadOp {
 #[op_interface_impl]
 impl LowerOp for AtomicUniformLoadOp {
     fn lower(&self, scope: &Scope) -> Vec<Value> {
+        scope.register(&SyncOp::new(
+            scope.ctx_mut(),
+            SyncScopeAttr::new(SyncScope::Cube),
+        ));
         let ptr = self.ptr(scope.ctx());
         vec![scope.register_with_result(&AtomicLoadOp::new(scope.ctx_mut(), ptr))]
     }

--- a/crates/cubecl-cpu/src/compiler/polyfill/ordered_atomic.rs
+++ b/crates/cubecl-cpu/src/compiler/polyfill/ordered_atomic.rs
@@ -9,6 +9,7 @@
 use cubecl_core::ir::dialect::atomic::AtomicLoadOp;
 use cubecl_core::ir::dialect::memory::LoadOp;
 use cubecl_core::ir::dialect::plane::{AtomicUniformLoadOp, UniformLoadOp};
+use cubecl_core::ir::dialect::synchronization::{SyncOp, SyncScope, SyncScopeAttr};
 use cubecl_core::ir::prelude::*;
 use cubecl_core::prelude::*;
 use cubecl_core::{self as cubecl};
@@ -81,6 +82,12 @@ pub fn atomic_fetch_add_acq_rel(atomic: &Atomic<u32>, value: u32) -> u32 {
 #[op_interface_impl]
 impl LowerOp for UniformLoadOp {
     fn lower(&self, scope: &Scope) -> Vec<Value> {
+        // Barrier first: these ops are a sync plus a load, so a value written
+        // by one unit is visible to the rest.
+        scope.register(&SyncOp::new(
+            scope.ctx_mut(),
+            SyncScopeAttr::new(SyncScope::Cube),
+        ));
         let ptr = self.ptr(scope.ctx());
         vec![scope.register_with_result(&LoadOp::new(scope.ctx_mut(), ptr))]
     }
@@ -89,6 +96,12 @@ impl LowerOp for UniformLoadOp {
 #[op_interface_impl]
 impl LowerOp for AtomicUniformLoadOp {
     fn lower(&self, scope: &Scope) -> Vec<Value> {
+        // Barrier first: these ops are a sync plus a load, so a value written
+        // by one unit is visible to the rest.
+        scope.register(&SyncOp::new(
+            scope.ctx_mut(),
+            SyncScopeAttr::new(SyncScope::Cube),
+        ));
         let ptr = self.ptr(scope.ctx());
         vec![scope.register_with_result(&AtomicLoadOp::new(scope.ctx_mut(), ptr))]
     }

--- a/crates/cubecl-spirv/src/ops/plane.rs
+++ b/crates/cubecl-spirv/src/ops/plane.rs
@@ -1,8 +1,8 @@
 use cubecl_core::{self as cubecl, prelude::*};
 use cubecl_ir::{dialect::plane, interfaces::TypedExt, prelude::*, types::scalar::BoolType};
 use pliron::builtin::ops::ConstantOp;
-use pliron_spirv::ops::{self};
-use rspirv::spirv::{GroupOperation, MemoryAccess, Scope};
+use pliron_spirv::ops::{self, ControlBarrierOp};
+use rspirv::spirv::{GroupOperation, MemoryAccess, MemorySemantics, Scope};
 
 use crate::{
     lower::LowerOp,
@@ -162,6 +162,16 @@ impl ToSpirvDialectOp for plane::UniformLoadOp {
         _operands_info: &OperandsInfo,
     ) -> Result<()> {
         let op = self.get_operation();
+        // `workgroup_uniform_load` is a barrier plus a load: WGSL's
+        // `workgroupUniformLoad` synchronises, and callers rely on that to
+        // publish a value written by one unit before the rest read it.
+        let sync = ControlBarrierOp::new(
+            ctx,
+            Scope::Workgroup,
+            Scope::Workgroup,
+            MemorySemantics::ACQUIRE_RELEASE | MemorySemantics::WORKGROUP_MEMORY,
+        );
+        rewriter.append_op(ctx, &sync);
         let ptr = self.ptr(ctx);
         let align = self.result_type(ctx).align(ctx) as u32;
         let out_ty = ty_to_spirv_dialect(ctx, self.result_type(ctx));
@@ -181,6 +191,16 @@ impl ToSpirvDialectOp for plane::AtomicUniformLoadOp {
         _operands_info: &OperandsInfo,
     ) -> Result<()> {
         let op = self.get_operation();
+        // `workgroup_uniform_load` is a barrier plus a load: WGSL's
+        // `workgroupUniformLoad` synchronises, and callers rely on that to
+        // publish a value written by one unit before the rest read it.
+        let sync = ControlBarrierOp::new(
+            ctx,
+            Scope::Workgroup,
+            Scope::Workgroup,
+            MemorySemantics::ACQUIRE_RELEASE | MemorySemantics::WORKGROUP_MEMORY,
+        );
+        rewriter.append_op(ctx, &sync);
         let ptr = self.ptr(ctx);
         let semantics = semantics_r(ctx, ptr);
         let out_ty = ty_to_spirv_dialect(ctx, self.result_type(ctx));


### PR DESCRIPTION
`workgroup_uniform_load` and `workgroup_uniform_load_atomic` are documented as "barrier plus a plain load" on non-WGSL backends. Only WGSL actually synchronises, through `workgroupUniformLoad`. cubecl-cpp, cubecl-spirv and cubecl-cpu all lower them to a bare load.

That matters because the barrier is observable: it lets one unit publish a value that the rest read without putting a `sync_cube` in non-uniform control flow.

The existing tests don't catch it because they call `sync_cube()` before the uniform load, so the load never has to synchronise anything. 