### PR TITLE
Add non-pointer MMA dialect

### DIFF
--- a/crates/cubecl-core/src/frontend/cmma.rs
+++ b/crates/cubecl-core/src/frontend/cmma.rs
@@ -935,14 +935,16 @@ pub mod load_tensor {
             ComptimeOptionExpand::None => None,
             ComptimeOptionExpand::Some(view) => Some(view.read_value(scope)),
         };
+        let out_ty = mat.elem.unwrap_ptr(scope.ctx());
 
-        scope.register(&LoadTensorOp::new(
+        let mat_out = scope.register_with_result(&LoadTensorOp::new(
             scope.ctx_mut(),
-            mat.elem,
+            out_ty,
             buffer,
             layout,
             view,
         ));
+        assign::expand_element(scope, mat_out.into(), mat.elem.into());
     }
 }
 

--- a/crates/cubecl-ir/src/dialect/matrix.rs
+++ b/crates/cubecl-ir/src/dialect/matrix.rs
@@ -89,8 +89,11 @@ synchronizes!(StoreOp, SyncScope::Plane);
 #[result_ty(none)]
 #[op_traits(CanMaterialize)]
 pub struct MultiplyAccumulateOp {
+    #[operand(ptr_read)]
     pub mat_a: Value,
+    #[operand(ptr_read)]
     pub mat_b: Value,
+    #[operand(ptr_read)]
     pub mat_c: Value,
     #[operand(ptr_write)]
     pub mat_d: Value,
@@ -275,6 +278,16 @@ impl Parsable for ElementwiseOp {
 
         let op = ElementwiseOp::new(ctx, mat_in, mat_out, closure, captures);
         Ok(OpObj::new(op)).into_parse_result()
+    }
+}
+
+#[op_interface_impl]
+impl MemoryEffects for ElementwiseOp {
+    fn memory_effects(&self, ctx: &Context) -> Vec<MemoryEffect> {
+        vec![
+            MemoryEffect::Read(self.matrix_in(ctx)),
+            MemoryEffect::Write(self.matrix_out(ctx)),
+        ]
     }
 }
 

--- a/crates/cubecl-ir/src/dialect/mod.rs
+++ b/crates/cubecl-ir/src/dialect/mod.rs
@@ -12,6 +12,7 @@ pub mod memory;
 pub mod plane;
 pub mod scf;
 pub mod spirv;
+pub mod ssa_matrix;
 pub mod synchronization;
 pub mod tma;
 pub mod vector;

--- a/crates/cubecl-ir/src/dialect/scf.rs
+++ b/crates/cubecl-ir/src/dialect/scf.rs
@@ -20,7 +20,7 @@ use pliron::{
 use crate::{
     attributes::{BoolAttr, ZeroAttr},
     dialect::branch::{self, ConditionOp, DeadRegionOp, YieldOp, block_side_effects},
-    interfaces::memory_slot::PromotableRegionOpInterface,
+    interfaces::{CanonicalizeInterface, memory_slot::PromotableRegionOpInterface},
     prelude::*,
     types::scalar::BoolType,
 };
@@ -252,6 +252,21 @@ impl PromotableRegionOpInterface for IfOp {
     }
 }
 
+#[op_interface_impl]
+impl CanonicalizeInterface for IfOp {
+    fn canonicalize(&self, ctx: &mut Context, _rewriter: &mut MatchRewriter) -> Result<()> {
+        let results = self.get_operation().results(ctx);
+        for (idx, res) in results.into_iter().enumerate().rev() {
+            if !res.is_used(ctx) {
+                remove_from_terminator::<YieldOp>(ctx, self.then_block(ctx), idx);
+                remove_from_terminator::<YieldOp>(ctx, self.else_block(ctx), idx);
+                Operation::remove_result(self.get_operation(), ctx, idx);
+            }
+        }
+        Ok(())
+    }
+}
+
 #[pliron_op(
     name = "scf.switch",
     format,
@@ -411,6 +426,23 @@ impl PromotableRegionOpInterface for SwitchOp {
     }
 }
 
+#[op_interface_impl]
+impl CanonicalizeInterface for SwitchOp {
+    fn canonicalize(&self, ctx: &mut Context, _rewriter: &mut MatchRewriter) -> Result<()> {
+        let results = self.get_operation().results(ctx);
+        for (idx, res) in results.into_iter().enumerate().rev() {
+            if !res.is_used(ctx) {
+                remove_from_terminator::<YieldOp>(ctx, self.default_block(ctx), idx);
+                for case_block in self.case_blocks(ctx) {
+                    remove_from_terminator::<YieldOp>(ctx, case_block, idx);
+                }
+                Operation::remove_result(self.get_operation(), ctx, idx);
+            }
+        }
+        Ok(())
+    }
+}
+
 #[pliron_op(name = "scf.range_loop", format, verifier = "succ")]
 #[op_interfaces(
     OneRegionInterface,
@@ -491,7 +523,7 @@ impl RangeLoopOp {
         BasicBlock::push_argument(self.loop_body(ctx), ctx, ty)
     }
 
