### PR TITLE
fix(cpp): emit casts using destination type

### DIFF
--- a/crates/cubecl-cpp/src/shared/unary.rs
+++ b/crates/cubecl-cpp/src/shared/unary.rs
@@ -185,7 +185,7 @@ unrolling!(FindFirstSetOp);
 
 shared_op_with_out!(CastOp, |op, ctx| {
     let input = op.input(ctx);
-    let ty = input.get_type(ctx);
+    let ty = op.get_result(ctx).get_type(ctx);
     format!("{}({})", ty.to_cpp(ctx), input.name(ctx))
 });
 unrolling!(CastOp);

--- a/crates/cubecl-metal/src/lib.rs
+++ b/crates/cubecl-metal/src/lib.rs
@@ -14,6 +14,8 @@ pub use runtime::MetalRuntime;
 pub(crate) type MetalCompiler = cubecl_cpp::shared::CppCompiler<cubecl_cpp::target::Metal>;
 
 #[cfg(test)]
+mod tests_bf16_cast;
+#[cfg(test)]
 mod tests_expm1;
 #[cfg(test)]
 mod tests_launch_errors;

--- a/crates/cubecl-metal/src/tests_bf16_cast.rs
+++ b/crates/cubecl-metal/src/tests_bf16_cast.rs
@@ -1,0 +1,38 @@
+use cubecl_core::{self as cubecl, prelude::*};
+use half::bf16;
+
+type R = crate::MetalRuntime;
+
+#[cube(launch_unchecked)]
+fn f32_to_bf16_cast(input: &[f32], output: &mut [bf16]) {
+    if ABSOLUTE_POS < output.len() {
+        output[ABSOLUTE_POS] = bf16::cast_from(input[ABSOLUTE_POS]);
+    }
+}
+
+#[test]
+fn f32_to_bf16_cast_compiles_and_runs() {
+    let client = R::client(&Default::default());
+    let input = [1.0f32, -2.5, 3.25, 0.0];
+    let len = input.len();
+
+    let input_handle = client.create_from_slice(f32::as_bytes(&input));
+    let output_handle = client.empty(len * core::mem::size_of::<bf16>());
+
+    unsafe {
+        f32_to_bf16_cast::launch_unchecked::<R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new_1d(len as u32),
+            BufferArg::from_raw_parts(input_handle, len),
+            BufferArg::from_raw_parts(output_handle.clone(), len),
+        );
+    }
+
+    let bytes = client.read_one_unchecked(output_handle);
+    let actual = bf16::from_bytes(&bytes);
+
+    for (actual, expected) in actual.iter().zip(input) {
+        assert_eq!(*actual, bf16::from_f32(expected));
+    }
+}

--- a/crates/cubecl-metal/src/tests_bf16_cast.rs
+++ b/crates/cubecl-metal/src/tests_bf16_cast.rs
@@ -13,7 +13,25 @@ fn f32_to_bf16_cast(input: &[f32], output: &mut [bf16]) {
 #[test]
 fn f32_to_bf16_cast_compiles_and_runs() {
     let client = R::client(&Default::default());
-    let input = [1.0f32, -2.5, 3.25, 0.0];
+    // Cover exact values, rounding, signed zero, range extremes, subnormals, infinities and NaN.
+    // NaN payloads are allowed to be canonicalized by the GPU, so they are compared by class
+    // below; every non-NaN value is compared bit-for-bit with `half`'s reference conversion.
+    let input = [
+        0.0,
+        -0.0,
+        1.0,
+        -2.5,
+        3.25,
+        1.003_906_2, // Halfway between adjacent bf16 values around 1.0 (ties-to-even).
+        1.003_906_4, // Immediately above that midpoint.
+        f32::MIN_POSITIVE,
+        f32::from_bits(1),
+        f32::MAX,
+        f32::MIN,
+        f32::INFINITY,
+        f32::NEG_INFINITY,
+        f32::NAN,
+    ];
     let len = input.len();
 
     let input_handle = client.create_from_slice(f32::as_bytes(&input));
@@ -29,10 +47,21 @@ fn f32_to_bf16_cast_compiles_and_runs() {
         );
     }
 
-    let bytes = client.read_one_unchecked(output_handle);
+    let bytes = client
+        .read_one(output_handle)
+        .expect("the f32-to-bf16 Metal kernel should compile and execute");
     let actual = bf16::from_bytes(&bytes);
 
-    for (actual, expected) in actual.iter().zip(input) {
-        assert_eq!(*actual, bf16::from_f32(expected));
+    for (actual, input) in actual.iter().zip(input) {
+        let expected = bf16::from_f32(input);
+        if expected.is_nan() {
+            assert!(actual.is_nan(), "expected NaN, got {actual:?}");
+        } else {
+            assert_eq!(
+                actual.to_bits(),
+                expected.to_bits(),
+                "unexpected conversion for input {input:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- emit shared C++ casts using the `CastOp` destination type instead of reconstructing the source type
- add a native Metal regression test for f32-to-bf16 conversion, including rounding boundaries, signed zero, subnormals, range extremes, infinities, and NaN

## Background

The shared emitter declared the cast result with its destination type but formatted the right-hand side with the input type. For f32-to-bf16 this generated invalid MSL like:

```metal
bfloat const v18 = float(v17);
```

Using the result type restores the cast semantics and emits the explicit conversion Metal requires:

```metal
bfloat const v18 = bfloat(v17);
```

The destination-typed behavior existed before the Pliron migration in #1402; the source-typed constructor was introduced during that refactor.

## Relationship to #1509

#1509 and this PR address separate layers. #1509 registers BF16 as a WGPU/MSL runtime capability, while this PR fixes the shared C++ `CastOp` emitter used by native Metal and WGPU/MSL.

On an Apple M5, locally enabling the same full BF16 registration produced by #1509 after its probe succeeds made WGPU report `Conversion | Arithmetic | DotProduct | Buffer`. An actual f32-to-bf16 kernel still emitted `bfloat = float(...)` and failed Metal compilation without this change. With this change it emitted `bfloat = bfloat(...)`, compiled, and returned the expected values.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p cubecl-cpp --all-features`
- `cargo test -p cubecl-metal f32_to_bf16_cast_compiles_and_runs -- --nocapture`
  - passed on an Apple M5 MacBook Air with a 10-core GPU, macOS 26.5.2
  - non-NaN results matched `half::bf16::from_f32` bit-for-bit; NaN was verified by classification
- restoring the old emitter reproduced the Metal compilation error deterministically
- enabling BF16 registration with the old emitter reproduced the same failure through WGPU/MSL

## Performance

No measurable performance regression was observed on the Apple M5. Since f32-to-bf16 does not compile before the fix, the shared `CastOp` emitter was compared using f32-to-f16, which compiles on both revisions and exercises the same changed path.

The device-timed benchmark used warmed compilation and allocations, 11 alternating samples of 200 large-buffer launches, and an unchanged f32 copy as a drift control. The median normalized cast/copy ratio was `0.760752` before the fix and `0.759177` after it, a `-0.21%` difference within normal run-to-run dispersion.

Fixes #1522.
