### PR TITLE
fix(metal): correct MSL capability detection

### DIFF
--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -106,6 +106,13 @@ pub fn register_metal_features(
             return false;
         };
         let raw = adapter.raw_device();
+        eprintln!(
+            "Metal device={:?}, metal3={}, apple7={}, mac2={}",
+            raw.name(),
+            raw.supportsFamily(MTLGPUFamily::Metal3),
+            raw.supportsFamily(MTLGPUFamily::Apple7),
+            raw.supportsFamily(MTLGPUFamily::Mac2),
+        );
         if !raw.supportsFamily(MTLGPUFamily::Metal3) {
             return false;
         };

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -100,24 +100,25 @@ pub fn register_metal_features(
     unsafe {
         use objc2::rc::autoreleasepool;
         use objc2_foundation::NSString;
-        use objc2_metal::{MTLDevice, MTLGPUFamily};
+        use objc2_metal::{MTLCompileOptions, MTLDevice, MTLGPUFamily, MTLLanguageVersion};
 
         let Some(adapter) = adapter.as_hal::<hal::api::Metal>() else {
             return false;
         };
         let raw = adapter.raw_device();
-        if !raw.supportsFamily(MTLGPUFamily::Apple7) {
+        if !raw.supportsFamily(MTLGPUFamily::Metal3) {
             return false;
         };
-        let supports_lambdas = autoreleasepool(|_| {
+        let canary_result = autoreleasepool(|_| {
             let canary = NSString::from_str(LAMBDA_CANARY);
-            raw.newLibraryWithSource_options_error(&canary, None)
-                .is_ok()
+            let options = MTLCompileOptions::new();
+            options.setLanguageVersion(MTLLanguageVersion::Version3_2);
+            raw.newLibraryWithSource_options_error(&canary, Some(&options))
         });
-        if !supports_lambdas {
+        if let Err(err) = canary_result {
             // This is a fixable issue, so we should warn users.
             log::warn!(
-                "Device can support native MSL, but Metal compiler version is too old. Upgrading to 3.2 or higher is recommended."
+                "Device can support native MSL, but Metal compiler version is too old. Upgrading to 3.2 or higher is recommended. MSL 3.2 canary compilation failed: {err:?}"
             );
             return false;
         }

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -106,16 +106,20 @@ pub fn register_metal_features(
             return false;
         };
         let raw = adapter.raw_device();
-        eprintln!(
-            "Metal device={:?}, metal3={}, apple7={}, mac2={}",
-            raw.name(),
-            raw.supportsFamily(MTLGPUFamily::Metal3),
-            raw.supportsFamily(MTLGPUFamily::Apple7),
-            raw.supportsFamily(MTLGPUFamily::Mac2),
-        );
-        if !raw.supportsFamily(MTLGPUFamily::Metal3) {
+
+        // The features registered below require SIMD-scoped operations, exposed through
+        // overlapping families.
+        // - Metal3 is the cross-platform programming model
+        // - Apple7 is the A14/M1-or-newer hardware baseline
+        // - Mac2 is the equivalent Mac capability family (including virtualized Metal device)
+        // MSL 3.2 compiler support is checked separately by the canary below.
+        let supports_required_family = raw.supportsFamily(MTLGPUFamily::Metal3)
+            || raw.supportsFamily(MTLGPUFamily::Apple7)
+            || raw.supportsFamily(MTLGPUFamily::Mac2);
+
+        if !supports_required_family {
             return false;
-        };
+        }
         let canary_result = autoreleasepool(|_| {
             let canary = NSString::from_str(LAMBDA_CANARY);
             let options = MTLCompileOptions::new();

--- a/crates/cubecl-wgpu/src/backend/metal.rs
+++ b/crates/cubecl-wgpu/src/backend/metal.rs
@@ -107,12 +107,18 @@ pub fn register_metal_features(
         };
         let raw = adapter.raw_device();
 
-        // The features registered below require SIMD-scoped operations, exposed through
-        // overlapping families.
-        // - Metal3 is the cross-platform programming model
-        // - Apple7 is the A14/M1-or-newer hardware baseline
-        // - Mac2 is the equivalent Mac capability family (including virtualized Metal device)
-        // MSL 3.2 compiler support is checked separately by the canary below.
+        // The native feature profile includes plane and CMMA operations that rely on Metal's
+        // SIMD-scoped capabilities. Metal can report those capabilities through overlapping
+        // programming-model and hardware families:
+        // - `Metal3`: the cross-platform programming-model family
+        // - `Apple7`: the A14/M1-or-newer hardware family
+        // - `Mac2`: the equivalent Mac hardware family, including Apple's paravirtualized device
+        //
+        // This matches wgpu-hal's SIMD-scoped capability check:
+        // https://github.com/gfx-rs/wgpu/blob/v30.0.0/wgpu-hal/src/metal/adapter.rs#L1073-L1077
+        //
+        // GPU-family support is independent of the supported MSL language version; the canary
+        // below verifies MSL 3.2 compiler support separately.
         let supports_required_family = raw.supportsFamily(MTLGPUFamily::Metal3)
             || raw.supportsFamily(MTLGPUFamily::Apple7)
             || raw.supportsFamily(MTLGPUFamily::Mac2);


### PR DESCRIPTION
Changes in #1512 broke the MacOS CI in burn. `!raw.supportsFamily(MTLGPUFamily::Apple7)` immediately returned, and the WGSL fallback was applied.

I updated the family support check.

MacOS CI now runs the tests: https://github.com/tracel-ai/burn/pull/5396 (looks like some tests fail, but at least now we can detect those lol)

## Follow-up

This fixes the immediate detection issue, but there might be a broader question wr.t. the fallback contract.

Right now, WGSL fallback applies even when `MslCompiler` is requested explicitly. Shouldn't it only apply to `AutoCompiler`, where selecting an available compiler is part of its contract? And `MslCompiler` should produce a clear initialization error instead of silently selecting WGSL.
