### PR TITLE
feat(quant): Software fp8 conversion on every backend, native where the hardware has it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,7 @@ dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-cpu",
  "cubecl-environment",
  "cubecl-opt",
  "cubecl-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-cpu",
  "cubecl-environment",
  "cubecl-ir",
  "cubecl-opt",

--- a/crates/cubecl-core/src/codegen/compiler.rs
+++ b/crates/cubecl-core/src/codegen/compiler.rs
@@ -17,6 +17,8 @@ pub struct VulkanCompilationOptions {
     pub supports_arbitrary_bitwise: bool,
     pub supports_uniform_standard_layout: bool,
     pub supports_uniform_unsized_array: bool,
+    /// Whether the driver has `VK_EXT_shader_float8`; without it fp8 casts are lowered in software.
+    pub supports_float8: bool,
 
     pub max_spirv_version: (u8, u8),
     pub max_vector_size: usize,

--- a/crates/cubecl-core/src/codegen/compiler.rs
+++ b/crates/cubecl-core/src/codegen/compiler.rs
@@ -17,7 +17,6 @@ pub struct VulkanCompilationOptions {
     pub supports_arbitrary_bitwise: bool,
     pub supports_uniform_standard_layout: bool,
     pub supports_uniform_unsized_array: bool,
-    /// Whether the driver has `VK_EXT_shader_float8`; without it fp8 casts are lowered in software.
     pub supports_float8: bool,
 
     pub max_spirv_version: (u8, u8),

--- a/crates/cubecl-core/src/post_processing/minifloat.rs
+++ b/crates/cubecl-core/src/post_processing/minifloat.rs
@@ -1,0 +1,321 @@
+//! Software fp8 conversion for targets without hardware fp8.
+//!
+//! The polyfills work on `u32` bit patterns and use no 8- or 16-bit types, so they also serve
+//! backends that cannot store a byte, given the bits in a word. [`LowerMinifloatCast`] rewrites
+//! the casts a target cannot convert natively into them.
+
+use cubecl_ir::{
+    NamedRewrite, Scope,
+    dialect::{base::OperationPtrExt, general::CastOp},
+    interfaces::TypedExt,
+    prelude::*,
+    types::scalar::{Float8E4M3Type, Float8E5M2Type},
+};
+use pliron::r#type::TypeHandle;
+
+use crate::{self as cubecl, prelude::*};
+
+define_size!(N);
+
+/// An 8-bit float encoding, by its field widths.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Fp8Format {
+    /// 4 exponent bits, 3 mantissa bits, bias 7. No infinities; `S.1111.111` is its only NaN.
+    E4M3,
+    /// 5 exponent bits, 2 mantissa bits, bias 15. IEEE-like: an all-ones exponent is inf or NaN.
+    E5M2,
+}
+
+impl Fp8Format {
+    pub const fn exponent_bits(self) -> u32 {
+        match self {
+            Fp8Format::E4M3 => 4,
+            Fp8Format::E5M2 => 5,
+        }
+    }
+
+    pub const fn mantissa_bits(self) -> u32 {
+        match self {
+            Fp8Format::E4M3 => 3,
+            Fp8Format::E5M2 => 2,
+        }
+    }
+
+    pub const fn bias(self) -> u32 {
+        match self {
+            Fp8Format::E4M3 => 7,
+            Fp8Format::E5M2 => 15,
+        }
+    }
+
+    /// The largest finite value.
+    pub const fn max_value(self) -> f32 {
+        match self {
+            Fp8Format::E4M3 => 448.0,
+            Fp8Format::E5M2 => 57344.0,
+        }
+    }
+
+    /// The code of [`max_value`](Self::max_value), sign bit clear.
+    pub const fn max_code(self) -> u32 {
+        match self {
+            Fp8Format::E4M3 => 0x7E,
+            Fp8Format::E5M2 => 0x7B,
+        }
+    }
+
+    /// The code an encoded NaN takes, sign bit clear.
+    pub const fn nan_code(self) -> u32 {
+        0x7F
+    }
+
+    /// Whether an all-ones exponent means inf or NaN, as in IEEE 754.
+    pub const fn has_infinity(self) -> bool {
+        matches!(self, Fp8Format::E5M2)
+    }
+
+    /// The smallest normal value, `2^(1 - bias)`.
+    pub const fn min_normal(self) -> f32 {
+        f32::from_bits((127 + 1 - self.bias()) << 23)
+    }
+
+    /// The distance between subnormals, `2^(1 - bias - mantissa_bits)`.
+    pub const fn subnormal_step(self) -> f32 {
+        f32::from_bits((127 + 1 - self.bias() - self.mantissa_bits()) << 23)
+    }
+
+    /// The format of a scalar type, if it is one of these.
+    pub fn of_type(ctx: &Context, ty: TypeHandle) -> Option<Self> {
+        let ty = ty.deref(ctx);
+        if ty.is::<Float8E4M3Type>() {
+            Some(Fp8Format::E4M3)
+        } else if ty.is::<Float8E5M2Type>() {
+            Some(Fp8Format::E5M2)
+        } else {
+            None
+        }
+    }
+}
+
+/// Decodes fp8 bit patterns held in the low byte of each lane. Bits above the byte are ignored.
+#[cube]
+pub fn fp8_bits_to_f32<N: Size>(bits: Vector<u32, N>, #[comptime] format: Fp8Format) -> Vector<f32, N> {
+    let mantissa_bits = comptime![format.mantissa_bits()];
+    let exponent_mask = comptime![(1u32 << format.exponent_bits()) - 1];
+    let mantissa_mask = comptime![(1u32 << mantissa_bits) - 1];
+    let rebias = comptime![127 - format.bias()];
+    let mantissa_shift = comptime![23 - mantissa_bits];
+    let subnormal_step = comptime![format.subnormal_step()];
+
+    let sign = (bits & Vector::new(0x80u32)) << Vector::new(24u32);
+    let exponent = (bits >> Vector::new(mantissa_bits)) & Vector::new(exponent_mask);
+    let mantissa = bits & Vector::new(mantissa_mask);
+
+    let normal = sign
+        | ((exponent + Vector::new(rebias)) << Vector::new(23u32))
+        | (mantissa << Vector::new(mantissa_shift));
+    let subnormal = sign
+        | Vector::<u32, N>::reinterpret(
+            Vector::<f32, N>::cast_from(mantissa) * Vector::new(subnormal_step),
+        );
+    let value = select_many(exponent.equal(&Vector::new(0u32)), subnormal, normal);
+
+    let nan = sign | Vector::new(0x7FC0_0000u32);
+    let result = if comptime![format.has_infinity()] {
+        let inf = sign | Vector::new(0x7F80_0000u32);
+        let special = select_many(mantissa.equal(&Vector::new(0u32)), inf, nan);
+        select_many(exponent.equal(&Vector::new(exponent_mask)), special, value)
+    } else {
+        let magnitude = bits & Vector::new(0x7Fu32);
+        select_many(magnitude.equal(&Vector::new(0x7Fu32)), nan, value)
+    };
+
+    Vector::<f32, N>::reinterpret(result)
+}
+
+/// Encodes to fp8 bit patterns in the low byte of each lane, upper bits zero.
+///
+/// Rounds to nearest even. Overflow and infinities saturate to the largest finite value rather
+/// than producing NaN or inf, matching the host codecs; a quantization scale must never come back
+/// as something that poisons every value it scales.
+#[cube]
+pub fn f32_to_fp8_bits<N: Size>(value: Vector<f32, N>, #[comptime] format: Fp8Format) -> Vector<u32, N> {
+    let mantissa_bits = comptime![format.mantissa_bits()];
+    let mantissa_shift = comptime![23 - mantissa_bits];
+    let bias = comptime![format.bias()];
+    let half_ulp = comptime![1u32 << (mantissa_shift - 1)];
+    let subnormal_scale = comptime![1.0 / format.subnormal_step()];
+    let min_normal = comptime![format.min_normal()];
+    let max_value = comptime![format.max_value()];
+    let max_code = comptime![format.max_code()];
+    let nan_code = comptime![format.nan_code()];
+
+    let bits = Vector::<u32, N>::reinterpret(value);
+    let sign = (bits >> Vector::new(24u32)) & Vector::new(0x80u32);
+    let magnitude_bits = bits & Vector::new(0x7FFF_FFFFu32);
+    let magnitude = Vector::<f32, N>::reinterpret(magnitude_bits);
+
+    // Below the smallest normal the code is a count of subnormal steps: truncate, then round to
+    // nearest even by hand, which needs no float rounding mode and survives fast-math.
+    let steps = magnitude * Vector::new(subnormal_scale);
+    let truncated = Vector::<u32, N>::cast_from(steps);
+    let fraction = steps - Vector::<f32, N>::cast_from(truncated);
+    let above_half = fraction.greater_than(&Vector::new(0.5f32));
+    let tie_to_odd = fraction
+        .equal(&Vector::new(0.5f32))
+        .vec_and((truncated & Vector::new(1u32)).equal(&Vector::new(1u32)));
+    let round_up = Vector::<u32, N>::cast_from(above_half.or(tie_to_odd));
+    let subnormal = truncated + round_up;
+
+    // In the normal range, rebias the exponent and round the mantissa in place; a mantissa that
+    // rounds over carries into the exponent on its own.
+    let exponent = (magnitude_bits >> Vector::new(23u32)) + Vector::new(bias);
+    let mantissa = magnitude_bits & Vector::new(0x007F_FFFFu32);
+    let lsb = (mantissa >> Vector::new(mantissa_shift)) & Vector::new(1u32);
+    let rounded = ((exponent - Vector::new(127u32)) << Vector::new(23u32) | mantissa)
+        + Vector::new(half_ulp - 1)
+        + lsb;
+    let normal = rounded >> Vector::new(mantissa_shift);
+
+    let code = select_many(magnitude.less_than(&Vector::new(min_normal)), subnormal, normal);
+    let code = select_many(
+        magnitude.greater_than(&Vector::new(max_value)),
+        Vector::new(max_code),
+        code,
+    );
+    let code = select_many(
+        magnitude_bits.greater_than(&Vector::new(0x7F80_0000u32)),
+        Vector::new(nan_code),
+        code,
+    );
+
+    code | sign
+}
+
+/// Which fp8 formats a target converts in hardware; every other minifloat cast is lowered.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NativeFp8 {
+    pub e4m3: bool,
+    pub e5m2: bool,
+}
+
+impl NativeFp8 {
+    pub const NONE: Self = Self {
+        e4m3: false,
+        e5m2: false,
+    };
+    pub const ALL: Self = Self {
+        e4m3: true,
+        e5m2: true,
+    };
+
+    pub fn contains(self, format: Fp8Format) -> bool {
+        match format {
+            Fp8Format::E4M3 => self.e4m3,
+            Fp8Format::E5M2 => self.e5m2,
+        }
+    }
+}
+
+pub type LowerMinifloatCastPass = MatchRewritePass<LowerMinifloatCast>;
+
+/// Lowers casts to and from fp8 the target has no instruction for into integer bit manipulation,
+/// through `f32`.
+#[derive(new, Clone, Copy, Debug, Default, NamedRewrite)]
+pub struct LowerMinifloatCast {
+    pub native: NativeFp8,
+}
+
+impl LowerMinifloatCast {
+    fn emulated(&self, ctx: &Context, value: impl Typed) -> Option<Fp8Format> {
+        Fp8Format::of_type(ctx, value.scalar_ty(ctx)).filter(|format| !self.native.contains(*format))
+    }
+}
+
+impl MatchRewrite for LowerMinifloatCast {
+    fn r#match(&mut self, ctx: &Context, op: Ptr<Operation>) -> bool {
+        if !op.is_op::<CastOp>(ctx) {
+            return false;
+        }
+        let input = op.operand(ctx, 0);
+        let result = op.result(ctx);
+        // Bool casts are lowered by the backends themselves and are not what an fp8 buffer holds.
+        if input.scalar_ty(ctx).is_bool(ctx) || result.scalar_ty(ctx).is_bool(ctx) {
+            return false;
+        }
+        self.emulated(ctx, input).is_some() || self.emulated(ctx, result).is_some()
+    }
+
+    fn rewrite(
+        &mut self,
+        ctx: &mut Context,
+        rewriter: &mut MatchRewriter,
+        op: Ptr<Operation>,
+    ) -> Result<()> {
+        let scope = Scope::from_context_and_inserter(ctx, rewriter);
+        let input = op.operand(ctx, 0);
+        let result_ty = op.result(ctx).get_type(ctx);
+        scope.register_size::<N>(input.vector_size(ctx));
+
+        let mut value = input;
+        if let Some(format) = self.emulated(ctx, input) {
+            value = decode(&scope, value, format);
+        }
+        let value = match self.emulated(ctx, result_ty) {
+            Some(format) => encode(&scope, value, format, result_ty),
+            None => cast_value(&scope, value, result_ty),
+        };
+        rewriter.replace_operation_with_values(ctx, op, vec![value]);
+        Ok(())
+    }
+}
+
+/// fp8 lanes to `f32` lanes: reinterpret as bytes, widen, decode.
+fn decode(scope: &Scope, value: Value, format: Fp8Format) -> Value {
+    let bytes = reinterpret_value(scope, value, Vector::<u8, N>::__expand_as_type(scope));
+    let bits = cast_value(scope, bytes, Vector::<u32, N>::__expand_as_type(scope));
+    fp8_bits_to_f32::expand::<N>(scope, bits.into(), format).read_value(scope)
+}
+
+/// Any numeric lanes to fp8 lanes: widen to `f32`, encode, narrow to bytes, reinterpret.
+fn encode(scope: &Scope, value: Value, format: Fp8Format, result_ty: TypeHandle) -> Value {
+    let value = cast_value(scope, value, Vector::<f32, N>::__expand_as_type(scope));
+    let bits = f32_to_fp8_bits::expand::<N>(scope, value.into(), format).read_value(scope);
+    let bytes = cast_value(scope, bits, Vector::<u8, N>::__expand_as_type(scope));
+    reinterpret_value(scope, bytes, result_ty)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_constants_agree_with_the_codecs() {
+        assert_eq!(Fp8Format::E4M3.max_value(), cubecl_common::e4m3::MAX.to_f32());
+        assert_eq!(Fp8Format::E5M2.max_value(), cubecl_common::e5m2::MAX.to_f32());
+        assert_eq!(
+            Fp8Format::E4M3.max_code(),
+            cubecl_common::e4m3::MAX.to_bits() as u32
+        );
+        assert_eq!(
+            Fp8Format::E5M2.max_code(),
+            cubecl_common::e5m2::MAX.to_bits() as u32
+        );
+        assert_eq!(
+            Fp8Format::E4M3.min_normal(),
+            cubecl_common::e4m3::MIN_POSITIVE.to_f32()
+        );
+        assert_eq!(
+            Fp8Format::E5M2.min_normal(),
+            cubecl_common::e5m2::MIN_POSITIVE.to_f32()
+        );
+        assert_eq!(
+            Fp8Format::E4M3.subnormal_step(),
+            cubecl_common::e4m3::from_bits(1).to_f32()
+        );
+        assert_eq!(
+            Fp8Format::E5M2.subnormal_step(),
+            cubecl_common::e5m2::from_bits(1).to_f32()
+        );
+    }
+}