-    pub fn remove_carried_value(&self, ctx: &mut Context, arg_idx: usize) {
+    pub fn remove_carried_value(&self, ctx: &Context, arg_idx: usize) {
         BasicBlock::remove_argument(self.loop_body(ctx), ctx, arg_idx + 1)
     }
 
@@ -587,6 +619,25 @@ impl PromotableRegionOpInterface for RangeLoopOp {
 
         let idx = Operation::push_result(self.get_operation(), ctx, alloc.ty);
         self.get_operation().deref(ctx).get_result(idx)
+    }
+}
+
+#[op_interface_impl]
+impl CanonicalizeInterface for RangeLoopOp {
+    fn canonicalize(&self, ctx: &mut Context, _rewriter: &mut MatchRewriter) -> Result<()> {
+        let results = self.get_operation().results(ctx);
+        let body_block = self.loop_body(ctx);
+        for (idx, res) in results.into_iter().enumerate().rev() {
+            let carried = self.get_carried_value(ctx, idx);
+            if !res.is_used(ctx) && only_used_for_forward::<YieldOp>(ctx, body_block, idx, carried)
+            {
+                remove_from_terminator::<YieldOp>(ctx, body_block, idx);
+                self.remove_initial_carried_value(ctx, idx);
+                self.remove_carried_value(ctx, idx);
+                Operation::remove_result(self.get_operation(), ctx, idx);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -772,6 +823,31 @@ impl PromotableRegionOpInterface for WhileOp {
     }
 }
 
+#[op_interface_impl]
+impl CanonicalizeInterface for WhileOp {
+    fn canonicalize(&self, ctx: &mut Context, _rewriter: &mut MatchRewriter) -> Result<()> {
+        let results = self.get_operation().results(ctx);
+        let before_block = self.before_block(ctx);
+        let after_block = self.after_block(ctx);
+        for (idx, res) in results.into_iter().enumerate().rev() {
+            let before_carried = self.get_before_carried_value(ctx, idx);
+            let after_carried = self.get_after_carried_value(ctx, idx);
+            if !res.is_used(ctx)
+                && only_used_for_forward::<ConditionOp>(ctx, before_block, idx + 1, before_carried)
+                && only_used_for_forward::<YieldOp>(ctx, after_block, idx, after_carried)
+            {
+                remove_from_terminator::<ConditionOp>(ctx, before_block, idx + 1);
+                remove_from_terminator::<YieldOp>(ctx, after_block, idx);
+                self.remove_initial_carried_value(ctx, idx);
+                self.remove_before_carried_value(ctx, idx);
+                self.remove_after_carried_value(ctx, idx);
+                Operation::remove_result(self.get_operation(), ctx, idx);
+            }
+        }
+        Ok(())
+    }
+}
+
 #[op_interface]
 trait BranchToSCFOp {
     verify_op_succ!();
@@ -821,4 +897,38 @@ fn update_terminator<T: Op>(
     let block_reaching_def = reaching_at_block_end.get(&block).copied();
     let block_reaching_def = block_reaching_def.unwrap_or(default_reaching_def);
     Operation::push_operand(term, ctx, block_reaching_def);
+}
+
+fn remove_from_terminator<T: Op>(ctx: &Context, block: Ptr<BasicBlock>, idx: usize) {
+    let Some(term) = block.deref(ctx).get_terminator(ctx) else {
+        return;
+    };
+    if !term.is_op::<T>(ctx) {
+        return;
+    }
+    Operation::remove_operand(term, ctx, idx);
+}
+
+/// Detects circularly used loop args, where the arg is used only to be forwarded to the after block
+/// or next iteration.
+fn only_used_for_forward<T: Op>(
+    ctx: &Context,
+    block: Ptr<BasicBlock>,
+    idx: usize,
+    val: Value,
+) -> bool {
+    if !val.is_used(ctx) {
+        return true;
+    }
+    let Some(term) = block.deref(ctx).get_terminator(ctx) else {
+        return false;
+    };
+    if !term.is_op::<T>(ctx) {
+        return false;
+    }
+    let uses = val.uses(ctx);
+    if uses.len() > 1 {
+        return false;
+    }
+    uses[0].user_op() == term && uses[0].find_index(ctx) == idx
 }

--- a/crates/cubecl-ir/src/dialect/spirv.rs
+++ b/crates/cubecl-ir/src/dialect/spirv.rs
@@ -4,35 +4,33 @@ use crate::{
     CanMaterialize, Pure,
     attributes::IndexAttr,
     prelude::*,
-    types::{
-        PointerType,
-        spirv::{ClampMode, TensorLayoutType},
-    },
+    types::spirv::{ClampMode, TensorLayoutType},
 };
 
 #[pliron_op(
     name = "matrix_spirv.load_tensor",
-    operands = (out_mat: PointerType, buffer, layout: TensorLayoutType),
+    operands = (buffer, layout: TensorLayoutType),
     format,
     verifier = "succ"
 )]
+#[op_interfaces(OneResultInterface)]
 #[op_traits(CanMaterialize)]
 pub struct LoadTensorOp;
 
 impl LoadTensorOp {
     pub fn new(
         ctx: &mut Context,
-        out_mat: Value,
+        out_ty: TypeHandle,
         buffer: Value,
         layout: Value,
         view: Option<Value>,
     ) -> Self {
-        let mut operands = vec![out_mat, buffer, layout];
+        let mut operands = vec![buffer, layout];
         operands.extend(view);
         let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),
-            vec![],
+            vec![out_ty],
             operands,
             vec![],
             0,
@@ -40,22 +38,18 @@ impl LoadTensorOp {
         Self { op }
     }
 
-    pub fn out_mat(&self, ctx: &Context) -> Value {
+    pub fn buffer(&self, ctx: &Context) -> Value {
         self.get_operation().deref(ctx).get_operand(0)
     }
 
-    pub fn buffer(&self, ctx: &Context) -> Value {
-        self.get_operation().deref(ctx).get_operand(1)
-    }
-
     pub fn layout(&self, ctx: &Context) -> Value {
-        self.get_operation().deref(ctx).get_operand(2)
+        self.get_operation().deref(ctx).get_operand(1)
     }
 
     pub fn view(&self, ctx: &Context) -> Option<Value> {
         let op = self.get_operation().deref(ctx);
-        if op.get_num_operands() > 3 {
-            Some(op.get_operand(3))
+        if op.get_num_operands() > 2 {
+            Some(op.get_operand(2))
         } else {
             None
         }

--- a/crates/cubecl-ir/src/dialect/ssa_matrix.rs
+++ b/crates/cubecl-ir/src/dialect/ssa_matrix.rs
@@ -1,0 +1,340 @@
+use core::fmt;
+
+use alloc::vec::Vec;
+
+use cubecl_macros_internal::{NamedRewrite, cube_op};
+use pliron::{
+    builtin::attributes::IdentifierAttr,
+    combine::{Parser, parser::char::char},
+    identifier::Identifier,
+    input_err,
+    irfmt::parsers::{process_parsed_ssa_defs, spaced, ssa_opd_parse},
+    location::Location,
+    op::OpObj,
+    parsable::{self, IntoParseResult, Parsable, ParseResult},
+    printable::{self, Printable},
+};
+
+use crate::{
+    CanMaterialize,
+    dialect::{
+        matrix::{self, MatrixLayoutAttr, parse_closure, print_closure},
+        memory,
+        synchronization::SyncScope,
+    },
+    interfaces::{TypedExt, synchronizes},
+    prelude::*,
+};
+
+/// Fill a matrix with a scalar value.
+/// Note: Unlike most matrix ops, this does not have implicit synchronization because there's no
+/// coordination between threads.
+#[cube_op(name = "ssa_matrix.fill")]
+#[result_ty(argument)]
+#[op_traits(CanMaterialize)]
+pub struct FillOp {
+    pub value: Value,
+}
+
+#[op_interface_impl]
+impl MatrixToSSAOp for matrix::FillOp {
+    fn to_owned_matrix(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _: &OperandsInfo,
+    ) -> Result<()> {
+        let value = self.value(ctx);
+        let out_ty = self.matrix(ctx).unwrap_ptr(ctx);
+        let op = FillOp::new(ctx, out_ty, value);
+        let matrix = rewriter.append_op_with_result(ctx, &op);
+        store_value(self.matrix(ctx), matrix, ctx, rewriter);
+        rewriter.erase_operation(ctx, self.get_operation());
+
+        Ok(())
+    }
+}
+
+#[cube_op(name = "ssa_matrix.load")]
+#[result_ty(argument)]
+#[op_traits(CanMaterialize)]
+pub struct LoadOp {
+    #[operand(ptr_read)]
+    pub source: Value,
+    pub stride: Value,
+    pub layout: MatrixLayoutAttr,
+}
+synchronizes!(LoadOp, SyncScope::Plane);
+
+#[op_interface_impl]
+impl MatrixToSSAOp for matrix::LoadOp {
+    fn to_owned_matrix(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _: &OperandsInfo,
+    ) -> Result<()> {
+        let source = self.source(ctx);
+        let stride = self.stride(ctx);
+        let layout = self.layout(ctx).0;
+        let out_ty = self.matrix(ctx).unwrap_ptr(ctx);
+        let op = LoadOp::new(ctx, out_ty, source, stride, layout);
+        let matrix = rewriter.append_op_with_result(ctx, &op);
+        store_value(self.matrix(ctx), matrix, ctx, rewriter);
+        rewriter.erase_operation(ctx, self.get_operation());
+
+        Ok(())
+    }
+}
+
+#[cube_op(name = "ssa_matrix.store")]
+#[result_ty(none)]
+#[op_traits(CanMaterialize)]
+pub struct StoreOp {
+    pub matrix: Value,
+    #[operand(ptr_write)]
+    pub destination: Value,
+    pub stride: Value,
+    pub layout: MatrixLayoutAttr,
+}
+synchronizes!(StoreOp, SyncScope::Plane);
+
+#[op_interface_impl]
+impl MatrixToSSAOp for matrix::StoreOp {
+    fn to_owned_matrix(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _: &OperandsInfo,
+    ) -> Result<()> {
+        let matrix = load_value(self.matrix(ctx), ctx, rewriter);
+        let dest = self.destination(ctx);
+        let stride = self.stride(ctx);
+        let layout = self.layout(ctx).0;
+        let op = StoreOp::new(ctx, matrix, dest, stride, layout);
+        rewriter.append_op(ctx, &op);
+        rewriter.erase_operation(ctx, self.get_operation());
+
+        Ok(())
+    }
+}
+
+#[cube_op(name = "ssa_matrix.multiply_accumulate")]
+#[result_ty(argument)]
+#[op_traits(CanMaterialize)]
+pub struct MultiplyAccumulateOp {
+    pub mat_a: Value,
+    pub mat_b: Value,
+    pub mat_c: Value,
+}
+synchronizes!(MultiplyAccumulateOp, SyncScope::Plane);
+
+#[op_interface_impl]
+impl MatrixToSSAOp for matrix::MultiplyAccumulateOp {
+    fn to_owned_matrix(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _: &OperandsInfo,
+    ) -> Result<()> {
+        let mat_a = load_value(self.mat_a(ctx), ctx, rewriter);
+        let mat_b = load_value(self.mat_b(ctx), ctx, rewriter);
+        let mat_c = load_value(self.mat_c(ctx), ctx, rewriter);
+        let out_ty = self.mat_d(ctx).unwrap_ptr(ctx);
+        let op = MultiplyAccumulateOp::new(ctx, out_ty, mat_a, mat_b, mat_c);
+        let matrix_out = rewriter.append_op_with_result(ctx, &op);
+        store_value(self.mat_d(ctx), matrix_out, ctx, rewriter);
+        rewriter.erase_operation(ctx, self.get_operation());
+
+        Ok(())
+    }
+}
+
+/// Cast a matrix from one type to another.
+/// Note: Unlike most matrix ops, this does not have implicit synchronization because there's no
+/// coordination between threads.
+#[cube_op(name = "ssa_matrix.cast")]
+#[result_ty(argument)]
+#[op_traits(CanMaterialize)]
+pub struct CastOp {
+    pub input: Value,
+}
+
+#[op_interface_impl]
+impl MatrixToSSAOp for matrix::CastOp {
+    fn to_owned_matrix(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _: &OperandsInfo,
+    ) -> Result<()> {
+        let matrix_in = load_value(self.input(ctx), ctx, rewriter);
+        let out_ty = self.output(ctx).unwrap_ptr(ctx);
+        let op = CastOp::new(ctx, out_ty, matrix_in);
+        let matrix_out = rewriter.append_op_with_result(ctx, &op);
+        store_value(self.output(ctx), matrix_out, ctx, rewriter);
+        rewriter.erase_operation(ctx, self.get_operation());
+
+        Ok(())
+    }
+}
+
+/// Executes a closure for each element in the matrix.
+/// Note: Unlike most matrix ops, this does not have implicit synchronization because there's no
+/// coordination between threads.
+#[pliron_op(
+    name = "ssa_matrix.elementwise",
+    attributes = (ssa_matrix_elementwise_closure: IdentifierAttr),
+    verifier = "succ"
+)]
+#[op_interfaces(OneResultInterface)]
+#[op_traits(CanMaterialize)]
+pub struct ElementwiseOp;
+
+impl ElementwiseOp {
+    pub fn new(
+        ctx: &mut Context,
+        matrix_in: Value,
+        closure: Identifier,
+        captures: Vec<Value>,
+    ) -> Self {
+        let out_ty = vec![matrix_in.get_type(ctx)];
+        let mut opds = vec![matrix_in];
+        opds.extend(captures);
+        let op = Self {
+            op: Operation::new(ctx, Self::get_concrete_op_info(), out_ty, opds, vec![], 0),
+        };
+        op.set_attr_ssa_matrix_elementwise_closure(ctx, IdentifierAttr::new(closure));
+        op
+    }
+
+    pub fn matrix_in(&self, ctx: &Context) -> Value {
+        self.get_operation().operand(ctx, 0)
+    }
+
+    pub fn closure(&self, ctx: &Context) -> Identifier {
+        let attr = self.get_attr_ssa_matrix_elementwise_closure(ctx).unwrap();
+        attr.clone().into()
+    }
+
+    pub fn closure_captures(&self, ctx: &Context) -> Vec<Value> {
+        self.get_operation().deref(ctx).operands().skip(1).collect()
+    }
+}
+
+impl Printable for ElementwiseOp {
+    fn fmt(
+        &self,
+        ctx: &Context,
+        _state: &printable::State,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(
+            f,
+            "{} = {} ({}) ",
+            self.get_result(ctx).disp(ctx),
+            self.get_opid().disp(ctx),
+            self.matrix_in(ctx).disp(ctx)
+        )?;
+        print_closure(ctx, &self.closure(ctx), &self.closure_captures(ctx), f)
+    }
+}
+impl Parsable for ElementwiseOp {
+    type Arg = Vec<(Identifier, Location)>;
+    type Parsed = OpObj;
+    fn parse<'a>(
+        input: &mut parsable::StateStream<'a>,
+        arg: Self::Arg,
+    ) -> ParseResult<'a, Self::Parsed> {
+        let cur_loc = input.loc();
+
+        spaced(char('(')).parse_stream(input).into_result()?;
+        let mat_in = ssa_opd_parse(input, ())?.0;
+        spaced(char(')')).parse_stream(input).into_result()?;
+
+        let (closure, captures) = parse_closure(input)?.0;
+        let ctx = &mut input.state.ctx;
+
+        if arg.len() != 1 {
+            input_err!(
+                cur_loc,
+                "Expected 1 result, got {} during parsing",
+                arg.len()
+            )?;
+        }
+
+        let op = ElementwiseOp::new(ctx, mat_in, closure, captures);
+        process_parsed_ssa_defs(input, &arg, op.get_operation())?;
+        Ok(OpObj::new(op)).into_parse_result()
+    }
+}
+
+#[op_interface_impl]
+impl MatrixToSSAOp for matrix::ElementwiseOp {
+    fn to_owned_matrix(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _: &OperandsInfo,
+    ) -> Result<()> {
+        let matrix_in = load_value(self.matrix_in(ctx), ctx, rewriter);
+        let closure = self.closure(ctx);
+        let captures = self.closure_captures(ctx);
+
+        let op = ElementwiseOp::new(ctx, matrix_in, closure, captures);
+        let matrix_out = rewriter.append_op_with_result(ctx, &op);
+        store_value(self.matrix_out(ctx), matrix_out, ctx, rewriter);
+        rewriter.erase_operation(ctx, self.get_operation());
+
+        Ok(())
+    }
+}
+
+fn load_value(ptr: Value, ctx: &mut Context, rewriter: &mut DialectConversionRewriter) -> Value {
+    let load = memory::LoadOp::new(ctx, ptr);
+    rewriter.append_op_with_result(ctx, &load)
+}
+
+fn store_value(
+    ptr: Value,
+    value: Value,
+    ctx: &mut Context,
+    rewriter: &mut DialectConversionRewriter,
+) {
+    let store = memory::StoreOp::new(ctx, ptr, value);
+    rewriter.append_op(ctx, &store);
+}
+
+#[op_interface]
+trait MatrixToSSAOp {
+    verify_op_succ!();
+    fn to_owned_matrix(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        operands_info: &OperandsInfo,
+    ) -> Result<()>;
+}
+
+pub type MatrixToSSAPass = DialectConversionPass<MatrixToSSAConversion>;
+
+#[derive(Default, NamedRewrite)]
+pub struct MatrixToSSAConversion;
+
+impl DialectConversion for MatrixToSSAConversion {
+    fn can_convert_op(&self, ctx: &Context, op: Ptr<Operation>) -> bool {
+        op.impls::<dyn MatrixToSSAOp>(ctx)
+    }
+
+    fn rewrite(
+        &mut self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        op: Ptr<Operation>,
+        operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        let dyn_op = op.dyn_op(ctx);
+        let to_owned = op_cast::<dyn MatrixToSSAOp>(&*dyn_op).unwrap();
+        to_owned.to_owned_matrix(ctx, rewriter, operands_info)
+    }
+}

--- a/crates/cubecl-ir/src/interfaces/mod.rs
+++ b/crates/cubecl-ir/src/interfaces/mod.rs
@@ -340,6 +340,12 @@ pub trait SimplifyInterface {
     fn check_fold(&self, ctx: &Context, operand_attrs: &[Option<AttrObj>]) -> Option<Value>;
 }
 
+#[op_interface]
+pub trait CanonicalizeInterface {
+    verify_op_succ!();
+    fn canonicalize(&self, ctx: &mut Context, rewriter: &mut MatchRewriter) -> Result<()>;
+}
+
 #[attr_interface]
 pub trait ConstantAttr: TypedAttrInterface {
     verify_attr_succ!();

--- a/crates/cubecl-ir/src/rewrite.rs
+++ b/crates/cubecl-ir/src/rewrite.rs
@@ -22,7 +22,11 @@ use pliron::{
     verify_err_noloc,
 };
 
-use crate::{dialect::BlockPtrExt, interfaces::SimplifyInterface, prelude::*};
+use crate::{
+    dialect::BlockPtrExt,
+    interfaces::{CanonicalizeInterface, SimplifyInterface},
+    prelude::*,
+};
 
 /// A preset config when order doesn't matter
 pub const WALKCONFIG_ANY: WalkConfig = WALKCONFIG_PREORDER_FORWARD;
@@ -123,6 +127,29 @@ fn const_operands(ctx: &Context, op: Ptr<Operation>) -> Vec<Option<AttrObj>> {
         .operands()
         .map(|opd| Some(opd.defining_op()?.as_op::<ConstantOp>(ctx)?.get_value(ctx)))
         .collect()
+}
+
+pub type CanonicalizePass = MatchRewritePass<Canonicalize>;
+
+#[derive(Default, Clone, Copy, NamedRewrite)]
+pub struct Canonicalize;
+
+impl MatchRewrite for Canonicalize {
+    fn r#match(&mut self, ctx: &Context, op: Ptr<Operation>) -> bool {
+        op.impls::<dyn CanonicalizeInterface>(ctx)
+    }
+
+    fn rewrite(
+        &mut self,
+        ctx: &mut Context,
+        rewriter: &mut MatchRewriter,
+        op: Ptr<Operation>,
+    ) -> Result<()> {
+        let dyn_op = op.dyn_op(ctx);
+        let canonicalize = op_cast::<dyn CanonicalizeInterface>(&*dyn_op).unwrap();
+        canonicalize.canonicalize(ctx, rewriter)?;
+        Ok(())
+    }
 }
 
 pub type VisitOpsCallback<T, State> = fn(&Context, &mut State, T);

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -25,7 +25,7 @@ use cubecl_ir::{
     attributes::{ATTR_BUFFER_IO, BufferIOAttr, EntrypointInterface},
     dialect::{scf::BranchToSCFPass, ssa_matrix::MatrixToSSAPass},
     prelude::{SingleBlockRegionInterface, SymbolOpInterface},
-    rewrite::visit_all_ops_of_type_mut,
+    rewrite::{CanonicalizePass, visit_all_ops_of_type_mut},
     settings::{Dim3, KernelSettings},
 };
 use cubecl_opt::passes::{
@@ -214,6 +214,7 @@ impl SpirvCompiler {
         func_passes.add_pass(SCCPPass);
         func_passes.add_pass(SimpleCSEPass);
         func_passes.add_pass(DCEPass);
+        func_passes.add_pass(CanonicalizePass::default());
 
         passes.add_pass(NestedOpsPass::new(func_passes));
         passes.add_pass(AnnotateGlobalVisibilityPass);

--- a/crates/cubecl-spirv/src/compiler.rs
+++ b/crates/cubecl-spirv/src/compiler.rs
@@ -23,7 +23,7 @@ use cubecl_core::{
 use cubecl_environment::backtrace::BackTrace;
 use cubecl_ir::{
     attributes::{ATTR_BUFFER_IO, BufferIOAttr, EntrypointInterface},
-    dialect::scf::BranchToSCFPass,
+    dialect::{scf::BranchToSCFPass, ssa_matrix::MatrixToSSAPass},
     prelude::{SingleBlockRegionInterface, SymbolOpInterface},
     rewrite::visit_all_ops_of_type_mut,
     settings::{Dim3, KernelSettings},
@@ -194,6 +194,7 @@ impl SpirvCompiler {
         func_passes.add_pass(AllocateSharedMemoryBlockPass);
         func_passes.add_pass(LowerSaturatingArithmeticPass::default());
         func_passes.add_pass(BranchToSCFPass::default());
+        func_passes.add_pass(MatrixToSSAPass::default());
 
         passes.add_pass(NestedOpsPass::new(func_passes));
         passes.add_pass(LowerBuiltinsPass);

--- a/crates/cubecl-spirv/src/ops/branch.rs
+++ b/crates/cubecl-spirv/src/ops/branch.rs
@@ -20,7 +20,7 @@ use pliron::{
 };
 use pliron_spirv::ops::{self, BranchOp, LoopOp, MergeOp, SelectionOp};
 
-use crate::ops::to_spirv_dialect::ToSpirvDialectOp;
+use crate::{ops::to_spirv_dialect::ToSpirvDialectOp, types::ty_to_spirv_dialect};
 
 // Custom branch because of `BoolType`
 #[pliron_op(
@@ -471,6 +471,40 @@ impl ToSpirvCFDialect for scf::WhileOp {
         rewriter.append_op(ctx, &r#loop);
         rewriter.replace_operation(ctx, self.get_operation(), r#loop.get_operation());
 
+        Ok(())
+    }
+}
+
+#[op_interface_impl]
+impl ToSpirvDialectOp for SelectionOp {
+    fn to_spirv_dialect(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        let results = self.get_operation().results(ctx);
+        for res in results {
+            let ty = ty_to_spirv_dialect(ctx, res.get_type(ctx));
+            rewriter.set_value_type(ctx, res, ty);
+        }
+        Ok(())
+    }
+}
+
+#[op_interface_impl]
+impl ToSpirvDialectOp for LoopOp {
+    fn to_spirv_dialect(
+        &self,
+        ctx: &mut Context,
+        rewriter: &mut DialectConversionRewriter,
+        _operands_info: &OperandsInfo,
+    ) -> Result<()> {
+        let results = self.get_operation().results(ctx);
+        for res in results {
+            let ty = ty_to_spirv_dialect(ctx, res.get_type(ctx));
+            rewriter.set_value_type(ctx, res, ty);
+        }
         Ok(())
     }
 }

--- a/crates/cubecl-spirv/src/ops/matrix.rs
+++ b/crates/cubecl-spirv/src/ops/matrix.rs
@@ -1,11 +1,11 @@
-use cubecl_ir::{dialect::matrix, interfaces::TypedExt, prelude::*, types::MatrixLayout};
+use cubecl_ir::{dialect::ssa_matrix, interfaces::TypedExt, prelude::*, types::MatrixLayout};
 use pliron::{
     builtin::{attributes::IntegerAttr, ops::ConstantOp, types::IntegerType},
     utils::apint::{APInt, bw},
 };
 use pliron_spirv::{
     ops::{
-        CompositeConstructOp, LoadOp, ShiftRightLogicalOp, StoreOp,
+        CompositeConstructOp, ShiftRightLogicalOp,
         khr::{CooperativeMatrixLoadOp, CooperativeMatrixMulAddOp, CooperativeMatrixStoreOp},
         nv::{CooperativeMatrixConvertOp, CooperativeMatrixPerElementOpOp},
     },
@@ -57,47 +57,42 @@ pub(super) fn unwrap_ptr(ty: impl Typed, ctx: &Context) -> TypeHandle {
 }
 
 fn matrix_ident(ctx: &Context, ty: impl Typed) -> CooperativeMatrixUse {
-    let ty = TypedHandle::<CooperativeMatrixType>::from_handle(unwrap_ptr(ty, ctx), ctx).unwrap();
+    let ty = TypedHandle::<CooperativeMatrixType>::from_handle(ty.get_type(ctx), ctx).unwrap();
     ty.deref(ctx).use_
 }
 
 #[op_interface_impl]
-impl ToSpirvDialectOp for matrix::FillOp {
+impl ToSpirvDialectOp for ssa_matrix::FillOp {
     fn to_spirv_dialect(
         &self,
         ctx: &mut Context,
         rewriter: &mut DialectConversionRewriter,
         _operands_info: &OperandsInfo,
     ) -> Result<()> {
-        let matrix_ptr = self.matrix(ctx);
         let value = self.value(ctx);
-        let matrix_ty = ty_to_spirv_dialect(ctx, unwrap_ptr(matrix_ptr, ctx));
+        let matrix_ty = ty_to_spirv_dialect(ctx, self.result_type(ctx));
         let value = CompositeConstructOp::new(ctx, matrix_ty, vec![value]);
         rewriter.append_op(ctx, &value);
-        let value = value.get_result(ctx);
-        let store = StoreOp::new(ctx, matrix_ptr, value, MemoryAccess::NONE, None);
-        rewriter.append_op(ctx, &store);
-        rewriter.erase_operation(ctx, self.get_operation());
+        rewriter.replace_operation(ctx, self.get_operation(), value.get_operation());
         Ok(())
     }
 }
 
 #[op_interface_impl]
-impl ToSpirvDialectOp for matrix::LoadOp {
+impl ToSpirvDialectOp for ssa_matrix::LoadOp {
     fn to_spirv_dialect(
         &self,
         ctx: &mut Context,
         rewriter: &mut DialectConversionRewriter,
         _operands_info: &OperandsInfo,
     ) -> Result<()> {
-        let matrix_ptr = self.matrix(ctx);
         let value_ptr = self.source(ctx);
         let align = unwrap_ptr(value_ptr, ctx).align(ctx) as u32;
         let layout = layout_to_spirv(self.layout(ctx).0);
         let stride = adjust_stride(ctx, rewriter, self.stride(ctx), value_ptr);
-        let matrix_ty = ty_to_spirv_dialect(ctx, unwrap_ptr(matrix_ptr, ctx));
+        let matrix_ty = ty_to_spirv_dialect(ctx, self.result_type(ctx));
 
-        let value = CooperativeMatrixLoadOp::new(
+        let load = CooperativeMatrixLoadOp::new(
             ctx,
             matrix_ty,
             value_ptr,
@@ -106,36 +101,30 @@ impl ToSpirvDialectOp for matrix::LoadOp {
             MemoryAccess::ALIGNED,
             Some(align),
         );
-        rewriter.append_op(ctx, &value);
-        let value = value.get_result(ctx);
-        let store = StoreOp::new(ctx, matrix_ptr, value, MemoryAccess::NONE, None);
-        rewriter.append_op(ctx, &store);
-        rewriter.erase_operation(ctx, self.get_operation());
+        rewriter.append_op(ctx, &load);
+        rewriter.replace_operation(ctx, self.get_operation(), load.get_operation());
         Ok(())
     }
 }
 
 #[op_interface_impl]
-impl ToSpirvDialectOp for matrix::StoreOp {
+impl ToSpirvDialectOp for ssa_matrix::StoreOp {
     fn to_spirv_dialect(
         &self,
         ctx: &mut Context,
         rewriter: &mut DialectConversionRewriter,
         _operands_info: &OperandsInfo,
     ) -> Result<()> {
-        let matrix_ptr = self.matrix(ctx);
+        let matrix = self.matrix(ctx);
         let value_ptr = self.destination(ctx);
         let align = unwrap_ptr(value_ptr, ctx).align(ctx) as u32;
         let layout = layout_to_spirv(self.layout(ctx).0);
         let stride = adjust_stride(ctx, rewriter, self.stride(ctx), value_ptr);
-        let matrix_ty = ty_to_spirv_dialect(ctx, unwrap_ptr(matrix_ptr, ctx));
 
-        let value = LoadOp::new(ctx, matrix_ty, matrix_ptr, MemoryAccess::NONE, None);
-        let value = rewriter.append_op_with_result(ctx, &value);
         let store = CooperativeMatrixStoreOp::new(
             ctx,
             value_ptr,
-            value,
+            matrix,
             layout,
             Some(stride),
             MemoryAccess::ALIGNED,
@@ -148,8 +137,8 @@ impl ToSpirvDialectOp for matrix::StoreOp {
 }
 
 pub(super) fn elem_ty_prev(
-    ctx: &Context,
     value: Value,
+    ctx: &Context,
     operands_info: &OperandsInfo,
 ) -> TypeHandle {
     let info = operands_info.lookup_most_recent_type(value).unwrap();
@@ -157,7 +146,7 @@ pub(super) fn elem_ty_prev(
 }
 
 #[op_interface_impl]
-impl ToSpirvDialectOp for matrix::MultiplyAccumulateOp {
+impl ToSpirvDialectOp for ssa_matrix::MultiplyAccumulateOp {
     fn to_spirv_dialect(
         &self,
         ctx: &mut Context,
@@ -167,48 +156,32 @@ impl ToSpirvDialectOp for matrix::MultiplyAccumulateOp {
         let mat_a = self.mat_a(ctx);
         let mat_b = self.mat_b(ctx);
         let mat_c = self.mat_c(ctx);
-        let mat_d = self.mat_d(ctx);
+        let out_ty = ty_to_spirv_dialect(ctx, self.result_type(ctx));
 
         let mut operands = CooperativeMatrixOperands::NONE_KHR;
-        if elem_ty_prev(ctx, mat_a, operands_info).is_signed_int(ctx) {
+        if elem_ty_prev(mat_a, ctx, operands_info).is_signed_int(ctx) {
             operands |= CooperativeMatrixOperands::MATRIX_A_SIGNED_COMPONENTS_KHR;
         }
-        if elem_ty_prev(ctx, mat_b, operands_info).is_signed_int(ctx) {
+        if elem_ty_prev(mat_b, ctx, operands_info).is_signed_int(ctx) {
             operands |= CooperativeMatrixOperands::MATRIX_B_SIGNED_COMPONENTS_KHR;
         }
-        if elem_ty_prev(ctx, mat_c, operands_info).is_signed_int(ctx) {
+        if elem_ty_prev(mat_c, ctx, operands_info).is_signed_int(ctx) {
             operands |= CooperativeMatrixOperands::MATRIX_C_SIGNED_COMPONENTS_KHR;
         }
-        if elem_ty_prev(ctx, mat_d, operands_info).is_signed_int(ctx) {
+        if self.result_type(ctx).element_ty(ctx).is_signed_int(ctx) {
             operands |= CooperativeMatrixOperands::MATRIX_RESULT_SIGNED_COMPONENTS_KHR;
         }
 
-        let mat_a = LoadOp::new(ctx, unwrap_ptr(mat_a, ctx), mat_a, MemoryAccess::NONE, None);
-        let mat_b = LoadOp::new(ctx, unwrap_ptr(mat_b, ctx), mat_b, MemoryAccess::NONE, None);
-        let mat_c = LoadOp::new(ctx, unwrap_ptr(mat_c, ctx), mat_c, MemoryAccess::NONE, None);
-
-        let mat_a = rewriter.append_op_with_result(ctx, &mat_a);
-        let mat_b = rewriter.append_op_with_result(ctx, &mat_b);
-        let mat_c = rewriter.append_op_with_result(ctx, &mat_c);
-
-        let execute = CooperativeMatrixMulAddOp::new(
-            ctx,
-            unwrap_ptr(mat_d, ctx),
-            mat_a,
-            mat_b,
-            mat_c,
-            Some(operands.into()),
-        );
-        let value_d = rewriter.append_op_with_result(ctx, &execute);
-        let store = StoreOp::new(ctx, mat_d, value_d, MemoryAccess::NONE, None);
-        rewriter.append_op(ctx, &store);
-        rewriter.erase_operation(ctx, self.get_operation());
+        let execute =
+            CooperativeMatrixMulAddOp::new(ctx, out_ty, mat_a, mat_b, mat_c, Some(operands.into()));
+        rewriter.append_op(ctx, &execute);
+        rewriter.replace_operation(ctx, self.get_operation(), execute.get_operation());
         Ok(())
     }
 }
 
 #[op_interface_impl]
-impl ToSpirvDialectOp for matrix::CastOp {
+impl ToSpirvDialectOp for ssa_matrix::CastOp {
     fn to_spirv_dialect(
         &self,
         ctx: &mut Context,
@@ -216,36 +189,28 @@ impl ToSpirvDialectOp for matrix::CastOp {
         operands_info: &OperandsInfo,
     ) -> Result<()> {
         let mat_in = self.input(ctx);
-        let mat_out = self.output(ctx);
+
+        let elem_in = elem_ty_prev(mat_in, ctx, operands_info);
+        let out_ty = ty_to_spirv_dialect(ctx, self.result_type(ctx));
+        let elem_out = self.result_type(ctx).element_ty(ctx);
 
         let input_ident = matrix_ident(ctx, mat_in);
-        let output_ident = matrix_ident(ctx, mat_out);
-
-        let in_ty = unwrap_ptr(mat_in, ctx);
-        let elem_in = elem_ty_prev(ctx, mat_in, operands_info);
-        let out_ty = unwrap_ptr(mat_out, ctx);
-        let elem_out = elem_ty_prev(ctx, mat_out, operands_info);
-
-        let mat_in = LoadOp::new(ctx, in_ty, mat_in, MemoryAccess::NONE, None);
-        let mat_in = rewriter.append_op_with_result(ctx, &mat_in);
+        let output_ident = matrix_ident(ctx, out_ty);
 
         let value_out = if elem_in == elem_out && input_ident != output_ident {
             let cast = CooperativeMatrixConvertOp::new(ctx, out_ty, mat_in);
             rewriter.append_op_with_result(ctx, &cast)
         } else {
-            let out_ty_prev = operands_info.lookup_most_recent_type(mat_out).unwrap();
-            cast(ctx, rewriter, mat_in, elem_in, out_ty_prev.unwrap_ptr(ctx))
+            cast(ctx, rewriter, mat_in, elem_in, self.result_type(ctx))
         };
 
-        let store = StoreOp::new(ctx, mat_out, value_out, MemoryAccess::NONE, None);
-        rewriter.append_op(ctx, &store);
-        rewriter.erase_operation(ctx, self.get_operation());
+        rewriter.replace_operation_with_values(ctx, self.get_operation(), vec![value_out]);
         Ok(())
     }
 }
 
 #[op_interface_impl]
-impl ToSpirvDialectOp for matrix::ElementwiseOp {
+impl ToSpirvDialectOp for ssa_matrix::ElementwiseOp {
     fn to_spirv_dialect(
         &self,
         ctx: &mut Context,
@@ -253,22 +218,14 @@ impl ToSpirvDialectOp for matrix::ElementwiseOp {
         _operands_info: &OperandsInfo,
     ) -> Result<()> {
         let mat_in = self.matrix_in(ctx);
-        let mat_out = self.matrix_out(ctx);
         let closure = self.closure(ctx);
         let captures = self.closure_captures(ctx);
 
-        let in_ty = unwrap_ptr(mat_in, ctx);
-        let out_ty = unwrap_ptr(mat_out, ctx);
-
-        let mat_in = LoadOp::new(ctx, in_ty, mat_in, MemoryAccess::NONE, None);
-        let mat_in = rewriter.append_op_with_result(ctx, &mat_in);
+        let out_ty = ty_to_spirv_dialect(ctx, self.result_type(ctx));
 
         let elemwise = CooperativeMatrixPerElementOpOp::new(ctx, out_ty, mat_in, closure, captures);
-        let value_out = rewriter.append_op_with_result(ctx, &elemwise);
-
-        let store = StoreOp::new(ctx, mat_out, value_out, MemoryAccess::NONE, None);
-        rewriter.append_op(ctx, &store);
-        rewriter.erase_operation(ctx, self.get_operation());
+        rewriter.append_op(ctx, &elemwise);
+        rewriter.replace_operation(ctx, self.get_operation(), elemwise.get_operation());
         Ok(())
     }
 }

--- a/crates/cubecl-spirv/src/ops/tensor_indexing.rs
+++ b/crates/cubecl-spirv/src/ops/tensor_indexing.rs
@@ -12,12 +12,9 @@ use pliron::{
 };
 use pliron_spirv::{
     attrs::CompositeAttr,
-    ops::{
-        StoreOp,
-        nv::{
-            CreateTensorLayoutOp, CreateTensorViewOp, TensorLayoutSetClampValueOp,
-            TensorLayoutSetDimensionOp, TensorLayoutSetStrideOp, TensorLayoutSliceOp,
-        },
+    ops::nv::{
+        CreateTensorLayoutOp, CreateTensorViewOp, TensorLayoutSetClampValueOp,
+        TensorLayoutSetDimensionOp, TensorLayoutSetStrideOp, TensorLayoutSliceOp,
     },
     tensor_addressing_nv::{CooperativeMatrixLoadTensorOp, CooperativeMatrixStoreTensorOp},
 };
@@ -25,11 +22,7 @@ use rspirv::spirv::{MemoryAccess, TensorAddressingOperands};
 
 use crate::{
     attributes::attr_to_spirv_dialect,
-    ops::{
-        builtin::const_op_int32,
-        matrix::{elem_ty_prev, unwrap_ptr},
-        to_spirv_dialect::ToSpirvDialectOp,
-    },
+    ops::{builtin::const_op_int32, matrix::elem_ty_prev, to_spirv_dialect::ToSpirvDialectOp},
     types::ty_to_spirv_dialect,
 };
 
@@ -107,15 +100,14 @@ impl ToSpirvDialectOp for spirv::LoadTensorOp {
         &self,
         ctx: &mut Context,
         rewriter: &mut DialectConversionRewriter,
-        operands_info: &OperandsInfo,
+        _: &OperandsInfo,
     ) -> Result<()> {
         let buffer = self.buffer(ctx);
         let layout = self.layout(ctx);
         let view = self.view(ctx);
-        let mat_out = self.out_mat(ctx);
 
-        let matrix_ty = ty_to_spirv_dialect(ctx, unwrap_ptr(mat_out, ctx));
-        let elem_ty = elem_ty_prev(ctx, mat_out, operands_info);
+        let matrix_ty = ty_to_spirv_dialect(ctx, self.result_type(ctx));
+        let elem_ty = self.result_type(ctx).element_ty(ctx);
         let align = elem_ty.align(ctx) as u32;
         let zero = const_matrix(ctx, rewriter, elem_ty, matrix_ty, 0.into());
 
@@ -124,7 +116,7 @@ impl ToSpirvDialectOp for spirv::LoadTensorOp {
             None => TensorAddressingOperands::NONE,
         };
 
-        let value = CooperativeMatrixLoadTensorOp::new(
+        let load = CooperativeMatrixLoadTensorOp::new(
             ctx,
             matrix_ty,
             buffer,
@@ -136,10 +128,8 @@ impl ToSpirvDialectOp for spirv::LoadTensorOp {
             view,
             None,
         );
-        let value = rewriter.append_op_with_result(ctx, &value);
-        let store = StoreOp::new(ctx, mat_out, value, MemoryAccess::NONE, None);
-        rewriter.append_op(ctx, &store);
-        rewriter.erase_operation(ctx, self.get_operation());
+        rewriter.append_op(ctx, &load);
+        rewriter.replace_operation(ctx, self.get_operation(), load.get_operation());
         Ok(())
     }
 }
@@ -157,7 +147,7 @@ impl ToSpirvDialectOp for spirv::StoreTensorOp {
         let layout = self.layout(ctx);
         let view = self.view(ctx);
 
-        let elem_ty = elem_ty_prev(ctx, matrix, operands_info);
+        let elem_ty = elem_ty_prev(matrix, ctx, operands_info);
         let align = elem_ty.align(ctx) as u32;
 
         let operands = match view {


### PR DESCRIPTION
Adds a new dialect for matrix ops that take the matrices as values instead of by pointer. The memory args are still pointers obviously. I wanted to use it for Metal, but it turns out that actually uses a weird hybrid model where fill returns a matrix by value, but other functions take them by C++ reference (not by pointer but it has the same IR semantics). So that stays with the pointer variant. Making it no longer dependent on the pointers allows `mem2reg` to convert the variable declarations to regular SSA values.

Performance impact is only ~1% for SPIR-V, but also sets up matrices for other optimizations that haven't been implemented yet.

While debugging I noticed leftover result/carried args on loops when a variable was both written to and read inside a loop, with no cross-loop dependencies. So I added a canonicalization pass that currently just cleans that up but may be used for other purposes in the future.
Fixes memory semantics for some matrix ops that were missing read/write annotations.
Fixes result types for SPIR-V control flow constructs, this was an existing bug unearthed by this change.