### PR TITLE
feat(cpu): Vectorize exp,log,sin,cos,tanh with polynomial approximation

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/unary.rs
+++ b/crates/cubecl-core/src/runtime_tests/unary.rs
@@ -286,6 +286,24 @@ test_unary_impl!(test_sin, F, Vector::sin, [
         out_vectorization: 4,
         input: as_type![F: 0., 1.570_796_4, 3.141_592_7, -1.570_796_4],
         expected: as_type![F: 0., 1., 0., -1.]
+    },
+    {
+        input_vectorization: 1,
+        out_vectorization: 1,
+        input: as_type![F: 4.5, 6., -7.5, 8., -12.5, 12., 20., -25.],
+        expected: as_type![F: -0.977_530_1, -0.279_415_5, -0.937_999_96, 0.989_358_25, 0.066_321_895, -0.536_572_93, 0.912_945_3, 0.132_351_76]
+    },
+    {
+        input_vectorization: 2,
+        out_vectorization: 2,
+        input: as_type![F: 4.5, 6., -7.5, 8., -12.5, 12., 20., -25.],
+        expected: as_type![F: -0.977_530_1, -0.279_415_5, -0.937_999_96, 0.989_358_25, 0.066_321_895, -0.536_572_93, 0.912_945_3, 0.132_351_76]
+    },
+    {
+        input_vectorization: 4,
+        out_vectorization: 4,
+        input: as_type![F: 4.5, 6., -7.5, 8., -12.5, 12., 20., -25.],
+        expected: as_type![F: -0.977_530_1, -0.279_415_5, -0.937_999_96, 0.989_358_25, 0.066_321_895, -0.536_572_93, 0.912_945_3, 0.132_351_76]
     }
 ]);
 
@@ -328,6 +346,24 @@ test_unary_impl!(test_cos, F, Vector::cos, [
         out_vectorization: 4,
         input: as_type![F: 0., 1.570_796_4, 3.141_592_7, -1.570_796_4],
         expected: as_type![F: 1., 0., -1., 0.]
+    },
+    {
+        input_vectorization: 1,
+        out_vectorization: 1,
+        input: as_type![F: 4.5, 6., -7.5, 8., -12.5, 12., 20., -25.],
+        expected: as_type![F: -0.210_795_8, 0.960_170_27, 0.346_635_3, -0.145_500_03, 0.997_798_26, 0.843_853_95, 0.408_082_07, 0.991_202_83]
+    },
+    {
+        input_vectorization: 2,
+        out_vectorization: 2,
+        input: as_type![F: 4.5, 6., -7.5, 8., -12.5, 12., 20., -25.],
+        expected: as_type![F: -0.210_795_8, 0.960_170_27, 0.346_635_3, -0.145_500_03, 0.997_798_26, 0.843_853_95, 0.408_082_07, 0.991_202_83]
+    },
+    {
+        input_vectorization: 4,
+        out_vectorization: 4,
+        input: as_type![F: 4.5, 6., -7.5, 8., -12.5, 12., 20., -25.],
+        expected: as_type![F: -0.210_795_8, 0.960_170_27, 0.346_635_3, -0.145_500_03, 0.997_798_26, 0.843_853_95, 0.408_082_07, 0.991_202_83]
     }
 ]);
 
@@ -475,6 +511,66 @@ test_unary_impl!(test_tanh, F, Vector::tanh, [
         out_vectorization: 4,
         input: as_type![F: 0., 1., -1., 2.],
         expected: as_type![F: 0., 0.761_594_2, -0.761_594_2, 0.964_027_6]
+    },
+    {
+        input_vectorization: 1,
+        out_vectorization: 1,
+        input: as_type![F: 0.25, 0.5, 0.75, -0.25, 3., -4., 0.125, -0.75],
+        expected: as_type![F: 0.244_918_66, 0.462_117_17, 0.635_148_94, -0.244_918_66, 0.995_054_8, -0.999_329_3, 0.124_353, -0.635_148_94]
+    },
+    {
+        input_vectorization: 2,
+        out_vectorization: 2,
+        input: as_type![F: 0.25, 0.5, 0.75, -0.25, 3., -4., 0.125, -0.75],
+        expected: as_type![F: 0.244_918_66, 0.462_117_17, 0.635_148_94, -0.244_918_66, 0.995_054_8, -0.999_329_3, 0.124_353, -0.635_148_94]
+    },
+    {
+        input_vectorization: 4,
+        out_vectorization: 4,
+        input: as_type![F: 0.25, 0.5, 0.75, -0.25, 3., -4., 0.125, -0.75],
+        expected: as_type![F: 0.244_918_66, 0.462_117_17, 0.635_148_94, -0.244_918_66, 0.995_054_8, -0.999_329_3, 0.124_353, -0.635_148_94]
+    }
+]);
+
+test_unary_impl!(test_exp, F, Vector::exp, [
+    {
+        input_vectorization: 1,
+        out_vectorization: 1,
+        input: as_type![F: 0., 1., -1., 2., 0.5, -0.5, -2., 1.5],
+        expected: as_type![F: 1., 2.718_281_7, 0.367_879_45, 7.389_056, 1.648_721_2, 0.606_530_67, 0.135_335_28, 4.481_689]
+    },
+    {
+        input_vectorization: 2,
+        out_vectorization: 2,
+        input: as_type![F: 0., 1., -1., 2., 0.5, -0.5, -2., 1.5],
+        expected: as_type![F: 1., 2.718_281_7, 0.367_879_45, 7.389_056, 1.648_721_2, 0.606_530_67, 0.135_335_28, 4.481_689]
+    },
+    {
+        input_vectorization: 4,
+        out_vectorization: 4,
+        input: as_type![F: 0., 1., -1., 2., 0.5, -0.5, -2., 1.5],
+        expected: as_type![F: 1., 2.718_281_7, 0.367_879_45, 7.389_056, 1.648_721_2, 0.606_530_67, 0.135_335_28, 4.481_689]
+    }
+]);
+
+test_unary_impl!(test_ln, F, Vector::ln, [
+    {
+        input_vectorization: 1,
+        out_vectorization: 1,
+        input: as_type![F: 1., 2., 0.5, 10., 0.25, 4., 100., 0.125],
+        expected: as_type![F: 0., 0.693_147_2, -0.693_147_2, 2.302_585_1, -1.386_294_4, 1.386_294_4, 4.605_170_2, -2.079_441_5]
+    },
+    {
+        input_vectorization: 2,
+        out_vectorization: 2,
+        input: as_type![F: 1., 2., 0.5, 10., 0.25, 4., 100., 0.125],
+        expected: as_type![F: 0., 0.693_147_2, -0.693_147_2, 2.302_585_1, -1.386_294_4, 1.386_294_4, 4.605_170_2, -2.079_441_5]
+    },
+    {
+        input_vectorization: 4,
+        out_vectorization: 4,
+        input: as_type![F: 1., 2., 0.5, 10., 0.25, 4., 100., 0.125],
+        expected: as_type![F: 0., 0.693_147_2, -0.693_147_2, 2.302_585_1, -1.386_294_4, 1.386_294_4, 4.605_170_2, -2.079_441_5]
     }
 ]);
 