--- a/crates/cubecl-core/src/post_processing/minifloat.rs
+++ b/crates/cubecl-core/src/post_processing/minifloat.rs
@@ -17,6 +17,18 @@ use crate::{self as cubecl, prelude::*};
 
 define_size!(N);
 
+/// The bits of the f32 mantissa field, the sign bit and everything under it.
+const F32_MANTISSA_BITS: u32 = f32::MANTISSA_DIGITS - 1;
+const F32_MANTISSA_MASK: u32 = (1 << F32_MANTISSA_BITS) - 1;
+const F32_MAGNITUDE_MASK: u32 = u32::MAX >> 1;
+const F32_EXPONENT_BIAS: u32 = (f32::MAX_EXP - 1) as u32;
+const F32_INFINITY_BITS: u32 = f32::INFINITY.to_bits();
+const F32_NAN_BITS: u32 = F32_INFINITY_BITS | 1 << (F32_MANTISSA_BITS - 1);
+/// The sign bit of an fp8 code, and how far it sits below f32's.
+const FP8_SIGN_BIT: u32 = 0x80;
+const FP8_MAGNITUDE_MASK: u32 = FP8_SIGN_BIT - 1;
+const SIGN_SHIFT: u32 = 31 - 7;
+
 /// An 8-bit float encoding, by its field widths.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Fp8Format {
