### PR TITLE
chore(deps): bump tracel-ai/github-actions from v10 to v11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v6
       # --------------------------------------------------------------------------------
       - name: Install Rust
-        uses: tracel-ai/github-actions/install-rust@v10
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux
@@ -75,7 +75,7 @@ jobs:
         run: xtask check --ci lint
       # --------------------------------------------------------------------------------
       - name: Typos
-        uses: tracel-ai/github-actions/check-typos@v10
+        uses: tracel-ai/github-actions/check-typos@v11
 
   documentation:
     runs-on: ubuntu-22.04
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v6
       # --------------------------------------------------------------------------------
       - name: Install Rust
-        uses: tracel-ai/github-actions/install-rust@v10
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux
@@ -127,17 +127,17 @@ jobs:
         uses: actions/checkout@v6
       # --------------------------------------------------------------------------------
       - name: Install Rust
-        uses: tracel-ai/github-actions/install-rust@v10
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux
           apt-packages: build-essential
       # --------------------------------------------------------------------------------
       - name: Install Mesa
-        uses: tracel-ai/github-actions/install-mesa@v10
+        uses: tracel-ai/github-actions/install-mesa@v11
       # --------------------------------------------------------------------------------
       - name: Install Vulkan SDK
-        uses: tracel-ai/github-actions/install-vulkan-sdk@v10
+        uses: tracel-ai/github-actions/install-vulkan-sdk@v11
       # --------------------------------------------------------------------------------
       - name: Tests
         run: xtask test --ci
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v6
       # --------------------------------------------------------------------------------
       - name: Install Rust
-        uses: tracel-ai/github-actions/install-rust@v10
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-miri-tests
@@ -173,10 +173,10 @@ jobs:
           apt-packages: build-essential
       # --------------------------------------------------------------------------------
       - name: Install Mesa
-        uses: tracel-ai/github-actions/install-mesa@v10
+        uses: tracel-ai/github-actions/install-mesa@v11
       # --------------------------------------------------------------------------------
       - name: Install Vulkan SDK
-        uses: tracel-ai/github-actions/install-vulkan-sdk@v10
+        uses: tracel-ai/github-actions/install-vulkan-sdk@v11
       # --------------------------------------------------------------------------------
       - name: Tests
         run: xtask +n test --miri ub-only --ci


### PR DESCRIPTION
Bumps the 9 shared-action pins in `ci.yml` from `@v10` to `@v11`. `publish.yml` is a separate PR.

## Why

v11 bounds every apt and curl call in `tracel-ai/github-actions` (tracel-ai/github-actions#5). Canonical's `azure.archive.ubuntu.com` intermittently stops answering from GitHub runners, apt fails over to `archive.ubuntu.com`, which accepts the connection and then delivers nothing. With nothing bounding it, the step runs to GitHub's 6 hour job ceiling.

cubecl lost 2 jobs that way over roughly 20 CI runs between 2026-08-17 and 2026-08-19, both in `code-quality (stable)` at `Install Rust`. `v10` was not moved when the fix landed, so this bump is what picks it up.

## What else changes

For the four actions used here, `v10` to `v11` is the timeout bounds plus one thing: the xtask install moves from two inline steps into `install-xtask-cli@v11`, which runs the same `cargo install tracel-xtask-cli`. Nothing else.

## Potential issues

- **The timeout changes have not run on a GitHub runner before.** They were verified locally against a server that accepts a connection and then delivers nothing, but this is among their first real executions. `install-vulkan-sdk` on macOS and Windows is untested anywhere.
- **If a mirror stalls during this run, the expected result is a red step in about 15 minutes**, not a hung job. That is the fix working, not a regression.
