### PR TITLE
feat(cpu): report the device last level cache size

### DIFF
--- a/crates/cubecl-cpu/src/compute/affinity/fallback.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/fallback.rs
@@ -17,6 +17,10 @@ impl ThreadAffinity for Platform {
         None
     }
 
+    fn llc_cache_size() -> Option<usize> {
+        None
+    }
+
     fn pin_current(_cpu: CoreId) {}
 }
 

--- a/crates/cubecl-cpu/src/compute/affinity/linux.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/linux.rs
@@ -41,6 +41,21 @@ impl ThreadAffinity for Platform {
         })
     }
 
+    fn llc_cache_size() -> Option<usize> {
+        // The deepest level sysfs reports, which is the cache a working set has
+        // to outgrow before it is streaming from memory rather than from chip.
+        (0..=5)
+            .filter_map(|index| {
+                let cache = format!("/sys/devices/system/cpu/cpu0/cache/index{index}");
+                let read = |file: &str| std::fs::read_to_string(format!("{cache}/{file}")).ok();
+                let level: u32 = read("level")?.trim().parse().ok()?;
+                (read("type")?.trim() != "Instruction").then_some(())?;
+                Some((level, parse_cache_size(read("size")?.trim())?))
+            })
+            .max_by_key(|(level, _)| *level)
+            .map(|(_, size)| size)
+    }
+
     fn pin_current(cpu: CoreId) {
         let mut set = new_cpu_set();
         let tid = unsafe { syscall(SYS_gettid) } as libc::id_t;

--- a/crates/cubecl-cpu/src/compute/affinity/macos.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/macos.rs
@@ -37,6 +37,16 @@ impl ThreadAffinity for Platform {
         sysctl(c"hw.l1dcachesize").map(|bytes| bytes as usize)
     }
 
+    fn llc_cache_size() -> Option<usize> {
+        // Only Intel Macs answer, and there the L3 is the last level. Apple
+        // Silicon's is a system level cache no sysctl reports, 24 MB on an M2
+        // Pro, and the `hw.l2cachesize` below it is the efficiency cluster's
+        // 4 MB, six times too small to stand in for it.
+        sysctl(c"hw.l3cachesize")
+            .filter(|size| *size > 0)
+            .map(|bytes| bytes as usize)
+    }
+
     fn pin_current(cpu: CoreId) {
         // Darwin has no hard pinning; the affinity tag only hints that
         // threads with different tags prefer different L2 caches, and Apple

--- a/crates/cubecl-cpu/src/compute/affinity/mod.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/mod.rs
@@ -48,6 +48,9 @@ trait ThreadAffinity {
     /// Bytes of a core's L1 data cache, or `None` when it cannot be read.
     fn l1d_cache_size() -> Option<usize>;
 
+    /// Bytes of the last level cache, or `None` when it cannot be read.
+    fn llc_cache_size() -> Option<usize>;
+
     /// Pins the calling thread to `cpu`.
     fn pin_current(cpu: CoreId);
 }
@@ -87,6 +90,14 @@ pub fn l1d_cache_size() -> Option<usize> {
     Platform::l1d_cache_size()
 }
 
+/// Bytes of the last level cache, or `None` when it cannot be read.
+///
+/// The size a working set has to outgrow before what it reaches is set by
+/// memory rather than by the chip.
+pub fn llc_cache_size() -> Option<usize> {
+    Platform::llc_cache_size()
+}
+
 /// Runs on every platform: the policy on a made-up topology, and the
 /// platform's own answers checked for the invariants the policy relies on.
 #[cfg(test)]
@@ -118,6 +129,10 @@ mod tests {
             }
 
             fn l1d_cache_size() -> Option<usize> {
+                None
+            }
+
+            fn llc_cache_size() -> Option<usize> {
                 None
             }
 
@@ -163,6 +178,22 @@ mod tests {
         if let Some(size) = size {
             assert!((4 * 1024..=1024 * 1024).contains(&size), "{size}");
             assert_eq!(size % 1024, 0, "{size}");
+        }
+    }
+
+    /// A platform that cannot read the last level says so rather than offering
+    /// the deepest cache it does know, which on Apple Silicon would be an
+    /// efficiency cluster's L2 six times under the real one. What is reported
+    /// has to be a plausible last level, so no smaller than the L1d.
+    #[test]
+    fn a_reported_last_level_cache_is_a_plausible_one() {
+        let Some(llc) = Platform::llc_cache_size() else {
+            return;
+        };
+
+        assert!(llc <= 4 * 1024 * 1024 * 1024, "{llc}");
+        if let Some(l1d) = Platform::l1d_cache_size() {
+            assert!(llc >= l1d, "last level {llc} under L1d {l1d}");
         }
     }
 

--- a/crates/cubecl-cpu/src/compute/affinity/windows.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/windows.rs
@@ -13,7 +13,7 @@ use winapi::um::processtopologyapi::{GetThreadGroupAffinity, SetThreadGroupAffin
 use winapi::um::sysinfoapi::GetLogicalProcessorInformationEx;
 use winapi::um::winbase::GetProcessAffinityMask;
 use winapi::um::winnt::{
-    CacheData, GROUP_AFFINITY, LOGICAL_PROCESSOR_RELATIONSHIP, RelationCache,
+    CacheData, CacheUnified, GROUP_AFFINITY, LOGICAL_PROCESSOR_RELATIONSHIP, RelationCache,
     RelationProcessorCore, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
 };
 
@@ -62,6 +62,19 @@ impl ThreadAffinity for Platform {
             .filter(|cache| cache.Level == 1 && cache.Type == CacheData && cache.CacheSize > 0)
             .map(|cache| cache.CacheSize as usize)
             .min()
+    }
+
+    fn llc_cache_size() -> Option<usize> {
+        // The largest cache of the deepest level, so a last level shared by
+        // several cores is taken whole rather than as one core's record.
+        records(RelationCache)
+            .iter()
+            .map(|record| unsafe { record.u.Cache() })
+            .filter(|cache| {
+                (cache.Type == CacheData || cache.Type == CacheUnified) && cache.CacheSize > 0
+            })
+            .max_by_key(|cache| (cache.Level, cache.CacheSize))
+            .map(|cache| cache.CacheSize as usize)
     }
 
     fn pin_current(cpu: CoreId) {

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -117,6 +117,7 @@ impl DeviceService for CpuServer {
             max_shared_memory_size,
             max_cube_count,
             num_cpu_cores: Some(available_parallelism as u32),
+            last_level_cache_size: affinity::llc_cache_size(),
             max_units_per_cube: available_parallelism,
             max_cube_dim,
             num_streaming_multiprocessors: None,

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -166,6 +166,7 @@ impl DeviceService for CudaServer {
                     Some(8)
                 },
                 num_cpu_cores: None,
+                last_level_cache_size: None,
                 max_vector_size: VectorSize::MAX,
                 cube_mma_reserved_shared_memory: 0,
             }

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -179,6 +179,7 @@ impl DeviceService for HipServer {
                 Some(16)
             },
             num_cpu_cores: None,
+            last_level_cache_size: None,
             max_vector_size: VectorSize::MAX,
             cube_mma_reserved_shared_memory: 0,
         };

--- a/crates/cubecl-ir/src/properties.rs
+++ b/crates/cubecl-ir/src/properties.rs
@@ -44,6 +44,12 @@ pub struct HardwareProperties {
     pub num_streaming_multiprocessors: Option<u32>,
     /// Number of available parallel cpu units, if the runtime is CPU.
     pub num_cpu_cores: Option<u32>,
+    /// Bytes of the device's last level cache, and `None`, never `Some(0)`,
+    /// where the runtime cannot read one.
+    ///
+    /// The size a working set has to outgrow before what it reaches is set by
+    /// memory rather than by the chip.
+    pub last_level_cache_size: Option<usize>,
     /// Number of tensor cores per SM, if any
     pub num_tensor_cores: Option<u32>,
     /// The minimum tiling dimension for a single axis in tensor cores.

--- a/crates/cubecl-metal/src/runtime.rs
+++ b/crates/cubecl-metal/src/runtime.rs
@@ -84,6 +84,7 @@ impl DeviceService for MetalServer {
             num_tensor_cores: None,
             min_tensor_cores_dim: None,
             num_cpu_cores: None,
+            last_level_cache_size: None,
             max_vector_size: 4,
             cube_mma_reserved_shared_memory: 0,
         };

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -321,6 +321,7 @@ impl DummyServer {
             num_tensor_cores: None,
             min_tensor_cores_dim: None,
             num_cpu_cores: None,
+            last_level_cache_size: None,
             max_vector_size: VectorSize::MAX,
             cube_mma_reserved_shared_memory: 0,
         };

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -338,6 +338,7 @@ pub(crate) fn create_server<C: WgpuCompiler>(
         num_tensor_cores: None,
         min_tensor_cores_dim: None,
         num_cpu_cores: None, // TODO: Check if device is CPU.
+        last_level_cache_size: None,
         max_vector_size: 4,
         // Init later if extension is enabled
         cube_mma_reserved_shared_memory: 0,


### PR DESCRIPTION
Whether a working set streams from memory or is served by the chip turns on how it compares to the last level cache. Nothing exposed that size, so anything needing to tell the two regimes apart had to guess at it. This adds `HardwareProperties::last_level_cache_size`, an `Option<usize>` that is `None`, never `Some(0)`, where the runtime cannot read one.

There is no consumer in this PR. The consumer is the stacked PR below.

## Where the value comes from

| runtime | source | on the machines tested |
| --- | --- | --- |
| CPU, Linux | deepest level in sysfs | 32 MiB on a 5700X, 18 MiB on a Core Ultra X7 358H |
| CPU, Windows | largest cache of the deepest level from `GetLogicalProcessorInformationEx` | detected, value in range |
| CPU, macOS | `hw.l3cachesize` | Intel Macs only, see below |
| everything else | not read | `None` |

## Why three cases report nothing rather than something

Each is a smaller cache sitting visibly in front of a larger last level the API will not expose. Reporting the near one is worse than reporting nothing, because a consumer would size against a cache several times too small.

- **Apple Silicon.** No L3. The last level is a system level cache, 24 MiB on an M2 Pro, that no sysctl reports. `hw.l2cachesize` there is the efficiency cluster's 4 MiB, six times too small, and `hw.perflevel0.l2cachesize` is one performance cluster's 16 MiB, which is also not the last level. Verified on an M2 Pro: `hw.l3cachesize` is absent entirely.
- **HIP.** `hipDeviceProp_t::l2CacheSize` is the 2 MiB L2 an RDNA part keeps behind a 32 MiB Infinity Cache, and the property struct exposes no way to read the Infinity Cache. Its own header also documents the field as returning 0 on some paths, which is why `Some(0)` is excluded by contract.
- **wgpu and Metal.** No API for it.

**CUDA is the one that could be filled in** with `CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE`, where L2 genuinely is the last level, using the `get_attribute` helper already in that file. It is left out because populating the field is what changes consumer behaviour, and nothing has measured what that does on a GPU yet.

## Testing

- `cargo test -p cubecl-cpu --lib affinity` on Linux (7 tests) and on Windows (8 tests, including the Windows-only record parser).
- macOS covered by reading the sysctls on an M2 Pro rather than by building, since the compile risk there is six lines through an existing helper and the real risk was the value.
- `cargo xtask validate` is green other than 12 pre-existing `plane_shuffle` failures in cubecl-wgpu, which reproduce identically on `4057f39e` on the same machine and are unrelated to this change.

Note that CI runs Linux only, so the Windows and macOS paths here are not covered by it.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [x] cubek was built and run against this branch. It only ever takes `&HardwareProperties`, never constructs one, so a new field is not a breaking change for it and no cubek PR is needed.
- [ ] burn not checked. Same reasoning should apply to anything that consumes properties rather than implementing a runtime, but a custom runtime implementor would need the new field.