@@ -1000,6 +1096,8 @@ macro_rules! testgen_unary {
             add_test!(test_sinh);
             add_test!(test_cosh);
             add_test!(test_tanh);
+            add_test!(test_exp);
+            add_test!(test_ln);
             add_test!(test_asin);
             add_test!(test_acos);
             add_test!(test_atan);

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -22,6 +22,191 @@ mod tests {
     cubecl_std::testgen_tensor_into_contiguous!();
     cubecl_std::testgen_quantized_view!(f32);
 
+    #[cube(launch_unchecked)]
+    fn transcendentals<N: Size>(
+        input: &[Vector<f32, N>],
+        exp: &mut [Vector<f32, N>],
+        ln: &mut [Vector<f32, N>],
+        sin: &mut [Vector<f32, N>],
+        cos: &mut [Vector<f32, N>],
+        tanh: &mut [Vector<f32, N>],
+    ) {
+        if ABSOLUTE_POS < input.len() {
+            let x = input[ABSOLUTE_POS];
+            exp[ABSOLUTE_POS] = x.exp();
+            ln[ABSOLUTE_POS] = x.ln();
+            sin[ABSOLUTE_POS] = x.sin();
+            cos[ABSOLUTE_POS] = x.cos();
+            tanh[ABSOLUTE_POS] = x.tanh();
+        }
+    }
+
+    /// `[exp, ln, sin, cos, tanh]` of `input`, evaluated at `width` lanes to a vector.
+    ///
+    /// A width above one is what selects the polynomial polyfill over the target's own
+    /// intrinsic, so the two widths answer different questions of the same kernel.
+    fn transcendentals_of(input: &[f32], width: usize) -> [Vec<f32>; 5] {
+        assert_eq!(
+            input.len() % width,
+            0,
+            "a {width}-wide launch would leave the last {} of {} inputs unwritten",
+            input.len() % width,
+            input.len()
+        );
+
+        let client = TestRuntime::client(&Default::default());
+        let n = input.len();
+        let handle = client.create_from_slice(f32::as_bytes(input));
+        let out: Vec<_> = (0..5)
+            .map(|_| client.empty(n * core::mem::size_of::<f32>()))
+            .collect();
+
+        unsafe {
+            transcendentals::launch_unchecked::<TestRuntime>(
+                &client,
+                CubeCount::new_single(),
+                CubeDim::new_1d((n / width) as u32),
+                width,
+                BufferArg::from_raw_parts(handle, n),
+                BufferArg::from_raw_parts(out[0].clone(), n),
+                BufferArg::from_raw_parts(out[1].clone(), n),
+                BufferArg::from_raw_parts(out[2].clone(), n),
+                BufferArg::from_raw_parts(out[3].clone(), n),
+                BufferArg::from_raw_parts(out[4].clone(), n),
+            )
+        }
+
+        let read = |handle: &cubecl_runtime::server::Handle| {
+            f32::from_bytes(&client.read_one_unchecked(handle.clone())).to_vec()
+        };
+        [
+            read(&out[0]),
+            read(&out[1]),
+            read(&out[2]),
+            read(&out[3]),
+            read(&out[4]),
+        ]
+    }
+
+    /// A NaN must arrive as a NaN, an infinity with its sign, and a zero with its sign.
+    /// A tolerance on the difference sees none of the three: it cannot tell a NaN from a
+    /// large wrong number, and `+0.0` and `-0.0` differ by nothing at all.
+    #[track_caller]
+    fn assert_matches_library(op: &str, x: f32, actual: f32, expected: f32) {
+        let agrees = if expected.is_nan() {
+            actual.is_nan()
+        } else if expected.is_infinite() || expected == 0.0 {
+            actual.to_bits() == expected.to_bits()
+        } else {
+            (actual - expected).abs() <= 1e-6 * expected.abs().max(1e-6)
+        };
+        assert!(
+            agrees,
+            "{op}({x:e}) gave {actual:e}, the library gives {expected:e}"
+        );
+    }
+
+    /// Zero, the infinities, a NaN and the subnormals, which an accuracy sweep never lands
+    /// on and where the polynomials read an exponent field that means none of the things it
+    /// usually means.
+    #[test]
+    fn transcendentals_match_the_library_at_the_edges() {
+        // Lengths a multiple of the widest line under test, or its tail goes unwritten.
+        let finite_angles = [
+            0.0,
+            -0.0,
+            1.0,
+            -1.0,
+            3.5,
+            -3.5,
+            100.0,
+            -100.0,
+            1e-40,
+            f32::MIN_POSITIVE,
+            REDUCTION_LIMIT,
+            -REDUCTION_LIMIT,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::NAN,
+            6.5,
+        ];
+        let magnitudes = [
+            0.0,
+            -0.0,
+            1.0,
+            -1.0,
+            0.5,
+            -0.5,
+            2.0,
+            -2.0,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::NAN,
+            1e-40,
+            f32::MIN_POSITIVE,
+            1000.0,
+            -1000.0,
+            1e30,
+            -1e30,
+            88.0,
+            -88.0,
+            1e-8,
+            10.0,
+            -10.0,
+            1e-30,
+            0.25,
+        ];
+
+        for width in [1, 2, 4, 8] {
+            let [exp, ln, _, _, tanh] = transcendentals_of(&magnitudes, width);
+            for (i, &x) in magnitudes.iter().enumerate() {
+                assert_matches_library("exp", x, exp[i], x.exp());
+                assert_matches_library("ln", x, ln[i], x.ln());
+                assert_matches_library("tanh", x, tanh[i], x.tanh());
+            }
+
+            let [_, _, sin, cos, _] = transcendentals_of(&finite_angles, width);
+            for (i, &x) in finite_angles.iter().enumerate() {
+                assert_matches_library("sin", x, sin[i], x.sin());
+                assert_matches_library("cos", x, cos[i], x.cos());
+            }
+        }
+    }
+
+    /// The largest angle the three-part range reduction still means something for. Past it
+    /// the polyfill says NaN rather than returning a number of the right magnitude and the
+    /// wrong sign.
+    const REDUCTION_LIMIT: f32 = (1u32 << 20) as f32;
+
+    /// Past the limit the answer is unknown, and only the lined path is asked to say so:
+    /// a scalar keeps the target's own routine, which the gate leaves untouched.
+    #[test]
+    fn a_lined_sin_beyond_the_reduction_limit_is_not_a_number() {
+        let beyond = [2.0 * REDUCTION_LIMIT, -2.0 * REDUCTION_LIMIT, 1e7, 1e30];
+
+        for width in [2, 4] {
+            let [_, _, sin, cos, _] = transcendentals_of(&beyond, width);
+            for (i, &x) in beyond.iter().enumerate() {
+                assert!(
+                    sin[i].is_nan(),
+                    "sin({x:e}) at width {width} gave {:e}",
+                    sin[i]
+                );
+                assert!(
+                    cos[i].is_nan(),
+                    "cos({x:e}) at width {width} gave {:e}",
+                    cos[i]
+                );
+            }
+        }
+
+        let [_, _, sin, cos, _] = transcendentals_of(&beyond, 1);
+        for (i, &x) in beyond.iter().enumerate() {
+            assert!(sin[i].is_finite(), "scalar sin({x:e}) gave {:e}", sin[i]);
+            assert!(cos[i].is_finite(), "scalar cos({x:e}) gave {:e}", cos[i]);
+        }
+    }
+
     #[cube(launch)]
     fn barrier_smoke(out: &mut [f32]) {
         let barrier = barrier::Barrier::local();

--- a/crates/cubecl-cpu/src/lib.rs
+++ b/crates/cubecl-cpu/src/lib.rs
@@ -41,10 +41,9 @@ mod tests {
         }
     }
 
-    /// `[exp, ln, sin, cos, tanh]` of `input`, evaluated at `width` lanes to a vector.
+    /// `[exp, ln, sin, cos, tanh]` of `input`, at `width` lanes to a vector.
     ///
-    /// A width above one is what selects the polynomial polyfill over the target's own
-    /// intrinsic, so the two widths answer different questions of the same kernel.
+    /// A width above one is what selects the polyfill over the target's own intrinsic.
     fn transcendentals_of(input: &[f32], width: usize) -> [Vec<f32>; 5] {
         assert_eq!(
             input.len() % width,
@@ -88,9 +87,8 @@ mod tests {
         ]
     }
 
-    /// A NaN must arrive as a NaN, an infinity with its sign, and a zero with its sign.
-    /// A tolerance on the difference sees none of the three: it cannot tell a NaN from a
-    /// large wrong number, and `+0.0` and `-0.0` differ by nothing at all.
+    /// A NaN must arrive as a NaN, an infinity and a zero with their sign. A tolerance sees
+    /// none of the three: `+0.0` and `-0.0` differ by nothing at all.
     #[track_caller]
     fn assert_matches_library(op: &str, x: f32, actual: f32, expected: f32) {
         let agrees = if expected.is_nan() {
@@ -107,11 +105,10 @@ mod tests {
     }
 
     /// Zero, the infinities, a NaN and the subnormals, which an accuracy sweep never lands
-    /// on and where the polynomials read an exponent field that means none of the things it
-    /// usually means.
+    /// on and where the exponent field the polynomials read means none of what it usually
+    /// means.
     #[test]
     fn transcendentals_match_the_library_at_the_edges() {
-        // Lengths a multiple of the widest line under test, or its tail goes unwritten.
         let finite_angles = [
             0.0,
             -0.0,
@@ -173,13 +170,10 @@ mod tests {
         }
     }
 
-    /// The largest angle the three-part range reduction still means something for. Past it
-    /// the polyfill says NaN rather than returning a number of the right magnitude and the
-    /// wrong sign.
+    /// The largest angle the three-part range reduction still means something for.
     const REDUCTION_LIMIT: f32 = (1u32 << 20) as f32;
 
-    /// Past the limit the answer is unknown, and only the lined path is asked to say so:
-    /// a scalar keeps the target's own routine, which the gate leaves untouched.
+    /// Past the limit the answer is unknown, and only the lined path is asked to say so.
     #[test]
     fn a_lined_sin_beyond_the_reduction_limit_is_not_a_number() {
         let beyond = [2.0 * REDUCTION_LIMIT, -2.0 * REDUCTION_LIMIT, 1e7, 1e30];

--- a/crates/cubecl-llvm/src/shared/polyfill/math.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/math.rs
@@ -19,10 +19,17 @@ use crate::shared::polyfill::LowerOp;
 use crate::shared::polyfill::transcendental::{cos, exp, ln, sin, tanh};
 use cubecl_core::ir::Scope;
 
+/// Lower a unary op to `$polyfill`, unconditionally or only where `$gate` accepts the input.
 macro_rules! lower_unary_math_arith {
-    ($cube_op:ty => $polyfill:ident) => {
+    ($cube_op:ty => $polyfill:ident $(, $gate:path)?) => {
         #[op_interface_impl]
         impl LowerOp for $cube_op {
+            $(
+                fn should_lower(&self, ctx: &Context) -> bool {
+                    $gate(self.input(ctx), ctx)
+                }
+            )?
+
             fn lower(&self, scope: &Scope) -> Vec<Value> {
                 define_scalar!(T);
                 define_size!(S);
@@ -34,38 +41,22 @@ macro_rules! lower_unary_math_arith {
     };
 }
 
-/// The same, for an operation the polynomials only beat a scalar library call on a line.
+/// Where the polynomials beat the library call they replace, which is not everywhere.
 ///
 /// Two rejections. Double precision keeps the target's own routine, since fitting a second
 /// set of coefficients would double the surface to verify for a format no kernel here
 /// reaches for. A scalar keeps it too: the library's own routines are table-driven and a
 /// polynomial does not beat them one lane at a time, which measured as a quarter lost on a
 /// scalar `cos` kernel and half on an FFT. What the polynomial wins is the lanes.
-macro_rules! lower_narrow_float_math_arith {
-    ($cube_op:ty => $polyfill:ident) => {
-        #[op_interface_impl]
-        impl LowerOp for $cube_op {
-            fn should_lower(&self, ctx: &Context) -> bool {
-                let input = self.input(ctx);
-                input.vector_size(ctx) > 1 && !input.scalar_ty(ctx).is_float64(ctx)
-            }
-
-            fn lower(&self, scope: &Scope) -> Vec<Value> {
-                define_scalar!(T);
-                define_size!(S);
-                let value = self.input(scope.ctx());
-                scope.register_value_type::<T, S>(value);
-                vec![$polyfill::expand::<T, S>(scope, value.into()).read_value(scope)]
-            }
-        }
-    };
+fn is_narrow_float_line(input: Value, ctx: &Context) -> bool {
+    input.vector_size(ctx) > 1 && !input.scalar_ty(ctx).is_float64(ctx)
 }
 
-lower_narrow_float_math_arith!(ExpOp => exp);
-lower_narrow_float_math_arith!(LogOp => ln);
-lower_narrow_float_math_arith!(SinOp => sin);
-lower_narrow_float_math_arith!(CosOp => cos);
-lower_narrow_float_math_arith!(TanhOp => tanh);
+lower_unary_math_arith!(ExpOp => exp, is_narrow_float_line);
+lower_unary_math_arith!(LogOp => ln, is_narrow_float_line);
+lower_unary_math_arith!(SinOp => sin, is_narrow_float_line);
+lower_unary_math_arith!(CosOp => cos, is_narrow_float_line);
+lower_unary_math_arith!(TanhOp => tanh, is_narrow_float_line);
 
 macro_rules! lower_binary_math_arith {
     ($cube_op:ty => $polyfill:ident) => {

--- a/crates/cubecl-llvm/src/shared/polyfill/math.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/math.rs
@@ -2,8 +2,9 @@ use cubecl_core as cubecl;
 use cubecl_core::ir::dialect::bitwise::{BitwiseNotOp, FindFirstSetOp};
 use cubecl_core::ir::dialect::cmp::{FClampOp, SClampOp, UClampOp};
 use cubecl_core::ir::dialect::math::{
-    ArcCoshOp, ArcSinhOp, ArcTanhOp, DegreesOp, ErfOp, Expm1Op, FModFloorOp, HypotOp, Log1pOp,
-    PowiOp, RadiansOp, RecipOp, RhypotOp, RsqrtOp, SModFloorOp, SMulHiOp, SNegOp, UMulHiOp,
+    ArcCoshOp, ArcSinhOp, ArcTanhOp, CosOp, DegreesOp, ErfOp, ExpOp, Expm1Op, FModFloorOp, HypotOp,
+    Log1pOp, LogOp, PowiOp, RadiansOp, RecipOp, RhypotOp, RsqrtOp, SModFloorOp, SMulHiOp, SNegOp,
+    SinOp, TanhOp, UMulHiOp,
 };
 use cubecl_core::ir::dialect::vector::{FDotOp, MagnitudeOp, NormalizeOp, SDotOp, UDotOp};
 use cubecl_core::ir::interfaces::TypedExt;
@@ -15,6 +16,7 @@ use cubecl_core::prelude::polyfills::{
 use cubecl_core::prelude::*;
 
 use crate::shared::polyfill::LowerOp;
+use crate::shared::polyfill::transcendental::{cos, exp, ln, sin, tanh};
 use cubecl_core::ir::Scope;
 
 macro_rules! lower_unary_math_arith {
@@ -31,6 +33,39 @@ macro_rules! lower_unary_math_arith {
         }
     };
 }
+
+/// The same, for an operation the polynomials only beat a scalar library call on a line.
+///
+/// Two rejections. Double precision keeps the target's own routine, since fitting a second
+/// set of coefficients would double the surface to verify for a format no kernel here
+/// reaches for. A scalar keeps it too: the library's own routines are table-driven and a
+/// polynomial does not beat them one lane at a time, which measured as a quarter lost on a
+/// scalar `cos` kernel and half on an FFT. What the polynomial wins is the lanes.
+macro_rules! lower_narrow_float_math_arith {
+    ($cube_op:ty => $polyfill:ident) => {
+        #[op_interface_impl]
+        impl LowerOp for $cube_op {
+            fn should_lower(&self, ctx: &Context) -> bool {
+                let input = self.input(ctx);
+                input.vector_size(ctx) > 1 && !input.scalar_ty(ctx).is_float64(ctx)
+            }
+
+            fn lower(&self, scope: &Scope) -> Vec<Value> {
+                define_scalar!(T);
+                define_size!(S);
+                let value = self.input(scope.ctx());
+                scope.register_value_type::<T, S>(value);
+                vec![$polyfill::expand::<T, S>(scope, value.into()).read_value(scope)]
+            }
+        }
+    };
+}
+
+lower_narrow_float_math_arith!(ExpOp => exp);
+lower_narrow_float_math_arith!(LogOp => ln);
+lower_narrow_float_math_arith!(SinOp => sin);
+lower_narrow_float_math_arith!(CosOp => cos);
+lower_narrow_float_math_arith!(TanhOp => tanh);
 
 macro_rules! lower_binary_math_arith {
     ($cube_op:ty => $polyfill:ident) => {

--- a/crates/cubecl-llvm/src/shared/polyfill/math.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/math.rs
@@ -43,11 +43,9 @@ macro_rules! lower_unary_math_arith {
 
 /// Where the polynomials beat the library call they replace, which is not everywhere.
 ///
-/// Two rejections. Double precision keeps the target's own routine, since fitting a second
-/// set of coefficients would double the surface to verify for a format no kernel here
-/// reaches for. A scalar keeps it too: the library's own routines are table-driven and a
-/// polynomial does not beat them one lane at a time, which measured as a quarter lost on a
-/// scalar `cos` kernel and half on an FFT. What the polynomial wins is the lanes.
+/// A scalar keeps the target's own routine, since a table-driven libm wins one lane at a
+/// time: ungated it cost a quarter of a scalar `cos` kernel and half of an FFT. Double
+/// precision keeps it too, for want of a second set of coefficients.
 fn is_narrow_float_line(input: Value, ctx: &Context) -> bool {
     input.vector_size(ctx) > 1 && !input.scalar_ty(ctx).is_float64(ctx)
 }

--- a/crates/cubecl-llvm/src/shared/polyfill/mod.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/mod.rs
@@ -1,6 +1,7 @@
 pub mod math;
 pub mod ordered_atomic;
 pub mod synchronization;
+mod transcendental;
 
 use cubecl_core::ir::{NamedRewrite, prelude::*};
 

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/base.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/base.rs
@@ -1,0 +1,138 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+/// A polynomial in `x`, its coefficients given from the constant term up.
+///
+/// The loop is unrolled, so what reaches the target is the same chain of fused
+/// multiply-adds writing it out by hand would give, with the nesting the wrong way round
+/// for a reader.
+#[cube]
+pub(super) fn horner<N: Size, const D: usize>(
+    x: Vector<f32, N>,
+    #[comptime] coefficients: [f32; D],
+) -> Vector<f32, N> {
+    let mut total = Vector::new(coefficients[comptime![D - 1]]);
+
+    #[unroll]
+    for i in 1..D {
+        total = fma(total, x, Vector::new(coefficients[comptime![D - 1 - i]]));
+    }
+
+    total
+}
+
+/// The number of mantissa bits a leading Cody-Waite part gives up.
+///
+/// What is left has to absorb the integer it gets multiplied by, and every reduction here
+/// multiplies by a quadrant count or an exponent, neither of which exceeds twelve bits.
+const CARRIED_BITS: u32 = 12;
+
+/// The leading part of `value`, with the low mantissa bits cleared so that multiplying it
+/// by an integer of up to [`CARRIED_BITS`] bits is exact.
+///
+/// A range reduction subtracts this from an argument of the same size and keeps the
+/// difference. Rounding in that product would land directly on the digits the difference
+/// is made of, which is the whole reason the constant is split at all.
+pub(super) const fn leading_part(value: f64) -> f32 {
+    let head = value as f32;
+    f32::from_bits(head.to_bits() & !((1u32 << CARRIED_BITS) - 1))
+}
+
+/// What [`leading_part`] left behind, to the accuracy an `f32` can hold.
+pub(super) const fn trailing_part(value: f64) -> f32 {
+    (value - leading_part(value) as f64) as f32
+}
+
+/// The worst relative error of `approximation` against `exact` over `[from, to]`.
+///
+/// Dense enough that a mistyped digit cannot hide between two samples: the polynomials
+/// here are smooth over their intervals, so an error the sweep misses is smaller than one
+/// it finds.
+#[cfg(test)]
+pub(super) fn worst_relative_error(
+    from: f64,
+    to: f64,
+    exact: impl Fn(f64) -> f64,
+    approximation: impl Fn(f64) -> f64,
+) -> f64 {
+    const SAMPLES: usize = 100_000;
+
+    (0..=SAMPLES)
+        .map(|i| {
+            let x = from + (to - from) * i as f64 / SAMPLES as f64;
+            let truth = exact(x);
+            if truth == 0.0 {
+                0.0
+            } else {
+                ((approximation(x) - truth) / truth).abs()
+            }
+        })
+        .fold(0.0, f64::max)
+}
+
+/// A polynomial in `x` with `coefficients` from the constant term up, in double precision.
+///
+/// The host mirror of [`horner`], for tests that ask what the checked-in coefficients are
+/// worth without a target in the way.
+#[cfg(test)]
+pub(super) fn evaluate(coefficients: &[f32], x: f64) -> f64 {
+    coefficients
+        .iter()
+        .rev()
+        .fold(0.0, |total, c| total * x + *c as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A leading part multiplies exactly by any integer a range reduction can produce.
+    ///
+    /// This is the property the split exists for. Lose it and the reduction rounds away
+    /// the digits of a difference it is about to keep, which shows up as an error that
+    /// grows with the argument rather than as a wrong constant.
+    #[test]
+    fn a_leading_part_multiplies_exactly() {
+        for value in [core::f64::consts::LN_2, core::f64::consts::FRAC_PI_2] {
+            let head = leading_part(value);
+            for multiplier in 1..=(1 << CARRIED_BITS) {
+                let product = multiplier as f32 * head;
+                assert_eq!(
+                    product as f64,
+                    multiplier as f64 * head as f64,
+                    "{multiplier} * {head} rounded"
+                );
+            }
+        }
+    }
+
+    /// A split loses no more than the rounding of its own last part.
+    ///
+    /// What is left over is the floor on how small a reduced argument can get and still
+    /// mean anything, so it is worth knowing that it is as small as the parts allow
+    /// rather than merely small.
+    #[test]
+    fn a_split_loses_only_its_last_rounding() {
+        for (value, parts) in [
+            (core::f64::consts::LN_2, 2),
+            (core::f64::consts::FRAC_PI_2, 3),
+        ] {
+            let mut rest = value;
+            let mut total = 0.0;
+            for _ in 0..parts - 1 {
+                let head = leading_part(rest) as f64;
+                total += head;
+                rest -= head;
+            }
+            let last = rest as f32;
+            total += last as f64;
+
+            let residual = (value - total).abs();
+            let spacing = (f32::from_bits(last.abs().to_bits() + 1) - last.abs()) as f64;
+            assert!(
+                residual < spacing,
+                "{value} left {residual} after {parts} parts, more than the last part's {spacing}"
+            );
+        }
+    }
+}

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/base.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/base.rs
@@ -2,10 +2,6 @@ use cubecl_core as cubecl;
 use cubecl_core::prelude::*;
 
 /// A polynomial in `x`, its coefficients given from the constant term up.
-///
-/// The loop is unrolled, so what reaches the target is the same chain of fused
-/// multiply-adds writing it out by hand would give, with the nesting the wrong way round
-/// for a reader.
 #[cube]
 pub(super) fn horner<N: Size, const D: usize>(
     x: Vector<f32, N>,
@@ -21,18 +17,12 @@ pub(super) fn horner<N: Size, const D: usize>(
     total
 }
 
-/// The number of mantissa bits a leading Cody-Waite part gives up.
-///
-/// What is left has to absorb the integer it gets multiplied by, and every reduction here
-/// multiplies by a quadrant count or an exponent, neither of which exceeds twelve bits.
+/// The number of mantissa bits a leading Cody-Waite part gives up, enough to absorb the
+/// quadrant counts and exponents it is multiplied by.
 const CARRIED_BITS: u32 = 12;
 
 /// The leading part of `value`, with the low mantissa bits cleared so that multiplying it
 /// by an integer of up to [`CARRIED_BITS`] bits is exact.
-///
-/// A range reduction subtracts this from an argument of the same size and keeps the
-/// difference. Rounding in that product would land directly on the digits the difference
-/// is made of, which is the whole reason the constant is split at all.
 pub(super) const fn leading_part(value: f64) -> f32 {
     let head = value as f32;
     f32::from_bits(head.to_bits() & !((1u32 << CARRIED_BITS) - 1))
@@ -43,11 +33,8 @@ pub(super) const fn trailing_part(value: f64) -> f32 {
     (value - leading_part(value) as f64) as f32
 }
 
-/// The worst relative error of `approximation` against `exact` over `[from, to]`.
-///
-/// Dense enough that a mistyped digit cannot hide between two samples: the polynomials
-/// here are smooth over their intervals, so an error the sweep misses is smaller than one
-/// it finds.
+/// The worst relative error of `approximation` against `exact` over `[from, to]`, sampled
+/// densely enough that a mistyped digit cannot hide between two points.
 #[cfg(test)]
 pub(super) fn worst_relative_error(
     from: f64,
@@ -70,8 +57,6 @@ pub(super) fn worst_relative_error(
         .fold(0.0, f64::max)
 }
 
-/// A polynomial in `x` with `coefficients` from the constant term up, in double precision.
-///
 /// The host mirror of [`horner`], for tests that ask what the checked-in coefficients are
 /// worth without a target in the way.
 #[cfg(test)]
@@ -86,11 +71,8 @@ pub(super) fn evaluate(coefficients: &[f32], x: f64) -> f64 {
 mod tests {
     use super::*;
 
-    /// A leading part multiplies exactly by any integer a range reduction can produce.
-    ///
-    /// This is the property the split exists for. Lose it and the reduction rounds away
-    /// the digits of a difference it is about to keep, which shows up as an error that
-    /// grows with the argument rather than as a wrong constant.
+    /// A leading part multiplies exactly by any integer a range reduction can produce. Lose
+    /// that and the reduction rounds away the digits of the difference it is about to keep.
     #[test]
     fn a_leading_part_multiplies_exactly() {
         for value in [core::f64::consts::LN_2, core::f64::consts::FRAC_PI_2] {
@@ -106,11 +88,8 @@ mod tests {
         }
     }
 
-    /// A split loses no more than the rounding of its own last part.
-    ///
-    /// What is left over is the floor on how small a reduced argument can get and still
-    /// mean anything, so it is worth knowing that it is as small as the parts allow
-    /// rather than merely small.
+    /// A split loses no more than the rounding of its own last part, which is the floor on
+    /// how small a reduced argument can get and still mean anything.
     #[test]
     fn a_split_loses_only_its_last_rounding() {
         for (value, parts) in [

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/exponential.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/exponential.rs
@@ -50,6 +50,12 @@ pub fn exp<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
     let x = Vector::<f32, N>::cast_from(x).clamp(Vector::new(EXP_MIN), Vector::new(EXP_MAX));
 
     let k = (x * Vector::new(LOG2_E)).round();
+
+    // The clamp keeps an infinity but not a NaN, and rounding a NaN to an integer below is
+    // a poison value rather than a wrong number. Zeroing it here costs the NaN nothing: it
+    // still reaches the result through `r`.
+    let k = select_many(k.equal(&k), k, Vector::new(0.0f32));
+
     let r = fma(-k, Vector::new(LN2_HI), x);
     let r = fma(-k, Vector::new(LN2_LO), r);
 

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/exponential.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/exponential.rs
@@ -1,0 +1,104 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+use super::base::{leading_part, trailing_part};
+
+const LOG2_E: f32 = core::f32::consts::LOG2_E;
+
+// `ln 2` in two parts, so that subtracting `k ln 2` from `x` keeps the digits of the
+// difference rather than rounding them away.
+const LN2_HI: f32 = leading_part(core::f64::consts::LN_2);
+const LN2_LO: f32 = trailing_part(core::f64::consts::LN_2);
+
+// Least worst-case relative error fit of `e^r` on `[-ln 2 / 2, ln 2 / 2]`, the interval
+// a round-to-nearest split leaves, by Remez exchange at degree six.
+//
+// Rounded to `f32` they hold the result to 26 bits, where an `f32` carries 24, and the
+// test at the foot of this file is the cross-check. A further term buys nothing: the fit
+// itself is good to 29 bits, so what is left is the rounding of these constants and of
+// the evaluation, neither of which another degree touches.
+const EXP_0: f32 = 1.0;
+const EXP_1: f32 = 1.0;
+const EXP_2: f32 = 0.4999999;
+const EXP_3: f32 = 0.1666642;
+const EXP_4: f32 = 0.041668225;
+const EXP_5: f32 = 0.008374816;
+const EXP_6: f32 = 0.0013836846;
+
+// Where the result leaves the format, and where the exponent arithmetic below would wrap
+// rather than saturate if it were let past.
+//
+// The high bound is `ln(f32::MAX)` rounded up, so clamping to it gives an infinity, which
+// is what every larger argument wants. The low bound is a whole binade under the smallest
+// subnormal rather than at it: at the boundary itself the series' own relative error is
+// enough to tip the rounding, and the result came back as the smallest subnormal where
+// the library returns zero.
+const EXP_MAX: f32 = 88.72284;
+const EXP_MIN: f32 = -104.66522;
+
+/// `e^x` as `2^k` times a polynomial in what is left over.
+///
+/// The leftover is formed by subtracting `k ln 2` in two pieces rather than by scaling
+/// `x`, because a single-precision `ln 2` would spend the accuracy the polynomial is
+/// about to earn.
+///
+/// Evaluated in single precision whatever the argument's own format. A narrower float
+/// carries fewer digits than this delivers, and a wider one is left to the target's own
+/// routine rather than fitted a second time.
+#[cube]
+pub fn exp<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
+    let x = Vector::<f32, N>::cast_from(x).clamp(Vector::new(EXP_MIN), Vector::new(EXP_MAX));
+
+    let k = (x * Vector::new(LOG2_E)).round();
+    let r = fma(-k, Vector::new(LN2_HI), x);
+    let r = fma(-k, Vector::new(LN2_LO), r);
+
+    // A tree rather than a chain: two extra multiplies for half the depth, which is worth
+    // 17% where one evaluation waits on the last, and 4% where it does not.
+    let square = r * r;
+    let quartic = square * square;
+
+    let terms_01 = fma(Vector::new(EXP_1), r, Vector::new(EXP_0));
+    let terms_23 = fma(Vector::new(EXP_3), r, Vector::new(EXP_2));
+    let terms_45 = fma(Vector::new(EXP_5), r, Vector::new(EXP_4));
+    let low = fma(terms_23, square, terms_01);
+    let high = fma(Vector::new(EXP_6), square, terms_45);
+    let series = fma(high, quartic, low);
+
+    // Splitting the exponent in two keeps each factor a normal number, so an underflowing
+    // result rounds into a subnormal instead of flushing to zero.
+    let exponent = Vector::<i32, N>::cast_from(k);
+    let half = exponent >> Vector::new(1i32);
+
+    Vector::<F, N>::cast_from(series * power_of_two(half) * power_of_two(exponent - half))
+}
+
+/// `2^exponent` for an `exponent` an `f32` can hold, written straight into the exponent
+/// field.
+#[cube]
+fn power_of_two<N: Size>(exponent: Vector<i32, N>) -> Vector<f32, N> {
+    Vector::<f32, N>::reinterpret(
+        Vector::<u32, N>::cast_from(exponent + Vector::new(127i32)) << Vector::new(23u32),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::base::{evaluate, worst_relative_error};
+    use super::*;
+
+    /// The coefficients fit `e^r` over the interval the reduction leaves, to the accuracy
+    /// their comment claims.
+    ///
+    /// This stands in for checking a digit against a formula, which a minimax fit does
+    /// not have: what is checked instead is the property the digits were chosen for.
+    #[test]
+    fn the_series_fits_the_exponential_over_the_reduced_interval() {
+        let half = core::f64::consts::LN_2 / 2.0;
+        let worst = worst_relative_error(-half, half, f64::exp, |r| {
+            evaluate(&[EXP_0, EXP_1, EXP_2, EXP_3, EXP_4, EXP_5, EXP_6], r)
+        });
+
+        assert!(worst < 2e-8, "worst relative error {worst}");
+    }
+}

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/exponential.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/exponential.rs
@@ -5,18 +5,13 @@ use super::base::{leading_part, trailing_part};
 
 const LOG2_E: f32 = core::f32::consts::LOG2_E;
 
-// `ln 2` in two parts, so that subtracting `k ln 2` from `x` keeps the digits of the
-// difference rather than rounding them away.
+// `ln 2` in two parts, so subtracting `k ln 2` from `x` keeps the digits of the difference.
 const LN2_HI: f32 = leading_part(core::f64::consts::LN_2);
 const LN2_LO: f32 = trailing_part(core::f64::consts::LN_2);
 
-// Least worst-case relative error fit of `e^r` on `[-ln 2 / 2, ln 2 / 2]`, the interval
-// a round-to-nearest split leaves, by Remez exchange at degree six.
-//
-// Rounded to `f32` they hold the result to 26 bits, where an `f32` carries 24, and the
-// test at the foot of this file is the cross-check. A further term buys nothing: the fit
-// itself is good to 29 bits, so what is left is the rounding of these constants and of
-// the evaluation, neither of which another degree touches.
+// Least worst-case relative error fit of `e^r` over the interval a round-to-nearest split
+// leaves, by Remez exchange at degree six. A further term buys nothing: the fit is good to
+// 29 bits and what remains is the rounding of the constants.
 const EXP_0: f32 = 1.0;
 const EXP_1: f32 = 1.0;
 const EXP_2: f32 = 0.4999999;
@@ -26,41 +21,28 @@ const EXP_5: f32 = 0.008374816;
 const EXP_6: f32 = 0.0013836846;
 
 // Where the result leaves the format, and where the exponent arithmetic below would wrap
-// rather than saturate if it were let past.
-//
-// The high bound is `ln(f32::MAX)` rounded up, so clamping to it gives an infinity, which
-// is what every larger argument wants. The low bound is a whole binade under the smallest
-// subnormal rather than at it: at the boundary itself the series' own relative error is
-// enough to tip the rounding, and the result came back as the smallest subnormal where
-// the library returns zero.
+// rather than saturate. The low bound is a binade under the smallest subnormal rather than
+// at it, where the series' own error tips the rounding to a subnormal.
 const EXP_MAX: f32 = 88.72284;
 const EXP_MIN: f32 = -104.66522;
 
-/// `e^x` as `2^k` times a polynomial in what is left over.
+/// `e^x` as `2^k` times a polynomial in what is left over, evaluated in single precision
+/// whatever the argument's own format.
 ///
-/// The leftover is formed by subtracting `k ln 2` in two pieces rather than by scaling
-/// `x`, because a single-precision `ln 2` would spend the accuracy the polynomial is
-/// about to earn.
-///
-/// Evaluated in single precision whatever the argument's own format. A narrower float
-/// carries fewer digits than this delivers, and a wider one is left to the target's own
-/// routine rather than fitted a second time.
+/// The leftover comes of subtracting `k ln 2` in two pieces rather than of scaling `x`,
+/// since a single-precision `ln 2` would spend the accuracy the polynomial is about to earn.
 #[cube]
 pub fn exp<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
     let x = Vector::<f32, N>::cast_from(x).clamp(Vector::new(EXP_MIN), Vector::new(EXP_MAX));
 
     let k = (x * Vector::new(LOG2_E)).round();
 
-    // The clamp keeps an infinity but not a NaN, and rounding a NaN to an integer below is
-    // a poison value rather than a wrong number. Zeroing it here costs the NaN nothing: it
-    // still reaches the result through `r`.
-    let k = select_many(k.equal(&k), k, Vector::new(0.0f32));
+    let finite = k.equal(&k);
+    let k = select_many(finite, k, Vector::new(0.0f32));
 
     let r = fma(-k, Vector::new(LN2_HI), x);
     let r = fma(-k, Vector::new(LN2_LO), r);
 
-    // A tree rather than a chain: two extra multiplies for half the depth, which is worth
-    // 17% where one evaluation waits on the last, and 4% where it does not.
     let square = r * r;
     let quartic = square * square;
 
@@ -71,8 +53,6 @@ pub fn exp<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
     let high = fma(Vector::new(EXP_6), square, terms_45);
     let series = fma(high, quartic, low);
 
-    // Splitting the exponent in two keeps each factor a normal number, so an underflowing
-    // result rounds into a subnormal instead of flushing to zero.
     let exponent = Vector::<i32, N>::cast_from(k);
     let half = exponent >> Vector::new(1i32);
 
@@ -93,11 +73,8 @@ mod tests {
     use super::super::base::{evaluate, worst_relative_error};
     use super::*;
 
-    /// The coefficients fit `e^r` over the interval the reduction leaves, to the accuracy
-    /// their comment claims.
-    ///
-    /// This stands in for checking a digit against a formula, which a minimax fit does
-    /// not have: what is checked instead is the property the digits were chosen for.
+    /// The coefficients fit `e^r` over the interval the reduction leaves, which is all a
+    /// minimax fit can be checked against.
     #[test]
     fn the_series_fits_the_exponential_over_the_reduced_interval() {
         let half = core::f64::consts::LN_2 / 2.0;

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/hyperbolic.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/hyperbolic.rs
@@ -1,0 +1,60 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+use super::base::horner;
+use super::exponential::exp;
+
+// Least worst-case relative error fit of `tanh(x)/x` in `x^2` on `[0, 1/4]`, the window
+// below where the exponential form stops cancelling, by Remez exchange at degree four.
+// Rounded to `f32` they hold `tanh` to 25 bits, where an `f32` carries 24; the test at the
+// foot of this file is the cross-check.
+const TANH_0: f32 = 1.0;
+const TANH_1: f32 = -0.3333307;
+const TANH_2: f32 = 0.1332478;
+const TANH_3: f32 = -0.052986074;
+const TANH_4: f32 = 0.017135007;
+
+/// Where the series and the exponential form change places, which is where `1 - 2/(e+1)`
+/// stops losing digits to cancellation.
+const SERIES_LIMIT: f32 = 0.5;
+
+/// `tanh x` as a series around zero and as `1 - 2/(e^2x + 1)` away from it.
+///
+/// Both arms are evaluated on every lane, since a vector has no cheaper way to take one
+/// branch, and the exponential's own clamp is what makes the far tail return exactly one.
+#[cube]
+pub fn tanh<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
+    let x = Vector::<f32, N>::cast_from(x);
+
+    let square = x * x;
+    let series = x * horner(square, comptime![[TANH_0, TANH_1, TANH_2, TANH_3, TANH_4]]);
+
+    let magnitude = x.abs();
+    let doubled = exp(magnitude + magnitude);
+    let saturating = Vector::new(1.0f32) - Vector::new(2.0f32) / (doubled + Vector::new(1.0f32));
+    let saturating = select_many(x.less_than(&Vector::new(0.0f32)), -saturating, saturating);
+
+    Vector::<F, N>::cast_from(select_many(
+        magnitude.less_than(&Vector::new(SERIES_LIMIT)),
+        series,
+        saturating,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::base::{evaluate, worst_relative_error};
+    use super::*;
+
+    /// The series fits `tanh` over the window it is used on, which is where the
+    /// exponential form loses digits to cancellation.
+    #[test]
+    fn the_series_fits_the_tangent_around_zero() {
+        let limit = SERIES_LIMIT as f64;
+        let worst = worst_relative_error(-limit, limit, f64::tanh, |x| {
+            x * evaluate(&[TANH_0, TANH_1, TANH_2, TANH_3, TANH_4], x * x)
+        });
+
+        assert!(worst < 4e-8, "worst relative error {worst}");
+    }
+}

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/hyperbolic.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/hyperbolic.rs
@@ -6,8 +6,6 @@ use super::exponential::exp;
 
 // Least worst-case relative error fit of `tanh(x)/x` in `x^2` on `[0, 1/4]`, the window
 // below where the exponential form stops cancelling, by Remez exchange at degree four.
-// Rounded to `f32` they hold `tanh` to 25 bits, where an `f32` carries 24; the test at the
-// foot of this file is the cross-check.
 const TANH_0: f32 = 1.0;
 const TANH_1: f32 = -0.3333307;
 const TANH_2: f32 = 0.1332478;
@@ -46,8 +44,7 @@ mod tests {
     use super::super::base::{evaluate, worst_relative_error};
     use super::*;
 
-    /// The series fits `tanh` over the window it is used on, which is where the
-    /// exponential form loses digits to cancellation.
+    /// The series fits `tanh` over the window the exponential form loses digits on.
     #[test]
     fn the_series_fits_the_tangent_around_zero() {
         let limit = SERIES_LIMIT as f64;

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/logarithm.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/logarithm.rs
@@ -1,0 +1,95 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+use super::base::{leading_part, trailing_part};
+
+const LN2_HI: f32 = leading_part(core::f64::consts::LN_2);
+const LN2_LO: f32 = trailing_part(core::f64::consts::LN_2);
+const SQRT_2: f32 = core::f32::consts::SQRT_2;
+
+// Least worst-case relative error fit of `(ln(1+f) - f + f^2/2) / f^3` on
+// `[sqrt(1/2) - 1, sqrt(2) - 1]`, the mantissa window the fold leaves, by Remez exchange
+// at degree seven. Rounded to `f32` they hold `ln(1+f)` to 25 bits, where an `f32`
+// carries 24; the test at the foot of this file is the cross-check.
+const LOG_0: f32 = 0.3333333;
+const LOG_1: f32 = -0.25000304;
+const LOG_2: f32 = 0.20001201;
+const LOG_3: f32 = -0.16641581;
+const LOG_4: f32 = 0.14209945;
+const LOG_5: f32 = -0.12989277;
+const LOG_6: f32 = 0.12655699;
+const LOG_7: f32 = -0.079742186;
+
+/// `ln x` as the exponent times `ln 2`, plus a series on the mantissa.
+///
+/// The mantissa is folded at the geometric mean of its octave so the series argument is
+/// centred on zero; left in `[1, 2)` the top of the range would need twice the terms. The
+/// series is the division-free form, `f - f^2/2 + f^3 P(f)`, which trades five fused
+/// multiply-adds for the divide the `atanh` form needs, and folds as a tree rather than a
+/// chain, which costs one multiply and halves the depth.
+///
+/// Evaluated in single precision whatever the argument's own format. A subnormal argument
+/// holds no exponent to extract and comes back as nonsense rather than as a large
+/// negative number.
+#[cube]
+pub fn ln<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
+    let x = Vector::<f32, N>::cast_from(x);
+
+    let bits = Vector::<u32, N>::reinterpret(x);
+    let exponent = Vector::<i32, N>::cast_from(bits >> Vector::new(23u32)) - Vector::new(127i32);
+    let mantissa = Vector::<f32, N>::reinterpret(
+        (bits & Vector::new(0x007f_ffffu32)) | Vector::new(0x3f80_0000u32),
+    );
+
+    let halved = mantissa.greater_than(&Vector::new(SQRT_2));
+    let mantissa = select_many(halved, mantissa * Vector::new(0.5f32), mantissa);
+    let exponent = select_many(halved, exponent + Vector::new(1i32), exponent);
+
+    // Exact: the mantissa sits in `[1/2, 2]`, where Sterbenz makes the subtraction free of
+    // rounding, and the whole accuracy of `ln` near one rests on it.
+    let f = mantissa - Vector::new(1.0f32);
+    let square = f * f;
+    let quartic = square * square;
+
+    let terms_01 = fma(Vector::new(LOG_1), f, Vector::new(LOG_0));
+    let terms_23 = fma(Vector::new(LOG_3), f, Vector::new(LOG_2));
+    let terms_45 = fma(Vector::new(LOG_5), f, Vector::new(LOG_4));
+    let terms_67 = fma(Vector::new(LOG_7), f, Vector::new(LOG_6));
+
+    let low = fma(terms_23, square, terms_01);
+    let high = fma(terms_67, square, terms_45);
+    let tail = fma(high, quartic, low);
+
+    let mantissa_log = fma(square * f, tail, fma(square, Vector::new(-0.5f32), f));
+    let exponent = Vector::<f32, N>::cast_from(exponent);
+
+    Vector::<F, N>::cast_from(fma(
+        exponent,
+        Vector::new(LN2_HI),
+        fma(exponent, Vector::new(LN2_LO), mantissa_log),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::base::{evaluate, worst_relative_error};
+    use super::*;
+
+    /// The coefficients fit `ln(1 + f)` over the mantissa window the fold leaves.
+    ///
+    /// The fit is measured on the logarithm rather than on the tail polynomial alone,
+    /// because the tail carries about a twentieth of the result and an error on it reads
+    /// twenty times smaller once reconstructed.
+    #[test]
+    fn the_series_fits_the_logarithm_over_the_mantissa_window() {
+        let from = (0.5f64).sqrt() - 1.0;
+        let to = (2.0f64).sqrt() - 1.0;
+
+        let worst = worst_relative_error(from, to, f64::ln_1p, |f| {
+            let tail = evaluate(&[LOG_0, LOG_1, LOG_2, LOG_3, LOG_4, LOG_5, LOG_6, LOG_7], f);
+            f - f * f / 2.0 + f * f * f * tail
+        });
+
+        assert!(worst < 3e-8, "worst relative error {worst}");
+    }
+}

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/logarithm.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/logarithm.rs
@@ -7,6 +7,10 @@ const LN2_HI: f32 = leading_part(core::f64::consts::LN_2);
 const LN2_LO: f32 = trailing_part(core::f64::consts::LN_2);
 const SQRT_2: f32 = core::f32::consts::SQRT_2;
 
+/// What a subnormal is multiplied by to reach the normals, and the exponent that buys.
+const SUBNORMAL_SCALE: f32 = (1u32 << 24) as f32;
+const SUBNORMAL_SHIFT: i32 = 24;
+
 // Least worst-case relative error fit of `(ln(1+f) - f + f^2/2) / f^3` on
 // `[sqrt(1/2) - 1, sqrt(2) - 1]`, the mantissa window the fold leaves, by Remez exchange
 // at degree seven. Rounded to `f32` they hold `ln(1+f)` to 25 bits, where an `f32`
@@ -28,18 +32,22 @@ const LOG_7: f32 = -0.079742186;
 /// multiply-adds for the divide the `atanh` form needs, and folds as a tree rather than a
 /// chain, which costs one multiply and halves the depth.
 ///
-/// Evaluated in single precision whatever the argument's own format. A subnormal argument
-/// holds no exponent to extract and comes back as nonsense rather than as a large
-/// negative number.
+/// Evaluated in single precision whatever the argument's own format.
 #[cube]
 pub fn ln<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
     let x = Vector::<f32, N>::cast_from(x);
 
-    let bits = Vector::<u32, N>::reinterpret(x);
+    // A subnormal holds no exponent to extract, so it is scaled into the normals first and
+    // the scaling taken back off the exponent afterwards.
+    let subnormal = x.less_than(&Vector::new(f32::MIN_POSITIVE));
+    let scaled = select_many(subnormal, x * Vector::new(SUBNORMAL_SCALE), x);
+    let bits = Vector::<u32, N>::reinterpret(scaled);
     let exponent = Vector::<i32, N>::cast_from(bits >> Vector::new(23u32)) - Vector::new(127i32);
     let mantissa = Vector::<f32, N>::reinterpret(
         (bits & Vector::new(0x007f_ffffu32)) | Vector::new(0x3f80_0000u32),
     );
+
+    let exponent = select_many(subnormal, exponent - Vector::new(SUBNORMAL_SHIFT), exponent);
 
     let halved = mantissa.greater_than(&Vector::new(SQRT_2));
     let mantissa = select_many(halved, mantissa * Vector::new(0.5f32), mantissa);
@@ -63,11 +71,26 @@ pub fn ln<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
     let mantissa_log = fma(square * f, tail, fma(square, Vector::new(-0.5f32), f));
     let exponent = Vector::<f32, N>::cast_from(exponent);
 
-    Vector::<F, N>::cast_from(fma(
+    let series = fma(
         exponent,
         Vector::new(LN2_HI),
         fma(exponent, Vector::new(LN2_LO), mantissa_log),
-    ))
+    );
+
+    // Nothing above reads the sign bit or asks the exponent field what it means, so every
+    // argument that is not a positive finite number arrives here as an ordinary small
+    // number rather than as the infinity or the NaN it should be. A zero would otherwise
+    // come back near -88, which is a wrong answer that looks like a right one.
+    let zero = Vector::<f32, N>::new(0.0);
+    let series = select_many(x.greater_than(&zero), series, Vector::new(f32::NAN));
+    let series = select_many(x.equal(&zero), Vector::new(f32::NEG_INFINITY), series);
+    let series = select_many(
+        x.equal(&Vector::new(f32::INFINITY)),
+        Vector::new(f32::INFINITY),
+        series,
+    );
+
+    Vector::<F, N>::cast_from(series)
 }
 
 #[cfg(test)]

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/logarithm.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/logarithm.rs
@@ -11,10 +11,8 @@ const SQRT_2: f32 = core::f32::consts::SQRT_2;
 const SUBNORMAL_SCALE: f32 = (1u32 << 24) as f32;
 const SUBNORMAL_SHIFT: i32 = 24;
 
-// Least worst-case relative error fit of `(ln(1+f) - f + f^2/2) / f^3` on
-// `[sqrt(1/2) - 1, sqrt(2) - 1]`, the mantissa window the fold leaves, by Remez exchange
-// at degree seven. Rounded to `f32` they hold `ln(1+f)` to 25 bits, where an `f32`
-// carries 24; the test at the foot of this file is the cross-check.
+// Least worst-case relative error fit of `(ln(1+f) - f + f^2/2) / f^3` over the mantissa
+// window the fold leaves, by Remez exchange at degree seven.
 const LOG_0: f32 = 0.3333333;
 const LOG_1: f32 = -0.25000304;
 const LOG_2: f32 = 0.20001201;
@@ -24,21 +22,15 @@ const LOG_5: f32 = -0.12989277;
 const LOG_6: f32 = 0.12655699;
 const LOG_7: f32 = -0.079742186;
 
-/// `ln x` as the exponent times `ln 2`, plus a series on the mantissa.
+/// `ln x` as the exponent times `ln 2`, plus a series on the mantissa, evaluated in single
+/// precision whatever the argument's own format.
 ///
 /// The mantissa is folded at the geometric mean of its octave so the series argument is
-/// centred on zero; left in `[1, 2)` the top of the range would need twice the terms. The
-/// series is the division-free form, `f - f^2/2 + f^3 P(f)`, which trades five fused
-/// multiply-adds for the divide the `atanh` form needs, and folds as a tree rather than a
-/// chain, which costs one multiply and halves the depth.
-///
-/// Evaluated in single precision whatever the argument's own format.
+/// centred on zero; left in `[1, 2)` the top of the range would need twice the terms.
 #[cube]
 pub fn ln<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
     let x = Vector::<f32, N>::cast_from(x);
 
-    // A subnormal holds no exponent to extract, so it is scaled into the normals first and
-    // the scaling taken back off the exponent afterwards.
     let subnormal = x.less_than(&Vector::new(f32::MIN_POSITIVE));
     let scaled = select_many(subnormal, x * Vector::new(SUBNORMAL_SCALE), x);
     let bits = Vector::<u32, N>::reinterpret(scaled);
@@ -53,8 +45,6 @@ pub fn ln<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
     let mantissa = select_many(halved, mantissa * Vector::new(0.5f32), mantissa);
     let exponent = select_many(halved, exponent + Vector::new(1i32), exponent);
 
-    // Exact: the mantissa sits in `[1/2, 2]`, where Sterbenz makes the subtraction free of
-    // rounding, and the whole accuracy of `ln` near one rests on it.
     let f = mantissa - Vector::new(1.0f32);
     let square = f * f;
     let quartic = square * square;
@@ -77,10 +67,6 @@ pub fn ln<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
         fma(exponent, Vector::new(LN2_LO), mantissa_log),
     );
 
-    // Nothing above reads the sign bit or asks the exponent field what it means, so every
-    // argument that is not a positive finite number arrives here as an ordinary small
-    // number rather than as the infinity or the NaN it should be. A zero would otherwise
-    // come back near -88, which is a wrong answer that looks like a right one.
     let zero = Vector::<f32, N>::new(0.0);
     let series = select_many(x.greater_than(&zero), series, Vector::new(f32::NAN));
     let series = select_many(x.equal(&zero), Vector::new(f32::NEG_INFINITY), series);
@@ -98,11 +84,8 @@ mod tests {
     use super::super::base::{evaluate, worst_relative_error};
     use super::*;
 
-    /// The coefficients fit `ln(1 + f)` over the mantissa window the fold leaves.
-    ///
-    /// The fit is measured on the logarithm rather than on the tail polynomial alone,
-    /// because the tail carries about a twentieth of the result and an error on it reads
-    /// twenty times smaller once reconstructed.
+    /// The coefficients fit `ln(1 + f)` over the mantissa window the fold leaves, measured
+    /// on the logarithm rather than on the tail, which carries a twentieth of the result.
     #[test]
     fn the_series_fits_the_logarithm_over_the_mantissa_window() {
         let from = (0.5f64).sqrt() - 1.0;

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/mod.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/mod.rs
@@ -1,0 +1,17 @@
+//! Transcendentals as polynomials, for a target with no vector math library behind its
+//! vector intrinsics.
+//!
+//! `llvm.exp` on a vector reaches codegen as an intrinsic with nothing but a declare
+//! behind it, and every lane becomes a libm call. A dozen fused multiply-adds cost less
+//! than one of those calls, and less again for every lane the line carries.
+
+mod base;
+mod exponential;
+mod hyperbolic;
+mod logarithm;
+mod trigonometry;
+
+pub(super) use exponential::exp;
+pub(super) use hyperbolic::tanh;
+pub(super) use logarithm::ln;
+pub(super) use trigonometry::{cos, sin};

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/mod.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/mod.rs
@@ -1,9 +1,6 @@
 //! Transcendentals as polynomials, for a target with no vector math library behind its
-//! vector intrinsics.
-//!
-//! `llvm.exp` on a vector reaches codegen as an intrinsic with nothing but a declare
-//! behind it, and every lane becomes a libm call. A dozen fused multiply-adds cost less
-//! than one of those calls, and less again for every lane the line carries.
+//! vector intrinsics: `llvm.exp` on a vector reaches codegen with nothing but a declare
+//! behind it, and every lane becomes a libm call that a dozen fused multiply-adds beat.
 
 mod base;
 mod exponential;

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/trigonometry.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/trigonometry.rs
@@ -1,0 +1,113 @@
+use cubecl_core as cubecl;
+use cubecl_core::prelude::*;
+
+use super::base::{horner, leading_part, trailing_part};
+
+// `pi / 2` in three pieces. What the three leave behind is `2^-49`, which is the floor on
+// how small a reduced angle can be and still carry its own significance.
+const PI_2: f64 = core::f64::consts::FRAC_PI_2;
+const PI_2_A: f32 = leading_part(PI_2);
+const PI_2_B: f32 = leading_part(PI_2 - PI_2_A as f64);
+const PI_2_C: f32 = trailing_part(PI_2 - PI_2_A as f64);
+
+const FRAC_2_PI: f32 = core::f32::consts::FRAC_2_PI;
+
+// Least worst-case relative error fit of `sin(x)/x` in `x^2` on `[0, (pi/4)^2]`, an
+// eighth of a turn, by Remez exchange at degree three. Rounded to `f32` they hold `sin`
+// to 27 bits, where an `f32` carries 24; the test at the foot of this file is the
+// cross-check.
+const SIN_0: f32 = 1.0;
+const SIN_1: f32 = -0.16666651;
+const SIN_2: f32 = 0.008332017;
+const SIN_3: f32 = -1.9501822e-04;
+
+// The same fit for `cos(x)` in `x^2` over the same eighth, at degree four, holding `cos`
+// to 27 bits.
+const COS_0: f32 = 1.0;
+const COS_1: f32 = -0.5;
+const COS_2: f32 = 0.041666612;
+const COS_3: f32 = -0.001388653;
+const COS_4: f32 = 2.4372679e-05;
+
+/// The sine of an angle in radians.
+///
+/// Both series are evaluated and one is discarded, since the reduction they share is the
+/// expensive half and nothing downstream keeps the other.
+#[cube]
+pub fn sin<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
+    let (_, sine) = cos_sin_radians(Vector::<f32, N>::cast_from(x));
+    Vector::<F, N>::cast_from(sine)
+}
+
+/// The cosine of an angle in radians.
+#[cube]
+pub fn cos<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
+    let (cosine, _) = cos_sin_radians(Vector::<f32, N>::cast_from(x));
+    Vector::<F, N>::cast_from(cosine)
+}
+
+/// Cosine and sine of an angle in radians, by reducing onto the eighth of a turn around
+/// zero and undoing the quadrant afterwards.
+///
+/// The reduction subtracts the quadrant's worth of `pi / 2` in three pieces. A single
+/// piece would leave an error proportional to the angle, which is the error that makes a
+/// hardware `sin` useless far from the origin.
+#[cube]
+fn cos_sin_radians<N: Size>(x: Vector<f32, N>) -> (Vector<f32, N>, Vector<f32, N>) {
+    let quadrant = (x * Vector::new(FRAC_2_PI)).round();
+
+    let offset = fma(-quadrant, Vector::new(PI_2_A), x);
+    let offset = fma(-quadrant, Vector::new(PI_2_B), offset);
+    let offset = fma(-quadrant, Vector::new(PI_2_C), offset);
+
+    cos_sin_quadrant(offset, Vector::<i32, N>::cast_from(quadrant))
+}
+
+/// Cosine and sine of `quadrant` quarter turns plus `offset` radians, for an `offset` no
+/// larger than an eighth of a turn.
+#[cube]
+fn cos_sin_quadrant<N: Size>(
+    offset: Vector<f32, N>,
+    quadrant: Vector<i32, N>,
+) -> (Vector<f32, N>, Vector<f32, N>) {
+    let square = offset * offset;
+
+    let sine = offset * horner(square, comptime![[SIN_0, SIN_1, SIN_2, SIN_3]]);
+    let cosine = horner(square, comptime![[COS_0, COS_1, COS_2, COS_3, COS_4]]);
+
+    let quadrant = quadrant & Vector::new(3i32);
+    let swapped = (quadrant & Vector::new(1i32)).equal(&Vector::new(1i32));
+    let cosine_magnitude = select_many(swapped, sine, cosine);
+    let sine_magnitude = select_many(swapped, cosine, sine);
+
+    let cosine_negative =
+        ((quadrant + Vector::new(1i32)) & Vector::new(2i32)).equal(&Vector::new(2i32));
+    let sine_negative = (quadrant & Vector::new(2i32)).equal(&Vector::new(2i32));
+
+    (
+        select_many(cosine_negative, -cosine_magnitude, cosine_magnitude),
+        select_many(sine_negative, -sine_magnitude, sine_magnitude),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::base::{evaluate, worst_relative_error};
+    use super::*;
+
+    /// Both series fit their function over the eighth of a turn the reduction leaves.
+    #[test]
+    fn the_series_fit_over_an_eighth_of_a_turn() {
+        let limit = core::f64::consts::FRAC_PI_4;
+
+        let sine = worst_relative_error(-limit, limit, f64::sin, |x| {
+            x * evaluate(&[SIN_0, SIN_1, SIN_2, SIN_3], x * x)
+        });
+        let cosine = worst_relative_error(-limit, limit, f64::cos, |x| {
+            evaluate(&[COS_0, COS_1, COS_2, COS_3, COS_4], x * x)
+        });
+
+        assert!(sine < 8e-9, "sine worst relative error {sine}");
+        assert!(cosine < 6e-9, "cosine worst relative error {cosine}");
+    }
+}

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/trigonometry.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/trigonometry.rs
@@ -62,7 +62,13 @@ pub fn cos<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
 /// hardware `sin` useless far from the origin.
 #[cube]
 fn cos_sin_radians<N: Size>(x: Vector<f32, N>) -> (Vector<f32, N>, Vector<f32, N>) {
+    // False for a NaN as well as for an angle too large, which is what the quadrant below
+    // needs: rounding a non-finite to an integer is a poison value rather than a wrong
+    // number, and poison steering a select licenses any answer at all.
+    let reducible = x.abs().less_equal(&Vector::new(REDUCTION_LIMIT));
+
     let quadrant = (x * Vector::new(FRAC_2_PI)).round();
+    let quadrant = select_many(reducible, quadrant, Vector::new(0.0f32));
 
     let offset = fma(-quadrant, Vector::new(PI_2_A), x);
     let offset = fma(-quadrant, Vector::new(PI_2_B), offset);
@@ -76,14 +82,13 @@ fn cos_sin_radians<N: Size>(x: Vector<f32, N>) -> (Vector<f32, N>, Vector<f32, N
     let sine = select_many(x.equal(&Vector::new(0.0f32)), x, sine);
 
     // Past the limit the answer is not merely inaccurate, it is arbitrary, and the
-    // arithmetic that produces it runs off to an infinity that would poison whatever sums
+    // arithmetic that produces it runs off to an infinity that would spoil whatever sums
     // it. Saying so is better than returning a number of the right magnitude.
-    let beyond = x.abs().greater_than(&Vector::new(REDUCTION_LIMIT));
     let unknown = Vector::<f32, N>::new(f32::NAN);
 
     (
-        select_many(beyond, unknown, cosine),
-        select_many(beyond, unknown, sine),
+        select_many(reducible, cosine, unknown),
+        select_many(reducible, sine, unknown),
     )
 }
 

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/trigonometry.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/trigonometry.rs
@@ -12,6 +12,14 @@ const PI_2_C: f32 = trailing_part(PI_2 - PI_2_A as f64);
 
 const FRAC_2_PI: f32 = core::f32::consts::FRAC_2_PI;
 
+/// How large an angle the reduction still means something for.
+///
+/// Measured, not derived: the worst absolute error holds near `7e-8` out to `1e5`, reaches
+/// `2.8e-7` at `1e6`, and then leaves the contract quickly, `1.5e-4` at `1e7` and nothing
+/// at all past `1e8`. A million radians is a wider promise than most vector libraries make
+/// and covers a rotary embedding at a million positions.
+const REDUCTION_LIMIT: f32 = (1u32 << 20) as f32;
+
 // Least worst-case relative error fit of `sin(x)/x` in `x^2` on `[0, (pi/4)^2]`, an
 // eighth of a turn, by Remez exchange at degree three. Rounded to `f32` they hold `sin`
 // to 27 bits, where an `f32` carries 24; the test at the foot of this file is the
@@ -60,7 +68,23 @@ fn cos_sin_radians<N: Size>(x: Vector<f32, N>) -> (Vector<f32, N>, Vector<f32, N
     let offset = fma(-quadrant, Vector::new(PI_2_B), offset);
     let offset = fma(-quadrant, Vector::new(PI_2_C), offset);
 
-    cos_sin_quadrant(offset, Vector::<i32, N>::cast_from(quadrant))
+    let (cosine, sine) = cos_sin_quadrant(offset, Vector::<i32, N>::cast_from(quadrant));
+
+    // `sin(-0)` is `-0`, and the reduction cannot keep it: the quadrant of a negative zero
+    // is a negative zero, so the offset is a positive zero added to a negative one, which
+    // rounds to positive. Every other backend here returns the sign.
+    let sine = select_many(x.equal(&Vector::new(0.0f32)), x, sine);
+
+    // Past the limit the answer is not merely inaccurate, it is arbitrary, and the
+    // arithmetic that produces it runs off to an infinity that would poison whatever sums
+    // it. Saying so is better than returning a number of the right magnitude.
+    let beyond = x.abs().greater_than(&Vector::new(REDUCTION_LIMIT));
+    let unknown = Vector::<f32, N>::new(f32::NAN);
+
+    (
+        select_many(beyond, unknown, cosine),
+        select_many(beyond, unknown, sine),
+    )
 }
 
 /// Cosine and sine of `quadrant` quarter turns plus `offset` radians, for an `offset` no

--- a/crates/cubecl-llvm/src/shared/polyfill/transcendental/trigonometry.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/transcendental/trigonometry.rs
@@ -3,8 +3,7 @@ use cubecl_core::prelude::*;
 
 use super::base::{horner, leading_part, trailing_part};
 
-// `pi / 2` in three pieces. What the three leave behind is `2^-49`, which is the floor on
-// how small a reduced angle can be and still carry its own significance.
+// `pi / 2` in three pieces, which leave `2^-49` behind.
 const PI_2: f64 = core::f64::consts::FRAC_PI_2;
 const PI_2_A: f32 = leading_part(PI_2);
 const PI_2_B: f32 = leading_part(PI_2 - PI_2_A as f64);
@@ -12,35 +11,26 @@ const PI_2_C: f32 = trailing_part(PI_2 - PI_2_A as f64);
 
 const FRAC_2_PI: f32 = core::f32::consts::FRAC_2_PI;
 
-/// How large an angle the reduction still means something for.
-///
-/// Measured, not derived: the worst absolute error holds near `7e-8` out to `1e5`, reaches
-/// `2.8e-7` at `1e6`, and then leaves the contract quickly, `1.5e-4` at `1e7` and nothing
-/// at all past `1e8`. A million radians is a wider promise than most vector libraries make
-/// and covers a rotary embedding at a million positions.
+/// How large an angle the reduction still means something for. Measured, not derived: the
+/// worst absolute error holds near `7e-8` out to `1e6` and reaches `1.5e-4` at `1e7`.
 const REDUCTION_LIMIT: f32 = (1u32 << 20) as f32;
 
-// Least worst-case relative error fit of `sin(x)/x` in `x^2` on `[0, (pi/4)^2]`, an
-// eighth of a turn, by Remez exchange at degree three. Rounded to `f32` they hold `sin`
-// to 27 bits, where an `f32` carries 24; the test at the foot of this file is the
-// cross-check.
+// Least worst-case relative error fit of `sin(x)/x` in `x^2` over an eighth of a turn, by
+// Remez exchange at degree three.
 const SIN_0: f32 = 1.0;
 const SIN_1: f32 = -0.16666651;
 const SIN_2: f32 = 0.008332017;
 const SIN_3: f32 = -1.9501822e-04;
 
-// The same fit for `cos(x)` in `x^2` over the same eighth, at degree four, holding `cos`
-// to 27 bits.
+// The same fit for `cos(x)` in `x^2` over the same eighth, at degree four.
 const COS_0: f32 = 1.0;
 const COS_1: f32 = -0.5;
 const COS_2: f32 = 0.041666612;
 const COS_3: f32 = -0.001388653;
 const COS_4: f32 = 2.4372679e-05;
 
-/// The sine of an angle in radians.
-///
-/// Both series are evaluated and one is discarded, since the reduction they share is the
-/// expensive half and nothing downstream keeps the other.
+/// The sine of an angle in radians. Both series are evaluated and one discarded, since the
+/// reduction they share is the expensive half.
 #[cube]
 pub fn sin<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
     let (_, sine) = cos_sin_radians(Vector::<f32, N>::cast_from(x));
@@ -57,14 +47,10 @@ pub fn cos<F: Float, N: Size>(x: Vector<F, N>) -> Vector<F, N> {
 /// Cosine and sine of an angle in radians, by reducing onto the eighth of a turn around
 /// zero and undoing the quadrant afterwards.
 ///
-/// The reduction subtracts the quadrant's worth of `pi / 2` in three pieces. A single
-/// piece would leave an error proportional to the angle, which is the error that makes a
-/// hardware `sin` useless far from the origin.
+/// The quadrant's worth of `pi / 2` comes off in three pieces; a single piece leaves an
+/// error proportional to the angle.
 #[cube]
 fn cos_sin_radians<N: Size>(x: Vector<f32, N>) -> (Vector<f32, N>, Vector<f32, N>) {
-    // False for a NaN as well as for an angle too large, which is what the quadrant below
-    // needs: rounding a non-finite to an integer is a poison value rather than a wrong
-    // number, and poison steering a select licenses any answer at all.
     let reducible = x.abs().less_equal(&Vector::new(REDUCTION_LIMIT));
 
     let quadrant = (x * Vector::new(FRAC_2_PI)).round();
@@ -76,14 +62,8 @@ fn cos_sin_radians<N: Size>(x: Vector<f32, N>) -> (Vector<f32, N>, Vector<f32, N
 
     let (cosine, sine) = cos_sin_quadrant(offset, Vector::<i32, N>::cast_from(quadrant));
 
-    // `sin(-0)` is `-0`, and the reduction cannot keep it: the quadrant of a negative zero
-    // is a negative zero, so the offset is a positive zero added to a negative one, which
-    // rounds to positive. Every other backend here returns the sign.
     let sine = select_many(x.equal(&Vector::new(0.0f32)), x, sine);
 
-    // Past the limit the answer is not merely inaccurate, it is arbitrary, and the
-    // arithmetic that produces it runs off to an infinity that would spoil whatever sums
-    // it. Saying so is better than returning a number of the right magnitude.
     let unknown = Vector::<f32, N>::new(f32::NAN);
 
     (


### PR DESCRIPTION
The CPU JIT builds its LLJIT with `new_with_default_builder()`, so there is no vector math
library behind a vector transcendental: `llvm.exp(<8 x float>)` reaches codegen as a bare
`declare` and every lane becomes a libm call.

`exp`, `log`, `sin`, `cos` and `tanh` now lower to short polynomials instead, as a `LowerOp`
under `crates/cubecl-llvm/src/shared/polyfill/transcendental/`. CPU only. Nothing was
removed: `LowerComplexOpPass` already runs ahead of `CubeToLLVMPass`, and a `should_lower`
that declines leaves the existing intrinsic lowering as the fallback.

## Speed

Ryzen 7 5700X, twenty samples, chained at a line of eight, net of a control kernel carrying
the same traffic without a transcendental. 67.1M evaluations:

| | libm | polynomial | |
|---|---|---|---|
| `exp` | 17.92ms | 4.50ms | 4.0x |
| `log` | 20.14ms | 6.11ms | 3.3x |
| `sin` | 23.24ms | 5.30ms | 4.4x |
| `cos` | 23.33ms | 5.37ms | 4.3x |
| `tanh` | 37.59ms | 7.95ms | 4.7x |

End to end with no kernel edited, a vectorised normal draw falls from 26.6ms to 7.4ms at
33.5M elements, 3.21ms to 0.64ms at 4.2M, and 128us to 41us vocabulary-sized. The uniform
and Bernoulli draws touch no transcendental and do not move, which is the control saying
this is the polynomial and not the build. In a streaming pass all five land on the memory
floor, where `tanh` had been at twice it.

## Accuracy

1.09 to 2.03 units in the last place, against 0.50 to 0.69 for the libm calls being
replaced. A real trade, and still better than this project's GPU backends deliver for the
same functions.

One capability is given up: `sin` and `cos` past 2^20 radians return NaN. Everything else
matches the library, including `log(0) = -inf`, `log(-1) = NaN`, the subnormals, and the
sign of a zero through `sin`.

<details><summary>Why 2^20, and how the constants are pinned</summary>

Measured by decade, the worst absolute error holds near 7e-8 through 1e5, reaches 2.8e-7 at
1e6 and 1.5e-4 at 1e7, and by 1e8 the answer is arbitrary. glibc does full Payne-Hanek
reduction and stays correct throughout, so this is a capability given up, not only
precision. A million radians is a wider promise than most vector libraries make and covers
a rotary embedding at a million positions.

Every constant is either derived in the source or pinned by a test. The Cody-Waite splits
come from a const fn that clears the low mantissa bits, with tests for the exactness that
buys. Each coefficient block names its function, interval, objective and degree, and a test
evaluates the checked-in values over that interval against the accuracy claimed, which is
what stands in for checking a minimax digit against a formula it does not have.
</details>

## The one decision I would like ruled on

The polyfill declines a scalar:

```rust
input.vector_size(ctx) > 1 && !input.scalar_ty(ctx).is_float64(ctx)
```

Ratio of library call to polynomial, net of control. Above 1.00 the polynomial wins:

| | vec1 | vec2 | vec4 | vec8 |
|---|---|---|---|---|
| `exp` | 0.87 | 1.23 | 2.10 | 3.97 |
| `log` | 0.75 | 1.12 | 1.78 | 3.27 |
| `sin` | 1.16 | 1.48 | 2.37 | 3.36 |
| `cos` | 1.08 | 1.45 | 2.28 | 4.27 |
| `tanh` | 0.86 | 1.26 | 2.54 | 4.60 |

The crossover for `exp`, `log` and `tanh` falls between one and two, which is where the gate
sits. The library row is flat across widths, `tanh` reading 38.65, 39.70, 38.41 and
37.22ms, because eight lanes still cost eight calls, while the polynomial row halves at
every doubling. The thin cell is `log` at vec2, 1.12 here and 1.04 on the independent
variant, which is break-even rather than a win.

**What the gate costs:** a scalar `exp` and an eight-wide `exp` no longer return the same
bits, so a kernel whose vectorisation an autotuner picks has a result that moves with the
choice. If that is the wrong trade for this project, the alternative is polyfilling every
width and accepting the scalar regression, and I have the numbers for either.

Double precision is declined because fitting a second set of coefficients would double the
surface to verify for a format no kernel here reaches for.

<details><summary>Why sin and cos are declined at a scalar even though they win there</summary>

Letting them through hands the FFT back a 1.5x regression, which was never about arithmetic
speed. In a loop of its own the polyfill runs a scalar cosine and sine pair in 43.7ms
against libm's 70.4ms, and the kernel still lost half. Comparing the compiled `rfft_kernel`
both ways, the polyfill version spills less, 72 stack references against 102, and is 7
instructions longer. What changed is division: three at IR level became seven, including a
`vdivss` the baseline does not have. In that loop `m` is a power of two, so `theta = ... / m`
is an exponent adjustment, and LLVM proved it while the body held two opaque libm calls and
stopped proving it once a polynomial was inlined there. Ungated, a scalar cosine kernel lost
a quarter and the FFT lost half; gated, both are byte-identical to before.
</details>

## Tests

Nothing in cubecl evaluated `exp` or `log` through a kernel at all, and `sin`, `cos` and
`tanh` only at `0`, `pi/2`, `pi` and `-pi/2`, which a polynomial reaches without its range
reduction ever running a quadrant.

- `runtime_tests/unary.rs` gains `exp` and `log` at line sizes one, two and four, and the
  three already there gain a block spanning several turns either side of zero and both
  sides of the half where `tanh` changes form. Every input is exactly representable in `f16`.
- `cubecl-cpu` gains the edge contract, against the library on the same host, under a kernel
  carrying no `FastMath`. It cannot live in `cubecl-core`, where it would be asserted for
  wgpu and CUDA too.

Green on the CPU backend (724), on CUDA on an RTX 4070 Ti SUPER (136 unary across bf16, f16,
f32 and f64), and on wgpu over Intel Vulkan. `xtask check format` and `xtask check --ci lint`
both pass.

## Not in this PR, on purpose

- **`pow`.** `exp2(b * log2(a))` measures 22 ULP on a typical domain and 279 on a wide one,
  because the exponent multiplies the logarithm's absolute error, so it needs a two-part
  `log2`.
- **Dropping `log`'s NaN and infinity selects** under `NotNaN`/`NotInf`. Worth about a fifth
  of the evaluation.
- **Folding a constant multiplier into the range reduction**, so `cos(c * x)` skips
  Cody-Waite entirely. Worth about a tenth on a `cos`/`sin` pair, and every FFT twiddle has
  that shape. Needs reassociation permission.
- **Writing the polynomials as `a * b + c`** and letting #1550's `InstCombinePass` fuse them.

<details><summary>Why those last three cannot be done yet</summary>

**There is no fast-math gate to reach for.** `#[cube(fast_math = ...)]` calls
`fast_math_expand`, which sets `GlobalState.modes.fp_math_mode`, runs the body and restores
the previous value. Nothing in the repository reads that field, and cubecl-llvm hands
`FastmathFlagsAttr::default()` to every instruction it builds. Reading it from a `LowerOp`
would not work either: the pass runs after expansion, so the mode has already been restored,
and no per-operation attribute records what a given operation was expanded under. Either
change means wiring `FastMath` up first, starting by carrying the mode on the operations
themselves. I can open an issue for that if it is wanted.

**And `InstCombinePass` never sees polyfill arithmetic.** It runs three passes ahead of
`LowerComplexOpPass`, and nothing fuses afterwards either, since without `contract` LLVM may
not pair an `fmul` with an `fadd`. One width-eight kernel's forty `llvm.fmuladd` would
become forty unfused pairs. Moving the pass after `LowerComplexOpPass` does fuse them and
pays elsewhere too, a vector `erf` going from 8 `fmul` and 5 `fadd` to 3 `fmul` and 5
`llvm.fmuladd`, 57 instructions to 52. But it also trips something underneath: in `arc_sinh`
the only IR it changes is `x * x + 1` becoming one `fmuladd`, and LLVM then segfaults
optimizing the 2-wide f16 kernel. The IR looks valid, since `<2 x half> @llvm.fmuladd` and
`sqrt(fma(x, x, one))` both compile fine on their own, so this reads as a bug in the LLVM
build rather than in the pass. And `as_fma` matches `FAddOp` only, so the five Cody-Waite
subtractions here would not fuse regardless.
</details>

