### PR TITLE
fix(throughput): stop the memory curve measuring cache, and collapse its modes

### DIFF
--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -83,21 +83,11 @@ pub struct MemorySpec {
 }
 
 impl ThroughputMode {
-    /// `access` over as much as the interface will take at once, which is what
-    /// the scalar variants named before a working set was a parameter.
+    /// `access` over as much as the interface will take at once.
     pub const fn memory(access: MemoryAccess) -> Self {
         Self::Memory(MemorySpec::new(access, access.default_working_set()))
     }
-}
 
-impl MemorySpec {
-    /// A probe moving `bytes` per pass in the directions `access` names.
-    pub const fn new(access: MemoryAccess, bytes: u64) -> Self {
-        Self { access, bytes }
-    }
-}
-
-impl ThroughputMode {
     /// What this mode asks of a memory probe, or `None` for the modes that do
     /// not measure memory.
     pub const fn memory_probe(&self) -> Option<MemorySpec> {
@@ -105,6 +95,13 @@ impl ThroughputMode {
             Self::Memory(spec) => Some(*spec),
             Self::ComputeDirect { .. } | Self::ComputeCmma { .. } | Self::Launch => None,
         }
+    }
+}
+
+impl MemorySpec {
+    /// A probe moving `bytes` per pass in the directions `access` names.
+    pub const fn new(access: MemoryAccess, bytes: u64) -> Self {
+        Self { access, bytes }
     }
 }
 

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -3,9 +3,8 @@ use alloc::{format, string::String};
 use core::time::Duration;
 use cubecl_ir::{ElemType, FloatKind};
 
-/// Bytes per buffer of the single-size memory probes, [`ThroughputMode::Memory`],
-/// [`ThroughputMode::MemoryRead`], and [`ThroughputMode::MemoryWrite`]. Clamped
-/// to the device's maximum allocation when the probe runs.
+/// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default
+/// working set. Clamped to the device's maximum allocation when the probe runs.
 pub const DEFAULT_BUFFER_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Which directions of traffic a memory probe issues.
@@ -62,68 +61,54 @@ pub enum ThroughputMode {
         /// The configuration of the CMMA operation.
         config: ComputeCmmaConfig,
     },
-    /// Memory input reads and output writes — a copy, at the default working
-    /// set. `ops_count` counts both directions, so this is total traffic across
-    /// the memory interface.
-    Memory,
-    /// Memory input reads only, no store, at the default working set. The
-    /// ceiling for a kernel that streams data it does not write back — a weight
-    /// stream, a reduction, a gather. Such a kernel can legitimately exceed
-    /// [`Memory`](Self::Memory), which is why it needs its own probe rather than
-    /// a correction factor.
-    MemoryRead,
-    /// Memory output writes only, no read, at the default working set. The
-    /// ceiling for a kernel that streams stores it never reads back: an RNG
-    /// fill, a memset, a broadcast. Such a kernel can legitimately exceed
-    /// [`Memory`](Self::Memory), which is why it needs its own probe rather
-    /// than a correction factor.
-    MemoryWrite,
-    /// One point of a memory curve: `access` over a working set of exactly
-    /// `bytes`.
+    /// Traffic across the memory interface, as described by its [`MemorySpec`].
     ///
-    /// `bytes` is the traffic one pass moves across the interface, the same
-    /// currency the measured rate is in — a [`Copy`](MemoryAccess::Copy) splits
-    /// it evenly between two buffers of `bytes / 2`, a
-    /// [`Read`](MemoryAccess::Read) moves all of it out of one buffer of
-    /// `bytes`. So a kernel that touches N bytes asks about N regardless of
-    /// which access it resembles.
+    /// `bytes` is what one pass moves, the same currency the measured rate is
+    /// in, so a kernel that touches N bytes asks about N whichever access it
+    /// resembles: a [`Copy`](MemoryAccess::Copy) splits it between two buffers
+    /// of `bytes / 2`, a [`Read`](MemoryAccess::Read) moves all of it out of
+    /// one.
     ///
-    /// The probe reads cold: every pass moves to a fresh window of a buffer far
-    /// larger than the working set, so a small size measures what a kernel that
-    /// size moves rather than the speed of re-reading something already in
-    /// cache. A size too small to keep the interface busy therefore reports
-    /// less than the hardware can do, which is not an error — it is the ceiling
-    /// for a kernel with that little in flight.
-    ///
-    /// Sweeping this over a range of sizes is
-    /// [`MemoryCurve`](crate::throughput::MemoryCurve).
-    MemoryWorkingSet {
-        /// Which directions of traffic the probe issues.
-        access: MemoryAccess,
-        /// The bytes moved in one pass.
-        bytes: u64,
-    },
+    /// Sweeping the size is [`MemoryCurve`](crate::throughput::MemoryCurve),
+    /// which is what a consumer wants: pick the curve that asks its question,
+    /// then read a ceiling off it with `ceiling_at`.
+    Memory(MemorySpec),
     /// Launch overhead measurement.
     Launch,
 }
 
+/// What a memory mode asks of a probe.
+#[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
+#[cfg_attr(std_io, derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(std_io, serde(deny_unknown_fields))]
+pub struct MemorySpec {
+    /// Which directions of traffic to issue.
+    pub access: MemoryAccess,
+    /// The bytes one pass moves across the interface.
+    pub bytes: u64,
+}
+
 impl ThroughputMode {
-    /// The access pattern and working set this mode probes, or `None` for the
-    /// modes that don't measure memory.
-    ///
-    /// The one place the single-size variants are mapped onto their access and
-    /// size, so nothing downstream has to repeat the equivalence.
-    pub const fn memory_probe(&self) -> Option<(MemoryAccess, u64)> {
+    /// `access` over as much as the interface will take at once, which is what
+    /// the scalar variants named before a working set was a parameter.
+    pub const fn memory(access: MemoryAccess) -> Self {
+        Self::Memory(MemorySpec::new(access, access.default_working_set()))
+    }
+}
+
+impl MemorySpec {
+    /// A probe moving `bytes` per pass in the directions `access` names.
+    pub const fn new(access: MemoryAccess, bytes: u64) -> Self {
+        Self { access, bytes }
+    }
+}
+
+impl ThroughputMode {
+    /// What this mode asks of a memory probe, or `None` for the modes that do
+    /// not measure memory.
+    pub const fn memory_probe(&self) -> Option<MemorySpec> {
         match self {
-            Self::Memory => Some((MemoryAccess::Copy, MemoryAccess::Copy.default_working_set())),
-            Self::MemoryRead => {
-                Some((MemoryAccess::Read, MemoryAccess::Read.default_working_set()))
-            }
-            Self::MemoryWrite => Some((
-                MemoryAccess::Write,
-                MemoryAccess::Write.default_working_set(),
-            )),
-            Self::MemoryWorkingSet { access, bytes } => Some((*access, *bytes)),
+            Self::Memory(spec) => Some(*spec),
             Self::ComputeDirect { .. } | Self::ComputeCmma { .. } | Self::Launch => None,
         }
     }
@@ -146,11 +131,7 @@ impl ThroughputKey {
             ThroughputMode::ComputeDirect { dtype } => dtype,
             ThroughputMode::ComputeCmma { dtype, .. } => dtype,
             // For memory and launch throughput, we use a default element type (F32).
-            ThroughputMode::Memory
-            | ThroughputMode::MemoryRead
-            | ThroughputMode::MemoryWrite
-            | ThroughputMode::MemoryWorkingSet { .. }
-            | ThroughputMode::Launch => ElemType::Float(FloatKind::F32),
+            ThroughputMode::Memory(_) | ThroughputMode::Launch => ElemType::Float(FloatKind::F32),
         }
     }
 }
