### PR TITLE
fix(cpu): yield between idle polls instead of spinning

### DIFF
--- a/crates/cubecl-cpu/src/compute/threadpool/scheduler/dispatcher.rs
+++ b/crates/cubecl-cpu/src/compute/threadpool/scheduler/dispatcher.rs
@@ -122,7 +122,9 @@ impl Worker for DispatcherWorker {
                             received = Some(task);
                             break;
                         }
-                        Err(_) => std::hint::spin_loop(),
+                        // The workers cover every logical CPU, so polling in earnest
+                        // starves the client and any still-running units.
+                        Err(_) => std::thread::yield_now(),
                     }
                 }
                 let task = match received {

--- a/crates/cubecl-cpu/src/compute/threadpool/scheduler/dispatcher.rs
+++ b/crates/cubecl-cpu/src/compute/threadpool/scheduler/dispatcher.rs
@@ -104,19 +104,19 @@ impl DispatcherWorker {
     }
 }
 
-/// How long an idle worker spins on `try_recv` before parking in the blocking
-/// `recv`. A parked worker costs a futex wake per launch — and a barrier
-/// kernel runs at the latency of its last-woken unit — while the budget caps
-/// what an actually-idle pool burns.
-const IDLE_SPIN: std::time::Duration = std::time::Duration::from_micros(200);
+/// How long an idle worker polls `try_recv`, yielding the CPU between
+/// misses, before parking in the blocking `recv`. A parked worker costs a
+/// futex wake per launch, and a barrier kernel runs at the latency of its
+/// last-woken unit, while the budget caps what an actually-idle pool burns.
+const IDLE_POLL: std::time::Duration = std::time::Duration::from_micros(200);
 
 impl Worker for DispatcherWorker {
     fn work(mut self) {
         loop {
             if self.aside.is_empty() {
                 let mut received = None;
-                let spin_start = std::time::Instant::now();
-                while spin_start.elapsed() < IDLE_SPIN {
+                let poll_start = std::time::Instant::now();
+                while poll_start.elapsed() < IDLE_POLL {
                     match self.rx.try_recv() {
                         Ok(task) => {
                             received = Some(task);


### PR DESCRIPTION
Dispatcher workers are pinned across every logical CPU, so the 200us idle poll window spinning in earnest starves the client thread and any units still running. On an 8-core machine a 16-unit launch writing 600KB regressed from ~33us to 150-250us medians with millisecond tails; yielding on each missed poll restores 33-42us at 42-54 percent of the measured write peak, while the window still spares barrier kernels a futex wake per worker.

Isolated by toggling each mechanism of #1533 separately on an idle machine (launch geometry pinned, 300 samples): the idle spin alone reproduces the regression; the flush yield and core reordering do not contribute. Capping the number of spinners benched slightly better medians on two of three shapes but reproduced poorly and parks most workers, which defeats the window for barrier kernels.