@@ -76,12 +88,14 @@ impl Fp8Format {
 
     /// The smallest normal value, `2^(1 - bias)`.
     pub const fn min_normal(self) -> f32 {
-        f32::from_bits((127 + 1 - self.bias()) << 23)
+        f32::from_bits((F32_EXPONENT_BIAS + 1 - self.bias()) << F32_MANTISSA_BITS)
     }
 
     /// The distance between subnormals, `2^(1 - bias - mantissa_bits)`.
     pub const fn subnormal_step(self) -> f32 {
-        f32::from_bits((127 + 1 - self.bias() - self.mantissa_bits()) << 23)
+        f32::from_bits(
+            (F32_EXPONENT_BIAS + 1 - self.bias() - self.mantissa_bits()) << F32_MANTISSA_BITS,
+        )
     }
 
     /// The format of a scalar type, if it is one of these.
@@ -106,16 +120,16 @@ pub fn fp8_bits_to_f32<N: Size>(
     let mantissa_bits = comptime![format.mantissa_bits()];
     let exponent_mask = comptime![(1u32 << format.exponent_bits()) - 1];
     let mantissa_mask = comptime![(1u32 << mantissa_bits) - 1];
-    let rebias = comptime![127 - format.bias()];
-    let mantissa_shift = comptime![23 - mantissa_bits];
+    let rebias = comptime![F32_EXPONENT_BIAS - format.bias()];
+    let mantissa_shift = comptime![F32_MANTISSA_BITS - mantissa_bits];
     let subnormal_step = comptime![format.subnormal_step()];
 
-    let sign = (bits & Vector::new(0x80u32)) << Vector::new(24u32);
+    let sign = (bits & Vector::new(FP8_SIGN_BIT)) << Vector::new(SIGN_SHIFT);
     let exponent = (bits >> Vector::new(mantissa_bits)) & Vector::new(exponent_mask);
     let mantissa = bits & Vector::new(mantissa_mask);
 
     let normal = sign
-        | ((exponent + Vector::new(rebias)) << Vector::new(23u32))
+        | ((exponent + Vector::new(rebias)) << Vector::new(F32_MANTISSA_BITS))
         | (mantissa << Vector::new(mantissa_shift));
     let subnormal = sign
         | Vector::<u32, N>::reinterpret(
@@ -123,14 +137,18 @@ pub fn fp8_bits_to_f32<N: Size>(
         );
     let value = select_many(exponent.equal(&Vector::new(0u32)), subnormal, normal);
 
-    let nan = sign | Vector::new(0x7FC0_0000u32);
+    let nan = sign | Vector::new(F32_NAN_BITS);
     let result = if comptime![format.has_infinity()] {
-        let inf = sign | Vector::new(0x7F80_0000u32);
+        let inf = sign | Vector::new(F32_INFINITY_BITS);
         let special = select_many(mantissa.equal(&Vector::new(0u32)), inf, nan);
         select_many(exponent.equal(&Vector::new(exponent_mask)), special, value)
     } else {
-        let magnitude = bits & Vector::new(0x7Fu32);
-        select_many(magnitude.equal(&Vector::new(0x7Fu32)), nan, value)
+        let magnitude = bits & Vector::new(FP8_MAGNITUDE_MASK);
+        select_many(
+            magnitude.equal(&Vector::new(FP8_MAGNITUDE_MASK)),
+            nan,
+            value,
+        )
     };
 
     Vector::<f32, N>::reinterpret(result)
@@ -147,7 +165,7 @@ pub fn f32_to_fp8_bits<N: Size>(
     #[comptime] format: Fp8Format,
 ) -> Vector<u32, N> {
     let mantissa_bits = comptime![format.mantissa_bits()];
-    let mantissa_shift = comptime![23 - mantissa_bits];
+    let mantissa_shift = comptime![F32_MANTISSA_BITS - mantissa_bits];
     let bias = comptime![format.bias()];
     let half_ulp = comptime![1u32 << (mantissa_shift - 1)];
     let subnormal_scale = comptime![1.0 / format.subnormal_step()];
@@ -157,8 +175,8 @@ pub fn f32_to_fp8_bits<N: Size>(
     let nan_code = comptime![format.nan_code()];
 
     let bits = Vector::<u32, N>::reinterpret(value);
-    let sign = (bits >> Vector::new(24u32)) & Vector::new(0x80u32);
-    let magnitude_bits = bits & Vector::new(0x7FFF_FFFFu32);
+    let sign = (bits >> Vector::new(SIGN_SHIFT)) & Vector::new(FP8_SIGN_BIT);
+    let magnitude_bits = bits & Vector::new(F32_MAGNITUDE_MASK);
     let magnitude = Vector::<f32, N>::reinterpret(magnitude_bits);
 
     // Below the smallest normal the code is a count of subnormal steps: truncate, then round to
@@ -175,10 +193,11 @@ pub fn f32_to_fp8_bits<N: Size>(
 
     // In the normal range, rebias the exponent and round the mantissa in place; a mantissa that
     // rounds over carries into the exponent on its own.
-    let exponent = (magnitude_bits >> Vector::new(23u32)) + Vector::new(bias);
-    let mantissa = magnitude_bits & Vector::new(0x007F_FFFFu32);
+    let exponent = (magnitude_bits >> Vector::new(F32_MANTISSA_BITS)) + Vector::new(bias);
+    let mantissa = magnitude_bits & Vector::new(F32_MANTISSA_MASK);
     let lsb = (mantissa >> Vector::new(mantissa_shift)) & Vector::new(1u32);
-    let rounded = ((exponent - Vector::new(127u32)) << Vector::new(23u32) | mantissa)
+    let rounded = ((exponent - Vector::new(F32_EXPONENT_BIAS)) << Vector::new(F32_MANTISSA_BITS)
+        | mantissa)
         + Vector::new(half_ulp - 1)
         + lsb;
     let normal = rounded >> Vector::new(mantissa_shift);
@@ -194,7 +213,7 @@ pub fn f32_to_fp8_bits<N: Size>(
         code,
     );
     let code = select_many(
-        magnitude_bits.greater_than(&Vector::new(0x7F80_0000u32)),
+        magnitude_bits.greater_than(&Vector::new(F32_INFINITY_BITS)),
         Vector::new(nan_code),
         code,
     );

--- a/crates/cubecl-core/src/post_processing/minifloat.rs
+++ b/crates/cubecl-core/src/post_processing/minifloat.rs
@@ -1,8 +1,5 @@
-//! Software fp8 conversion for targets without hardware fp8.
-//!
-//! The polyfills work on `u32` bit patterns and use no 8- or 16-bit types, so they also serve
-//! backends that cannot store a byte, given the bits in a word. [`LowerMinifloatCast`] rewrites
-//! the casts a target cannot convert natively into them.
+//! Software fp8 conversion, on `u32` bit patterns only so that a backend with no 8- or 16-bit types
+//! can still call it on the bits in a word.
 
 use cubecl_ir::{
     NamedRewrite, Scope,
@@ -17,24 +14,19 @@ use crate::{self as cubecl, prelude::*};
 
 define_size!(N);
 
-/// The bits of the f32 mantissa field, the sign bit and everything under it.
 const F32_MANTISSA_BITS: u32 = f32::MANTISSA_DIGITS - 1;
 const F32_MANTISSA_MASK: u32 = (1 << F32_MANTISSA_BITS) - 1;
 const F32_MAGNITUDE_MASK: u32 = u32::MAX >> 1;
 const F32_EXPONENT_BIAS: u32 = (f32::MAX_EXP - 1) as u32;
 const F32_INFINITY_BITS: u32 = f32::INFINITY.to_bits();
 const F32_NAN_BITS: u32 = F32_INFINITY_BITS | 1 << (F32_MANTISSA_BITS - 1);
-/// The sign bit of an fp8 code, and how far it sits below f32's.
 const FP8_SIGN_BIT: u32 = 0x80;
 const FP8_MAGNITUDE_MASK: u32 = FP8_SIGN_BIT - 1;
 const SIGN_SHIFT: u32 = 31 - 7;
 
-/// An 8-bit float encoding, by its field widths.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Fp8Format {
-    /// 4 exponent bits, 3 mantissa bits, bias 7. No infinities; `S.1111.111` is its only NaN.
     E4M3,
-    /// 5 exponent bits, 2 mantissa bits, bias 15. IEEE-like: an all-ones exponent is inf or NaN.
     E5M2,
 }
 
@@ -60,7 +52,6 @@ impl Fp8Format {
         }
     }
 
-    /// The largest finite value.
     pub const fn max_value(self) -> f32 {
         match self {
             Fp8Format::E4M3 => 448.0,
@@ -68,7 +59,6 @@ impl Fp8Format {
         }
     }
 
-    /// The code of [`max_value`](Self::max_value), sign bit clear.
     pub const fn max_code(self) -> u32 {
         match self {
             Fp8Format::E4M3 => 0x7E,
@@ -76,29 +66,24 @@ impl Fp8Format {
         }
     }
 
-    /// The code an encoded NaN takes, sign bit clear.
     pub const fn nan_code(self) -> u32 {
         0x7F
     }
 
-    /// Whether an all-ones exponent means inf or NaN, as in IEEE 754.
     pub const fn has_infinity(self) -> bool {
         matches!(self, Fp8Format::E5M2)
     }
 
-    /// The smallest normal value, `2^(1 - bias)`.
     pub const fn min_normal(self) -> f32 {
         f32::from_bits((F32_EXPONENT_BIAS + 1 - self.bias()) << F32_MANTISSA_BITS)
     }
 
-    /// The distance between subnormals, `2^(1 - bias - mantissa_bits)`.
     pub const fn subnormal_step(self) -> f32 {
         f32::from_bits(
             (F32_EXPONENT_BIAS + 1 - self.bias() - self.mantissa_bits()) << F32_MANTISSA_BITS,
         )
     }
 
-    /// The format of a scalar type, if it is one of these.
     pub fn of_type(ctx: &Context, ty: TypeHandle) -> Option<Self> {
         let ty = ty.deref(ctx);
         if ty.is::<Float8E4M3Type>() {
@@ -111,7 +96,7 @@ impl Fp8Format {
     }
 }
 
-/// Decodes fp8 bit patterns held in the low byte of each lane. Bits above the byte are ignored.
+/// Bits above the low byte are ignored.
 #[cube]
 pub fn fp8_bits_to_f32<N: Size>(
     bits: Vector<u32, N>,
@@ -154,11 +139,8 @@ pub fn fp8_bits_to_f32<N: Size>(
     Vector::<f32, N>::reinterpret(result)
 }
 
-/// Encodes to fp8 bit patterns in the low byte of each lane, upper bits zero.
-///
-/// Rounds to nearest even. Overflow and infinities saturate to the largest finite value rather
-/// than producing NaN or inf, matching the host codecs; a quantization scale must never come back
-/// as something that poisons every value it scales.
+/// Round to nearest even; overflow and infinities saturate to the largest finite value, as the host
+/// codecs do.
 #[cube]
 pub fn f32_to_fp8_bits<N: Size>(
     value: Vector<f32, N>,
@@ -179,8 +161,7 @@ pub fn f32_to_fp8_bits<N: Size>(
     let magnitude_bits = bits & Vector::new(F32_MAGNITUDE_MASK);
     let magnitude = Vector::<f32, N>::reinterpret(magnitude_bits);
 
-    // Below the smallest normal the code is a count of subnormal steps: truncate, then round to
-    // nearest even by hand, which needs no float rounding mode and survives fast-math.
+    // Rounding by hand: the usual magic-number trick does not survive fast-math reassociation.
     let steps = magnitude * Vector::new(subnormal_scale);
     let truncated = Vector::<u32, N>::cast_from(steps);
     let fraction = steps - Vector::<f32, N>::cast_from(truncated);
@@ -191,8 +172,6 @@ pub fn f32_to_fp8_bits<N: Size>(
     let round_up = Vector::<u32, N>::cast_from(above_half.or(tie_to_odd));
     let subnormal = truncated + round_up;
 
-    // In the normal range, rebias the exponent and round the mantissa in place; a mantissa that
-    // rounds over carries into the exponent on its own.
     let exponent = (magnitude_bits >> Vector::new(F32_MANTISSA_BITS)) + Vector::new(bias);
     let mantissa = magnitude_bits & Vector::new(F32_MANTISSA_MASK);
     let lsb = (mantissa >> Vector::new(mantissa_shift)) & Vector::new(1u32);
@@ -221,7 +200,6 @@ pub fn f32_to_fp8_bits<N: Size>(
     code | sign
 }
 
-/// Which fp8 formats a target converts in hardware; every other minifloat cast is lowered.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct NativeFp8 {
     pub e4m3: bool,
@@ -248,8 +226,6 @@ impl NativeFp8 {
 
 pub type LowerMinifloatCastPass = MatchRewritePass<LowerMinifloatCast>;
 
-/// Lowers casts to and from fp8 the target has no instruction for into integer bit manipulation,
-/// through `f32`.
 #[derive(new, Clone, Copy, Debug, Default, NamedRewrite)]
 pub struct LowerMinifloatCast {
     pub native: NativeFp8,
@@ -269,7 +245,7 @@ impl MatchRewrite for LowerMinifloatCast {
         }
         let input = op.operand(ctx, 0);
         let result = op.result(ctx);
-        // Bool casts are lowered by the backends themselves and are not what an fp8 buffer holds.
+        // Bool casts belong to the backends' own lowering.
         if input.scalar_ty(ctx).is_bool(ctx) || result.scalar_ty(ctx).is_bool(ctx) {
             return false;
         }
@@ -300,14 +276,12 @@ impl MatchRewrite for LowerMinifloatCast {
     }
 }
 
-/// fp8 lanes to `f32` lanes: reinterpret as bytes, widen, decode.
 fn decode(scope: &Scope, value: Value, format: Fp8Format) -> Value {
     let bytes = reinterpret_value(scope, value, Vector::<u8, N>::__expand_as_type(scope));
     let bits = cast_value(scope, bytes, Vector::<u32, N>::__expand_as_type(scope));
     fp8_bits_to_f32::expand::<N>(scope, bits.into(), format).read_value(scope)
 }
 
-/// Any numeric lanes to fp8 lanes: widen to `f32`, encode, narrow to bytes, reinterpret.
 fn encode(scope: &Scope, value: Value, format: Fp8Format, result_ty: TypeHandle) -> Value {
     let value = cast_value(scope, value, Vector::<f32, N>::__expand_as_type(scope));
     let bits = f32_to_fp8_bits::expand::<N>(scope, value.into(), format).read_value(scope);

--- a/crates/cubecl-core/src/post_processing/minifloat.rs
+++ b/crates/cubecl-core/src/post_processing/minifloat.rs
@@ -10,6 +10,8 @@ use cubecl_ir::{
 };
 use pliron::r#type::TypeHandle;
 
+use cubecl_common::{e4m3, e5m2};
+
 use crate::{self as cubecl, prelude::*};
 
 define_size!(N);
@@ -19,10 +21,10 @@ const F32_MANTISSA_MASK: u32 = (1 << F32_MANTISSA_BITS) - 1;
 const F32_MAGNITUDE_MASK: u32 = u32::MAX >> 1;
 const F32_EXPONENT_BIAS: u32 = (f32::MAX_EXP - 1) as u32;
 const F32_INFINITY_BITS: u32 = f32::INFINITY.to_bits();
-const F32_NAN_BITS: u32 = F32_INFINITY_BITS | 1 << (F32_MANTISSA_BITS - 1);
-const FP8_SIGN_BIT: u32 = 0x80;
+const F32_NAN_BITS: u32 = f32::NAN.to_bits();
+const FP8_SIGN_BIT: u32 = 1 << (u8::BITS - 1);
 const FP8_MAGNITUDE_MASK: u32 = FP8_SIGN_BIT - 1;
-const SIGN_SHIFT: u32 = 31 - 7;
+const SIGN_SHIFT: u32 = u32::BITS - u8::BITS;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Fp8Format {
@@ -32,56 +34,66 @@ pub enum Fp8Format {
 
 impl Fp8Format {
     pub const fn exponent_bits(self) -> u32 {
-        match self {
-            Fp8Format::E4M3 => 4,
-            Fp8Format::E5M2 => 5,
-        }
+        7 - self.mantissa_bits()
     }
 
     pub const fn mantissa_bits(self) -> u32 {
         match self {
-            Fp8Format::E4M3 => 3,
-            Fp8Format::E5M2 => 2,
+            Fp8Format::E4M3 => e4m3::MANTISSA_DIGITS - 1,
+            Fp8Format::E5M2 => e5m2::MANTISSA_DIGITS - 1,
         }
     }
 
     pub const fn bias(self) -> u32 {
-        match self {
-            Fp8Format::E4M3 => 7,
-            Fp8Format::E5M2 => 15,
-        }
+        let min_exp = match self {
+            Fp8Format::E4M3 => e4m3::MIN_EXP,
+            Fp8Format::E5M2 => e5m2::MIN_EXP,
+        };
+        (2 - min_exp) as u32
     }
 
     pub const fn max_value(self) -> f32 {
         match self {
-            Fp8Format::E4M3 => 448.0,
-            Fp8Format::E5M2 => 57344.0,
+            Fp8Format::E4M3 => e4m3::MAX.to_f32(),
+            Fp8Format::E5M2 => e5m2::MAX.to_f32(),
         }
     }
 
     pub const fn max_code(self) -> u32 {
         match self {
-            Fp8Format::E4M3 => 0x7E,
-            Fp8Format::E5M2 => 0x7B,
+            Fp8Format::E4M3 => e4m3::MAX.to_bits() as u32,
+            Fp8Format::E5M2 => e5m2::MAX.to_bits() as u32,
         }
     }
 
     pub const fn nan_code(self) -> u32 {
-        0x7F
+        let nan = match self {
+            Fp8Format::E4M3 => e4m3::NAN.to_bits(),
+            Fp8Format::E5M2 => e5m2::NAN.to_bits(),
+        };
+        nan as u32 & FP8_MAGNITUDE_MASK
     }
 
     pub const fn has_infinity(self) -> bool {
-        matches!(self, Fp8Format::E5M2)
+        self.decode(self.max_code() + 1).is_infinite()
     }
 
     pub const fn min_normal(self) -> f32 {
-        f32::from_bits((F32_EXPONENT_BIAS + 1 - self.bias()) << F32_MANTISSA_BITS)
+        match self {
+            Fp8Format::E4M3 => e4m3::MIN_POSITIVE.to_f32(),
+            Fp8Format::E5M2 => e5m2::MIN_POSITIVE.to_f32(),
+        }
     }
 
     pub const fn subnormal_step(self) -> f32 {
-        f32::from_bits(
-            (F32_EXPONENT_BIAS + 1 - self.bias() - self.mantissa_bits()) << F32_MANTISSA_BITS,
-        )
+        self.decode(1)
+    }
+
+    const fn decode(self, code: u32) -> f32 {
+        match self {
+            Fp8Format::E4M3 => e4m3::from_bits(code as u8).to_f32(),
+            Fp8Format::E5M2 => e5m2::from_bits(code as u8).to_f32(),
+        }
     }
 
     pub fn of_type(ctx: &Context, ty: TypeHandle) -> Option<Self> {
@@ -287,45 +299,4 @@ fn encode(scope: &Scope, value: Value, format: Fp8Format, result_ty: TypeHandle)
     let bits = f32_to_fp8_bits::expand::<N>(scope, value.into(), format).read_value(scope);
     let bytes = cast_value(scope, bits, Vector::<u8, N>::__expand_as_type(scope));
     reinterpret_value(scope, bytes, result_ty)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn field_constants_agree_with_the_codecs() {
-        assert_eq!(
-            Fp8Format::E4M3.max_value(),
-            cubecl_common::e4m3::MAX.to_f32()
-        );
-        assert_eq!(
-            Fp8Format::E5M2.max_value(),
-            cubecl_common::e5m2::MAX.to_f32()
-        );
-        assert_eq!(
-            Fp8Format::E4M3.max_code(),
-            cubecl_common::e4m3::MAX.to_bits() as u32
-        );
-        assert_eq!(
-            Fp8Format::E5M2.max_code(),
-            cubecl_common::e5m2::MAX.to_bits() as u32
-        );
-        assert_eq!(
-            Fp8Format::E4M3.min_normal(),
-            cubecl_common::e4m3::MIN_POSITIVE.to_f32()
-        );
-        assert_eq!(
-            Fp8Format::E5M2.min_normal(),
-            cubecl_common::e5m2::MIN_POSITIVE.to_f32()
-        );
-        assert_eq!(
-            Fp8Format::E4M3.subnormal_step(),
-            cubecl_common::e4m3::from_bits(1).to_f32()
-        );
-        assert_eq!(
-            Fp8Format::E5M2.subnormal_step(),
-            cubecl_common::e5m2::from_bits(1).to_f32()
-        );
-    }
 }

--- a/crates/cubecl-core/src/post_processing/minifloat.rs
+++ b/crates/cubecl-core/src/post_processing/minifloat.rs
@@ -99,7 +99,10 @@ impl Fp8Format {
 
 /// Decodes fp8 bit patterns held in the low byte of each lane. Bits above the byte are ignored.
 #[cube]
-pub fn fp8_bits_to_f32<N: Size>(bits: Vector<u32, N>, #[comptime] format: Fp8Format) -> Vector<f32, N> {
+pub fn fp8_bits_to_f32<N: Size>(
+    bits: Vector<u32, N>,
+    #[comptime] format: Fp8Format,
+) -> Vector<f32, N> {
     let mantissa_bits = comptime![format.mantissa_bits()];
     let exponent_mask = comptime![(1u32 << format.exponent_bits()) - 1];
     let mantissa_mask = comptime![(1u32 << mantissa_bits) - 1];
@@ -139,7 +142,10 @@ pub fn fp8_bits_to_f32<N: Size>(bits: Vector<u32, N>, #[comptime] format: Fp8For
 /// than producing NaN or inf, matching the host codecs; a quantization scale must never come back
 /// as something that poisons every value it scales.
 #[cube]
-pub fn f32_to_fp8_bits<N: Size>(value: Vector<f32, N>, #[comptime] format: Fp8Format) -> Vector<u32, N> {
+pub fn f32_to_fp8_bits<N: Size>(
+    value: Vector<f32, N>,
+    #[comptime] format: Fp8Format,
+) -> Vector<u32, N> {
     let mantissa_bits = comptime![format.mantissa_bits()];
     let mantissa_shift = comptime![23 - mantissa_bits];
     let bias = comptime![format.bias()];
@@ -177,7 +183,11 @@ pub fn f32_to_fp8_bits<N: Size>(value: Vector<f32, N>, #[comptime] format: Fp8Fo
         + lsb;
     let normal = rounded >> Vector::new(mantissa_shift);
 
-    let code = select_many(magnitude.less_than(&Vector::new(min_normal)), subnormal, normal);
+    let code = select_many(
+        magnitude.less_than(&Vector::new(min_normal)),
+        subnormal,
+        normal,
+    );
     let code = select_many(
         magnitude.greater_than(&Vector::new(max_value)),
         Vector::new(max_code),
@@ -228,7 +238,8 @@ pub struct LowerMinifloatCast {
 
 impl LowerMinifloatCast {
     fn emulated(&self, ctx: &Context, value: impl Typed) -> Option<Fp8Format> {
-        Fp8Format::of_type(ctx, value.scalar_ty(ctx)).filter(|format| !self.native.contains(*format))
+        Fp8Format::of_type(ctx, value.scalar_ty(ctx))
+            .filter(|format| !self.native.contains(*format))
     }
 }
 
@@ -291,8 +302,14 @@ mod tests {
 
     #[test]
     fn field_constants_agree_with_the_codecs() {
-        assert_eq!(Fp8Format::E4M3.max_value(), cubecl_common::e4m3::MAX.to_f32());
-        assert_eq!(Fp8Format::E5M2.max_value(), cubecl_common::e5m2::MAX.to_f32());
+        assert_eq!(
+            Fp8Format::E4M3.max_value(),
+            cubecl_common::e4m3::MAX.to_f32()
+        );
+        assert_eq!(
+            Fp8Format::E5M2.max_value(),
+            cubecl_common::e5m2::MAX.to_f32()
+        );
         assert_eq!(
             Fp8Format::E4M3.max_code(),
             cubecl_common::e4m3::MAX.to_bits() as u32

--- a/crates/cubecl-core/src/post_processing/mod.rs
+++ b/crates/cubecl-core/src/post_processing/mod.rs
@@ -1,5 +1,6 @@
 pub mod bitwise;
 pub mod checked_io;
+pub mod minifloat;
 pub mod saturating;
 pub mod unroll;
 pub mod util;

--- a/crates/cubecl-core/src/runtime_tests/minifloat.rs
+++ b/crates/cubecl-core/src/runtime_tests/minifloat.rs
@@ -5,6 +5,7 @@ use crate::{self as cubecl, as_type};
 use cubecl::prelude::*;
 use cubecl_common::{e2m1x2, e2m3, e3m2, e4m3, e5m2, ue8m0};
 use cubecl_ir::features::TypeUsage;
+use enumset::EnumSet;
 
 #[cube(launch_unchecked)]
 pub fn kernel_fp8<F: Float, N: Size>(input: &mut [Vector<F, N>], out: &mut [Vector<u8, N>]) {
@@ -38,6 +39,32 @@ pub fn kernel_fp4<F: Float, N: Size, N2: Size>(
 
         out[0] = Vector::reinterpret(Vector::<e2m1x2, N2>::cast_from(value));
         input[0] = Vector::cast_from(Vector::<e2m1x2, N2>::reinterpret(out[0]));
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn kernel_fp8_decode<N: Size>(
+    input: &[Vector<u8, N>],
+    out_e4m3: &mut [Vector<f32, N>],
+    out_e5m2: &mut [Vector<f32, N>],
+) {
+    if ABSOLUTE_POS < input.len() {
+        let bytes = input[ABSOLUTE_POS];
+        out_e4m3[ABSOLUTE_POS] = Vector::cast_from(Vector::<e4m3, N>::reinterpret(bytes));
+        out_e5m2[ABSOLUTE_POS] = Vector::cast_from(Vector::<e5m2, N>::reinterpret(bytes));
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn kernel_fp8_encode<N: Size>(
+    input: &[Vector<f32, N>],
+    out_e4m3: &mut [Vector<u8, N>],
+    out_e5m2: &mut [Vector<u8, N>],
+) {
+    if ABSOLUTE_POS < input.len() {
+        let value = input[ABSOLUTE_POS];
+        out_e4m3[ABSOLUTE_POS] = Vector::reinterpret(Vector::<e4m3, N>::cast_from(value));
+        out_e5m2[ABSOLUTE_POS] = Vector::reinterpret(Vector::<e5m2, N>::cast_from(value));
     }
 }
 
@@ -187,6 +214,196 @@ pub fn test_fp4<R: Runtime, F: Float + CubeElement>(
     assert_eq!(&actual_2[..num_out], &expected_data[..num_out]);
 }
 
+fn fp8_supported<R: Runtime>(client: &ComputeClient<R>) -> bool {
+    let usable = |uses: EnumSet<TypeUsage>| uses.contains(TypeUsage::Conversion);
+    usable(e4m3::supported_uses(client)) && usable(e5m2::supported_uses(client))
+}
+
+/// Every one of the 256 bit patterns of both formats decodes to what the host codec says.
+pub fn test_fp8_decode_exhaustive<R: Runtime>(client: ComputeClient<R>, vector_size: VectorSize) {
+    if !fp8_supported(&client) {
+        println!("Unsupported, skipping");
+        return;
+    }
+
+    let bytes: Vec<u8> = (0..=u8::MAX).collect();
+    let input = client.create_from_slice(u8::as_bytes(&bytes));
+    let out_e4m3 = client.empty(bytes.len() * size_of::<f32>());
+    let out_e5m2 = client.empty(bytes.len() * size_of::<f32>());
+    let vectors = bytes.len() / vector_size;
+
+    unsafe {
+        kernel_fp8_decode::launch_unchecked::<R>(
+            &client,
+            CubeCount::Static(vectors.div_ceil(32) as u32, 1, 1),
+            CubeDim::new_1d(32),
+            vector_size,
+            BufferArg::from_raw_parts(input, bytes.len()),
+            BufferArg::from_raw_parts(out_e4m3.clone(), bytes.len()),
+            BufferArg::from_raw_parts(out_e5m2.clone(), bytes.len()),
+        )
+    };
+
+    let actual_e4m3 = client.read_one_unchecked(out_e4m3);
+    let actual_e5m2 = client.read_one_unchecked(out_e5m2);
+    for (bits, (actual_e4m3, actual_e5m2)) in bytes.iter().zip(
+        f32::from_bytes(&actual_e4m3)
+            .iter()
+            .zip(f32::from_bytes(&actual_e5m2)),
+    ) {
+        assert_same_float(
+            *actual_e4m3,
+            e4m3::from_bits(*bits).to_f32(),
+            "e4m3",
+            *bits as u32,
+        );
+        assert_same_float(
+            *actual_e5m2,
+            e5m2::from_bits(*bits).to_f32(),
+            "e5m2",
+            *bits as u32,
+        );
+    }
+}
+
+/// Every f16 value, plus the rounding and range edges, encodes to the byte the host codec gives.
+pub fn test_fp8_encode_exhaustive<R: Runtime>(client: ComputeClient<R>, vector_size: VectorSize) {
+    if !fp8_supported(&client) {
+        println!("Unsupported, skipping");
+        return;
+    }
+
+    let mut values: Vec<f32> = (0..=u16::MAX)
+        .map(|bits| half::f16::from_bits(bits).to_f32())
+        .collect();
+    values.extend(fp8_encode_edges());
+    // The kernel reads whole vectors, and every lane must hold a value the codec was asked about.
+    while !values.len().is_multiple_of(vector_size) {
+        values.push(0.0);
+    }
+
+    let input = client.create_from_slice(f32::as_bytes(&values));
+    let out_e4m3 = client.empty(values.len());
+    let out_e5m2 = client.empty(values.len());
+    let vectors = values.len() / vector_size;
+
+    unsafe {
+        kernel_fp8_encode::launch_unchecked::<R>(
+            &client,
+            CubeCount::Static(vectors.div_ceil(64) as u32, 1, 1),
+            CubeDim::new_1d(64),
+            vector_size,
+            BufferArg::from_raw_parts(input, values.len()),
+            BufferArg::from_raw_parts(out_e4m3.clone(), values.len()),
+            BufferArg::from_raw_parts(out_e5m2.clone(), values.len()),
+        )
+    };
+
+    let actual_e4m3 = client.read_one_unchecked(out_e4m3);
+    let actual_e5m2 = client.read_one_unchecked(out_e5m2);
+    for (value, (actual_e4m3, actual_e5m2)) in values.iter().zip(
+        u8::from_bytes(&actual_e4m3)
+            .iter()
+            .zip(u8::from_bytes(&actual_e5m2)),
+    ) {
+        let expected_e4m3 = e4m3::from_f32(*value);
+        let expected_e5m2 = e5m2::from_f32(*value);
+        if value.is_nan() {
+            assert!(
+                e4m3::from_bits(*actual_e4m3).is_nan(),
+                "e4m3 of NaN: {actual_e4m3:#04x}"
+            );
+            assert!(
+                e5m2::from_bits(*actual_e5m2).is_nan(),
+                "e5m2 of NaN: {actual_e5m2:#04x}"
+            );
+            continue;
+        }
+        assert_eq!(
+            *actual_e4m3,
+            expected_e4m3.to_bits(),
+            "e4m3 of {value:e} ({:#010x})",
+            value.to_bits()
+        );
+        assert_eq!(
+            *actual_e5m2,
+            expected_e5m2.to_bits(),
+            "e5m2 of {value:e} ({:#010x})",
+            value.to_bits()
+        );
+    }
+}
+
+/// Values at the edges of what encoding has to get right: ties in both rounding regimes of both
+/// formats, the underflow and saturation boundaries, and the specials.
+fn fp8_encode_edges() -> Vec<f32> {
+    let mut edges = vec![
+        0.0,
+        -0.0,
+        f32::INFINITY,
+        f32::NEG_INFINITY,
+        f32::NAN,
+        f32::MAX,
+        f32::MIN_POSITIVE,
+        f32::from_bits(1),
+        448.0,
+        -448.0,
+        464.0,
+        480.0,
+        57344.0,
+        -57344.0,
+        61440.0,
+        65536.0,
+    ];
+    for (min_normal, step) in [(1.0 / 64.0, 1.0 / 512.0), (1.0 / 16384.0, 1.0 / 65536.0)] {
+        for k in 0..8 {
+            let below = k as f32 * step;
+            edges.extend([
+                below,
+                below + step / 2.0,
+                below + step / 4.0,
+                below + step * 3.0 / 4.0,
+            ]);
+        }
+        edges.extend([
+            step / 2.0,
+            step / 4.0,
+            min_normal,
+            min_normal * 0.999,
+            min_normal * 1.001,
+        ]);
+    }
+    for value in [1.0f32, 1.5, 3.0, 100.0, 1000.0] {
+        // Halfway between neighbouring codes, on both sides of an even code, from a few ulps away.
+        for step in [1.0 / 8.0, 1.0 / 4.0] {
+            let half = value * step / 2.0;
+            edges.extend([value + half, value + half * 3.0, value - half]);
+            edges.extend([
+                f32::from_bits((value + half).to_bits() + 1),
+                f32::from_bits((value + half).to_bits() - 1),
+            ]);
+        }
+    }
+    let negatives: Vec<f32> = edges.iter().map(|value| -value).collect();
+    edges.extend(negatives);
+    edges
+}
+
+fn assert_same_float(actual: f32, expected: f32, format: &str, bits: u32) {
+    if expected.is_nan() {
+        assert!(
+            actual.is_nan(),
+            "{format} {bits:#04x}: expected NaN, got {actual:e}"
+        );
+    } else {
+        assert_eq!(
+            actual.to_bits(),
+            expected.to_bits(),
+            "{format} {bits:#04x}: expected {expected:e}, got {actual:e}"
+        );
+    }
+}
+
 pub fn test_scale<R: Runtime>(client: ComputeClient<R>, vector_size: VectorSize) {
     if !ue8m0::supported_uses(&client).contains(TypeUsage::Conversion) {
         println!("Unsupported, skipping");
@@ -244,6 +461,28 @@ macro_rules! testgen_minifloat {
                 client.clone(),
                 4,
             );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_fp8_decode_exhaustive() {
+            let client = TestRuntime::client(&Default::default());
+            for vector_size in [1, 4] {
+                cubecl_core::runtime_tests::minifloat::test_fp8_decode_exhaustive::<TestRuntime>(
+                    client.clone(),
+                    vector_size,
+                );
+            }
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_fp8_encode_exhaustive() {
+            let client = TestRuntime::client(&Default::default());
+            for vector_size in [1, 4] {
+                cubecl_core::runtime_tests::minifloat::test_fp8_encode_exhaustive::<TestRuntime>(
+                    client.clone(),
+                    vector_size,
+                );
+            }
         }
 
         #[$crate::runtime_tests::test_log::test]

--- a/crates/cubecl-core/src/runtime_tests/minifloat.rs
+++ b/crates/cubecl-core/src/runtime_tests/minifloat.rs
@@ -219,7 +219,6 @@ fn fp8_supported<R: Runtime>(client: &ComputeClient<R>) -> bool {
     usable(e4m3::supported_uses(client)) && usable(e5m2::supported_uses(client))
 }
 
-/// Every one of the 256 bit patterns of both formats decodes to what the host codec says.
 pub fn test_fp8_decode_exhaustive<R: Runtime>(client: ComputeClient<R>, vector_size: VectorSize) {
     if !fp8_supported(&client) {
         println!("Unsupported, skipping");
@@ -266,7 +265,6 @@ pub fn test_fp8_decode_exhaustive<R: Runtime>(client: ComputeClient<R>, vector_s
     }
 }
 
-/// Every f16 value, plus the rounding and range edges, encodes to the byte the host codec gives.
 pub fn test_fp8_encode_exhaustive<R: Runtime>(client: ComputeClient<R>, vector_size: VectorSize) {
     if !fp8_supported(&client) {
         println!("Unsupported, skipping");
@@ -277,7 +275,6 @@ pub fn test_fp8_encode_exhaustive<R: Runtime>(client: ComputeClient<R>, vector_s
         .map(|bits| half::f16::from_bits(bits).to_f32())
         .collect();
     values.extend(fp8_encode_edges());
-    // The kernel reads whole vectors, and every lane must hold a value the codec was asked about.
     while !values.len().is_multiple_of(vector_size) {
         values.push(0.0);
     }
@@ -334,8 +331,6 @@ pub fn test_fp8_encode_exhaustive<R: Runtime>(client: ComputeClient<R>, vector_s
     }
 }
 
-/// Values at the edges of what encoding has to get right: ties in both rounding regimes of both
-/// formats, the underflow and saturation boundaries, and the specials.
 fn fp8_encode_edges() -> Vec<f32> {
     let mut edges = vec![
         0.0,
@@ -374,7 +369,6 @@ fn fp8_encode_edges() -> Vec<f32> {
         ]);
     }
     for value in [1.0f32, 1.5, 3.0, 100.0, 1000.0] {
-        // Halfway between neighbouring codes, on both sides of an even code, from a few ulps away.
         for step in [1.0 / 8.0, 1.0 / 4.0] {
             let half = value * step / 2.0;
             edges.extend([value + half, value + half * 3.0, value - half]);

--- a/crates/cubecl-cpp/Cargo.toml
+++ b/crates/cubecl-cpp/Cargo.toml
@@ -64,3 +64,7 @@ thiserror = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 pliron = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+# The CPU runtime lends a client to expand kernels for codegen tests; nothing runs on it.
+cubecl-cpu = { path = "../cubecl-cpu", version = "=0.11.0-pre.2" }

--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -57,7 +57,7 @@ impl LowerOp<Cuda> for CastOp {
         let should_lower_from = (input.is_fp8_fp6_fp4(ctx) || input.is_float4x2(ctx))
             && intermediate_for_ty(ctx, input.get_type(ctx)) != out.get_type(ctx);
         let should_lower_to = (out.is_fp8_fp6_fp4(ctx) || out.is_float4x2(ctx))
-            && intermediate_for_ty(ctx, out.get_type(ctx)) != input.get_type(ctx);
+            && !encodes_directly(ctx, input, out.get_type(ctx));
         should_lower_from || should_lower_to
     }
 
@@ -69,10 +69,42 @@ impl LowerOp<Cuda> for CastOp {
             let intermediate = intermediate_for_ty(ctx, current.get_type(ctx));
             current = cast_value(scope, current, intermediate);
         }
-        if out_ty.is_fp8_fp6_fp4(ctx) || out_ty.is_float4x2(ctx) {
-            current = cast_value(scope, current, intermediate_for_ty(ctx, out_ty));
+        if (out_ty.is_fp8_fp6_fp4(ctx) || out_ty.is_float4x2(ctx))
+            && !encodes_directly(ctx, current, out_ty)
+        {
+            let intermediate = match out_ty.is_float8(ctx) {
+                true => f32_like(ctx, out_ty),
+                false => intermediate_for_ty(ctx, out_ty),
+            };
+            current = cast_value(scope, current, intermediate);
         }
         vec![cast_value(scope, current, out_ty)]
+    }
+}
+
+/// Whether `input` converts into `out_ty` with one `__nv_cvt_*` call and no intermediate.
+///
+/// fp8 has an intrinsic from every float width, and has to use it: routing f32 through f16 first
+/// rounds twice, and a value one f32 ulp past an f16 tie then lands on the wrong fp8 code. Wide
+/// sources are fine, f16/bf16 pairs pack into the `x2` converters and the rest unroll to scalars.
+fn encodes_directly(ctx: &Context, input: Value, out_ty: TypeHandle) -> bool {
+    if !out_ty.is_float8(ctx) {
+        return intermediate_for_ty(ctx, out_ty) == input.get_type(ctx);
+    }
+    let scalar = input.get_type(ctx).scalar_ty(ctx);
+    scalar.is_float16(ctx)
+        || scalar.is_bfloat16(ctx)
+        || scalar.is_float32(ctx)
+        || scalar.is_float64(ctx)
+}
+
+fn f32_like(ctx: &Context, ty: TypeHandle) -> TypeHandle {
+    let vector_size = ty.vector_size(ctx);
+    let scalar = Float32Type::get(ctx).to_handle();
+    if vector_size > 1 {
+        VectorType::get(ctx, scalar, vector_size).to_handle()
+    } else {
+        scalar
     }
 }
 
@@ -129,17 +161,23 @@ fn cast_minifloat_to_half(ctx: &Context, input: Value) -> String {
     })
 }
 
-// Cast to minifloat from half/bf16. Could be made more generic, but a simple mapping is easier
-// to understand. The naming is very inconsistent (i.e. halfraw2 vs bf162raw)
+// Cast to minifloat from half/bf16 (fp8 also from float/double). Could be made more generic, but
+// a simple mapping is easier to understand. The naming is very inconsistent (i.e. halfraw2 vs
+// bf162raw).
+//
+// fp8 saturates: `__NV_SATFINITE` is what the codecs and every other backend do on overflow, and
+// the only mode with a hardware instruction; `__NV_NOSAT` is the header's software path even on
+// sm_89.
 fn cast_half_to_minifloat(ctx: &Context, input: Value, out_ty: TypeHandle) -> String {
     let in_val = input.name(ctx);
+    let fp8_source = || fp8_source_prefix(ctx, input);
     match_ty!((out_ty.deref(ctx)) {
         Float8E8M0Type => format!("__nv_cvt_bfloat16raw_to_e8m0({in_val}, __NV_NOSAT, cudaRoundPosInf)"),
         Float8E8M0x2Type => format!("__nv_cvt_bfloat162raw_to_e8m0x2({in_val}, __NV_NOSAT, cudaRoundPosInf)"),
-        Float8E4M3Type => format!("__nv_cvt_halfraw_to_fp8({in_val}, __NV_NOSAT, __NV_E4M3)"),
-        Float8E4M3x2Type => format!("__nv_cvt_halfraw2_to_fp8x2({in_val}, __NV_NOSAT, __NV_E4M3)"),
-        Float8E5M2Type => format!("__nv_cvt_halfraw_to_fp8({in_val}, __NV_NOSAT, __NV_E5M2)"),
-        Float8E5M2x2Type => format!("__nv_cvt_halfraw2_to_fp8x2({in_val}, __NV_NOSAT, __NV_E5M2)"),
+        Float8E4M3Type => format!("__nv_cvt_{}_to_fp8({in_val}, __NV_SATFINITE, __NV_E4M3)", fp8_source()),
+        Float8E4M3x2Type => format!("__nv_cvt_{}_to_fp8x2({in_val}, __NV_SATFINITE, __NV_E4M3)", fp8_source()),
+        Float8E5M2Type => format!("__nv_cvt_{}_to_fp8({in_val}, __NV_SATFINITE, __NV_E5M2)", fp8_source()),
+        Float8E5M2x2Type => format!("__nv_cvt_{}_to_fp8x2({in_val}, __NV_SATFINITE, __NV_E5M2)", fp8_source()),
         Float6E2M3Type => format!("__nv_cvt_halfraw_to_fp6({in_val}, __NV_E2M3, cudaRoundNearest)"),
         Float6E2M3x2Type => format!("__nv_cvt_halfraw2_to_fp6x2({in_val}, __NV_E2M3, cudaRoundNearest)"),
         Float6E3M2Type => format!("__nv_cvt_halfraw_to_fp6({in_val}, __NV_E3M2, cudaRoundNearest)"),
@@ -147,5 +185,19 @@ fn cast_half_to_minifloat(ctx: &Context, input: Value, out_ty: TypeHandle) -> St
         Float4E2M1Type => format!("__nv_cvt_halfraw_to_fp4({in_val}, __NV_E2M1, cudaRoundNearest)"),
         Float4E2M1x2Type => format!("__nv_cvt_halfraw2_to_fp4x2({in_val}, __NV_E2M1, cudaRoundNearest)"),;
         _ => panic!("Unsupported type {}", out_ty.deref(ctx).display(ctx))
+    })
+}
+
+/// The `__nv_cvt_<source>_to_fp8` / `_to_fp8x2` variant for a float source or a packed pair.
+fn fp8_source_prefix(ctx: &Context, input: Value) -> &'static str {
+    let scalar = input.get_type(ctx).scalar_ty(ctx);
+    match_ty!((scalar.deref(ctx)) {
+        Float16Type => "halfraw",
+        Float16x2Type => "halfraw2",
+        BFloat16Type => "bfloat16raw",
+        BFloat16x2Type => "bfloat16raw2",
+        Float32Type => "float",
+        Float64Type => "double",;
+        _ => panic!("fp8 converts from a float source, got {}", scalar.deref(ctx).display(ctx))
     })
 }

--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -82,11 +82,7 @@ impl LowerOp<Cuda> for CastOp {
     }
 }
 
-/// Whether `input` converts into `out_ty` with one `__nv_cvt_*` call and no intermediate.
-///
-/// fp8 has an intrinsic from every float width, and has to use it: routing f32 through f16 first
-/// rounds twice, and a value one f32 ulp past an f16 tie then lands on the wrong fp8 code. Wide
-/// sources are fine, f16/bf16 pairs pack into the `x2` converters and the rest unroll to scalars.
+/// fp8 must convert straight from its source: an f16 detour rounds twice.
 fn encodes_directly(ctx: &Context, input: Value, out_ty: TypeHandle) -> bool {
     if !out_ty.is_float8(ctx) {
         return intermediate_for_ty(ctx, out_ty) == input.get_type(ctx);
@@ -163,10 +159,7 @@ fn cast_minifloat_to_half(ctx: &Context, input: Value) -> String {
 
 // Cast to minifloat from half/bf16 (fp8 also from float/double). Could be made more generic, but
 // a simple mapping is easier to understand. The naming is very inconsistent (i.e. halfraw2 vs
-// bf162raw).
-//
-// fp8 saturates: `__NV_SATFINITE` is what the codecs and every other backend do on overflow, and
-// the only mode with a hardware instruction; `__NV_NOSAT` is the header's software path even on
+// bf162raw). fp8 saturates like the codecs; `__NV_NOSAT` is the header's software path even on
 // sm_89.
 fn cast_half_to_minifloat(ctx: &Context, input: Value, out_ty: TypeHandle) -> String {
     let in_val = input.name(ctx);
@@ -188,7 +181,6 @@ fn cast_half_to_minifloat(ctx: &Context, input: Value, out_ty: TypeHandle) -> St
     })
 }
 
-/// The `__nv_cvt_<source>_to_fp8` / `_to_fp8x2` variant for a float source or a packed pair.
 fn fp8_source_prefix(ctx: &Context, input: Value) -> &'static str {
     let scalar = input.get_type(ctx).scalar_ty(ctx);
     match_ty!((scalar.deref(ctx)) {

--- a/crates/cubecl-cpp/src/hip/ty.rs
+++ b/crates/cubecl-cpp/src/hip/ty.rs
@@ -4,7 +4,7 @@ use cubecl_core::{
         prelude::*,
         types::{
             PointerType,
-            scalar::{BFloat16Type, Float16Type},
+            scalar::{BFloat16Type, Float8E4M3Type, Float8E5M2Type, Float16Type},
         },
     },
 };
@@ -31,6 +31,9 @@ pub(super) use hip_ty;
 
 hip_ty!(Float16Type, |_, _| "__half".into());
 hip_ty!(BFloat16Type, |_, _| "__hip_bfloat16".into());
+// fp8 converts through the software polyfill, so its storage is the bare byte.
+hip_ty!(Float8E4M3Type, |_, _| "uint8_t".into());
+hip_ty!(Float8E5M2Type, |_, _| "uint8_t".into());
 
 hip_ty!(PointerType, |ty, ctx| format!(
     "{} {}*",

--- a/crates/cubecl-cpp/src/hip/ty.rs
+++ b/crates/cubecl-cpp/src/hip/ty.rs
@@ -31,7 +31,6 @@ pub(super) use hip_ty;
 
 hip_ty!(Float16Type, |_, _| "__half".into());
 hip_ty!(BFloat16Type, |_, _| "__hip_bfloat16".into());
-// fp8 converts through the software polyfill, so its storage is the bare byte.
 hip_ty!(Float8E4M3Type, |_, _| "uint8_t".into());
 hip_ty!(Float8E5M2Type, |_, _| "uint8_t".into());
 

--- a/crates/cubecl-cpp/src/lib.rs
+++ b/crates/cubecl-cpp/src/lib.rs
@@ -20,3 +20,6 @@ pub mod target;
 
 #[cfg(feature = "metal")]
 pub type MslCompiler = shared::CppCompiler<target::Metal>;
+
+#[cfg(test)]
+mod tests;

--- a/crates/cubecl-cpp/src/metal/ty.rs
+++ b/crates/cubecl-cpp/src/metal/ty.rs
@@ -3,7 +3,7 @@ use cubecl_core::ir::{
     prelude::*,
     types::{
         AtomicType, PointerType,
-        scalar::{BFloat16Type, Float16Type},
+        scalar::{BFloat16Type, Float8E4M3Type, Float8E5M2Type, Float16Type},
     },
 };
 
@@ -26,6 +26,9 @@ pub(super) use metal_ty;
 
 metal_ty!(Float16Type, |_, _| "half".into());
 metal_ty!(BFloat16Type, |_, _| "bfloat".into());
+// fp8 converts through the software polyfill, so its storage is the bare byte.
+metal_ty!(Float8E4M3Type, |_, _| "uint8_t".into());
+metal_ty!(Float8E5M2Type, |_, _| "uint8_t".into());
 
 metal_ty!(PointerType, |ty, ctx| format!(
     "{} {} {}*",

--- a/crates/cubecl-cpp/src/metal/ty.rs
+++ b/crates/cubecl-cpp/src/metal/ty.rs
@@ -26,7 +26,6 @@ pub(super) use metal_ty;
 
 metal_ty!(Float16Type, |_, _| "half".into());
 metal_ty!(BFloat16Type, |_, _| "bfloat".into());
-// fp8 converts through the software polyfill, so its storage is the bare byte.
 metal_ty!(Float8E4M3Type, |_, _| "uint8_t".into());
 metal_ty!(Float8E5M2Type, |_, _| "uint8_t".into());
 

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -28,6 +28,7 @@ use cubecl_core::{
     post_processing::{
         bitwise::PromoteBitwisePass,
         checked_io::{CheckedIo, CheckedIoPass},
+        minifloat::{LowerMinifloatCast, LowerMinifloatCastPass, NativeFp8},
         saturating::LowerSaturatingArithmeticPass,
     },
     prelude::KernelDefinition,
@@ -204,6 +205,15 @@ where
         )));
         func_passes.add_pass(AllocateSharedMemoryBlockPass);
 
+        // CUDA converts fp8 with cuda_fp8.h, which carries its own software path below sm_89.
+        let native_fp8 = match T::target() {
+            Target::Cuda => NativeFp8::ALL,
+            Target::Hip | Target::Metal => NativeFp8::NONE,
+        };
+        func_passes.add_pass(LowerMinifloatCastPass::new(LowerMinifloatCast::new(
+            native_fp8,
+        )));
+
         // Shared lowerings can create ops that need target-specific lowerings, but target-specific
         // lowerings should take priority. So we just run the target-specific lowerings twice.
         func_passes.add_pass(LowerOpsCppPass::<T>::default());
@@ -313,6 +323,14 @@ pub fn register_supported_types(props: &mut DeviceProperties) {
 
     for ty in supported_types {
         props.register_type_usage(ty, TypeUsage::all());
+    }
+
+    // Converted natively or in software, never computed on: everything casts to compute.
+    for ty in [FloatKind::E4M3, FloatKind::E5M2] {
+        props.register_type_usage(
+            ElemType::Float(ty),
+            TypeUsage::Conversion | TypeUsage::Buffer,
+        );
     }
 
     for ty in supported_atomic_types {

--- a/crates/cubecl-cpp/src/shared/base.rs
+++ b/crates/cubecl-cpp/src/shared/base.rs
@@ -325,7 +325,6 @@ pub fn register_supported_types(props: &mut DeviceProperties) {
         props.register_type_usage(ty, TypeUsage::all());
     }
 
-    // Converted natively or in software, never computed on: everything casts to compute.
     for ty in [FloatKind::E4M3, FloatKind::E5M2] {
         props.register_type_usage(
             ElemType::Float(ty),

--- a/crates/cubecl-cpp/src/tests/mod.rs
+++ b/crates/cubecl-cpp/src/tests/mod.rs
@@ -50,7 +50,14 @@ fn cuda_converts_fp8_with_the_header_intrinsics() {
     let source = fp8_round_trip_source::<Cuda>();
     assert!(source.contains("cuda_fp8.h"), "{source}");
     assert!(source.contains("__nv_cvt_fp8_to_halfraw"), "{source}");
-    assert!(source.contains("__nv_cvt_halfraw_to_fp8"), "{source}");
+    // Straight from f32 and saturating: the f16 detour rounds twice and NOSAT is the header's
+    // software path.
+    assert!(
+        source.contains("__nv_cvt_float_to_fp8(") && source.contains("__NV_SATFINITE"),
+        "{source}"
+    );
+    assert!(!source.contains("__NV_NOSAT"), "{source}");
+    assert!(!source.contains("__nv_cvt_halfraw_to_fp8"), "{source}");
 }
 
 #[test]

--- a/crates/cubecl-cpp/src/tests/mod.rs
+++ b/crates/cubecl-cpp/src/tests/mod.rs
@@ -1,0 +1,75 @@
+//! Codegen assertions on the generated C++ text: which fp8 path each dialect emits, without a
+//! device. The IR is expanded through the CPU runtime's client and printed by each dialect.
+
+use cubecl_common::e4m3;
+use cubecl_core::{self as cubecl, ir::settings::Dim3, prelude::*};
+use cubecl_cpu::CpuRuntime;
+use cubecl_runtime::{
+    compiler::{Compiler, CubeTask},
+    kernel::KernelTask,
+};
+
+use crate::{
+    shared::{CompilationOptions, CppCompiler},
+    target::{CppTarget, Cuda, Hip},
+};
+
+#[cube(launch_unchecked)]
+fn fp8_round_trip(input: &[e4m3], output: &mut [e4m3]) {
+    let value = f32::cast_from(input[ABSOLUTE_POS]);
+    output[ABSOLUTE_POS] = e4m3::cast_from(value * 2.0);
+}
+
+/// The C++ a target's dialect prints for [`fp8_round_trip`].
+fn fp8_round_trip_source<T: CppTarget>() -> String
+where
+    CppCompiler<T>: Compiler<CompilationOptions = CompilationOptions>,
+{
+    let client = CpuRuntime::client(&Default::default());
+    let settings =
+        KernelSettings::new(Dim3::new_single(), ExecutionMode::Checked, AddressType::U32);
+    let kernel = fp8_round_trip::Fp8RoundTrip::<CpuRuntime>::new(
+        settings,
+        client,
+        BufferCompilationArg { inplace: None },
+        BufferCompilationArg { inplace: None },
+    );
+    let task = KernelTask::<CppCompiler<T>, _>::new(kernel);
+    let definition = task.define();
+    task.compile(
+        definition,
+        &mut CppCompiler::<T>::default(),
+        &CompilationOptions::default(),
+    )
+    .expect("fp8 kernel compiles")
+    .source
+}
+
+#[test]
+fn cuda_converts_fp8_with_the_header_intrinsics() {
+    let source = fp8_round_trip_source::<Cuda>();
+    assert!(source.contains("cuda_fp8.h"), "{source}");
+    assert!(source.contains("__nv_cvt_fp8_to_halfraw"), "{source}");
+    assert!(source.contains("__nv_cvt_halfraw_to_fp8"), "{source}");
+}
+
+#[test]
+fn hip_converts_fp8_in_software_on_bytes() {
+    let source = fp8_round_trip_source::<Hip>();
+    assert_software_fp8(&source);
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn metal_converts_fp8_in_software_on_bytes() {
+    let source = fp8_round_trip_source::<crate::target::Metal>();
+    assert_software_fp8(&source);
+}
+
+/// The fp8 buffers are plain bytes and no vendor conversion intrinsic or header is named.
+fn assert_software_fp8(source: &str) {
+    assert!(source.contains("uint8_t const*"), "{source}");
+    for vendor in ["__nv_", "cuda_fp8", "__hip_fp8", "hip_fp8"] {
+        assert!(!source.contains(vendor), "{vendor}: {source}");
+    }
+}

--- a/crates/cubecl-cpp/src/tests/mod.rs
+++ b/crates/cubecl-cpp/src/tests/mod.rs
@@ -1,5 +1,4 @@
-//! Codegen assertions on the generated C++ text: which fp8 path each dialect emits, without a
-//! device. The IR is expanded through the CPU runtime's client and printed by each dialect.
+//! The IR is expanded through the CPU runtime's client, so no device is involved.
 
 use cubecl_common::e4m3;
 use cubecl_core::{self as cubecl, ir::settings::Dim3, prelude::*};
@@ -20,7 +19,6 @@ fn fp8_round_trip(input: &[e4m3], output: &mut [e4m3]) {
     output[ABSOLUTE_POS] = e4m3::cast_from(value * 2.0);
 }
 
-/// The C++ a target's dialect prints for [`fp8_round_trip`].
 fn fp8_round_trip_source<T: CppTarget>() -> String
 where
     CppCompiler<T>: Compiler<CompilationOptions = CompilationOptions>,
@@ -50,8 +48,6 @@ fn cuda_converts_fp8_with_the_header_intrinsics() {
     let source = fp8_round_trip_source::<Cuda>();
     assert!(source.contains("cuda_fp8.h"), "{source}");
     assert!(source.contains("__nv_cvt_fp8_to_halfraw"), "{source}");
-    // Straight from f32 and saturating: the f16 detour rounds twice and NOSAT is the header's
-    // software path.
     assert!(
         source.contains("__nv_cvt_float_to_fp8(") && source.contains("__NV_SATFINITE"),
         "{source}"
@@ -73,7 +69,6 @@ fn metal_converts_fp8_in_software_on_bytes() {
     assert_software_fp8(&source);
 }
 
-/// The fp8 buffers are plain bytes and no vendor conversion intrinsic or header is named.
 fn assert_software_fp8(source: &str) {
     assert!(source.contains("uint8_t const*"), "{source}");
     for vendor in ["__nv_", "cuda_fp8", "__hip_fp8", "hip_fp8"] {

--- a/crates/cubecl-cpu/src/compiler/mod.rs
+++ b/crates/cubecl-cpu/src/compiler/mod.rs
@@ -18,8 +18,12 @@ use cubecl_opt::passes::{simple_cse::SimpleCSEPass, sroa::SROAPass};
 use cubecl_runtime::compiler::CompilationError;
 
 use cubecl_core::{
-    Compiler, ir::dialect::scf::BranchToSCFPass, ir::rewrite::SimplifyOpsPass,
-    post_processing::bitwise::PromoteBitwisePass, prelude::*,
+    Compiler,
+    ir::dialect::scf::BranchToSCFPass,
+    ir::rewrite::SimplifyOpsPass,
+    post_processing::bitwise::PromoteBitwisePass,
+    post_processing::minifloat::{LowerMinifloatCast, LowerMinifloatCastPass, NativeFp8},
+    prelude::*,
 };
 use pliron::{
     builtin::ops::{FuncOp, ModuleOp},
@@ -114,6 +118,9 @@ impl PlironCompiler {
         func_passes.add_pass(SimpleCSEPass);
         func_passes.add_pass(SimplifyOpsPass::default());
         func_passes.add_pass(PromoteBitwisePass);
+        func_passes.add_pass(LowerMinifloatCastPass::new(LowerMinifloatCast::new(
+            NativeFp8::NONE,
+        )));
         func_passes.add_pass(LowerComplexOpPass::default());
         func_passes.add_pass(DCEPass);
         func_passes.add_pass(SROAPass);

--- a/crates/cubecl-cpu/src/compiler/to_llvm/ty.rs
+++ b/crates/cubecl-cpu/src/compiler/to_llvm/ty.rs
@@ -28,7 +28,6 @@ impl_cube_to_llvm_type!(Float64Type, self, ctx => FP64Type::get(ctx));
 impl_cube_to_llvm_type!(Float32Type, self, ctx => FP32Type::get(ctx));
 impl_cube_to_llvm_type!(FloatFlex32Type, self, ctx => FP32Type::get(ctx));
 impl_cube_to_llvm_type!(Float16Type, self, ctx => FP16Type::get(ctx));
-// LLVM has no fp8 types; the bytes are stored as-is and every conversion is lowered before this.
 impl_cube_to_llvm_type!(Float8E4M3Type, self, ctx => IntegerType::get(ctx, 8, Signedness::Signless));
 impl_cube_to_llvm_type!(Float8E5M2Type, self, ctx => IntegerType::get(ctx, 8, Signedness::Signless));
 impl_cube_to_llvm_type!(CubePointerType, self, ctx => LlvmPointerType::get(ctx, 0));

--- a/crates/cubecl-cpu/src/compiler/to_llvm/ty.rs
+++ b/crates/cubecl-cpu/src/compiler/to_llvm/ty.rs
@@ -1,7 +1,9 @@
 use super::prelude::*;
 use cubecl_core::ir::types::{
     ArrayType, AtomicType,
-    scalar::{Float16Type, Float32Type, Float64Type, FloatFlex32Type},
+    scalar::{
+        Float8E4M3Type, Float8E5M2Type, Float16Type, Float32Type, Float64Type, FloatFlex32Type,
+    },
 };
 use pliron::printable::Printable;
 
@@ -26,6 +28,9 @@ impl_cube_to_llvm_type!(Float64Type, self, ctx => FP64Type::get(ctx));
 impl_cube_to_llvm_type!(Float32Type, self, ctx => FP32Type::get(ctx));
 impl_cube_to_llvm_type!(FloatFlex32Type, self, ctx => FP32Type::get(ctx));
 impl_cube_to_llvm_type!(Float16Type, self, ctx => FP16Type::get(ctx));
+// LLVM has no fp8 types; the bytes are stored as-is and every conversion is lowered before this.
+impl_cube_to_llvm_type!(Float8E4M3Type, self, ctx => IntegerType::get(ctx, 8, Signedness::Signless));
+impl_cube_to_llvm_type!(Float8E5M2Type, self, ctx => IntegerType::get(ctx, 8, Signedness::Signless));
 impl_cube_to_llvm_type!(CubePointerType, self, ctx => LlvmPointerType::get(ctx, 0));
 impl_cube_to_llvm_type!(CubeVectorType, self, ctx => LlvmVectorType::get(ctx, cube_type_to_llvm(ctx, self.inner), self.vectorization as u32, VectorTypeKind::Fixed));
 impl_cube_to_llvm_type!(AtomicType, self, ctx => cube_type_to_llvm(ctx, self.inner));

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -67,6 +67,14 @@ fn register_supported_types(props: &mut DeviceProperties) {
         props.register_type_usage(ty, TypeUsage::all());
     }
 
+    // Converted in software, so no arithmetic; every value goes through a cast to compute.
+    for ty in [FloatKind::E4M3, FloatKind::E5M2] {
+        props.register_type_usage(
+            ElemType::Float(ty),
+            TypeUsage::Conversion | TypeUsage::Buffer,
+        );
+    }
+
     for ty in supported_atomic_types {
         props.register_atomic_type_usage(Type::atomic(ty), AtomicUsage::all());
     }

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -67,7 +67,6 @@ fn register_supported_types(props: &mut DeviceProperties) {
         props.register_type_usage(ty, TypeUsage::all());
     }
 
-    // Converted in software, so no arithmetic; every value goes through a cast to compute.
     for ty in [FloatKind::E4M3, FloatKind::E5M2] {
         props.register_type_usage(
             ElemType::Float(ty),

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -230,16 +230,6 @@ impl DeviceService for CudaServer {
             device_props.features.copy_async = true;
         }
 
-        if arch_version >= 89 {
-            device_props.register_type_usage(
-                ElemType::Float(FloatKind::E4M3),
-                TypeUsage::Conversion | TypeUsage::Buffer,
-            );
-            device_props.register_type_usage(
-                ElemType::Float(FloatKind::E5M2),
-                TypeUsage::Conversion | TypeUsage::Buffer,
-            );
-        }
         if arch_version >= 90 {
             device_props.features.tma.insert(Tma::Base);
             device_props.register_opaque_type(OpaqueType::TensorMap);

--- a/crates/cubecl-metal/src/runtime.rs
+++ b/crates/cubecl-metal/src/runtime.rs
@@ -223,7 +223,6 @@ fn register_types(props: &mut DeviceProperties) {
     for ty in types {
         props.register_type_usage(ty, TypeUsage::all());
     }
-    // Converted through cubecl's software polyfill, never computed on.
     for ty in [FloatKind::E4M3, FloatKind::E5M2] {
         props.register_type_usage(
             ElemType::Float(ty),

--- a/crates/cubecl-metal/src/runtime.rs
+++ b/crates/cubecl-metal/src/runtime.rs
@@ -223,6 +223,13 @@ fn register_types(props: &mut DeviceProperties) {
     for ty in types {
         props.register_type_usage(ty, TypeUsage::all());
     }
+    // Converted through cubecl's software polyfill, never computed on.
+    for ty in [FloatKind::E4M3, FloatKind::E5M2] {
+        props.register_type_usage(
+            ElemType::Float(ty),
+            TypeUsage::Conversion | TypeUsage::Buffer,
+        );
+    }
 
     // Metal natively supports the full integer atomic set; float atomics are
     // limited to add + load/store (no native float min/max).

--- a/crates/cubecl-spirv/Cargo.toml
+++ b/crates/cubecl-spirv/Cargo.toml
@@ -65,3 +65,7 @@ cubecl-opt = { path = "../cubecl-opt", version = "=0.11.0-pre.2" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 pliron = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+# The CPU runtime lends a client to expand kernels for codegen tests; nothing runs on it.
+cubecl-cpu = { path = "../cubecl-cpu", version = "=0.11.0-pre.2" }

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -15,6 +15,7 @@ use cubecl_core::{
     post_processing::{
         bitwise::PromoteBitwisePass,
         checked_io::{CheckedIo, CheckedIoPass},
+        minifloat::{LowerMinifloatCast, LowerMinifloatCastPass, NativeFp8},
         saturating::LowerSaturatingArithmeticPass,
         unroll::UnrollPass,
     },
@@ -193,6 +194,12 @@ impl SpirvCompiler {
         func_passes.add_pass(UnrollPass::new(comp_opts.vulkan.max_vector_size));
         func_passes.add_pass(AllocateSharedMemoryBlockPass);
         func_passes.add_pass(LowerSaturatingArithmeticPass::default());
+        func_passes.add_pass(LowerMinifloatCastPass::new(LowerMinifloatCast::new(
+            match comp_opts.vulkan.supports_float8 {
+                true => NativeFp8::ALL,
+                false => NativeFp8::NONE,
+            },
+        )));
         func_passes.add_pass(BranchToSCFPass::default());
 
         passes.add_pass(NestedOpsPass::new(func_passes));

--- a/crates/cubecl-spirv/src/lib.rs
+++ b/crates/cubecl-spirv/src/lib.rs
@@ -62,3 +62,6 @@ impl Display for SpirvKernel {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/cubecl-spirv/src/ops/convert.rs
+++ b/crates/cubecl-spirv/src/ops/convert.rs
@@ -6,7 +6,7 @@ use cubecl_core::{
 };
 use cubecl_ir::{Scope, dialect::general::CastOp, interfaces::TypedExt, prelude::*};
 use pliron::printable::Printable;
-use pliron_spirv::{ops::*, types::FloatType};
+use pliron_spirv::{decorations::DecoratableOp, ops::*, types::FloatType};
 
 use crate::{lower::LowerOp, ops::to_spirv_dialect::ToSpirvDialectOp, types::ty_to_spirv_dialect};
 
@@ -78,6 +78,11 @@ pub(crate) fn cast(
         rewriter.append_op_with_result(ctx, &conv)
     } else if in_float && out_float {
         let conv = FConvertOp::new(ctx, out_ty, from);
+        // Native fp8 otherwise sends overflow to NaN (e4m3) or inf (e5m2); the codecs and every
+        // other backend clip to the largest finite value.
+        if Fp8Format::of_type(ctx, to_ty).is_some() {
+            conv.set_decoration_saturated_to_largest_float8_normal_conversion_ext(ctx);
+        }
         rewriter.append_op_with_result(ctx, &conv)
     } else {
         panic!(

--- a/crates/cubecl-spirv/src/ops/convert.rs
+++ b/crates/cubecl-spirv/src/ops/convert.rs
@@ -1,6 +1,7 @@
 use cubecl_core::{
     self as cubecl, define_scalar, define_size,
     num_traits::{One, Zero},
+    post_processing::minifloat::Fp8Format,
     prelude::*,
 };
 use cubecl_ir::{Scope, dialect::general::CastOp, interfaces::TypedExt, prelude::*};
@@ -45,10 +46,15 @@ pub(crate) fn cast(
 
     let in_float = in_ty_spirv.deref(ctx).is::<FloatType>();
     let in_sint = in_ty.is_signed_int(ctx);
-    let in_uint = in_ty.is_unsigned_int(ctx) || in_ty.is_index(ctx);
+    // fp8 without a SPIR-V float type is emulated: the value is its byte, zero extended.
+    let in_uint = in_ty.is_unsigned_int(ctx)
+        || in_ty.is_index(ctx)
+        || (!in_float && Fp8Format::of_type(ctx, in_ty).is_some());
     let out_float = to_ty_spirv.deref(ctx).is::<FloatType>();
     let out_sint = to_ty.is_signed_int(ctx);
-    let out_uint = to_ty.is_unsigned_int(ctx) || to_ty.is_index(ctx);
+    let out_uint = to_ty.is_unsigned_int(ctx)
+        || to_ty.is_index(ctx)
+        || (!out_float && Fp8Format::of_type(ctx, to_ty).is_some());
 
     if in_ty_spirv == to_ty_spirv {
         from

--- a/crates/cubecl-spirv/src/ops/general.rs
+++ b/crates/cubecl-spirv/src/ops/general.rs
@@ -29,7 +29,32 @@ use crate::{
 binop_to_spirv_dialect!(general::BoolAndOp => ops::LogicalAndOp);
 binop_to_spirv_dialect!(general::BoolOrOp => ops::LogicalOrOp);
 unop_to_spirv_dialect!(general::BoolNotOp => ops::LogicalNotOp);
-unop_to_spirv_dialect!(general::ReinterpretCastOp => ops::BitcastOp);
+#[op_interface_impl]
+impl ToSpirvDialectOp for general::ReinterpretCastOp {
+    fn to_spirv_dialect(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        let op = self.get_operation();
+        let input = op.operand(ctx, 0);
+        let from_ty = operands_info
+            .lookup_most_recent_type(input)
+            .unwrap_or_else(|| input.get_type(ctx));
+        let out_ty = ty_to_spirv_dialect(ctx, self.get_result(ctx).get_type(ctx));
+        // Two cube types can share one SPIR-V type (emulated fp8 is a byte), and a bitcast to
+        // the same type is invalid SPIR-V.
+        if ty_to_spirv_dialect(ctx, from_ty) == out_ty {
+            rewriter.replace_operation_with_values(ctx, op, vec![input]);
+        } else {
+            let new_op = ops::BitcastOp::new(ctx, out_ty, input);
+            rewriter.append_op(ctx, &new_op);
+            rewriter.replace_operation(ctx, op, new_op.get_operation());
+        }
+        Ok(())
+    }
+}
 
 #[op_interface_impl]
 impl ToSpirvDialectOp for general::SelectOp {

--- a/crates/cubecl-spirv/src/ops/general.rs
+++ b/crates/cubecl-spirv/src/ops/general.rs
@@ -43,8 +43,7 @@ impl ToSpirvDialectOp for general::ReinterpretCastOp {
             .lookup_most_recent_type(input)
             .unwrap_or_else(|| input.get_type(ctx));
         let out_ty = ty_to_spirv_dialect(ctx, self.get_result(ctx).get_type(ctx));
-        // Two cube types can share one SPIR-V type (emulated fp8 is a byte), and a bitcast to
-        // the same type is invalid SPIR-V.
+        // Emulated fp8 and u8 share one SPIR-V type, and a same-type bitcast is invalid.
         if ty_to_spirv_dialect(ctx, from_ty) == out_ty {
             rewriter.replace_operation_with_values(ctx, op, vec![input]);
         } else {

--- a/crates/cubecl-spirv/src/tests.rs
+++ b/crates/cubecl-spirv/src/tests.rs
@@ -1,0 +1,69 @@
+//! Codegen assertions on the SPIR-V text for both fp8 states of a driver, without a device. The
+//! IR is expanded through the CPU runtime's client and compiled with the option set by hand.
+
+use cubecl_common::e4m3;
+use cubecl_core::{
+    self as cubecl, VulkanCompilationOptions, WgpuCompilationOptions, ir::settings::Dim3,
+    prelude::*,
+};
+use cubecl_cpu::CpuRuntime;
+use cubecl_runtime::{compiler::CubeTask, kernel::KernelTask};
+
+use crate::SpirvCompiler;
+
+#[cube(launch_unchecked)]
+fn fp8_round_trip(input: &[e4m3], output: &mut [e4m3]) {
+    let value = f32::cast_from(input[ABSOLUTE_POS]);
+    output[ABSOLUTE_POS] = e4m3::cast_from(value * 2.0);
+}
+
+/// The disassembled SPIR-V of [`fp8_round_trip`] for a driver with or without fp8.
+fn fp8_round_trip_spirv(supports_float8: bool) -> String {
+    let client = CpuRuntime::client(&Default::default());
+    let settings =
+        KernelSettings::new(Dim3::new_single(), ExecutionMode::Checked, AddressType::U32);
+    let kernel = fp8_round_trip::Fp8RoundTrip::<CpuRuntime>::new(
+        settings,
+        client,
+        BufferCompilationArg { inplace: None },
+        BufferCompilationArg { inplace: None },
+    );
+    let options = WgpuCompilationOptions {
+        supports_vulkan_compiler: true,
+        vulkan: VulkanCompilationOptions {
+            supports_float8,
+            max_spirv_version: (1, 6),
+            max_vector_size: 4,
+            push_constant_size: 128,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let task = KernelTask::<SpirvCompiler, _>::new(kernel);
+    let definition = task.define();
+    task.compile(definition, &mut SpirvCompiler, &options)
+        .expect("fp8 kernel compiles")
+        .repr
+        .expect("compiled SPIR-V")
+        .to_string()
+}
+
+#[test]
+fn with_the_extension_fp8_is_a_float_and_encoding_saturates() {
+    let spirv = fp8_round_trip_spirv(true);
+    assert!(spirv.contains("OpCapability Float8EXT"), "{spirv}");
+    assert!(spirv.contains("OpTypeFloat 8"), "{spirv}");
+    assert!(spirv.contains("OpFConvert"), "{spirv}");
+    assert!(
+        spirv.contains("SaturatedToLargestFloat8NormalConversionEXT"),
+        "{spirv}"
+    );
+}
+
+#[test]
+fn without_the_extension_fp8_is_a_byte_and_no_float8_is_named() {
+    let spirv = fp8_round_trip_spirv(false);
+    assert!(!spirv.contains("Float8"), "{spirv}");
+    assert!(spirv.contains("OpTypeInt 8"), "{spirv}");
+    assert!(!spirv.contains("OpFConvert"), "{spirv}");
+}

--- a/crates/cubecl-spirv/src/tests.rs
+++ b/crates/cubecl-spirv/src/tests.rs
@@ -1,5 +1,4 @@
-//! Codegen assertions on the SPIR-V text for both fp8 states of a driver, without a device. The
-//! IR is expanded through the CPU runtime's client and compiled with the option set by hand.
+//! The IR is expanded through the CPU runtime's client, so no device is involved.
 
 use cubecl_common::e4m3;
 use cubecl_core::{
@@ -17,7 +16,6 @@ fn fp8_round_trip(input: &[e4m3], output: &mut [e4m3]) {
     output[ABSOLUTE_POS] = e4m3::cast_from(value * 2.0);
 }
 
-/// The disassembled SPIR-V of [`fp8_round_trip`] for a driver with or without fp8.
 fn fp8_round_trip_spirv(supports_float8: bool) -> String {
     let client = CpuRuntime::client(&Default::default());
     let settings =

--- a/crates/cubecl-spirv/src/types.rs
+++ b/crates/cubecl-spirv/src/types.rs
@@ -75,8 +75,6 @@ float_type!(FloatFlex32Type, 32, None);
 float_type!(Float16Type, 16, None);
 float_type!(BFloat16Type, 16, Some(FPEncoding::BFloat16KHR));
 
-/// Without `VK_EXT_shader_float8` an fp8 value is its byte: `OpTypeFloat 8` would be rejected,
-/// and every conversion has already been lowered to integer arithmetic on that byte.
 macro_rules! fp8_type {
     ($ty: ty, $encoding: expr) => {
         #[type_interface_impl]

--- a/crates/cubecl-spirv/src/types.rs
+++ b/crates/cubecl-spirv/src/types.rs
@@ -1,4 +1,4 @@
-use cubecl_core::cmma::MatrixType;
+use cubecl_core::{WgpuCompilationOptions, cmma::MatrixType};
 use cubecl_ir::{
     AddressSpace, ContextExt,
     interfaces::TypedExt,
@@ -74,8 +74,30 @@ float_type!(Float32Type, 32, None);
 float_type!(FloatFlex32Type, 32, None);
 float_type!(Float16Type, 16, None);
 float_type!(BFloat16Type, 16, Some(FPEncoding::BFloat16KHR));
-float_type!(Float8E4M3Type, 8, Some(FPEncoding::Float8E4M3EXT));
-float_type!(Float8E5M2Type, 8, Some(FPEncoding::Float8E5M2EXT));
+
+/// Without `VK_EXT_shader_float8` an fp8 value is its byte: `OpTypeFloat 8` would be rejected,
+/// and every conversion has already been lowered to integer arithmetic on that byte.
+macro_rules! fp8_type {
+    ($ty: ty, $encoding: expr) => {
+        #[type_interface_impl]
+        impl ToSpirvDialectType for $ty {
+            fn to_spirv_ty(&self, ctx: &Context) -> TypeHandle {
+                if ctx
+                    .aux_ty::<WgpuCompilationOptions>()
+                    .vulkan
+                    .supports_float8
+                {
+                    FloatType::get(ctx, 8, Some($encoding)).to_handle()
+                } else {
+                    IntegerType::get(ctx, 8, Signedness::Signless).to_handle()
+                }
+            }
+        }
+    };
+}
+
+fp8_type!(Float8E4M3Type, FPEncoding::Float8E4M3EXT);
+fp8_type!(Float8E5M2Type, FPEncoding::Float8E5M2EXT);
 float_type!(Float8E8M0Type, 8, Some(FPEncoding::Float8UnsignedE8M0EXT));
 float_type!(Float6E3M2Type, 6, Some(FPEncoding::Float6E3M2EXT));
 float_type!(Float6E2M3Type, 6, Some(FPEncoding::Float6E2M3EXT));

--- a/crates/cubecl-std/src/tests/view/quantized.rs
+++ b/crates/cubecl-std/src/tests/view/quantized.rs
@@ -1,9 +1,9 @@
 use cubecl::prelude::*;
 use cubecl_common::{
-    e2m1, e2m1x2,
+    e2m1, e2m1x2, e4m3,
     quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantValue},
 };
-use cubecl_core::{self as cubecl};
+use cubecl_core::{self as cubecl, ir::features::TypeUsage};
 use half::f16;
 
 use crate::tensor::{
@@ -265,6 +265,74 @@ pub fn test_quantized_two_level_int<R: Runtime, F: Float + CubeElement>(client: 
     }
 }
 
+/// Two levels with the block scales stored as e4m3, the layout the second level exists for. Runs
+/// natively or through cubecl's software fp8 conversion, whichever the runtime has.
+pub fn test_quantized_two_level_ue4m3<R: Runtime, F: Float + CubeElement>(
+    client: ComputeClient<R>,
+) {
+    let usage = client.properties().type_usage(e4m3::elem_type_native());
+    if !usage.is_superset(TypeUsage::Conversion | TypeUsage::Buffer) {
+        return;
+    }
+    let vector_size_float = 8;
+    let block = 8;
+
+    let scheme = QuantScheme::default()
+        .with_value(QuantValue::Q4F)
+        .with_param(QuantParam::UE4M3)
+        .with_level(QuantLevel::block_tensor([block as u8], QuantParam::F32));
+
+    // Powers of two and short mantissas, so every product is exact in f16 too.
+    let global_scale = 2f32.powi(-3);
+    let block_scales = [e4m3::from_f32(1.5), e4m3::from_f32(0.1171875)];
+    assert_eq!(block_scales.map(|s| s.to_f32()), [1.5, 0.1171875]);
+    let expected = (0..16)
+        .map(|i| F::new(global_scale * block_scales[i / block].to_f32() * (i as f32 - 8.0)))
+        .collect::<Vec<_>>();
+
+    let values = client.create_from_slice(u32::as_bytes(&[0xFEDCBA98, 0x76543210]));
+    let scales = client.create_from_slice(&block_scales.map(|s| s.to_bits()));
+    let global = client.create_from_slice(f32::as_bytes(&[global_scale]));
+
+    for mode in [
+        ReadMode::Read,
+        ReadMode::Checked,
+        ReadMode::Masked,
+        ReadMode::Unchecked,
+    ] {
+        let output = client.empty(16 * size_of::<F>());
+
+        let values_view = ViewArg::new_array::<PlainLayout>(
+            unsafe { BufferArg::from_raw_parts(values.clone(), 2) },
+            (),
+        );
+        let scales_view = ViewArg::new_array::<PlainLayout>(
+            unsafe { BufferArg::from_raw_parts(scales.clone(), 2) },
+            (),
+        );
+        let global_buffer = unsafe { BufferArg::from_raw_parts(global.clone(), 1) };
+        let quantized_view =
+            ViewArg::new_quantized_two_level(values_view, scales_view, global_buffer, scheme);
+
+        unsafe {
+            kernel_quantized_view::launch_unchecked::<F, R>(
+                &client,
+                CubeCount::new_single(),
+                CubeDim::new_1d(2),
+                vector_size_float,
+                quantized_view,
+                BufferArg::from_raw_parts(output.clone(), 16),
+                mode,
+            );
+        }
+
+        let actual = client.read_one_unchecked(output);
+        let actual = F::from_bytes(&actual);
+
+        assert_eq!(actual, &expected, "reading through {mode:?}");
+    }
+}
+
 /// The per-tensor scale earns the f32 intermediate its keep here: the block scales overflow `f16`,
 /// so folding the multiply back into `F` reconstructs every value as infinity.
 ///
@@ -318,6 +386,14 @@ macro_rules! testgen_quantized_view {
         fn test_quantized_view_two_level_int() {
             let client = TestRuntime::client(&Default::default());
             cubecl_std::tests::view::quantized::test_quantized_two_level_int::<TestRuntime, $ty>(
+                client,
+            );
+        }
+
+        #[$crate::tests::test_log::test]
+        fn test_quantized_view_two_level_ue4m3() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_std::tests::view::quantized::test_quantized_two_level_ue4m3::<TestRuntime, $ty>(
                 client,
             );
         }

--- a/crates/cubecl-std/src/tests/view/quantized.rs
+++ b/crates/cubecl-std/src/tests/view/quantized.rs
@@ -265,8 +265,6 @@ pub fn test_quantized_two_level_int<R: Runtime, F: Float + CubeElement>(client: 
     }
 }
 
-/// Two levels with the block scales stored as e4m3, the layout the second level exists for. Runs
-/// natively or through cubecl's software fp8 conversion, whichever the runtime has.
 pub fn test_quantized_two_level_ue4m3<R: Runtime, F: Float + CubeElement>(
     client: ComputeClient<R>,
 ) {

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -516,8 +516,6 @@ fn register_types(props: &mut DeviceProperties, ext_feat: &ExtendedFeatures<'_>)
                 ElemType::UInt(UIntKind::U8),
                 TypeUsage::maybe_store(storage8),
             );
-            // fp8 converts natively with `VK_EXT_shader_float8` and in software otherwise; either
-            // way it lives in 8-bit ints, so it stores exactly where they do.
             for kind in [FloatKind::E4M3, FloatKind::E5M2] {
                 props.register_type_usage(ElemType::Float(kind), TypeUsage::Conversion);
                 if storage8 {

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -362,6 +362,12 @@ fn register_features(
         comp_options.vulkan.supports_fp_fast_math = true;
     }
 
+    if let Some(float8) = &extended_feat.float8
+        && float8.shader_float8 == TRUE
+    {
+        comp_options.vulkan.supports_float8 = true;
+    }
+
     if let Some(wg_explicit_layout) = &extended_feat.wg_explicit_layout
         && wg_explicit_layout.workgroup_memory_explicit_layout == TRUE
     {
@@ -453,8 +459,8 @@ fn register_types(props: &mut DeviceProperties, ext_feat: &ExtendedFeatures<'_>)
         .buf_16
         .is_some_and(|it| it.uniform_and_storage_buffer16_bit_access == TRUE);
     let storage8 = ext_feat
-        .buf_16
-        .is_some_and(|it| it.uniform_and_storage_buffer16_bit_access == TRUE);
+        .buf_8
+        .is_some_and(|it| it.uniform_and_storage_buffer8_bit_access == TRUE);
 
     for ty in default_types {
         props.register_type_usage(ty, TypeUsage::all());
@@ -510,6 +516,14 @@ fn register_types(props: &mut DeviceProperties, ext_feat: &ExtendedFeatures<'_>)
                 ElemType::UInt(UIntKind::U8),
                 TypeUsage::maybe_store(storage8),
             );
+            // fp8 converts natively with `VK_EXT_shader_float8` and in software otherwise; either
+            // way it lives in 8-bit ints, so it stores exactly where they do.
+            for kind in [FloatKind::E4M3, FloatKind::E5M2] {
+                props.register_type_usage(ElemType::Float(kind), TypeUsage::Conversion);
+                if storage8 {
+                    props.register_type_usage(ElemType::Float(kind), TypeUsage::Buffer);
+                }
+            }
         }
     }
 
@@ -522,17 +536,6 @@ fn register_types(props: &mut DeviceProperties, ext_feat: &ExtendedFeatures<'_>)
         }
         if bfloat16.shader_b_float16_dot_product == TRUE {
             props.register_type_usage(ElemType::Float(FloatKind::BF16), TypeUsage::DotProduct);
-        }
-    }
-
-    if let Some(float8) = ext_feat.float8
-        && float8.shader_float8 == TRUE
-    {
-        props.register_type_usage(ElemType::Float(FloatKind::E4M3), TypeUsage::Conversion);
-        props.register_type_usage(ElemType::Float(FloatKind::E5M2), TypeUsage::Conversion);
-        if storage8 {
-            props.register_type_usage(ElemType::Float(FloatKind::E4M3), TypeUsage::Buffer);
-            props.register_type_usage(ElemType::Float(FloatKind::E5M2), TypeUsage::Buffer);
         }
     }
 


### PR DESCRIPTION
Software fp8 (e4m3, e5m2) conversion for every backend, native where the hardware has it, one set of semantics everywhere, checked exhaustively against the host codecs.

## Why

`e4m3`/`e5m2` only converted where the hardware did: CUDA through `cuda_fp8.h`, SPIR-V through `OpTypeFloat 8` + `OpFConvert` behind `VK_EXT_shader_float8`. HIP, Metal, CPU and any Vulkan driver without the extension (Intel Arc under Mesa, for one) failed at codegen on the first fp8 cast. That blocks two-level quantization's point: `UE4M3` block scales are what make the second level worth having, and they have to read on the machines with the least memory, not only on Ada and up.

The polyfill is integer arithmetic on `u32` bit patterns and touches no 8- or 16-bit type, so a backend with no byte type at all can still call it on the bits inside a word (that is what a packed-scale binding will use for WGSL later).

## What changed

- `cubecl-core/src/post_processing/minifloat.rs`: `Fp8Format` (constants read off `cubecl_common::{e4m3, e5m2}`, nothing restated), the `#[cube]` polyfills `fp8_bits_to_f32` / `f32_to_fp8_bits`, and `LowerMinifloatCast`, a `MatchRewrite` pass modelled on `saturating.rs` that rewrites any `CastOp` touching an fp8 type the target does not convert natively into reinterpret-to-byte, widen, polyfill, cast. Each compiler wires it with its own `EnumSet<Fp8Format>` of the formats its target converts natively.
- SPIR-V: new `VulkanCompilationOptions::supports_float8`. Without it, `Float8E4M3Type`/`Float8E5M2Type` map to `OpTypeInt 8` and casts go through the pass; a same-type reinterpret forwards its operand instead of emitting an invalid `OpBitcast`; `cast()` widens an emulated fp8 as an unsigned byte. With it, the native float type stays and the fp8-producing `OpFConvert` gets `SaturatedToLargestFloat8NormalConversionEXT`.
- Vulkan registration: fp8 `Conversion` wherever `shaderInt8` or `shaderFloat8` exists, `Buffer` wherever 8-bit storage does. `shaderInt8` is what the emulated path needs, since fp8 is an 8-bit int there, but `VK_EXT_shader_float8` does not depend on it, so gating on int8 alone would have let a device with native fp8 and no int8 compile fp8 while reporting it unsupported. The `storage8` gate read the 16-bit storage feature; it now reads `buf_8`.
- CPU: fp8 maps to LLVM `i8`, pass in the pipeline, `Conversion | Buffer` registered.
- cpp: HIP and Metal map fp8 to `uint8_t` and take the pass; CUDA keeps its intrinsics (both formats marked native), and since `cuda_fp8.hpp` carries its own software path below sm_89 the CUDA runtime registers fp8 on every arch rather than from Ada up.
- CUDA encode: `__NV_SATFINITE` instead of `__NV_NOSAT` (overflow to NaN, and the header's software path even on sm_89; `SATFINITE` is the `cvt.rn.satfinite` instruction), and one `__nv_cvt_{halfraw,bfloat16raw,float,double}_to_fp8` per source width instead of a detour through f16, which rounded twice. Packed pairs keep `halfraw2` / `bfloat16raw2`. `ue8m0` is deliberately outside this: `__nv_cvt_bfloat16raw_to_e8m0` is the only intrinsic for it, so it keeps the bf16 intermediate and the direct-encode check keys on e4m3/e5m2 rather than on the broader "is an 8-bit float" predicate.

## Semantics

Round to nearest even; overflow and infinities saturate to the largest finite value (448 / 57344); NaN stays NaN; below half the smallest subnormal flushes to zero. This is what `e4m3::from_f32` / `e5m2::from_f32` already do, and now what every device path does too. Quantization never overflows (scales are rounded up and saturated, values clamped), so no quantized number changes; the edge cases just agree across backends.

## Tests

- `runtime_tests/minifloat.rs`: all 256 codes of both formats decode bit-exact against the codec; every f16 value plus rounding ties, underflow and saturation edges and the specials encode to the codec's byte; vector sizes 1 and 4. The existing `test_fp8` now runs everywhere. A mutation check (round-half-up instead of RNE) fails on the first tie.
- `cubecl-std`: two-level quantized view with e4m3 block scales, f32 and f16 compute.

Verified on hardware:

| runtime | path | result |
| --- | --- | --- |
| CPU | emulated | `cargo test -p cubecl-cpu` 678 passed |
| wgpu Vulkan, Intel Arc B390 (no `VK_EXT_shader_float8`) | emulated, u8 storage | fp8 and ue4m3 tests pass; suite 650 passed, the 18 `plane_shuffle` failures are pre-existing on main |
| CUDA, RTX 4070 Ti SUPER (sm_89) | native | 12/12 fp8 tests bit-exact; suite 805 passed, `test_cmma_manual` fails on main too |
| HIP, RX 7600 (gfx1102) | emulated | 6/6 fp8 tests |
| Metal | emulated | not run, no hardware reachable |
| SPIR-V with the extension | native | not run, no hardware reachable |

The CUDA row predates the rebase onto main and the e8m0 fix above. sm_89 does not register `UE8M0` at all, so no CUDA machine here can reach the e8m0 cast path either way; it is unverified on hardware and reasoned from the generated source.

## Not in this PR

- WGSL: no 8-bit types, so fp8 stays unregistered there; the packed-scale binding that reaches it calls these polyfills on `u32` words and comes separately.
- fp4 (`e2m1`), fp6, `ue8m0`: same polyfill shape, but fp4 needs lane doubling in the pass and `ue8m0` needs a round-up rule downstream before its cast is useful; each its own PR.
- HIP native fp8 (gfx950 only, gfx942 is FNUZ): parked, no hardware to verify on.
- A compile check for the cpp backends. Nothing in CI builds or tests `cubecl-cuda`, `cubecl-hip` or `cubecl-metal`, so their codegen has no automated cover. Asserting on the generated source text pins how it is spelled rather than whether it is correct, and fails on any refactor that emits equally valid code, so that is not the answer. Feeding the generated source through NVRTC tests the real property and needs the CUDA toolkit but no GPU; separate PR.

## Downstream

No scheme or launch API changes. burn's ue4m3 tests currently gated `#[cfg(not(feature = "wgpu"))]` can become runtime `type_usage` checks; cubek's `e4m3::supported_uses(...)` gates start running on Vulkan/CPU/HIP with no change.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.