@@ -203,10 +184,7 @@ impl ThroughputValue {
             ThroughputMode::ComputeDirect { .. } | ThroughputMode::ComputeCmma { .. } => {
                 (self.ops_per_s(), "OPS")
             }
-            ThroughputMode::Memory
-            | ThroughputMode::MemoryRead
-            | ThroughputMode::MemoryWrite
-            | ThroughputMode::MemoryWorkingSet { .. } => (self.bytes_per_s(key), "bytes"),
+            ThroughputMode::Memory(_) => (self.bytes_per_s(key), "bytes"),
             ThroughputMode::Launch => {
                 let dur = self.duration_per_op();
                 if dur.is_zero() {
@@ -266,24 +244,32 @@ mod tests {
     use super::*;
 
     /// The throughput cache keys on the serialized key, so a layout change
-    /// drops every measurement users already paid for. Adding a variant must
-    /// leave the existing ones encoded exactly as before.
+    /// drops every measurement users have already paid for. That is what a
+    /// version bump is for; a change that is not one must leave these alone.
     #[test]
-    fn existing_keys_keep_their_serialized_form() {
+    fn a_memory_key_keeps_its_serialized_form() {
         let encode = |mode| serde_json::to_string(&ThroughputKey { mode }).unwrap();
 
-        assert_eq!(encode(ThroughputMode::Memory), r#"{"mode":"Memory"}"#);
         assert_eq!(
-            encode(ThroughputMode::MemoryRead),
-            r#"{"mode":"MemoryRead"}"#
+            encode(ThroughputMode::memory(MemoryAccess::Copy)),
+            r#"{"mode":{"Memory":{"access":"Copy","bytes":1073741824}}}"#
         );
         assert_eq!(
-            encode(ThroughputMode::MemoryWrite),
-            r#"{"mode":"MemoryWrite"}"#
+            encode(ThroughputMode::Memory(MemorySpec::new(
+                MemoryAccess::Read,
+                8192
+            ))),
+            r#"{"mode":{"Memory":{"access":"Read","bytes":8192}}}"#
         );
+    }
 
-        // And an entry written before the variant existed still reads back.
-        let cached: ThroughputKey = serde_json::from_str(r#"{"mode":"Memory"}"#).unwrap();
-        assert_eq!(cached.mode, ThroughputMode::Memory);
+    /// A working set is part of the key, so two sizes of the same access are
+    /// separate measurements rather than one overwriting the other.
+    #[test]
+    fn a_working_set_is_part_of_the_key() {
+        let small = ThroughputMode::Memory(MemorySpec::new(MemoryAccess::Read, 8192));
+        let large = ThroughputMode::Memory(MemorySpec::new(MemoryAccess::Read, 16384));
+
+        assert_ne!(small, large);
     }
 }

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -63,15 +63,9 @@ pub enum ThroughputMode {
     },
     /// Traffic across the memory interface, as described by its [`MemorySpec`].
     ///
-    /// `bytes` is what one pass moves, the same currency the measured rate is
-    /// in, so a kernel that touches N bytes asks about N whichever access it
-    /// resembles: a [`Copy`](MemoryAccess::Copy) splits it between two buffers
-    /// of `bytes / 2`, a [`Read`](MemoryAccess::Read) moves all of it out of
-    /// one.
-    ///
-    /// Sweeping the size is [`MemoryCurve`](crate::throughput::MemoryCurve),
-    /// which is what a consumer wants: pick the curve that asks its question,
-    /// then read a ceiling off it with `ceiling_at`.
+    /// `bytes` is the total one pass moves, so a
+    /// [`Copy`](MemoryAccess::Copy) splits it across two buffers where a
+    /// [`Read`](MemoryAccess::Read) takes it all from one.
     Memory(MemorySpec),
     /// Launch overhead measurement.
     Launch,

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -75,7 +75,12 @@ impl ThroughputBenchmarker {
     /// measuring what it claims rather than merely to be timed accurately.
     fn warmup(&self, min_iterations: usize, sample: impl Fn(usize) -> Duration) -> usize {
         const MAX_WARMUP: usize = 50;
-        const MAX_ITERATIONS: usize = 1_000;
+        // A guard on the branch below that doubles blind when the timer reads
+        // zero, not a budget: what a launch costs is the duration target, and
+        // capping the count instead leaves a cheap pass measuring the fixed
+        // cost of the launch around it. A probe holding its working set still
+        // has no walk to make it expensive, so it needs the whole range.
+        const MAX_ITERATIONS: usize = 1 << 24;
         const PLATEAU_TOL: f64 = 0.03;
         const PATIENCE: usize = 3;
         const TARGET_DURATION_MS: f64 = 20.0;
@@ -135,12 +140,22 @@ impl ThroughputBenchmarker {
         const MAX_SAMPLES: usize = 200;
         const REL_TOL: f64 = 0.01;
         const PATIENCE: usize = 12;
+        // Counting samples prices them all the same, and they are not: a probe
+        // whose launch fills the duration target costs forty times one whose
+        // pass is a few microseconds. Spending a fixed time instead leaves the
+        // cheap probes their long survey and stops the dear ones once the
+        // minimum has had a fair number of chances to fall.
+        const SAMPLE_BUDGET: Duration = Duration::from_millis(200);
 
         let mut best = f64::INFINITY;
         let mut stale = 0;
+        let mut spent = Duration::ZERO;
 
         for i in 0..MAX_SAMPLES {
-            let s = sample_once(iterations).as_secs_f64();
+            let sample = sample_once(iterations);
+            spent += sample;
+
+            let s = sample.as_secs_f64();
             if s < best * (1.0 - REL_TOL) {
                 best = s;
                 stale = 0;
@@ -148,7 +163,7 @@ impl ThroughputBenchmarker {
                 best = best.min(s);
                 stale += 1;
             }
-            if i > MIN_SAMPLES && stale >= PATIENCE {
+            if (i > MIN_SAMPLES && stale >= PATIENCE) || spent >= SAMPLE_BUDGET {
                 break;
             }
         }

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -16,6 +16,13 @@ pub struct KernelConfig {
     pub sample: Box<dyn Fn(usize) -> Duration>,
     /// The number of operations processed in one iteration.
     pub ops_count: usize,
+    /// Iterations a launch must carry however quickly they turn out to run.
+    ///
+    /// A duration target cannot express this. What makes a memory probe cold is
+    /// that its window walks a whole pool before returning to bytes it already
+    /// read, and the shorter the window the more iterations that same walk
+    /// takes.
+    pub min_iterations: usize,
 }
 
 /// A marker for measuring throughput of compute kernels.
@@ -46,7 +53,7 @@ impl ThroughputBenchmarker {
 
         let sample = kernel_config.sample;
 
-        let iterations = self.warmup(&sample);
+        let iterations = self.warmup(kernel_config.min_iterations, &sample);
         let duration = self.sample_peak_duration(iterations, &sample);
 
         let value = ThroughputValue {
@@ -63,7 +70,10 @@ impl ThroughputBenchmarker {
 
     /// Warms up the device by running the kernel multiple times
     /// and estimating the number of iterations needed to reach a stable duration.
-    fn warmup(&self, sample: impl Fn(usize) -> Duration) -> usize {
+    ///
+    /// Never returns fewer than `min_iterations`, which the kernel needs to be
+    /// measuring what it claims rather than merely to be timed accurately.
+    fn warmup(&self, min_iterations: usize, sample: impl Fn(usize) -> Duration) -> usize {
         const MAX_WARMUP: usize = 50;
         const MAX_ITERATIONS: usize = 1_000;
         const PLATEAU_TOL: f64 = 0.03;
@@ -72,7 +82,8 @@ impl ThroughputBenchmarker {
 
         let mut best = f64::INFINITY;
         let mut stable = 0;
-        let mut iterations = 1;
+        let mut iterations = min_iterations.max(1);
+        let ceiling = MAX_ITERATIONS.max(iterations);
 
         for _ in 0..MAX_WARMUP {
             let duration = sample(iterations).as_secs_f64() * 1000.0;
@@ -83,7 +94,10 @@ impl ThroughputBenchmarker {
                 } else {
                     iterations
                 };
-                iterations = (iterations + extra_iters.max(1)).min(MAX_ITERATIONS);
+                if iterations == ceiling {
+                    break;
+                }
+                iterations = (iterations + extra_iters.max(1)).min(ceiling);
                 best = f64::INFINITY;
                 stable = 0;
                 continue;

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use alloc::boxed::Box;
 use alloc::sync::Arc;
-use cubecl_common::profile::Duration;
+use cubecl_common::profile::{Duration, Instant};
 use cubecl_environment::config::RuntimeConfig;
 use cubecl_environment::sync::Mutex;
 
@@ -49,8 +49,8 @@ impl ThroughputBenchmarker {
 
         let sample = kernel_config.sample;
 
-        let iterations = self.warmup(kernel_config.min_iterations, &sample);
-        let duration = self.sample_peak_duration(iterations, &sample);
+        let iterations = Self::warmup(kernel_config.min_iterations, &sample);
+        let duration = Self::sample_peak_duration(iterations, &sample);
 
         let value = ThroughputValue {
             ops_count: kernel_config.ops_count,
@@ -69,11 +69,13 @@ impl ThroughputBenchmarker {
     ///
     /// Never returns fewer than `min_iterations`, which the kernel needs to be
     /// measuring what it claims rather than merely to be timed accurately.
-    fn warmup(&self, min_iterations: usize, sample: impl Fn(usize) -> Duration) -> usize {
+    fn warmup(min_iterations: usize, sample: impl Fn(usize) -> Duration) -> usize {
         const MAX_WARMUP: usize = 50;
-        // Guards the blind doubling below, rather than budgeting the launch,
-        // which the duration target does.
         const MAX_ITERATIONS: usize = 1 << 24;
+        // A timer reading zero says nothing about the pass, so doubling against
+        // it converges on nothing and stops early. An iteration is a real launch
+        // for the probe that measures launches, which pays for every one.
+        const MAX_BLIND_ITERATIONS: usize = 1 << 10;
         const PLATEAU_TOL: f64 = 0.03;
         const PATIENCE: usize = 3;
         const TARGET_DURATION_MS: f64 = 20.0;
@@ -81,18 +83,22 @@ impl ThroughputBenchmarker {
         let mut best = f64::INFINITY;
         let mut stable = 0;
         let mut iterations = min_iterations.max(1);
-        let ceiling = MAX_ITERATIONS.max(iterations);
 
         for _ in 0..MAX_WARMUP {
             let duration = sample(iterations).as_secs_f64() * 1000.0;
             if duration < TARGET_DURATION_MS {
-                let extra_iters = if duration > 1e-6 {
+                let (extra_iters, ceiling) = if duration > 1e-6 {
                     let duration_per_iter = duration / iterations as f64;
-                    ((TARGET_DURATION_MS - duration) / duration_per_iter).ceil() as usize
+                    (
+                        ((TARGET_DURATION_MS - duration) / duration_per_iter).ceil() as usize,
+                        MAX_ITERATIONS,
+                    )
                 } else {
-                    iterations
+                    (iterations, MAX_BLIND_ITERATIONS)
                 };
-                if iterations == ceiling {
+
+                let ceiling = ceiling.max(min_iterations);
+                if iterations >= ceiling {
                     break;
                 }
                 iterations = (iterations + extra_iters.max(1)).min(ceiling);
@@ -120,7 +126,6 @@ impl ThroughputBenchmarker {
     /// Sample the peak throughput of the kernel by running it multiple times
     /// and measuring the duration of each iteration.
     fn sample_peak_duration(
-        &self,
         iterations: usize,
         sample_once: impl Fn(usize) -> Duration,
     ) -> Duration {
@@ -139,13 +144,12 @@ impl ThroughputBenchmarker {
 
         let mut best = f64::INFINITY;
         let mut stale = 0;
-        let mut spent = Duration::ZERO;
+        // Wall clock, not the sum of what the samples report: a probe whose
+        // timer reads zero would otherwise never spend any of the budget.
+        let start = Instant::now();
 
         for i in 0..MAX_SAMPLES {
-            let sample = sample_once(iterations);
-            spent += sample;
-
-            let s = sample.as_secs_f64();
+            let s = sample_once(iterations).as_secs_f64();
             if s < best * (1.0 - REL_TOL) {
                 best = s;
                 stale = 0;
@@ -153,11 +157,56 @@ impl ThroughputBenchmarker {
                 best = best.min(s);
                 stale += 1;
             }
-            if (i > MIN_SAMPLES && stale >= PATIENCE) || spent >= SAMPLE_BUDGET {
+            if (i > MIN_SAMPLES && stale >= PATIENCE) || start.elapsed() >= SAMPLE_BUDGET {
                 break;
             }
         }
 
         Duration::from_secs_f64(best / iterations as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::Cell;
+
+    /// One iteration of the launch probe is a real launch, so a device whose
+    /// timer reads zero must not be answered by doubling toward the ceiling the
+    /// duration target drives.
+    #[test]
+    fn a_timer_reading_zero_does_not_climb_to_the_duration_ceiling() {
+        let iterations = ThroughputBenchmarker::warmup(1, |_| Duration::ZERO);
+
+        assert!(iterations <= 1 << 10, "climbed to {iterations}");
+    }
+
+    /// The passes a probe needs to be measuring what it claims are not the
+    /// timer's to give away.
+    #[test]
+    fn a_blind_timer_never_cuts_below_the_passes_a_probe_needs() {
+        let needed = 1 << 20;
+
+        assert!(ThroughputBenchmarker::warmup(needed, |_| Duration::ZERO) >= needed);
+    }
+
+    #[test]
+    fn a_timer_reading_zero_still_stops_sampling() {
+        let calls = Cell::new(0);
+        let _ = ThroughputBenchmarker::sample_peak_duration(1, |_| {
+            calls.set(calls.get() + 1);
+            Duration::ZERO
+        });
+
+        assert!(calls.get() < 200, "ran {} samples", calls.get());
+    }
+
+    /// A working timer still drives the count to the duration target.
+    #[test]
+    fn a_pass_far_under_the_target_grows_until_it_reaches_it() {
+        let iterations =
+            ThroughputBenchmarker::warmup(1, |iterations| Duration::from_micros(iterations as u64));
+
+        assert_eq!(iterations, 20_000);
     }
 }

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -134,9 +134,10 @@ impl ThroughputBenchmarker {
             "iterations must be positive to avoid division by zero"
         );
 
-        const MIN_SAMPLES: usize = 20;
         const MAX_SAMPLES: usize = 200;
         const REL_TOL: f64 = 0.01;
+        // Also the floor on samples, since the first always improves on
+        // infinity and only the ones after it can go stale.
         const PATIENCE: usize = 12;
         // A sample count prices them all the same, and a probe filling the
         // duration target costs forty times one whose pass is microseconds.
@@ -148,7 +149,7 @@ impl ThroughputBenchmarker {
         // timer reads zero would otherwise never spend any of the budget.
         let start = Instant::now();
 
-        for i in 0..MAX_SAMPLES {
+        for _ in 0..MAX_SAMPLES {
             let s = sample_once(iterations).as_secs_f64();
             if s < best * (1.0 - REL_TOL) {
                 best = s;
@@ -157,7 +158,7 @@ impl ThroughputBenchmarker {
                 best = best.min(s);
                 stale += 1;
             }
-            if (i > MIN_SAMPLES && stale >= PATIENCE) || start.elapsed() >= SAMPLE_BUDGET {
+            if stale >= PATIENCE || start.elapsed() >= SAMPLE_BUDGET {
                 break;
             }
         }

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -16,12 +16,8 @@ pub struct KernelConfig {
     pub sample: Box<dyn Fn(usize) -> Duration>,
     /// The number of operations processed in one iteration.
     pub ops_count: usize,
-    /// Iterations a launch must carry however quickly they turn out to run.
-    ///
-    /// A duration target cannot express this. What makes a memory probe cold is
-    /// that its window walks a whole pool before returning to bytes it already
-    /// read, and the shorter the window the more iterations that same walk
-    /// takes.
+    /// Iterations a launch must carry however quickly they turn out to run,
+    /// which a duration target cannot express.
     pub min_iterations: usize,
 }
 
@@ -75,11 +71,8 @@ impl ThroughputBenchmarker {
     /// measuring what it claims rather than merely to be timed accurately.
     fn warmup(&self, min_iterations: usize, sample: impl Fn(usize) -> Duration) -> usize {
         const MAX_WARMUP: usize = 50;
-        // A guard on the branch below that doubles blind when the timer reads
-        // zero, not a budget: what a launch costs is the duration target, and
-        // capping the count instead leaves a cheap pass measuring the fixed
-        // cost of the launch around it. A probe holding its working set still
-        // has no walk to make it expensive, so it needs the whole range.
+        // Guards the blind doubling below, rather than budgeting the launch,
+        // which the duration target does.
         const MAX_ITERATIONS: usize = 1 << 24;
         const PLATEAU_TOL: f64 = 0.03;
         const PATIENCE: usize = 3;
@@ -140,11 +133,8 @@ impl ThroughputBenchmarker {
         const MAX_SAMPLES: usize = 200;
         const REL_TOL: f64 = 0.01;
         const PATIENCE: usize = 12;
-        // Counting samples prices them all the same, and they are not: a probe
-        // whose launch fills the duration target costs forty times one whose
-        // pass is a few microseconds. Spending a fixed time instead leaves the
-        // cheap probes their long survey and stops the dear ones once the
-        // minimum has had a fair number of chances to fall.
+        // A sample count prices them all the same, and a probe filling the
+        // duration target costs forty times one whose pass is microseconds.
         const SAMPLE_BUDGET: Duration = Duration::from_millis(200);
 
         let mut best = f64::INFINITY;

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -10,6 +10,11 @@ use cubecl_environment::sync::Mutex;
 
 type Cache = Arc<Mutex<ThroughputCache>>;
 
+/// Wall clock a warmup may spend growing its iteration count. Generous next to
+/// the tens of milliseconds a converging one needs, and the only thing bounding
+/// a probe whose timer is too coarse to ever reach the target.
+const WARMUP_BUDGET: Duration = Duration::from_secs(2);
+
 /// Configuration and payload for a benchmarkable compute kernel.
 pub struct KernelConfig {
     /// A closure that executes the kernel for the given number of iterations and returns the duration.
@@ -49,7 +54,7 @@ impl ThroughputBenchmarker {
 
         let sample = kernel_config.sample;
 
-        let iterations = Self::warmup(kernel_config.min_iterations, &sample);
+        let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
         let duration = Self::sample_peak_duration(iterations, &sample);
 
         let value = ThroughputValue {
@@ -69,7 +74,15 @@ impl ThroughputBenchmarker {
     ///
     /// Never returns fewer than `min_iterations`, which the kernel needs to be
     /// measuring what it claims rather than merely to be timed accurately.
-    fn warmup(min_iterations: usize, sample: impl Fn(usize) -> Duration) -> usize {
+    ///
+    /// `budget` bounds the growing, not the sampling: a timer too coarse to
+    /// ever reach the target reports the same reading at every count, which
+    /// asks for a larger one each round without converging.
+    fn warmup(
+        min_iterations: usize,
+        budget: Duration,
+        sample: impl Fn(usize) -> Duration,
+    ) -> usize {
         const MAX_WARMUP: usize = 50;
         const MAX_ITERATIONS: usize = 1 << 24;
         // A timer reading zero says nothing about the pass, so doubling against
@@ -83,6 +96,7 @@ impl ThroughputBenchmarker {
         let mut best = f64::INFINITY;
         let mut stable = 0;
         let mut iterations = min_iterations.max(1);
+        let start = Instant::now();
 
         for _ in 0..MAX_WARMUP {
             let duration = sample(iterations).as_secs_f64() * 1000.0;
@@ -98,7 +112,7 @@ impl ThroughputBenchmarker {
                 };
 
                 let ceiling = ceiling.max(min_iterations);
-                if iterations >= ceiling {
+                if iterations >= ceiling || start.elapsed() >= budget {
                     break;
                 }
                 iterations = (iterations + extra_iters.max(1)).min(ceiling);
@@ -177,7 +191,7 @@ mod tests {
     /// duration target drives.
     #[test]
     fn a_timer_reading_zero_does_not_climb_to_the_duration_ceiling() {
-        let iterations = ThroughputBenchmarker::warmup(1, |_| Duration::ZERO);
+        let iterations = ThroughputBenchmarker::warmup(1, WARMUP_BUDGET, |_| Duration::ZERO);
 
         assert!(iterations <= 1 << 10, "climbed to {iterations}");
     }
@@ -188,7 +202,23 @@ mod tests {
     fn a_blind_timer_never_cuts_below_the_passes_a_probe_needs() {
         let needed = 1 << 20;
 
-        assert!(ThroughputBenchmarker::warmup(needed, |_| Duration::ZERO) >= needed);
+        assert!(ThroughputBenchmarker::warmup(needed, WARMUP_BUDGET, |_| Duration::ZERO) >= needed);
+    }
+
+    /// A timer too coarse to resolve the target reports the same reading at
+    /// every count, so each round divides it by a larger number and asks for a
+    /// larger one still. The iteration ceiling alone stops that only after the
+    /// rounds it takes to reach it, which the probe pays for in real launches.
+    #[test]
+    fn a_timer_that_never_reaches_the_target_stops_growing_on_the_budget() {
+        let iterations = ThroughputBenchmarker::warmup(1, Duration::from_millis(12), |_| {
+            let start = Instant::now();
+            while start.elapsed() < Duration::from_millis(5) {}
+
+            Duration::from_millis(1)
+        });
+
+        assert!(iterations < 1 << 20, "climbed to {iterations}");
     }
 
     #[test]
@@ -205,8 +235,9 @@ mod tests {
     /// A working timer still drives the count to the duration target.
     #[test]
     fn a_pass_far_under_the_target_grows_until_it_reaches_it() {
-        let iterations =
-            ThroughputBenchmarker::warmup(1, |iterations| Duration::from_micros(iterations as u64));
+        let iterations = ThroughputBenchmarker::warmup(1, WARMUP_BUDGET, |iterations| {
+            Duration::from_micros(iterations as u64)
+        });
 
         assert_eq!(iterations, 20_000);
     }

--- a/crates/cubecl-runtime/src/throughput/curve.rs
+++ b/crates/cubecl-runtime/src/throughput/curve.rs
@@ -18,10 +18,10 @@ use crate::throughput::{MemoryAccess, ThroughputKey, ThroughputMode, ThroughputV
 /// The smallest working set a curve is measured at, in bytes moved per pass.
 ///
 /// Low enough to catch the bottom of the ramp, which is further down than it
-/// looks: on an M2 Pro the curve is already within 12% of the bus figure at
-/// 256 KiB and only falls away below that — 146 GB/s at 128 KiB, 94 at 64 KiB,
-/// 11 at 8 KiB. A sweep starting a few hundred kilobytes up would report an
-/// almost flat curve and miss the effect it exists to measure.
+/// looks: an Arc iGPU reads within 5% of its sustained figure at 128 KiB and
+/// only falls away below that, 102 GB/s at 64 KiB, 66 at 32 KiB and 17 at
+/// 8 KiB against 110. A sweep starting a few hundred kilobytes up would report
+/// an almost flat curve and miss the effect it exists to measure.
 pub const MIN_WORKING_SET: u64 = 8 * 1024;
 
 /// The working sets a curve is measured at: powers of two from

--- a/crates/cubecl-runtime/src/throughput/curve.rs
+++ b/crates/cubecl-runtime/src/throughput/curve.rs
@@ -17,11 +17,8 @@ use crate::throughput::{MemoryAccess, MemorySpec, ThroughputKey, ThroughputMode,
 
 /// The smallest working set a curve is measured at, in bytes moved per pass.
 ///
-/// Low enough to catch the bottom of the ramp, which is further down than it
-/// looks: an Arc iGPU reads within 5% of its sustained figure at 128 KiB and
-/// only falls away below that, 102 GB/s at 64 KiB, 66 at 32 KiB and 17 at
-/// 8 KiB against 110. A sweep starting a few hundred kilobytes up would report
-/// an almost flat curve and miss the effect it exists to measure.
+/// The ramp bottoms out further down than it looks: an Arc iGPU reads 102 GB/s
+/// at 64 KiB, 66 at 32 KiB and 17 at 8 KiB, against 110 sustained.
 pub const MIN_WORKING_SET: u64 = 8 * 1024;
 
 /// The working sets a curve is measured at: powers of two from
@@ -55,11 +52,7 @@ pub fn working_set_sweep(cap: u64) -> Vec<u64> {
 /// The sweep size a working set of `bytes` is probed at: the next power of two
 /// at or above it, never below [`MIN_WORKING_SET`].
 ///
-/// A probe per distinct byte count would fill the cache with sizes measured
-/// once and never asked for again. Snapping to the grid the curve already
-/// samples bounds that to one entry an octave, and costs at most the
-/// difference between neighbouring points of a curve read by interpolation
-/// anyway.
+/// One cache entry an octave, rather than one per distinct byte count.
 pub fn sweep_size(bytes: u64) -> u64 {
     bytes.max(MIN_WORKING_SET).next_power_of_two()
 }

--- a/crates/cubecl-runtime/src/throughput/curve.rs
+++ b/crates/cubecl-runtime/src/throughput/curve.rs
@@ -49,12 +49,17 @@ pub fn working_set_sweep(cap: u64) -> Vec<u64> {
     sizes
 }
 
-/// The sweep size a working set of `bytes` is probed at: the next power of two
-/// at or above it, never below [`MIN_WORKING_SET`].
+/// The sweep size a working set of `bytes` is probed at: the power of two at or
+/// below it, never below [`MIN_WORKING_SET`].
 ///
-/// One cache entry an octave, rather than one per distinct byte count.
+/// One cache entry an octave, rather than one per distinct byte count. Down, so
+/// the ceiling a consumer reads is one the working set can reach: the rate
+/// climbs steeply per octave along the ramp, and the size above would report
+/// close to twice what these bytes move.
 pub fn sweep_size(bytes: u64) -> u64 {
-    bytes.max(MIN_WORKING_SET).next_power_of_two()
+    let bytes = bytes.max(MIN_WORKING_SET);
+
+    1 << (u64::BITS - 1 - bytes.leading_zeros())
 }
 
 /// One measured point of a [`MemoryCurve`].
@@ -165,6 +170,40 @@ fn log2(bytes: u64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_sweep_size_is_the_octave_at_or_below_the_working_set() {
+        assert_eq!(sweep_size(16 * 1024), 16 * 1024);
+        assert_eq!(sweep_size(16 * 1024 + 1), 16 * 1024);
+        assert_eq!(sweep_size(32 * 1024 - 1), 16 * 1024);
+    }
+
+    /// Reading a ceiling from the octave above would credit a kernel with a
+    /// rate its own working set cannot reach.
+    #[test]
+    fn a_sweep_size_never_rounds_up() {
+        for bytes in [MIN_WORKING_SET, 9 * 1024, 100_000, 1 << 30] {
+            assert!(sweep_size(bytes) <= bytes, "at {bytes}");
+        }
+    }
+
+    /// Every size lands on the grid the curve is measured at, so a probe is
+    /// shared rather than added.
+    #[test]
+    fn a_sweep_size_lands_on_the_measured_grid() {
+        let grid = working_set_sweep(1 << 30);
+
+        for bytes in [1, 9 * 1024, 100_000, 1 << 20, 1 << 30] {
+            assert!(grid.contains(&sweep_size(bytes)), "at {bytes}");
+        }
+    }
+
+    /// Below the smallest measured point there is nothing to round down to.
+    #[test]
+    fn a_working_set_under_the_floor_gets_the_floor() {
+        assert_eq!(sweep_size(0), MIN_WORKING_SET);
+        assert_eq!(sweep_size(1), MIN_WORKING_SET);
+    }
     use core::time::Duration;
 
     const MB: u64 = 1024 * 1024;

--- a/crates/cubecl-runtime/src/throughput/curve.rs
+++ b/crates/cubecl-runtime/src/throughput/curve.rs
@@ -13,7 +13,7 @@
 
 use alloc::vec::Vec;
 
-use crate::throughput::{MemoryAccess, ThroughputKey, ThroughputMode, ThroughputValue};
+use crate::throughput::{MemoryAccess, MemorySpec, ThroughputKey, ThroughputMode, ThroughputValue};
 
 /// The smallest working set a curve is measured at, in bytes moved per pass.
 ///
@@ -50,6 +50,18 @@ pub fn working_set_sweep(cap: u64) -> Vec<u64> {
     }
 
     sizes
+}
+
+/// The sweep size a working set of `bytes` is probed at: the next power of two
+/// at or above it, never below [`MIN_WORKING_SET`].
+///
+/// A probe per distinct byte count would fill the cache with sizes measured
+/// once and never asked for again. Snapping to the grid the curve already
+/// samples bounds that to one entry an octave, and costs at most the
+/// difference between neighbouring points of a curve read by interpolation
+/// anyway.
+pub fn sweep_size(bytes: u64) -> u64 {
+    bytes.max(MIN_WORKING_SET).next_power_of_two()
 }
 
 /// One measured point of a [`MemoryCurve`].
@@ -137,12 +149,9 @@ impl MemoryCurve {
 
     /// What a point measured, in bytes moved per second.
     fn rate(&self, point: &MemoryPoint) -> f64 {
-        point.value.bytes_per_s(&ThroughputKey {
-            mode: ThroughputMode::MemoryWorkingSet {
-                access: self.access,
-                bytes: point.bytes,
-            },
-        })
+        let mode = ThroughputMode::Memory(MemorySpec::new(self.access, point.bytes));
+
+        point.value.bytes_per_s(&ThroughputKey { mode })
     }
 }
 

--- a/crates/cubecl-runtime/src/tune/bounds_generator.rs
+++ b/crates/cubecl-runtime/src/tune/bounds_generator.rs
@@ -161,7 +161,7 @@ impl TimeBound for Bounds {
 
 #[cfg(test)]
 mod tests {
-    use crate::throughput::ThroughputMode;
+    use crate::throughput::{MemoryAccess, ThroughputMode};
 
     use super::*;
     use alloc::vec;
@@ -233,7 +233,7 @@ mod tests {
             memory: 1.0,
         };
         let key = ThroughputKey {
-            mode: ThroughputMode::Memory,
+            mode: ThroughputMode::memory(MemoryAccess::Copy),
         };
 
         let bounds = calculate_bounds(

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -142,12 +142,13 @@ pub fn roofline_bounds<R: Runtime>(
 ) -> Bounds {
     // The ceiling a kernel is scored against is the one for the traffic it
     // actually moves. Probing the default working set instead asked what half
-    // a gigabyte reaches, which no autotuned kernel is.
+    // a gigabyte reaches, which no autotuned kernel is. Past what the device
+    // will allocate the probe measures the cap regardless, so capping the ask
+    // keeps one cache entry rather than one per oversized kernel.
+    let access = MemoryAccess::Copy;
+    let footprint = (work.bytes as u64).min(working_set_cap(client, access));
     let memory_key = ThroughputKey {
-        mode: ThroughputMode::Memory(MemorySpec::new(
-            MemoryAccess::Copy,
-            sweep_size(work.bytes as u64),
-        )),
+        mode: ThroughputMode::Memory(MemorySpec::new(access, sweep_size(footprint))),
     };
     let launch_key = ThroughputKey {
         mode: ThroughputMode::Launch,

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -140,11 +140,8 @@ pub fn roofline_bounds<R: Runtime>(
     work: Work,
     thresholds: Thresholds,
 ) -> Bounds {
-    // The ceiling a kernel is scored against is the one for the traffic it
-    // actually moves. Probing the default working set instead asked what half
-    // a gigabyte reaches, which no autotuned kernel is. Past what the device
-    // will allocate the probe measures the cap regardless, so capping the ask
-    // keeps one cache entry rather than one per oversized kernel.
+    // Past what the device will allocate the probe measures the cap regardless,
+    // so capping the ask keeps one cache entry rather than one per kernel.
     let access = MemoryAccess::Copy;
     let footprint = (work.bytes as u64).min(working_set_cap(client, access));
     let memory_key = ThroughputKey {

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -107,20 +107,11 @@ pub fn measure_peak_throughput<R: Runtime>(
             }
             compute_cmma::build_kernel(client, key, cmma_config, launch_config)
         }
-        ThroughputMode::Memory(_) => {
-            // The memory modes differ only in what they ask of the probe, and
-            // `memory_probe` is the one place that mapping lives.
-            let spec = key
-                .mode
-                .memory_probe()
-                .expect("A memory mode describes a probe");
-
-            match spec.access {
-                MemoryAccess::Copy => memory_direct::build_kernel(client, key, launch_config, spec),
-                MemoryAccess::Read => memory_read::build_kernel(client, key, launch_config, spec),
-                MemoryAccess::Write => memory_write::build_kernel(client, key, launch_config, spec),
-            }
-        }
+        ThroughputMode::Memory(spec) => match spec.access {
+            MemoryAccess::Copy => memory_direct::build_kernel(client, key, launch_config, spec),
+            MemoryAccess::Read => memory_read::build_kernel(client, key, launch_config, spec),
+            MemoryAccess::Write => memory_write::build_kernel(client, key, launch_config, spec),
+        },
         ThroughputMode::Launch => launch_overhead::build_kernel(client, key, launch_config),
     };
 

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -4,8 +4,8 @@ use cubecl_runtime::{
     runtime::Runtime,
     server::CubeDim,
     throughput::{
-        DEFAULT_BUFFER_BYTES, MemoryAccess, MemoryCurve, MemoryPoint, ThroughputKey,
-        ThroughputMode, ThroughputValue, working_set_sweep,
+        DEFAULT_BUFFER_BYTES, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec, ThroughputKey,
+        ThroughputMode, ThroughputValue, sweep_size, working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
@@ -39,28 +39,36 @@ pub fn device_throughput<R: Runtime>(
 ///
 /// One point per size in [`working_set_sweep`], each measured and cached
 /// exactly like the single-size probe — [`measure_peak_throughput`] with a
-/// [`ThroughputMode::MemoryWorkingSet`] key — so a curve costs one probe per
-/// size on the first run and nothing afterwards.
+/// [`ThroughputMode::Memory`] key — so a curve costs one probe per size on the
+/// first run and nothing afterwards.
 ///
 /// Native only, panics on WASM
 pub fn measure_memory_curve<R: Runtime>(
     client: &ComputeClient<R>,
     access: MemoryAccess,
 ) -> MemoryCurve {
-    let points = working_set_sweep(working_set_cap(client, access))
-        .into_iter()
-        .map(|bytes| {
-            let key = ThroughputKey {
-                mode: ThroughputMode::MemoryWorkingSet { access, bytes },
-            };
-
-            MemoryPoint {
-                bytes,
-                value: measure_peak_throughput::<R>(client, key),
-            }
-        });
+    let points = sweep::<R>(client, access, |bytes| {
+        ThroughputMode::Memory(MemorySpec::new(access, bytes))
+    });
 
     MemoryCurve::new(access, points)
+}
+
+/// One measured point per size in [`working_set_sweep`], each cached exactly
+/// like the single-size probe, so a curve costs one probe per size on the
+/// first run and nothing afterwards.
+fn sweep<R: Runtime>(
+    client: &ComputeClient<R>,
+    access: MemoryAccess,
+    mode: impl Fn(u64) -> ThroughputMode,
+) -> alloc::vec::Vec<MemoryPoint> {
+    working_set_sweep(working_set_cap(client, access))
+        .into_iter()
+        .map(|bytes| MemoryPoint {
+            bytes,
+            value: measure_peak_throughput::<R>(client, ThroughputKey { mode: mode(bytes) }),
+        })
+        .collect()
 }
 
 /// The largest working set `access` can be probed at: as much as one buffer can
@@ -99,28 +107,18 @@ pub fn measure_peak_throughput<R: Runtime>(
             }
             compute_cmma::build_kernel(client, key, cmma_config, launch_config)
         }
-        ThroughputMode::Memory
-        | ThroughputMode::MemoryRead
-        | ThroughputMode::MemoryWrite
-        | ThroughputMode::MemoryWorkingSet { .. } => {
-            // The memory modes differ only in access and working set, and
+        ThroughputMode::Memory(_) => {
+            // The memory modes differ only in what they ask of the probe, and
             // `memory_probe` is the one place that mapping lives.
-            let (access, working_set) = key
+            let spec = key
                 .mode
                 .memory_probe()
                 .expect("A memory mode describes a probe");
-            let working_set = working_set.min(usize::MAX as u64) as usize;
 
-            match access {
-                MemoryAccess::Copy => {
-                    memory_direct::build_kernel(client, key, launch_config, working_set)
-                }
-                MemoryAccess::Read => {
-                    memory_read::build_kernel(client, key, launch_config, working_set)
-                }
-                MemoryAccess::Write => {
-                    memory_write::build_kernel(client, key, launch_config, working_set)
-                }
+            match spec.access {
+                MemoryAccess::Copy => memory_direct::build_kernel(client, key, launch_config, spec),
+                MemoryAccess::Read => memory_read::build_kernel(client, key, launch_config, spec),
+                MemoryAccess::Write => memory_write::build_kernel(client, key, launch_config, spec),
             }
         }
         ThroughputMode::Launch => launch_overhead::build_kernel(client, key, launch_config),
@@ -142,8 +140,14 @@ pub fn roofline_bounds<R: Runtime>(
     work: Work,
     thresholds: Thresholds,
 ) -> Bounds {
+    // The ceiling a kernel is scored against is the one for the traffic it
+    // actually moves. Probing the default working set instead asked what half
+    // a gigabyte reaches, which no autotuned kernel is.
     let memory_key = ThroughputKey {
-        mode: ThroughputMode::Memory,
+        mode: ThroughputMode::Memory(MemorySpec::new(
+            MemoryAccess::Copy,
+            sweep_size(work.bytes as u64),
+        )),
     };
     let launch_key = ThroughputKey {
         mode: ThroughputMode::Launch,

--- a/crates/cubecl-std/src/throughput/runners/compute_cmma.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_cmma.rs
@@ -41,7 +41,11 @@ pub fn build_kernel<R: Runtime>(
     let planes_per_cube = config.cube_dim / config.plane_size;
     let ops_count = config.cube_count * planes_per_cube * ops_per_cmma;
 
-    KernelConfig { sample, ops_count }
+    KernelConfig {
+        sample,
+        ops_count,
+        min_iterations: 1,
+    }
 }
 
 #[cube(launch_unchecked)]

--- a/crates/cubecl-std/src/throughput/runners/compute_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_direct.rs
@@ -39,7 +39,11 @@ pub fn build_kernel<R: Runtime>(
     let ops_count =
         ops_per_chain * CHAINS * config.cube_count * config.cube_dim * config.vector_size;
 
-    KernelConfig { sample, ops_count }
+    KernelConfig {
+        sample,
+        ops_count,
+        min_iterations: 1,
+    }
 }
 
 /// Independent accumulator chains per lane to hide arithmetic latency.

--- a/crates/cubecl-std/src/throughput/runners/launch_overhead.rs
+++ b/crates/cubecl-std/src/throughput/runners/launch_overhead.rs
@@ -36,6 +36,7 @@ pub fn build_kernel<R: cubecl_runtime::runtime::Runtime>(
     cubecl_runtime::throughput::KernelConfig {
         sample,
         ops_count: 1,
+        min_iterations: 1,
     }
 }
 

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -48,7 +48,11 @@ pub fn build_kernel<R: Runtime>(
     // One pass moves the window twice: once in, once out.
     let ops_count = 2 * probe.window_lines * config.vector_size;
 
-    KernelConfig { sample, ops_count }
+    KernelConfig {
+        sample,
+        ops_count,
+        min_iterations: probe.min_iterations(),
+    }
 }
 
 #[cube(launch_unchecked)]

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_runtime::throughput::{KernelConfig, MemoryAccess, ThroughputKey};
+use cubecl_runtime::throughput::{KernelConfig, MemorySpec, ThroughputKey};
 
 use crate::throughput::{
     LaunchConfig,
@@ -13,13 +13,13 @@ pub fn build_kernel<R: Runtime>(
     client: &ComputeClient<R>,
     key: ThroughputKey,
     config: LaunchConfig,
-    working_set: usize,
+    spec: MemorySpec,
 ) -> KernelConfig {
     let client = client.clone();
     let dtype = key.dtype();
 
     let line_bytes = config.vector_size * dtype.size();
-    let probe = MemoryProbe::new(&client, config, line_bytes, MemoryAccess::Copy, working_set);
+    let probe = MemoryProbe::new(&client, config, line_bytes, spec);
 
     let in_handle = client.empty(probe.buffer_bytes);
     memory_probe::prime(&client, &in_handle, probe.pool_lines, config, dtype);
@@ -108,11 +108,11 @@ pub fn memory_direct_throughput<I: Numeric, N: Size>(
         }
 
         start += window;
-        // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes. The
-        // test is whether the window starts past the end, not whether it
-        // reaches past: the index wraps, so the last position of a cycle
-        // straddles the end rather than being skipped.
+        // Back to the beginning, one line further along each time round,
+        // so a window that fills the whole buffer still moves between
+        // passes. The test is whether the window starts past the end, not
+        // whether it reaches past: the index wraps, so the last position
+        // of a cycle straddles the end rather than being skipped.
         if start >= len {
             wrap += 1;
             if wrap >= window {

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -108,11 +108,9 @@ pub fn memory_direct_throughput<I: Numeric, N: Size>(
         }
 
         start += window;
-        // Back to the beginning, one line further along each time round,
-        // so a window that fills the whole buffer still moves between
-        // passes. The test is whether the window starts past the end, not
-        // whether it reaches past: the index wraps, so the last position
-        // of a cycle straddles the end rather than being skipped.
+        // One line further along each round, so a window filling the whole
+        // buffer still moves. The index wraps, so a cycle's last position
+        // straddles the end rather than being skipped.
         if start >= len {
             wrap += 1;
             if wrap >= window {

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -67,6 +67,17 @@ struct DeviceShape {
 }
 
 impl MemoryProbe {
+    /// Passes a launch has to carry for the window to come back to bytes a
+    /// whole pool of traffic has since evicted, which is the only thing making
+    /// a window smaller than the cache cold.
+    ///
+    /// One where the window is its own pool, since such a window is already
+    /// cold. Every pass moves a window, so this is the pool however small the
+    /// window: a launch costs a pool of traffic and no more.
+    pub fn min_iterations(&self) -> usize {
+        self.pool_lines.div_ceil(self.window_lines)
+    }
+
     /// Sizes a probe moving `working_set` bytes per pass, split evenly across
     /// the buffers `access` touches.
     ///
@@ -256,6 +267,28 @@ mod tests {
         assert_eq!(pinned.buffer_bytes, 128 * MB);
         assert_eq!(walked.buffer_bytes, 512 * MB);
         assert_eq!(copy.buffer_bytes, 512 * MB);
+    }
+
+    #[test]
+    fn a_small_window_carries_the_passes_that_walk_the_pool() {
+        // 8 KiB of a half-gigabyte pool: 65536 passes to come back round.
+        let small = probe(8 * KB, MemoryAccess::Read);
+        assert_eq!(small.min_iterations(), 512 * MB / (8 * KB));
+
+        // A pinned window is its own pool and cold without walking anywhere.
+        let pinned = probe(128 * MB, MemoryAccess::Read);
+        assert_eq!(pinned.min_iterations(), 1);
+    }
+
+    #[test]
+    fn walking_the_pool_costs_the_pool_whatever_the_window() {
+        // Every pass moves one window, so the traffic a launch must carry is
+        // the pool, and a small window buys passes rather than time.
+        for bytes in [8 * KB, 256 * KB, 4 * MB] {
+            let probe = probe(bytes, MemoryAccess::Read);
+            let walked = probe.min_iterations() * probe.window_lines;
+            assert_eq!(walked, probe.pool_lines, "at {bytes} bytes");
+        }
     }
 
     #[test]

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -45,22 +45,12 @@ pub struct MemoryProbe {
     pub blocked: bool,
 }
 
-/// Last level caches a window must span before the probe stops walking it
-/// across the pool and pins it to its own bytes.
-///
-/// A window this far past the cache is cold on its own, so the walk only
-/// spreads the probe over bytes the kernel it scores never touches: on a
-/// 32 MiB-L3 Zen 3 a fill reaches 24.3 GB/s over 128 MiB and 19.8 over 512.
-const MIN_WINDOW_CACHE_MULTIPLE: usize = 4;
-
 /// All [`MemoryProbe::sized`] needs of a device, so the sizing can be exercised
 /// without one.
 #[derive(Clone, Copy)]
 struct DeviceShape {
     /// Bytes the device will hand out in a single allocation.
     max_alloc: usize,
-    /// Bytes of its last level cache, when it reports one.
-    cache_bytes: Option<usize>,
     /// Threads per cube, and cubes, of the probe's launch.
     cube_dim: usize,
     cube_count: usize,
@@ -94,7 +84,6 @@ impl MemoryProbe {
         let blocked = config.plane_size == 1;
         let shape = DeviceShape {
             max_alloc: client.properties().memory.max_page_size as usize,
-            cache_bytes: client.properties().hardware.last_level_cache_size,
             cube_dim: config.cube_dim,
             cube_count: if blocked { 1 } else { config.cube_count },
         };
@@ -105,9 +94,10 @@ impl MemoryProbe {
     /// The geometry itself, with the device reduced to its allocation limit and
     /// launch shape so the sizing can be exercised without one.
     ///
-    /// The pool is the whole buffer, so the window has somewhere cold to come
-    /// back to, until the window spans [`MIN_WINDOW_CACHE_MULTIPLE`] caches and
-    /// the pool shrinks to the window itself.
+    /// The pool is always the whole buffer, so every window has somewhere cold
+    /// to come back to. A window pinned to its own bytes revisits them one line
+    /// further along each pass, which is a stationary probe: on both a 32 MiB
+    /// and an 18 MiB last level cache that reads 10% and writes 20% high.
     ///
     /// The launch shrinks with the window instead of the window growing to fill
     /// the launch. A small window measured with the full dispatch would either
@@ -122,17 +112,7 @@ impl MemoryProbe {
         let cold_lines = (shape.max_alloc.min(DEFAULT_BUFFER_BYTES as usize) / line_bytes).max(1);
         let window_lines = (window_bytes / line_bytes).max(1).min(cold_lines);
 
-        // Only a device that reports its cache can tell a window that outgrew
-        // it from one that fits: without that, the walk is the sole thing
-        // keeping the window cold and dropping it would measure residency. A
-        // zero is such a device rather than a cacheless one, which
-        // `hipDeviceProp_t::l2CacheSize` documents itself as returning, and
-        // taken at face value it would pin every window.
-        let pins = shape
-            .cache_bytes
-            .filter(|cache| *cache > 0)
-            .is_some_and(|cache| window_bytes >= cache.saturating_mul(MIN_WINDOW_CACHE_MULTIPLE));
-        let pool_lines = if pins { window_lines } else { cold_lines };
+        let pool_lines = cold_lines;
 
         let cube_count = (window_lines / shape.cube_dim).clamp(1, shape.cube_count);
 
@@ -201,11 +181,10 @@ mod tests {
     const KB: usize = 1024;
     const MB: usize = 1024 * 1024;
 
-    /// Half a gigabyte of allocation, 256-thread cubes, a full dispatch of
-    /// 2048 cubes, and a 32 MiB last level cache.
+    /// Half a gigabyte of allocation, 256-thread cubes, and a full dispatch of
+    /// 2048 cubes.
     const DEVICE: DeviceShape = DeviceShape {
         max_alloc: 512 * MB,
-        cache_bytes: Some(32 * MB),
         cube_dim: 256,
         cube_count: 2048,
     };
@@ -214,16 +193,6 @@ mod tests {
     fn probe(working_set: usize, access: MemoryAccess) -> MemoryProbe {
         let spec = MemorySpec::new(access, working_set as u64);
         MemoryProbe::sized(DEVICE, 16, spec, false)
-    }
-
-    /// The same device, saying nothing about its cache.
-    fn uncached(working_set: usize, access: MemoryAccess) -> MemoryProbe {
-        let shape = DeviceShape {
-            cache_bytes: None,
-            ..DEVICE
-        };
-        let spec = MemorySpec::new(access, working_set as u64);
-        MemoryProbe::sized(shape, 16, spec, false)
     }
 
     #[test]
@@ -240,25 +209,17 @@ mod tests {
         assert_eq!(copy.window_lines, 128 * KB / 16);
     }
 
+    /// A window pinned to its own bytes would revisit them one line further
+    /// along each pass, which is a stationary probe reading its own cache.
+    /// Nothing below the top of the sweep may stop walking.
     #[test]
-    fn a_window_spanning_four_caches_becomes_its_own_pool() {
-        let pinned = probe(128 * MB, MemoryAccess::Read);
-        assert_eq!(pinned.pool_lines, pinned.window_lines);
-
-        // Just under, the walk is still what keeps the window cold.
-        let walked = probe(127 * MB, MemoryAccess::Read);
-        assert_eq!(walked.pool_lines, 512 * MB / 16);
-
-        // A copy splits its working set in two, so the same traffic leaves a
-        // window half the size in each buffer, and that one still gets walked.
-        let copy = probe(128 * MB, MemoryAccess::Copy);
-        assert_eq!(copy.pool_lines, 512 * MB / 16);
-
-        // The allocation follows the pool, so the kernels, which wrap at the
-        // buffer's length, cannot reach past the window that was primed.
-        assert_eq!(pinned.buffer_bytes, 128 * MB);
-        assert_eq!(walked.buffer_bytes, 512 * MB);
-        assert_eq!(copy.buffer_bytes, 512 * MB);
+    fn no_window_short_of_the_pool_stops_walking() {
+        for bytes in [256 * KB, 64 * MB, 128 * MB, 256 * MB] {
+            let probe = probe(bytes, MemoryAccess::Read);
+            assert_eq!(probe.pool_lines, 512 * MB / 16, "at {bytes} bytes");
+            assert!(probe.window_lines < probe.pool_lines, "at {bytes} bytes");
+            assert_eq!(probe.buffer_bytes, 512 * MB, "at {bytes} bytes");
+        }
     }
 
     #[test]
@@ -267,9 +228,9 @@ mod tests {
         let small = probe(8 * KB, MemoryAccess::Read);
         assert_eq!(small.min_iterations(), 512 * MB / (8 * KB));
 
-        // A pinned window is its own pool and cold without walking anywhere.
-        let pinned = probe(128 * MB, MemoryAccess::Read);
-        assert_eq!(pinned.min_iterations(), 1);
+        // Only the top of the sweep, where the window is the pool, needs one.
+        let whole = probe(512 * MB, MemoryAccess::Read);
+        assert_eq!(whole.min_iterations(), 1);
     }
 
     #[test]
@@ -281,29 +242,6 @@ mod tests {
             let walked = probe.min_iterations() * probe.window_lines;
             assert_eq!(walked, probe.pool_lines, "at {bytes} bytes");
         }
-    }
-
-    #[test]
-    fn a_device_that_reports_no_cache_walks_every_window() {
-        for bytes in [256 * KB, 128 * MB, 512 * MB] {
-            let probe = uncached(bytes, MemoryAccess::Read);
-            assert_eq!(probe.pool_lines, 512 * MB / 16, "at {bytes} bytes");
-        }
-    }
-
-    /// A zero cache is a runtime that could not read one, so it has to walk
-    /// like any other. Read as a size it is one every window spans, which
-    /// would pin the whole sweep and report cache bandwidth throughout.
-    #[test]
-    fn a_zero_cache_is_an_unknown_one() {
-        let shape = DeviceShape {
-            cache_bytes: Some(0),
-            ..DEVICE
-        };
-        let spec = MemorySpec::new(MemoryAccess::Read, 256 * KB as u64);
-        let probe = MemoryProbe::sized(shape, 16, spec, false);
-
-        assert_eq!(probe.pool_lines, 512 * MB / 16);
     }
 
     #[test]

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -67,13 +67,9 @@ struct DeviceShape {
 }
 
 impl MemoryProbe {
-    /// Passes a launch has to carry for the window to come back to bytes a
-    /// whole pool of traffic has since evicted, which is the only thing making
-    /// a window smaller than the cache cold.
-    ///
-    /// One where the window is its own pool, since such a window is already
-    /// cold. Every pass moves a window, so this is the pool however small the
-    /// window: a launch costs a pool of traffic and no more.
+    /// Passes a launch carries for the window to come back to bytes a whole
+    /// pool of traffic has since evicted, which is what keeps a window smaller
+    /// than the cache cold.
     pub fn min_iterations(&self) -> usize {
         self.pool_lines.div_ceil(self.window_lines)
     }

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, ir::ElemType};
 use cubecl_runtime::{
     server::Handle,
-    throughput::{DEFAULT_BUFFER_BYTES, MemoryAccess},
+    throughput::{DEFAULT_BUFFER_BYTES, MemorySpec},
 };
 
 use crate::throughput::LaunchConfig;
@@ -93,8 +93,7 @@ impl MemoryProbe {
         client: &ComputeClient<R>,
         config: LaunchConfig,
         line_bytes: usize,
-        access: MemoryAccess,
-        working_set: usize,
+        spec: MemorySpec,
     ) -> Self {
         let blocked = config.plane_size == 1;
         let shape = DeviceShape {
@@ -104,7 +103,7 @@ impl MemoryProbe {
             cube_count: if blocked { 1 } else { config.cube_count },
         };
 
-        Self::sized(shape, line_bytes, access, working_set, blocked)
+        Self::sized(shape, line_bytes, spec, blocked)
     }
 
     /// The geometry itself, with the device reduced to its allocation limit and
@@ -120,15 +119,9 @@ impl MemoryProbe {
     /// neither is the small-kernel behaviour the curve exists to describe: a
     /// kernel that moves little has little in flight, and that is precisely
     /// what limits it.
-    fn sized(
-        shape: DeviceShape,
-        line_bytes: usize,
-        access: MemoryAccess,
-        working_set: usize,
-        blocked: bool,
-    ) -> Self {
-        let buffers = access.buffers() as usize;
-        let window_bytes = working_set / buffers;
+    fn sized(shape: DeviceShape, line_bytes: usize, spec: MemorySpec, blocked: bool) -> Self {
+        let buffers = spec.access.buffers() as usize;
+        let window_bytes = (spec.bytes.min(usize::MAX as u64) as usize) / buffers;
 
         let cold_lines = (shape.max_alloc.min(DEFAULT_BUFFER_BYTES as usize) / line_bytes).max(1);
         let window_lines = (window_bytes / line_bytes).max(1).min(cold_lines);
@@ -207,6 +200,7 @@ fn prime_buffer<I: Numeric, N: Size>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cubecl_runtime::throughput::MemoryAccess;
 
     const KB: usize = 1024;
     const MB: usize = 1024 * 1024;
@@ -222,7 +216,8 @@ mod tests {
 
     /// A probe of that device, in the 16-byte lines a `vec4` of f32 comes in.
     fn probe(working_set: usize, access: MemoryAccess) -> MemoryProbe {
-        MemoryProbe::sized(DEVICE, 16, access, working_set, false)
+        let spec = MemorySpec::new(access, working_set as u64);
+        MemoryProbe::sized(DEVICE, 16, spec, false)
     }
 
     /// The same device, saying nothing about its cache.
@@ -231,7 +226,8 @@ mod tests {
             cache_bytes: None,
             ..DEVICE
         };
-        MemoryProbe::sized(shape, 16, access, working_set, false)
+        let spec = MemorySpec::new(access, working_set as u64);
+        MemoryProbe::sized(shape, 16, spec, false)
     }
 
     #[test]
@@ -308,7 +304,8 @@ mod tests {
             cache_bytes: Some(0),
             ..DEVICE
         };
-        let probe = MemoryProbe::sized(shape, 16, MemoryAccess::Read, 256 * KB, false);
+        let spec = MemorySpec::new(MemoryAccess::Read, 256 * KB as u64);
+        let probe = MemoryProbe::sized(shape, 16, spec, false);
 
         assert_eq!(probe.pool_lines, 512 * MB / 16);
     }
@@ -347,7 +344,8 @@ mod tests {
             max_alloc: 4 * MB,
             ..DEVICE
         };
-        let probe = MemoryProbe::sized(shape, 16, MemoryAccess::Read, 512 * MB, false);
+        let spec = MemorySpec::new(MemoryAccess::Read, 512 * MB as u64);
+        let probe = MemoryProbe::sized(shape, 16, spec, false);
 
         assert_eq!(probe.buffer_bytes, 4 * MB);
         assert_eq!(probe.window_lines, probe.pool_lines);

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -62,7 +62,11 @@ pub fn build_kernel<R: Runtime>(
     // Reads only — no `2 *`. That factor is the whole difference from the copy.
     let ops_count = probe.window_lines * config.vector_size;
 
-    KernelConfig { sample, ops_count }
+    KernelConfig {
+        sample,
+        ops_count,
+        min_iterations: probe.min_iterations(),
+    }
 }
 
 #[cube(launch_unchecked)]

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -138,11 +138,9 @@ pub fn memory_read_throughput<I: Numeric, N: Size>(
         }
 
         start += window;
-        // Back to the beginning, one line further along each time round,
-        // so a window that fills the whole buffer still moves between
-        // passes. The test is whether the window starts past the end, not
-        // whether it reaches past: the index wraps, so the last position
-        // of a cycle straddles the end rather than being skipped.
+        // One line further along each round, so a window filling the whole
+        // buffer still moves. The index wraps, so a cycle's last position
+        // straddles the end rather than being skipped.
         if start >= len {
             wrap += 1;
             if wrap >= window {

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_runtime::throughput::{KernelConfig, MemoryAccess, ThroughputKey};
+use cubecl_runtime::throughput::{KernelConfig, MemorySpec, ThroughputKey};
 
 use crate::throughput::{
     LaunchConfig,
@@ -26,13 +26,13 @@ pub fn build_kernel<R: Runtime>(
     client: &ComputeClient<R>,
     key: ThroughputKey,
     config: LaunchConfig,
-    working_set: usize,
+    spec: MemorySpec,
 ) -> KernelConfig {
     let client = client.clone();
     let dtype = key.dtype();
 
     let line_bytes = config.vector_size * dtype.size();
-    let probe = MemoryProbe::new(&client, config, line_bytes, MemoryAccess::Read, working_set);
+    let probe = MemoryProbe::new(&client, config, line_bytes, spec);
 
     let in_handle = client.empty(probe.buffer_bytes);
     memory_probe::prime(&client, &in_handle, probe.pool_lines, config, dtype);
@@ -138,11 +138,11 @@ pub fn memory_read_throughput<I: Numeric, N: Size>(
         }
 
         start += window;
-        // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes. The
-        // test is whether the window starts past the end, not whether it
-        // reaches past: the index wraps, so the last position of a cycle
-        // straddles the end rather than being skipped.
+        // Back to the beginning, one line further along each time round,
+        // so a window that fills the whole buffer still moves between
+        // passes. The test is whether the window starts past the end, not
+        // whether it reaches past: the index wraps, so the last position
+        // of a cycle straddles the end rather than being skipped.
         if start >= len {
             wrap += 1;
             if wrap >= window {

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -58,7 +58,11 @@ pub fn build_kernel<R: Runtime>(
     // Writes only, no `2 *`. That factor is the whole difference from the copy.
     let ops_count = probe.window_lines * config.vector_size;
 
-    KernelConfig { sample, ops_count }
+    KernelConfig {
+        sample,
+        ops_count,
+        min_iterations: probe.min_iterations(),
+    }
 }
 
 #[cube(launch_unchecked)]

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -124,11 +124,9 @@ pub fn memory_write_throughput<I: Numeric, N: Size>(
         }
 
         start += window;
-        // Back to the beginning, one line further along each time round,
-        // so a window that fills the whole buffer still moves between
-        // passes. The test is whether the window starts past the end, not
-        // whether it reaches past: the index wraps, so the last position
-        // of a cycle straddles the end rather than being skipped.
+        // One line further along each round, so a window filling the whole
+        // buffer still moves. The index wraps, so a cycle's last position
+        // straddles the end rather than being skipped.
         if start >= len {
             wrap += 1;
             if wrap >= window {

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_runtime::throughput::{KernelConfig, MemoryAccess, ThroughputKey};
+use cubecl_runtime::throughput::{KernelConfig, MemorySpec, ThroughputKey};
 
 use crate::throughput::{LaunchConfig, memory_probe::MemoryProbe};
 
@@ -20,19 +20,13 @@ pub fn build_kernel<R: Runtime>(
     client: &ComputeClient<R>,
     key: ThroughputKey,
     config: LaunchConfig,
-    working_set: usize,
+    spec: MemorySpec,
 ) -> KernelConfig {
     let client = client.clone();
     let dtype = key.dtype();
 
     let line_bytes = config.vector_size * dtype.size();
-    let probe = MemoryProbe::new(
-        &client,
-        config,
-        line_bytes,
-        MemoryAccess::Write,
-        working_set,
-    );
+    let probe = MemoryProbe::new(&client, config, line_bytes, spec);
 
     let out_handle = client.empty(probe.buffer_bytes);
 
@@ -130,11 +124,11 @@ pub fn memory_write_throughput<I: Numeric, N: Size>(
         }
 
         start += window;
-        // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes. The
-        // test is whether the window starts past the end, not whether it
-        // reaches past: the index wraps, so the last position of a cycle
-        // straddles the end rather than being skipped.
+        // Back to the beginning, one line further along each time round,
+        // so a window that fills the whole buffer still moves between
+        // passes. The test is whether the window starts past the end, not
+        // whether it reaches past: the index wraps, so the last position
+        // of a cycle straddles the end rather than being skipped.
         if start >= len {
             wrap += 1;
             if wrap >= window {

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -87,7 +87,7 @@ pub fn memory_curve<R: Runtime>(device: &R::Device) {
 }
 
 fn print_curve(access: MemoryAccess, curve: &MemoryCurve) {
-    println!("\n  {access:?}{:>16}", "peak");
+    println!("\n  {:<8}{:>18}", format!("{access:?}"), "peak");
 
     for point in curve.points() {
         let rate = match curve.ceiling_at(point.bytes) {

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -82,22 +82,20 @@ pub fn memory_curve<R: Runtime>(device: &R::Device) {
     println!("Memory curve — {}", R::name(&client));
 
     for access in [MemoryAccess::Read, MemoryAccess::Write, MemoryAccess::Copy] {
-        let curve = measure_memory_curve::<R>(&client, access);
-        print_curve(access, &curve);
+        print_curve(access, &measure_memory_curve::<R>(&client, access));
     }
 }
 
 fn print_curve(access: MemoryAccess, curve: &MemoryCurve) {
-    println!("\n  {access:?}");
+    println!("\n  {access:?}{:>16}", "peak");
 
     for point in curve.points() {
-        let bytes_per_s = curve.ceiling_at(point.bytes).unwrap_or(f64::NAN);
+        let rate = match curve.ceiling_at(point.bytes) {
+            Some(bytes_per_s) => format!("{:.1} GB/s", bytes_per_s / 1e9),
+            None => String::from("N/A"),
+        };
 
-        println!(
-            "    {:>10}{:>14}",
-            bytes_label(point.bytes),
-            format!("{:.1} GB/s", bytes_per_s / 1e9),
-        );
+        println!("    {:>10}{:>14}", bytes_label(point.bytes), rate);
     }
 }
 
@@ -162,11 +160,8 @@ fn describe(key: &ThroughputKey) -> String {
             input_dtype, cfg.accumulator_type, cfg.cmma_dims.m, cfg.cmma_dims.n, cfg.cmma_dims.k,
         ),
         ThroughputMode::ComputeDirect { .. } => key.dtype().to_string(),
-        ThroughputMode::MemoryWorkingSet { bytes, .. } => bytes_label(bytes),
-        ThroughputMode::Memory
-        | ThroughputMode::MemoryRead
-        | ThroughputMode::MemoryWrite
-        | ThroughputMode::Launch => String::new(),
+        ThroughputMode::Memory(spec) => bytes_label(spec.bytes),
+        ThroughputMode::Launch => String::new(),
     }
 }
 
@@ -174,21 +169,11 @@ fn mode_label(mode: &ThroughputMode) -> &'static str {
     match mode {
         ThroughputMode::ComputeDirect { .. } => "compute-direct",
         ThroughputMode::ComputeCmma { .. } => "compute-cmma",
-        ThroughputMode::Memory
-        | ThroughputMode::MemoryWorkingSet {
-            access: MemoryAccess::Copy,
-            ..
-        } => "memory",
-        ThroughputMode::MemoryRead
-        | ThroughputMode::MemoryWorkingSet {
-            access: MemoryAccess::Read,
-            ..
-        } => "memory-read",
-        ThroughputMode::MemoryWrite
-        | ThroughputMode::MemoryWorkingSet {
-            access: MemoryAccess::Write,
-            ..
-        } => "memory-write",
+        ThroughputMode::Memory(spec) => match spec.access {
+            MemoryAccess::Copy => "memory",
+            MemoryAccess::Read => "memory-read",
+            MemoryAccess::Write => "memory-write",
+        },
         ThroughputMode::Launch => "launch",
     }
 }
@@ -219,19 +204,19 @@ fn compute_cmma_key() -> ThroughputKey {
 
 fn memory_key() -> ThroughputKey {
     ThroughputKey {
-        mode: ThroughputMode::Memory,
+        mode: ThroughputMode::memory(MemoryAccess::Copy),
     }
 }
 
 fn memory_read_key() -> ThroughputKey {
     ThroughputKey {
-        mode: ThroughputMode::MemoryRead,
+        mode: ThroughputMode::memory(MemoryAccess::Read),
     }
 }
 
 fn memory_write_key() -> ThroughputKey {
     ThroughputKey {
-        mode: ThroughputMode::MemoryWrite,
+        mode: ThroughputMode::memory(MemoryAccess::Write),
     }
 }
 


### PR DESCRIPTION
The memory curve stops reporting speeds the hardware cannot reach, and its four memory modes collapse to one.

## The small end was measuring cache

A probe stays cold by walking a whole pool before returning to bytes it already read, but `warmup` capped a launch at 1000 iterations, and 1000 passes of 8 KiB is 8 MB against a 32 MiB L3. Tower 5700X, whose walls are 44 / 19.8 / 26 GB/s:

| tower CPU | 8 KiB | 32 KiB | 64 KiB | 512 MiB |
| --- | --- | --- | --- | --- |
| read | 134 → **46** | 173 → **46** | 69 → 42 | 44 → 44 |
| write | 90 → **18** | 133 → **19** | 30 → 18 | 20 → 20 |
| copy | 105 → **24** | 121 → **26** | 39 → 26 | 26 → 26 |

`KernelConfig` now carries `min_iterations`, which `MemoryProbe` derives as `pool_lines / window_lines`, so a launch costs exactly one pool of traffic however small the window. Only the top of the sweep, where the window is the pool, asks for one. GPUs gain in the mid-range instead, where launch cost was the contaminant: wgpu read at 128 KiB 243 → 357, vulkan write at 64 KiB 446 → 520. A full curve also got **faster**, CPU 32.0 → 26.4 s.

Reaching those counts means `warmup` may now ask for 16.7M iterations where it stopped at 1000, so two guards bound what a timer can drive it to. A reading of zero says nothing about the pass, so the branch that doubles blind gets its own ceiling of 1024; a reading too coarse to resolve the target says the same thing at every count, which no ceiling catches before the rounds it takes to reach it, so growing also stops on a wall clock. Sampling gets the same treatment, a 200 ms budget, which replaces a twenty sample floor it could never have reached.

A window also stopped walking too early. `MIN_WINDOW_CACHE_MULTIPLE` pinned a window past four last level caches to its own bytes, on the grounds it was cold there. It is not: a pinned window revisits those bytes one line further along each pass, which is a stationary probe reading its own cache.

| cpu write | 64 MiB | **128 MiB** | 256 MiB | 512 MiB |
| --- | --- | --- | --- | --- |
| tower, pinned | 19.8 | **24.3** | 19.9 | 19.8 |
| tower, walking | 19.8 | **19.8** | 19.8 | 19.7 |
| xps, pinned | 58.1 | **69.0** | 58.7 | 57.2 |
| xps, walking | 60.3 | **60.3** | 60.6 | 60.5 |

Raising the threshold does not rescue it. The spike lands at 128 MiB on both machines, which is four caches on tower's 32 MiB L3 and 7.1 on the xps's 18 MiB, so the window size predicts it and no multiple of the cache does. Every window walks the pool now. That costs the points past the old threshold up to four passes where they cost one, and deletes the constant, the branch, and the zero-cache case `hipDeviceProp_t::l2CacheSize` needed. Only `cubecl-cpu` ever reported a cache, so no other backend changes at all.

## The compute probes move too

That 1000 cap applied to every mode, so the compute probes never settled at a steady clock:

| tower 4070 Ti SUPER | base | this branch |
| --- | --- | --- |
| compute-direct f16 | 30.70 | **34.62** TOPS/s |
| compute-cmma f16→f16 | 147.56 | **192.91** TOPS/s |

The spread matters more than the level: cmma spans 147.6 to 186.8 across three unpatched runs, and 192.8 to 193.0 across two here. It reaches autotune opposite to the memory work, since `Vec::time_limit` takes the max of the two bounds: a compute bound kernel now meets a ceiling 31% higher and a limit roughly a quarter tighter.

## API

```rust
ThroughputMode::Memory(MemorySpec { access, bytes })
```

Access and size are two fields rather than two families of variant. `ThroughputMode::memory(access)` is the old shorthand, but consumers should not name a mode at all: measure a curve with `measure_memory_curve`, then read a ceiling off it with `ceiling_at`.

`roofline_bounds` asked what half a gigabyte reaches, which no autotuned kernel is. It now asks about `work.bytes`, snapped to the sweep grid and clamped to what the device can allocate, so **no caller passes anything new**.

Downstream breaks, all one line: `KernelConfig` gained `min_iterations`; `memory_probe()` returns `MemorySpec`; exhaustive matches on `ThroughputMode`; and `MemoryProbe::new` plus the three `build_kernel`s take a `MemorySpec`. Both are taken, in tracel-ai/cubek#562 and tracel-ai/burn#5510. **cubek#562 is worth reviewing alongside this one** and is blocked on it merging.

## Known, not fixed

- **CUDA cold read drops at 8 to 32 KiB** (195 → 110) where wgpu and vulkan hold. Those points are reading the card's L2.
- **The GPU ramp is launch geometry, not residency.** `cube_count` is `(window_lines / cube_dim).clamp(1, cube_count)`, so a smaller window affords fewer cubes and fewer cubes reach less bandwidth. That is the ceiling a small kernel should be scored against, but it is not the cache effect the first section names.
- **The CPU curve is flat.** `blocked = plane_size == 1` pins `cube_count` to 1, so nothing scales with the window there, and the rotation leaves a sequential stream the prefetcher follows anyway. Every cpu point lands within 89 to 105% of its own peak, against 4% to 94% for a gpu read, so `ceiling_at` returns one number on cpu and the sweep buys nothing a single probe would not. The floor is not what hides a ramp: dropped to 128 B the cpu read still reaches 97% of its peak by 512 B.

<details>
<summary>Why there is no second curve for cached working sets</summary>

An earlier revision added one, the same probe without the walk. A probe that stays put re-touches identical addresses every pass, which makes each pass optimizable in ways a real kernel is not: `ncu` at 128 MiB on a 4070 Ti SUPER shows 92% of its stores and 99.85% of its reads never reaching DRAM, the latter because each thread's lines are loop invariant and the backend hoists them into registers. A single pass is honest in both cases, and a single pass past the cache is just a cold pass.

</details>

## Verification

Tower under an exclusive lock, `CUBECL_THROUGHPUT_CACHE=0`, on cpu / wgpu / vulkan / cuda. Two controls: the top of the curve, where the loop fixes provably cannot apply, agrees within 1.5% across all twelve access/backend pairs, and within 0.9% on eleven of them; the cold curve, which the rotation fix should not touch, moves a median 0.5% across 208 points. Those predate the later commits, so the merge candidate was measured on its own. Tower cpu, where the pin used to fire:

| tower cpu | 64 MiB | 128 MiB | 256 MiB | 512 MiB |
| --- | --- | --- | --- | --- |
| read, pinned | 43.8 | 48.5 | 44.0 | 44.0 |
| read, merge candidate | 44.0 | **43.9** | 44.0 | 44.0 |
| write, pinned | 19.8 | 24.3 | 19.9 | 19.8 |
| write, merge candidate | 19.8 | **19.8** | 19.8 | 19.7 |

No point on cpu or cuda reads above its neighbours any more, and cuda's own top of curve is unmoved at 661.5 read, 505.8 write and 518.2 copy, within 0.2% of the merge base, which is what a backend reporting no cache should do.

`cargo fmt`, `cargo clippy` and the unit suites are clean, and three broken rustdoc links are gone with the modes they pointed at. `cargo test -p cubecl-cuda` on the merge candidate is 894 passed and 1 failed, `tests::test_cmma_manual`, which fails identically on main.





