### PR TITLE
chore(deps): bump tracel-ai/github-actions from v8 to v11 in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   publish-cubecl-zspace:
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-zspace
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -24,7 +24,7 @@ jobs:
   publish-cubecl-common:
     needs:
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-common
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -32,7 +32,7 @@ jobs:
       CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
 
   publish-cubecl-environment:
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-environment
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -40,7 +40,7 @@ jobs:
       CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
 
   publish-cubecl-macros-internal:
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-macros-internal
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -52,7 +52,7 @@ jobs:
       - publish-cubecl-common
       - publish-cubecl-environment
       - publish-cubecl-macros-internal
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-ir
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -64,7 +64,7 @@ jobs:
       - publish-cubecl-core
       - publish-cubecl-environment
       - publish-cubecl-runtime
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-std
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -76,7 +76,7 @@ jobs:
       - publish-cubecl-ir
       - publish-cubecl-common
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-runtime
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -86,7 +86,7 @@ jobs:
   publish-cubecl-macros:
     needs:
       - publish-cubecl-common
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-macros
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -99,7 +99,7 @@ jobs:
       - publish-cubecl-runtime
       - publish-cubecl-macros
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-core
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -112,7 +112,7 @@ jobs:
       - publish-cubecl-common
       - publish-cubecl-core
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-opt
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -126,7 +126,7 @@ jobs:
       - publish-cubecl-core
       - publish-cubecl-runtime
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-spirv
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -141,7 +141,7 @@ jobs:
       - publish-cubecl-runtime
       - publish-cubecl-core
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-wgpu
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -155,7 +155,7 @@ jobs:
       - publish-cubecl-core
       - publish-cubecl-opt
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-cpp
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -170,7 +170,7 @@ jobs:
       - publish-cubecl-runtime
       - publish-cubecl-core
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-cuda
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -185,7 +185,7 @@ jobs:
       - publish-cubecl-runtime
       - publish-cubecl-core
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-hip
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -200,7 +200,7 @@ jobs:
       - publish-cubecl-runtime
       - publish-cubecl-opt
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-cpu
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -216,7 +216,7 @@ jobs:
       - publish-cubecl-ir
       - publish-cubecl-runtime
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl-metal
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -231,7 +231,7 @@ jobs:
       - publish-cubecl-cpu
       - publish-cubecl-metal
       - publish-cubecl-environment
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubecl
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}


### PR DESCRIPTION
Bumps the 18 `publish-crate.yml` pins in `publish.yml` from `@v8` to `@v11`.

Split out from #1535 so it can be judged separately. The two PRs touch disjoint files and are independent, either can merge first.

`publish-crate.yml` did not change between v8 and v9, so this is the identical change as tracel-ai/burn#5391.

## What it does

v11's `publish-crate.yml` bounds its `apt-get update` and `apt-get install`, so a stalled Ubuntu mirror cannot hang a release job to GitHub's 6 hour ceiling. It also changes how xtask is invoked:

| | v8 | v11 |
|---|---|---|
| command | `cargo xtask publish` | `xtask publish` |
| resolves via | cubecl's `.cargo/config.toml` alias | the `tracel-xtask-cli` binary |

## Why that is not a behavior change

`tracel-xtask-cli` is a **launcher**, not a reimplementation. It finds the git root, locates the local xtask crate, and runs it ([main.rs](https://github.com/tracel-ai/xtask/blob/main/crates/tracel-xtask-cli/src/main.rs)):

> The xtask crate is a real workspace member, so we can invoke it via:
> `cargo run --package <package> --bin <bin> -- ...`

That is what cubecl's alias already does. Both paths execute cubecl's own `xtask` crate, so the publish logic still comes from `tracel-xtask = "=4.16.0"` as pinned in `xtask/Cargo.toml`. The CLI's own version does not affect what publish does.

## What actually differs

- **Target directory.** The alias uses `target/xtask`; the CLI uses a persistent cache under `~/.cache/xtask/targets/`. Both are cold on a fresh runner.
- **`sync_workspace_dependencies` runs first**, and it can rewrite `Cargo.toml` files. It returns immediately when there is no `Dependencies.toml` at the git root. **cubecl has none**, so this is a no-op here. Worth knowing if cubecl ever adds one.
- **A new step on the release path.** The publish job now runs `cargo install tracel-xtask-cli`, unpinned. A new compile and a new network dependency, so a new place the release can fail. It fails loudly rather than publishing something wrong.

## Verdict

Low risk. The residual concerns are the unpinned launcher and one extra step on a path that runs a handful of times a year. Separate from #1535 because it touches releases and #1535 does not.
