### PR TITLE
feat(cpu): implement thread affinity and topology on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,12 @@ futures-util = { version = "0.3.32", default-features = false, features = [
 # CubeCL-CPU
 libc = "^0.2.186"
 sysinfo = "0.39"
-winapi = { version = "^0.3.9", features = ["processthreadsapi", "winbase"] }
+winapi = { version = "^0.3.9", features = [
+    "processthreadsapi",
+    "processtopologyapi",
+    "sysinfoapi",
+    "winbase",
+] }
 
 inflections = "1"
 

--- a/crates/cubecl-cpu/src/compute/affinity/fallback.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/fallback.rs
@@ -19,3 +19,15 @@ impl ThreadAffinity for Platform {
 
     fn pin_current(_cpu: CoreId) {}
 }
+
+/// What the tests in [`super`] need of this platform beyond the trait.
+#[cfg(test)]
+impl Platform {
+    /// No topology to read, so the tests require nothing of it.
+    pub(super) const READS_TOPOLOGY: bool = false;
+
+    /// Nothing is pinned, so there is nothing to observe.
+    pub(super) fn current_cpu() -> Option<CoreId> {
+        None
+    }
+}

--- a/crates/cubecl-cpu/src/compute/affinity/linux.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/linux.rs
@@ -70,3 +70,16 @@ fn get_affinity_mask() -> cpu_set_t {
 fn new_cpu_set() -> cpu_set_t {
     unsafe { std::mem::zeroed::<cpu_set_t>() }
 }
+
+/// What the tests in [`super`] need of this platform beyond the trait.
+#[cfg(test)]
+impl Platform {
+    /// sysfs reports a real topology here.
+    pub(super) const READS_TOPOLOGY: bool = true;
+
+    /// The CPU the calling thread is on, which a pinned thread cannot leave.
+    pub(super) fn current_cpu() -> Option<CoreId> {
+        let cpu = unsafe { libc::sched_getcpu() };
+        usize::try_from(cpu).ok().map(CoreId)
+    }
+}

--- a/crates/cubecl-cpu/src/compute/affinity/macos.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/macos.rs
@@ -74,3 +74,16 @@ fn sysctl(name: &CStr) -> Option<u64> {
     // little-endian targets macOS runs on.
     (ret == 0 && (size == 4 || size == 8)).then_some(value)
 }
+
+/// What the tests in [`super`] need of this platform beyond the trait.
+#[cfg(test)]
+impl Platform {
+    /// The `hw` sysctls report a real topology here.
+    pub(super) const READS_TOPOLOGY: bool = true;
+
+    /// Darwin only hints at affinity and offers userspace no way to ask which
+    /// CPU a thread is on, so the pinning test has nothing to check against.
+    pub(super) fn current_cpu() -> Option<CoreId> {
+        None
+    }
+}

--- a/crates/cubecl-cpu/src/compute/affinity/mod.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/mod.rs
@@ -56,12 +56,18 @@ trait ThreadAffinity {
 /// siblings after, so a launch with up to `physical cores` units gets a whole
 /// core per unit. A CPU whose physical core is unknown counts as its own.
 pub fn get_active_cores() -> impl Iterator<Item = CoreId> {
-    let cpus = Platform::active_cpus();
+    ordered_cores::<Platform>()
+}
+
+/// [`get_active_cores`] over any platform, so the policy is testable on a
+/// made-up topology.
+fn ordered_cores<P: ThreadAffinity>() -> impl Iterator<Item = CoreId> {
+    let cpus = P::active_cpus();
     let mut primaries = Vec::with_capacity(cpus.len());
     let mut siblings = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for cpu in cpus {
-        let core = Platform::physical_core(cpu).unwrap_or(cpu);
+        let core = P::physical_core(cpu).unwrap_or(cpu);
         if seen.insert(core) {
             primaries.push(cpu);
         } else {
@@ -79,4 +85,101 @@ pub fn set_for_current(core_id: CoreId) {
 /// Bytes of a core's L1 data cache, or `None` when it cannot be read.
 pub fn l1d_cache_size() -> Option<usize> {
     Platform::l1d_cache_size()
+}
+
+/// Runs on every platform: the policy on a made-up topology, and the
+/// platform's own answers checked for the invariants the policy relies on.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(cpus: impl IntoIterator<Item = CoreId>) -> Vec<usize> {
+        cpus.into_iter().map(|cpu| cpu.0).collect()
+    }
+
+    #[test]
+    fn cores_are_ordered_one_per_physical_core_then_siblings() {
+        // The SMT machine the one running this may not be: sibling pairs
+        // (0, 1) and (2, 3), a CPU whose core is unknown, then a lone core.
+        struct Fake;
+
+        impl ThreadAffinity for Fake {
+            fn active_cpus() -> Vec<CoreId> {
+                (0..6).map(CoreId).collect()
+            }
+
+            fn physical_core(cpu: CoreId) -> Option<CoreId> {
+                match cpu.0 {
+                    0 | 1 => Some(CoreId(0)),
+                    2 | 3 => Some(CoreId(2)),
+                    4 => None,
+                    _ => Some(cpu),
+                }
+            }
+
+            fn l1d_cache_size() -> Option<usize> {
+                None
+            }
+
+            fn pin_current(_cpu: CoreId) {}
+        }
+
+        assert_eq!(ids(ordered_cores::<Fake>()), [0, 2, 4, 5, 1, 3]);
+    }
+
+    #[test]
+    fn active_cpus_are_distinct_and_ascending() {
+        let cpus = ids(Platform::active_cpus());
+        assert!(!cpus.is_empty());
+        assert!(cpus.windows(2).all(|pair| pair[0] < pair[1]), "{cpus:?}");
+    }
+
+    #[test]
+    fn active_cores_are_the_active_cpus_reordered() {
+        let mut cores = ids(get_active_cores());
+        cores.sort_unstable();
+        assert_eq!(cores, ids(Platform::active_cpus()));
+    }
+
+    #[test]
+    fn physical_core_is_a_sibling_no_higher_than_the_cpu_and_its_own_core() {
+        for cpu in Platform::active_cpus() {
+            let core = Platform::physical_core(cpu);
+            assert!(
+                core.is_some() || !Platform::READS_TOPOLOGY,
+                "no core for {cpu:?}"
+            );
+            if let Some(core) = core {
+                assert!(core <= cpu, "{cpu:?} belongs to {core:?}");
+                assert_eq!(Platform::physical_core(core), Some(core));
+            }
+        }
+    }
+
+    #[test]
+    fn l1d_cache_size_is_a_plausible_cache_size() {
+        let size = Platform::l1d_cache_size();
+        assert!(size.is_some() || !Platform::READS_TOPOLOGY);
+        if let Some(size) = size {
+            assert!((4 * 1024..=1024 * 1024).contains(&size), "{size}");
+            assert_eq!(size % 1024, 0, "{size}");
+        }
+    }
+
+    #[test]
+    fn pinned_threads_run_on_their_cpu() {
+        let cpus = Platform::active_cpus();
+        // On a thread of its own: pinning sticks to the thread that asked.
+        std::thread::spawn(move || {
+            for cpu in cpus {
+                set_for_current(cpu);
+                // A pinned thread can only be running on its CPU.
+                if let Some(running) = Platform::current_cpu() {
+                    assert_eq!(running, cpu);
+                }
+            }
+        })
+        .join()
+        .unwrap();
+    }
 }

--- a/crates/cubecl-cpu/src/compute/affinity/windows.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/windows.rs
@@ -1,49 +1,238 @@
-use winapi::shared::basetsd::{DWORD_PTR, PDWORD_PTR};
+//! Windows numbers logical processors per *processor group* of at most 64 (a
+//! `KAFFINITY` of bits); only a machine with more than 64 has several groups.
+//! A [`CoreId`] here is `group * 64 + bit`, one flat numbering across groups,
+//! and both pinning and topology go through the group-aware APIs, so such a
+//! machine is covered whole rather than through its first group.
+
+use std::{mem, ptr};
+
+use winapi::shared::basetsd::{DWORD_PTR, KAFFINITY};
+use winapi::shared::minwindef::DWORD;
 use winapi::um::processthreadsapi::{GetCurrentProcess, GetCurrentThread};
-use winapi::um::winbase::{GetProcessAffinityMask, SetThreadAffinityMask};
+use winapi::um::processtopologyapi::{GetThreadGroupAffinity, SetThreadGroupAffinity};
+use winapi::um::sysinfoapi::GetLogicalProcessorInformationEx;
+use winapi::um::winbase::GetProcessAffinityMask;
+use winapi::um::winnt::{
+    CacheData, GROUP_AFFINITY, LOGICAL_PROCESSOR_RELATIONSHIP, RelationCache,
+    RelationProcessorCore, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+};
 
 use super::{CoreId, ThreadAffinity};
+
+/// One record of `GetLogicalProcessorInformationEx`.
+type Record = SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
+
+/// `CoreId`s per processor group: a group holds one `KAFFINITY` of logical
+/// processors (`MAXIMUM_PROC_PER_GROUP`, 64 on 64-bit Windows).
+const GROUP_STRIDE: usize = KAFFINITY::BITS as usize;
 
 pub(super) struct Platform;
 
 impl ThreadAffinity for Platform {
-    /// A system with more than 64 cores needs another API on Windows that is
-    /// not currently implemented.
     fn active_cpus() -> Vec<CoreId> {
-        let mask = get_affinity_mask();
-        (0..64_u64)
-            .filter(|&i| (mask & 1 << i) == 1 << i)
-            .map(|i| CoreId(i as usize))
-            .collect()
+        let mut cpus: Vec<_> = match process_affinity() {
+            Some(affinity) => cpus_of(&affinity).collect(),
+            // Every processor of every group, since each belongs to one core.
+            None => core_masks().iter().flat_map(cpus_of).collect(),
+        };
+        cpus.sort_unstable();
+        if cpus.is_empty() {
+            // Nothing could be read; std's count, numbered from 0, keeps the
+            // pool from ending up with no core to put a worker on.
+            let cores = std::thread::available_parallelism().map_or(1, |n| n.get());
+            cpus = (0..cores).map(CoreId).collect();
+        }
+        cpus
     }
 
-    fn physical_core(_cpu: CoreId) -> Option<CoreId> {
-        // Needs `GetLogicalProcessorInformationEx`, not implemented yet.
-        None
+    fn physical_core(cpu: CoreId) -> Option<CoreId> {
+        core_masks()
+            .iter()
+            .find(|siblings| cpus_of(siblings).any(|sibling| sibling == cpu))
+            .and_then(|siblings| cpus_of(siblings).next())
     }
 
     fn l1d_cache_size() -> Option<usize> {
-        // Needs `GetLogicalProcessorInformation`, not implemented yet.
-        None
+        // One record per cache instance; the smallest L1d, since hybrid parts
+        // give their efficiency cores less and a stage sized to that stays
+        // resident on whichever core runs it.
+        records(RelationCache)
+            .iter()
+            .map(|record| unsafe { record.u.Cache() })
+            .filter(|cache| cache.Level == 1 && cache.Type == CacheData && cache.CacheSize > 0)
+            .map(|cache| cache.CacheSize as usize)
+            .min()
     }
 
     fn pin_current(cpu: CoreId) {
-        let mask: u64 = 1 << cpu.0;
-        unsafe { SetThreadAffinityMask(GetCurrentThread(), mask as DWORD_PTR) };
+        let affinity = GROUP_AFFINITY {
+            Mask: 1 << (cpu.0 % GROUP_STRIDE),
+            Group: (cpu.0 / GROUP_STRIDE) as u16,
+            Reserved: [0; 3],
+        };
+        unsafe { SetThreadGroupAffinity(GetCurrentThread(), &affinity, ptr::null_mut()) };
     }
 }
 
-fn get_affinity_mask() -> u64 {
-    let mut system_mask: usize = 0;
-    let mut process_mask: usize = 0;
+/// The SMT siblings of every physical core, one group affinity each.
+fn core_masks() -> Vec<GROUP_AFFINITY> {
+    records(RelationProcessorCore)
+        .iter()
+        // A core's logical processors always share one group, so Windows
+        // documents `GroupCount` as 1 and `GroupMask[0]` is the whole core.
+        .map(|record| unsafe { record.u.Processor() }.GroupMask[0])
+        .collect()
+}
 
-    unsafe {
-        GetProcessAffinityMask(
-            GetCurrentProcess(),
-            &mut process_mask as PDWORD_PTR,
-            &mut system_mask as PDWORD_PTR,
-        );
+/// The affinity of the calling process, or `None` once its threads span
+/// several groups, the default past 64 logical processors, which reports an
+/// all-zero mask and may run on every processor of every group.
+fn process_affinity() -> Option<GROUP_AFFINITY> {
+    let (mut process, mut system): (DWORD_PTR, DWORD_PTR) = (0, 0);
+    let ok = unsafe { GetProcessAffinityMask(GetCurrentProcess(), &mut process, &mut system) };
+    if ok == 0 || process == 0 {
+        return None;
+    }
+    // A non-zero mask means every thread is in one group, the caller's, whose
+    // number is all this reads back; the process mask is the one to keep.
+    let mut affinity: GROUP_AFFINITY = unsafe { mem::zeroed() };
+    let ok = unsafe { GetThreadGroupAffinity(GetCurrentThread(), &mut affinity) };
+    affinity.Mask = process;
+    (ok != 0).then_some(affinity)
+}
+
+/// The CPUs a group affinity selects, lowest first.
+fn cpus_of(affinity: &GROUP_AFFINITY) -> impl Iterator<Item = CoreId> {
+    let (mask, group) = (affinity.Mask, affinity.Group as usize);
+    (0..GROUP_STRIDE)
+        .filter(move |bit| mask >> bit & 1 == 1)
+        .map(move |bit| CoreId(group * GROUP_STRIDE + bit))
+}
+
+/// The records `GetLogicalProcessorInformationEx` returns for `relationship`,
+/// or none when the query fails.
+fn records(relationship: LOGICAL_PROCESSOR_RELATIONSHIP) -> Vec<Record> {
+    // Without a buffer the call fails and reports the length needed. The
+    // buffer is `u64`s so the records land at the alignment they are laid out
+    // with, the parser reading their fields back out of the bytes.
+    let mut len: DWORD = 0;
+    unsafe { GetLogicalProcessorInformationEx(relationship, ptr::null_mut(), &mut len) };
+    let mut buffer = vec![0u64; (len as usize).div_ceil(mem::size_of::<u64>())];
+    let ok = unsafe {
+        GetLogicalProcessorInformationEx(relationship, buffer.as_mut_ptr().cast(), &mut len)
+    };
+    let bytes = bytemuck::cast_slice::<u64, u8>(&buffer);
+    let filled = if ok != 0 { len as usize } else { 0 };
+    parse(&bytes[..filled.min(bytes.len())], relationship)
+}
+
+/// Splits a query buffer into the records matching `relationship`. Records are
+/// variable-length, a header then a body ending in an array, so each is
+/// copied into the fixed-size struct, which holds the array's first entry:
+/// the whole of a core (one group affinity) or of a cache.
+fn parse(bytes: &[u8], relationship: LOGICAL_PROCESSOR_RELATIONSHIP) -> Vec<Record> {
+    let header = mem::offset_of!(Record, u);
+    let mut records = Vec::new();
+    let mut offset = 0;
+    while offset + header <= bytes.len() {
+        let size = &bytes[offset + mem::offset_of!(Record, Size)..][..mem::size_of::<DWORD>()];
+        let size = DWORD::from_ne_bytes(size.try_into().unwrap()) as usize;
+        // A record smaller than its own header, or reaching past the buffer,
+        // leaves the rest unwalkable; a zero size would never advance either.
+        if size < header || offset + size > bytes.len() {
+            break;
+        }
+        let mut record: Record = unsafe { mem::zeroed() };
+        unsafe {
+            ptr::copy_nonoverlapping(
+                bytes[offset..].as_ptr(),
+                ptr::from_mut(&mut record).cast::<u8>(),
+                size.min(mem::size_of::<Record>()),
+            );
+        }
+        if record.Relationship == relationship {
+            records.push(record);
+        }
+        offset += size;
+    }
+    records
+}
+
+/// What the tests in [`super`] need of this platform beyond the trait.
+#[cfg(test)]
+impl Platform {
+    /// `GetLogicalProcessorInformationEx` reports a real topology here.
+    pub(super) const READS_TOPOLOGY: bool = true;
+
+    /// The CPU the calling thread is on, which a pinned thread cannot leave.
+    pub(super) fn current_cpu() -> Option<CoreId> {
+        let mut number: winapi::um::winnt::PROCESSOR_NUMBER = unsafe { mem::zeroed() };
+        unsafe { winapi::um::processthreadsapi::GetCurrentProcessorNumberEx(&mut number) };
+        Some(CoreId(
+            number.Group as usize * GROUP_STRIDE + number.Number as usize,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use winapi::um::winnt::PROCESSOR_RELATIONSHIP;
+
+    use super::*;
+
+    fn put(record: &mut [u8], offset: usize, bytes: &[u8]) {
+        record[offset..offset + bytes.len()].copy_from_slice(bytes);
     }
 
-    process_mask as u64
+    /// A `RelationProcessorCore` record for one core, its SMT siblings the set
+    /// bits of `mask` within processor group `group`.
+    fn core(group: u16, mask: KAFFINITY) -> Vec<u8> {
+        let body = mem::offset_of!(Record, u);
+        let masks = body + mem::offset_of!(PROCESSOR_RELATIONSHIP, GroupMask);
+        let size = masks + mem::size_of::<GROUP_AFFINITY>();
+        let mut record = vec![0u8; size];
+        let relationship = RelationProcessorCore.to_ne_bytes();
+        put(
+            &mut record,
+            mem::offset_of!(Record, Relationship),
+            &relationship,
+        );
+        put(
+            &mut record,
+            mem::offset_of!(Record, Size),
+            &(size as u32).to_ne_bytes(),
+        );
+        let count = body + mem::offset_of!(PROCESSOR_RELATIONSHIP, GroupCount);
+        put(&mut record, count, &1u16.to_ne_bytes());
+        put(
+            &mut record,
+            masks + mem::offset_of!(GROUP_AFFINITY, Mask),
+            &mask.to_ne_bytes(),
+        );
+        put(
+            &mut record,
+            masks + mem::offset_of!(GROUP_AFFINITY, Group),
+            &group.to_ne_bytes(),
+        );
+        record
+    }
+
+    /// The multi-group machine the one running this is unlikely to be: two SMT
+    /// cores in group 0 and one in group 1, then a tail too short to be a
+    /// record. Everything else the platform does is checked live in `super`.
+    #[test]
+    fn records_split_by_size_and_number_cpus_group_major() {
+        let mut bytes = [core(0, 0b0011), core(0, 0b1100), core(1, 0b0101)].concat();
+        bytes.extend_from_slice(&core(1, 0b1)[..4]);
+
+        let cores: Vec<Vec<usize>> = parse(&bytes, RelationProcessorCore)
+            .iter()
+            .map(|record| unsafe { record.u.Processor() }.GroupMask[0])
+            .map(|siblings| cpus_of(&siblings).map(|cpu| cpu.0).collect())
+            .collect();
+
+        let g = GROUP_STRIDE;
+        assert_eq!(cores, [vec![0, 1], vec![2, 3], vec![g, g + 2]]);
+        assert!(parse(&bytes, RelationCache).is_empty());
+    }
 }


### PR DESCRIPTION
Follow-up to #1533, which left the Windows side of `compute/affinity` stubbed
because nobody on it had a Windows machine. macOS landed there too, so this
brings Windows to parity, and past it on core count.

## What was missing

`physical_core` and `l1d_cache_size` returned `None`, so every Windows CPU
counted as its own physical core and shared memory fell back to the 64 KB
guess rather than the detected L1d. Both now read
`GetLogicalProcessorInformationEx`.

## The 64-CPU ceiling

Pinning moves from `SetThreadAffinityMask` to `SetThreadGroupAffinity`, which
is the part that matters for large machines. Windows numbers logical
processors per *processor group* of at most 64, and the mask APIs only ever
see the caller's group; past 64 processors a process spans groups and its
affinity mask reads back as **zero**, which previously left the pool with no
core to pin to at all. A `CoreId` is now `group * 64 + bit`, one flat
numbering, so a machine of any size is covered whole instead of through its
first group.

For context on where the other platforms sit: Linux reaches 1024 CPUs via
`CPU_SETSIZE`, macOS is unbounded. Windows was the odd one out.

L1d takes the smallest level-1 data cache, matching what macOS does: hybrid
parts give their efficiency cores less, and a stage sized to the smaller one
stays resident on whichever core ends up running it.

## Tests

The behavioural tests move to the shared module and run on **every** platform,
against whichever `Platform` is compiled in. Two of them need something the
trait cannot express, whether the topology is real and which CPU a thread is
actually on, so each platform declares those in a `#[cfg(test)] impl Platform`
block at the bottom of its file. `ThreadAffinity` itself stays untouched
production code, and a platform that omits the hooks fails to compile rather
than silently skipping coverage.

## Verified

**Windows 11**, Intel Core Ultra X7 358H (16 CPUs, one group, no SMT):

- 16 CPUs enumerated, matching the process mask `0xFFFF`
- L1d reports 32 KB, the E-core cache rather than the 48 KB P-core one,
  cross-checked against WMI and the part's spec
- pinning confirmed per-CPU via `GetCurrentProcessorNumberEx`
- the group-aware decoder cross-checked against the legacy
  `GetLogicalProcessorInformation` output: identical results
- `cargo test -p cubecl-cpu --lib` 678/678, clippy and rustfmt clean

**Linux** (Fedora 44, kernel 7.1.8), same part, which is where the shared tests
and the `linux.rs` hook ran for the first time:

- `cargo test -p cubecl-cpu --lib affinity`: 6 passed, the six now-shared
  behavioural tests. The seventh, `windows::tests::records_split_by_size_...`,
  is `cfg`-gated to Windows.
- `cargo test -p cubecl-cpu --lib`: 677 passed, 0 failed, 13 ignored. The
  count differs from Windows by exactly that gated test.
- `cargo clippy -p cubecl-cpu --tests` clean; the five affinity files clean
  under `rustfmt --edition 2024 --check`.
- `cargo doc -p cubecl-cpu --no-deps` adds no warning. The one it does emit,
  an unresolved `super::to_llvm::atomic` in `polyfill/ordered_atomic.rs`, is
  already on `main`.
- Both test hooks were mutation-tested here as well as on Windows: reverting
  `linux.rs`'s `pin_current` to a no-op fails
  `pinned_threads_run_on_their_cpu`, and its `physical_core` to `None` fails
  `physical_core_is_a_sibling_...`. Neither hook is decorative on either
  platform.

## What still wants a real machine

Worth a reviewer's attention, since these could not be covered on either box:

1. **No machine with >64 logical CPUs.** The multi-group path, the main point
   of the change, is covered only by a synthetic-buffer unit test and code
   review. If you have a dual-socket box, this is the bit to try.
2. **No SMT machine.** Both machines used here are the same 16-CPU hybrid part
   with one thread per core, so lowest-sibling mapping and the
   primaries-then-siblings ordering are still covered by the synthetic test
   only, on both platforms.
3. **macOS was built on neither machine** (the crate cannot cross-compile; the
   LLVM bundler is per-target). That change is small, one inherent-impl block,
   but CI is its first real check.

Known limitation, documented in the code: a process that is both
affinity-restricted *and* spanning groups reports a zero mask, and Win32
exposes no way to recover per-group masks, so all CPUs are enumerated; any
worker the OS then declines to pin simply stays unpinned.

## Noticed while verifying, not addressed here

On this hybrid part the two platforms disagree about L1d on identical
hardware: Windows reports 32 KB and Linux 48 KB. `linux.rs` scans `cpu0`'s
cache indices only, and `cpu0` is a P-core, so it picks the larger cache;
Windows and macOS both take the smallest deliberately, for the reason quoted
above. sysfs on this box shows 48 KB on cpus 0-3 and 32 KB on cpus 4-15, so a
stage sized to Linux's answer does not stay resident once a worker lands on an
E-core.

That is pre-existing on `main` and `linux.rs`'s `l1d_cache_size` is untouched
by this PR, so it is left alone rather than folded in. Happy to open a
separate issue.

Unrelated, also pre-existing: `tests::i8_ty::test_atomic_max_int` fails
intermittently on Windows (roughly 1 run in 6 of the full lib suite), on
`main` as well as here. It did not reproduce on Linux in one full-suite run
plus eight isolated ones, though isolated runs are a weaker probe than the
parallel suite. That kernel launches `CubeCount::new_single()` under
`if UNIT_POS == 0`, so neither pinning nor the shared-memory size can reach
it; it points at how the CPU runtime lowers narrow signed atomics. Also worth
its own issue.
