### PR TITLE
fix(throughput): probe a working set at its own footprint

### DIFF
--- a/crates/cubecl-cpu/src/compute/affinity/fallback.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/fallback.rs
@@ -17,6 +17,10 @@ impl ThreadAffinity for Platform {
         None
     }
 
+    fn llc_cache_size() -> Option<usize> {
+        None
+    }
+
     fn pin_current(_cpu: CoreId) {}
 }
 

--- a/crates/cubecl-cpu/src/compute/affinity/linux.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/linux.rs
@@ -41,6 +41,21 @@ impl ThreadAffinity for Platform {
         })
     }
 
+    fn llc_cache_size() -> Option<usize> {
+        // The deepest level sysfs reports, which is the cache a working set has
+        // to outgrow before it is streaming from memory rather than from chip.
+        (0..=5)
+            .filter_map(|index| {
+                let cache = format!("/sys/devices/system/cpu/cpu0/cache/index{index}");
+                let read = |file: &str| std::fs::read_to_string(format!("{cache}/{file}")).ok();
+                let level: u32 = read("level")?.trim().parse().ok()?;
+                (read("type")?.trim() != "Instruction").then_some(())?;
+                Some((level, parse_cache_size(read("size")?.trim())?))
+            })
+            .max_by_key(|(level, _)| *level)
+            .map(|(_, size)| size)
+    }
+
     fn pin_current(cpu: CoreId) {
         let mut set = new_cpu_set();
         let tid = unsafe { syscall(SYS_gettid) } as libc::id_t;

--- a/crates/cubecl-cpu/src/compute/affinity/macos.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/macos.rs
@@ -37,6 +37,16 @@ impl ThreadAffinity for Platform {
         sysctl(c"hw.l1dcachesize").map(|bytes| bytes as usize)
     }
 
+    fn llc_cache_size() -> Option<usize> {
+        // Only Intel Macs answer, and there the L3 is the last level. Apple
+        // Silicon's is a system level cache no sysctl reports, 24 MB on an M2
+        // Pro, and the `hw.l2cachesize` below it is the efficiency cluster's
+        // 4 MB, six times too small to stand in for it.
+        sysctl(c"hw.l3cachesize")
+            .filter(|size| *size > 0)
+            .map(|bytes| bytes as usize)
+    }
+
     fn pin_current(cpu: CoreId) {
         // Darwin has no hard pinning; the affinity tag only hints that
         // threads with different tags prefer different L2 caches, and Apple

--- a/crates/cubecl-cpu/src/compute/affinity/mod.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/mod.rs
@@ -48,6 +48,9 @@ trait ThreadAffinity {
     /// Bytes of a core's L1 data cache, or `None` when it cannot be read.
     fn l1d_cache_size() -> Option<usize>;
 
+    /// Bytes of the last level cache, or `None` when it cannot be read.
+    fn llc_cache_size() -> Option<usize>;
+
     /// Pins the calling thread to `cpu`.
     fn pin_current(cpu: CoreId);
 }
@@ -87,6 +90,14 @@ pub fn l1d_cache_size() -> Option<usize> {
     Platform::l1d_cache_size()
 }
 
+/// Bytes of the last level cache, or `None` when it cannot be read.
+///
+/// The size a working set has to outgrow before what it reaches is set by
+/// memory rather than by the chip.
+pub fn llc_cache_size() -> Option<usize> {
+    Platform::llc_cache_size()
+}
+
 /// Runs on every platform: the policy on a made-up topology, and the
 /// platform's own answers checked for the invariants the policy relies on.
 #[cfg(test)]
@@ -118,6 +129,10 @@ mod tests {
             }
 
             fn l1d_cache_size() -> Option<usize> {
+                None
+            }
+
+            fn llc_cache_size() -> Option<usize> {
                 None
             }
 
@@ -163,6 +178,22 @@ mod tests {
         if let Some(size) = size {
             assert!((4 * 1024..=1024 * 1024).contains(&size), "{size}");
             assert_eq!(size % 1024, 0, "{size}");
+        }
+    }
+
+    /// A platform that cannot read the last level says so rather than offering
+    /// the deepest cache it does know, which on Apple Silicon would be an
+    /// efficiency cluster's L2 six times under the real one. What is reported
+    /// has to be a plausible last level, so no smaller than the L1d.
+    #[test]
+    fn a_reported_last_level_cache_is_a_plausible_one() {
+        let Some(llc) = Platform::llc_cache_size() else {
+            return;
+        };
+
+        assert!(llc <= 4 * 1024 * 1024 * 1024, "{llc}");
+        if let Some(l1d) = Platform::l1d_cache_size() {
+            assert!(llc >= l1d, "last level {llc} under L1d {l1d}");
         }
     }
 

--- a/crates/cubecl-cpu/src/compute/affinity/windows.rs
+++ b/crates/cubecl-cpu/src/compute/affinity/windows.rs
@@ -13,7 +13,7 @@ use winapi::um::processtopologyapi::{GetThreadGroupAffinity, SetThreadGroupAffin
 use winapi::um::sysinfoapi::GetLogicalProcessorInformationEx;
 use winapi::um::winbase::GetProcessAffinityMask;
 use winapi::um::winnt::{
-    CacheData, GROUP_AFFINITY, LOGICAL_PROCESSOR_RELATIONSHIP, RelationCache,
+    CacheData, CacheUnified, GROUP_AFFINITY, LOGICAL_PROCESSOR_RELATIONSHIP, RelationCache,
     RelationProcessorCore, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
 };
 
@@ -62,6 +62,19 @@ impl ThreadAffinity for Platform {
             .filter(|cache| cache.Level == 1 && cache.Type == CacheData && cache.CacheSize > 0)
             .map(|cache| cache.CacheSize as usize)
             .min()
+    }
+
+    fn llc_cache_size() -> Option<usize> {
+        // The largest cache of the deepest level, so a last level shared by
+        // several cores is taken whole rather than as one core's record.
+        records(RelationCache)
+            .iter()
+            .map(|record| unsafe { record.u.Cache() })
+            .filter(|cache| {
+                (cache.Type == CacheData || cache.Type == CacheUnified) && cache.CacheSize > 0
+            })
+            .max_by_key(|cache| (cache.Level, cache.CacheSize))
+            .map(|cache| cache.CacheSize as usize)
     }
 
     fn pin_current(cpu: CoreId) {

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -117,6 +117,7 @@ impl DeviceService for CpuServer {
             max_shared_memory_size,
             max_cube_count,
             num_cpu_cores: Some(available_parallelism as u32),
+            last_level_cache_size: affinity::llc_cache_size(),
             max_units_per_cube: available_parallelism,
             max_cube_dim,
             num_streaming_multiprocessors: None,

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -166,6 +166,7 @@ impl DeviceService for CudaServer {
                     Some(8)
                 },
                 num_cpu_cores: None,
+                last_level_cache_size: None,
                 max_vector_size: VectorSize::MAX,
                 cube_mma_reserved_shared_memory: 0,
             }

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -179,6 +179,7 @@ impl DeviceService for HipServer {
                 Some(16)
             },
             num_cpu_cores: None,
+            last_level_cache_size: None,
             max_vector_size: VectorSize::MAX,
             cube_mma_reserved_shared_memory: 0,
         };

--- a/crates/cubecl-ir/src/properties.rs
+++ b/crates/cubecl-ir/src/properties.rs
@@ -44,6 +44,12 @@ pub struct HardwareProperties {
     pub num_streaming_multiprocessors: Option<u32>,
     /// Number of available parallel cpu units, if the runtime is CPU.
     pub num_cpu_cores: Option<u32>,
+    /// Bytes of the device's last level cache, and `None`, never `Some(0)`,
+    /// where the runtime cannot read one.
+    ///
+    /// The size a working set has to outgrow before what it reaches is set by
+    /// memory rather than by the chip.
+    pub last_level_cache_size: Option<usize>,
     /// Number of tensor cores per SM, if any
     pub num_tensor_cores: Option<u32>,
     /// The minimum tiling dimension for a single axis in tensor cores.

--- a/crates/cubecl-metal/src/runtime.rs
+++ b/crates/cubecl-metal/src/runtime.rs
@@ -84,6 +84,7 @@ impl DeviceService for MetalServer {
             num_tensor_cores: None,
             min_tensor_cores_dim: None,
             num_cpu_cores: None,
+            last_level_cache_size: None,
             max_vector_size: 4,
             cube_mma_reserved_shared_memory: 0,
         };

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -321,6 +321,7 @@ impl DummyServer {
             num_tensor_cores: None,
             min_tensor_cores_dim: None,
             num_cpu_cores: None,
+            last_level_cache_size: None,
             max_vector_size: VectorSize::MAX,
             cube_mma_reserved_shared_memory: 0,
         };

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -24,14 +24,17 @@ use crate::throughput::LaunchConfig;
 /// moves, which is the thing being measured.
 #[derive(Clone, Copy, Debug)]
 pub struct MemoryProbe {
-    /// Lines in each buffer: as much as the device will allocate, whatever the
-    /// working set, so a window has somewhere cold to come back to.
+    /// Lines of each buffer the probe walks: what the window is cold against,
+    /// and the whole buffer until the window spans several last level caches
+    /// and is cold on its own.
     pub pool_lines: usize,
     /// Lines one pass moves through, per buffer. Never more than
     /// [`pool_lines`](Self::pool_lines); equal to it at the top of the sweep,
-    /// where the working set is the whole buffer.
+    /// where the window is its own pool.
     pub window_lines: usize,
-    /// Bytes in each buffer.
+    /// Bytes in each buffer, which is exactly the pool. The probe kernels take
+    /// their wrap-around from `len()`, so a buffer longer than the pool would
+    /// walk them past what [`prime`] wrote.
     pub buffer_bytes: usize,
     /// Cubes to dispatch, which is [`LaunchConfig::cube_count`] unless the
     /// window is too small to give every thread a line.
@@ -40,6 +43,27 @@ pub struct MemoryProbe {
     /// rather than coalesced across threads. Set on plane-1 runtimes, where a
     /// worker has no plane neighbour to coalesce with.
     pub blocked: bool,
+}
+
+/// Last level caches a window must span before the probe stops walking it
+/// across the pool and pins it to its own bytes.
+///
+/// A window this far past the cache is cold on its own, so the walk only
+/// spreads the probe over bytes the kernel it scores never touches: on a
+/// 32 MiB-L3 Zen 3 a fill reaches 24.3 GB/s over 128 MiB and 19.8 over 512.
+const MIN_WINDOW_CACHE_MULTIPLE: usize = 4;
+
+/// All [`MemoryProbe::sized`] needs of a device, so the sizing can be exercised
+/// without one.
+#[derive(Clone, Copy)]
+struct DeviceShape {
+    /// Bytes the device will hand out in a single allocation.
+    max_alloc: usize,
+    /// Bytes of its last level cache, when it reports one.
+    cache_bytes: Option<usize>,
+    /// Threads per cube, and cubes, of the probe's launch.
+    cube_dim: usize,
+    cube_count: usize,
 }
 
 impl MemoryProbe {
@@ -61,23 +85,23 @@ impl MemoryProbe {
         access: MemoryAccess,
         working_set: usize,
     ) -> Self {
-        let max_alloc = client.properties().memory.max_page_size as usize;
         let blocked = config.plane_size == 1;
-        let cube_count = if blocked { 1 } else { config.cube_count };
+        let shape = DeviceShape {
+            max_alloc: client.properties().memory.max_page_size as usize,
+            cache_bytes: client.properties().hardware.last_level_cache_size,
+            cube_dim: config.cube_dim,
+            cube_count: if blocked { 1 } else { config.cube_count },
+        };
 
-        Self::sized(
-            max_alloc,
-            config.cube_dim,
-            cube_count,
-            line_bytes,
-            access,
-            working_set,
-            blocked,
-        )
+        Self::sized(shape, line_bytes, access, working_set, blocked)
     }
 
     /// The geometry itself, with the device reduced to its allocation limit and
     /// launch shape so the sizing can be exercised without one.
+    ///
+    /// The pool is the whole buffer, so the window has somewhere cold to come
+    /// back to, until the window spans [`MIN_WINDOW_CACHE_MULTIPLE`] caches and
+    /// the pool shrinks to the window itself.
     ///
     /// The launch shrinks with the window instead of the window growing to fill
     /// the launch. A small window measured with the full dispatch would either
@@ -86,25 +110,31 @@ impl MemoryProbe {
     /// kernel that moves little has little in flight, and that is precisely
     /// what limits it.
     fn sized(
-        max_alloc: usize,
-        cube_dim: usize,
-        cube_count: usize,
+        shape: DeviceShape,
         line_bytes: usize,
         access: MemoryAccess,
         working_set: usize,
         blocked: bool,
     ) -> Self {
         let buffers = access.buffers() as usize;
-
-        // As large as allowed regardless of the working set: the pool is what
-        // the window is cold against.
-        let pool_bytes = max_alloc.min(DEFAULT_BUFFER_BYTES as usize);
-        let pool_lines = (pool_bytes / line_bytes).max(1);
-
         let window_bytes = working_set / buffers;
-        let window_lines = (window_bytes / line_bytes).max(1).min(pool_lines);
 
-        let cube_count = (window_lines / cube_dim).clamp(1, cube_count);
+        let cold_lines = (shape.max_alloc.min(DEFAULT_BUFFER_BYTES as usize) / line_bytes).max(1);
+        let window_lines = (window_bytes / line_bytes).max(1).min(cold_lines);
+
+        // Only a device that reports its cache can tell a window that outgrew
+        // it from one that fits: without that, the walk is the sole thing
+        // keeping the window cold and dropping it would measure residency. A
+        // zero is such a device rather than a cacheless one, which
+        // `hipDeviceProp_t::l2CacheSize` documents itself as returning, and
+        // taken at face value it would pin every window.
+        let pins = shape
+            .cache_bytes
+            .filter(|cache| *cache > 0)
+            .is_some_and(|cache| window_bytes >= cache.saturating_mul(MIN_WINDOW_CACHE_MULTIPLE));
+        let pool_lines = if pins { window_lines } else { cold_lines };
+
+        let cube_count = (window_lines / shape.cube_dim).clamp(1, shape.cube_count);
 
         Self {
             pool_lines,
@@ -170,24 +200,84 @@ mod tests {
     const KB: usize = 1024;
     const MB: usize = 1024 * 1024;
 
+    /// Half a gigabyte of allocation, 256-thread cubes, a full dispatch of
+    /// 2048 cubes, and a 32 MiB last level cache.
+    const DEVICE: DeviceShape = DeviceShape {
+        max_alloc: 512 * MB,
+        cache_bytes: Some(32 * MB),
+        cube_dim: 256,
+        cube_count: 2048,
+    };
+
+    /// A probe of that device, in the 16-byte lines a `vec4` of f32 comes in.
     fn probe(working_set: usize, access: MemoryAccess) -> MemoryProbe {
-        // 16-byte lines and 256-thread cubes, as a device with `vec4` f32 and a
-        // full dispatch of 2048 cubes reports.
-        MemoryProbe::sized(512 * MB, 256, 2048, 16, access, working_set, false)
+        MemoryProbe::sized(DEVICE, 16, access, working_set, false)
+    }
+
+    /// The same device, saying nothing about its cache.
+    fn uncached(working_set: usize, access: MemoryAccess) -> MemoryProbe {
+        let shape = DeviceShape {
+            cache_bytes: None,
+            ..DEVICE
+        };
+        MemoryProbe::sized(shape, 16, access, working_set, false)
     }
 
     #[test]
     fn the_pool_stays_large_however_small_the_window() {
         // 256 KiB of traffic, but still half a gigabyte to be cold against.
         let small = probe(256 * KB, MemoryAccess::Read);
-        assert_eq!(small.buffer_bytes, 512 * MB);
+        assert_eq!(small.pool_lines, 512 * MB / 16);
         assert_eq!(small.window_lines, 256 * KB / 16);
 
         // A copy splits its working set across two buffers, so the same traffic
         // is half the window per buffer.
         let copy = probe(256 * KB, MemoryAccess::Copy);
-        assert_eq!(copy.buffer_bytes, 512 * MB);
+        assert_eq!(copy.pool_lines, 512 * MB / 16);
         assert_eq!(copy.window_lines, 128 * KB / 16);
+    }
+
+    #[test]
+    fn a_window_spanning_four_caches_becomes_its_own_pool() {
+        let pinned = probe(128 * MB, MemoryAccess::Read);
+        assert_eq!(pinned.pool_lines, pinned.window_lines);
+
+        // Just under, the walk is still what keeps the window cold.
+        let walked = probe(127 * MB, MemoryAccess::Read);
+        assert_eq!(walked.pool_lines, 512 * MB / 16);
+
+        // A copy splits its working set in two, so the same traffic leaves a
+        // window half the size in each buffer, and that one still gets walked.
+        let copy = probe(128 * MB, MemoryAccess::Copy);
+        assert_eq!(copy.pool_lines, 512 * MB / 16);
+
+        // The allocation follows the pool, so the kernels, which wrap at the
+        // buffer's length, cannot reach past the window that was primed.
+        assert_eq!(pinned.buffer_bytes, 128 * MB);
+        assert_eq!(walked.buffer_bytes, 512 * MB);
+        assert_eq!(copy.buffer_bytes, 512 * MB);
+    }
+
+    #[test]
+    fn a_device_that_reports_no_cache_walks_every_window() {
+        for bytes in [256 * KB, 128 * MB, 512 * MB] {
+            let probe = uncached(bytes, MemoryAccess::Read);
+            assert_eq!(probe.pool_lines, 512 * MB / 16, "at {bytes} bytes");
+        }
+    }
+
+    /// A zero cache is a runtime that could not read one, so it has to walk
+    /// like any other. Read as a size it is one every window spans, which
+    /// would pin the whole sweep and report cache bandwidth throughout.
+    #[test]
+    fn a_zero_cache_is_an_unknown_one() {
+        let shape = DeviceShape {
+            cache_bytes: Some(0),
+            ..DEVICE
+        };
+        let probe = MemoryProbe::sized(shape, 16, MemoryAccess::Read, 256 * KB, false);
+
+        assert_eq!(probe.pool_lines, 512 * MB / 16);
     }
 
     #[test]
@@ -220,7 +310,11 @@ mod tests {
     fn a_device_that_allocates_little_shrinks_the_pool_with_it() {
         // The pool is the allocation limit, and the window follows it down
         // rather than asking for memory the device does not have.
-        let probe = MemoryProbe::sized(4 * MB, 256, 2048, 16, MemoryAccess::Read, 512 * MB, false);
+        let shape = DeviceShape {
+            max_alloc: 4 * MB,
+            ..DEVICE
+        };
+        let probe = MemoryProbe::sized(shape, 16, MemoryAccess::Read, 512 * MB, false);
 
         assert_eq!(probe.buffer_bytes, 4 * MB);
         assert_eq!(probe.window_lines, probe.pool_lines);

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -338,6 +338,7 @@ pub(crate) fn create_server<C: WgpuCompiler>(
         num_tensor_cores: None,
         min_tensor_cores_dim: None,
         num_cpu_cores: None, // TODO: Check if device is CPU.
+        last_level_cache_size: None,
         max_vector_size: 4,
         // Init later if extension is enabled
         cube_mma_reserved_shared_memory: 0,


### PR DESCRIPTION
Stacked on https://github.com/tracel-ai/cubecl/pull/1551, which adds the property this reads. Base is `feat/cpu-last-level-cache`; it will not compile against `main` alone.

## The problem

`ThroughputMode::MemoryWorkingSet { access: Write, .. }` reported a ceiling that real kernels beat. On an idle 5700X, cubek's contiguous f32 fill of 128 MiB ran at 23.4 GB/s against a probe reporting 19.9, so the roofline printed it at **118% of peak**. A percent-of-peak column whose denominator is a fifth low hides the last fifth of headroom and trains people to ignore the column.

## What it was

Not sampling noise, launch overhead, `ops_count`, worker count, line width, or per-line instruction cost. Each was measured and each costs nothing:

| variant, 512 MB span | GB/s | | variant, 128 MB span | GB/s |
| --- | --- | --- | --- | --- |
| minimal fill | 19.8 | | minimal fill | 24.3 |
| + bounds check | 19.8 | | + bounds check | 25.0 |
| + wrap check | 19.8 | | + wrap check | 24.3 |
| + walk, the real probe | 19.9 | | + walk | 24.3 |
| 8 / 32 workers | 21.1 / 19.8 | | 8 / 32 workers | 25.0 / 24.3 |
| 4 / 8 lanes | 19.8 / 19.8 | | 4 / 8 lanes | 24.3 / 24.3 |
| plain Rust threads, no cubecl | **20.1** | | plain Rust threads | **24.0** |

The number is a function of one thing, the total bytes touched, and the walk made that the whole 512 MB pool no matter which working set was being probed:

| touched span | 16 M | 32 M | 64 M | 128 M | 256 M | 512 M |
| --- | --- | --- | --- | --- | --- | --- |
| GB/s | 444 | 219 | 34.0 | 24.3 | 20.3 | 19.8 |

The knee sits at ~32 MiB of total span for 4, 8 and 16 workers alike, so it tracks the shared L3 rather than per-thread TLB reach.

## The fix

A window several times the last level cache evicts itself within one pass, so the walk buys it no coldness and only spreads the probe over bytes the kernel it scores never touches. Such a window becomes its own pool, and the buffer shrinks with it so the kernels, which wrap at the buffer's length, stay inside what `prime` wrote.

A device that reports no cache cannot distinguish a window that outgrew one from a window that fits, so it keeps walking every window. **That is every GPU runtime today**, and their geometry comes out of the same arithmetic as before. The three probe kernels are byte-identical to `main`, so `git diff main -- crates/cubecl-std/src/throughput/runners/memory_{read,write,direct}.rs` is empty and the GPU path is unchanged as a property of the diff rather than a claim about a measurement.

## Results, tower 5700X

| | before | after |
| --- | --- | --- |
| write @128 MiB | 19.8 | **24.3** |
| read @128 MiB | 44.0 | 51.2 |
| copy, every size | 26.0 | 26.0 to 27.5 |
| every other point | | unchanged |

cubek `random`, Uniform 3D (32x512x2048), 100 samples: Auto **118% to 97%**, Blocked **118% to 96%**, no rows over peak.

Also run: the full curve on wgpu/Vulkan and on the CPU backend of a second machine, both unchanged where the code is unchanged.

## Known limits

- Working sets between one and four times the cache still walk, so a 64 MiB fill on this machine would still print about 172%. There is no threshold that removes that seam: it is where the curve switches between the cold-stream model and the own-footprint model, and on this hardware those disagree by up to 2.5x. `MIN_WINDOW_CACHE_MULTIPLE` is the single constant that moves it.
- Working sets below the cache are still deliberately measured cold, so a benchmark rewriting a cache-resident buffer will still exceed them by design.

## Unrelated bug found while validating, not fixed here

The curve point where the working set equals **half the pool** reports impossible bandwidth on GPUs, on unmodified `main`: 3103 and 3129 GB/s read on an RTX 4070 Ti SUPER whose bus does 672, against 670 to 795 GB/s at neighbouring sizes, reproduced twice. wgpu bumps at the same point. Tracing `start += window; if start + window > span { wrap += 1; start = wrap }` with `window == span / 2`, the window covers both halves once and then advances by a single line per pass, so it stops walking. That explains why this one size is special but not the magnitude. Worth its own issue.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [x] cubek was built and its `random` bench run against this exact branch, which is where the 118% to 96% figure comes from. No cubek changes needed.
- [ ] burn not checked. This changes measured values, not any API.
