### PR TITLE
fix(throughput): walk the last window of every cycle

### DIFF
--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -105,8 +105,11 @@ pub fn memory_direct_throughput<I: Numeric, N: Size>(
 
         start += window;
         // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes.
-        if start + window > len {
+        // window that fills the whole buffer still moves between passes. The
+        // test is whether the window starts past the end, not whether it
+        // reaches past: the index wraps, so the last position of a cycle
+        // straddles the end rather than being skipped.
+        if start >= len {
             wrap += 1;
             if wrap >= window {
                 wrap = 0;

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -135,8 +135,11 @@ pub fn memory_read_throughput<I: Numeric, N: Size>(
 
         start += window;
         // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes.
-        if start + window > len {
+        // window that fills the whole buffer still moves between passes. The
+        // test is whether the window starts past the end, not whether it
+        // reaches past: the index wraps, so the last position of a cycle
+        // straddles the end rather than being skipped.
+        if start >= len {
             wrap += 1;
             if wrap >= window {
                 wrap = 0;

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -127,8 +127,11 @@ pub fn memory_write_throughput<I: Numeric, N: Size>(
 
         start += window;
         // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes.
-        if start + window > len {
+        // window that fills the whole buffer still moves between passes. The
+        // test is whether the window starts past the end, not whether it
+        // reaches past: the index wraps, so the last position of a cycle
+        // straddles the end rather than being skipped.
+        if start >= len {
             wrap += 1;
             if wrap >= window {
                 wrap = 0;


### PR DESCRIPTION
Independent of the other two probe PRs: this touches only the three probe kernels, they touch only `memory_probe.rs`, so there is no overlap and any merge order works.

## The bug

The walk marches a window across the pool in window-sized strides and restarts one line further along each cycle, so a window smaller than the pool only comes back to data a whole pool of traffic has evicted. That coldness is the entire reason the curve's small end means anything.

It restarts one stride too early:

```rust
start += window;
if start + window > span { wrap += 1; ...; start = wrap; }
```

The guard asks whether the window would *reach* past the end of the pool. But the index already wraps (`if idx >= span { idx -= span }`), so a window straddling the end is perfectly valid. The guard rejects a position the kernel could have used, and **every cycle loses its last position** once `wrap` is non-zero.

The fix is to ask whether the window *starts* past the end:

```rust
if start >= span {
```

## Why it is worst at exactly half the pool

The cost scales with how few positions a cycle has, which is `span / window`:

| window | positions | dropped | pool visited |
| --- | --- | --- | --- |
| span/8 | 8 | 1 | 88% |
| span/4 | 4 | 1 | 75% |
| **span/2** | **2** | **1** | **50%** |

At half the pool the walk degenerates completely. `start` goes 0, span/2, then 1, 2, 3, advancing a single line per pass instead of half a pool, so the window stops walking and creeps across one half forever while the other is never touched.

## Measured, RTX 4070 Ti SUPER, rated 672 GB/s

| working set | read before | read after | write before | write after |
| --- | --- | --- | --- | --- |
| 32 MiB | 677.5 | 663.9 | 591.5 | 567.5 |
| 64 MiB | 690.5 | 664.9 | 633.1 | 569.5 |
| 128 MiB | 792.6 | 663.0 | 800.3 | 566.1 |
| **256 MiB** | **3112.4** | **660.4** | **1564.6** | **556.8** |
| 512 MiB | 662.4 | 663.6 | 539.0 | 539.0 |

The top of the read curve is now flat between 660 and 684 GB/s, which is 98% of the card's rated bandwidth, instead of peaking at 4.6 times what the bus can carry. The inflation before the fix is monotone in `window / span`, exactly as the dropped-position count predicts.

The before figures are reproducible: the 256 MiB read measured 3103, 3129 and 3112 GB/s across three separate runs on unmodified `main`.

**The copy probe confirms the mechanism.** A copy splits its working set over two buffers, so its half-pool point is at a working set of 512 MiB rather than 256 MiB, and that is the copy point that moved (591.3 to 529.2) while its 256 MiB point barely changed. The affected size tracks the buffer geometry rather than the working set, which is what this explanation predicts and a generic "large working sets are wrong" story would not.

wgpu shows the same bump at the same point, so it is not vendor specific.

## CPU backends are unaffected

A stationary window of hundreds of megabytes is memory bound either way. The tower's curves are unchanged to within their run to run spread: write 19.4 to 20.5 before against 19.6 to 20.4 after, copy 25.9 to 26.1 against 26.0 to 26.2.

## One thing this does not explain

The dropped position accounts for which sizes misbehave and in what order, and removing it produces a flat plateau at the card's rated bandwidth. It does not by itself account for a 4.6x read against a 256 MiB footprint on a 48 MiB L2, so something about the near-stationary window is amplifying it beyond the change in footprint. The corrected numbers are the physically sensible ones either way.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [x] No API change, measured values only. cubek consumes the probe through `ThroughputKey` and needs no change.
- [ ] burn not checked, for the same reason.
