### PR TITLE
feat(throughput): measure a working set where it already sits

### DIFF
--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -103,8 +103,62 @@ pub enum ThroughputMode {
         /// The bytes moved in one pass.
         bytes: u64,
     },
+    /// One point of a *resident* memory curve: `access` over a working set of
+    /// exactly `bytes`, measured where it already sits.
+    ///
+    /// [`MemoryWorkingSet`](Self::MemoryWorkingSet) walks its window across a
+    /// far larger pool so every pass finds the bytes evicted, which answers
+    /// what a kernel reaching into memory can do. A kernel that comes back to
+    /// the same tile, a fused chain or a blocked matmul, is asking something
+    /// else, and against the cold figure it can legitimately report several
+    /// hundred percent.
+    ///
+    /// So this probe does not walk. Whether the working set is genuinely
+    /// resident is then a question of its size against the cache rather than
+    /// anything the probe arranges: past the cache the two curves are the same
+    /// measurement and should meet.
+    MemoryResident {
+        /// Which directions of traffic the probe issues.
+        access: MemoryAccess,
+        /// The bytes moved in one pass.
+        bytes: u64,
+    },
     /// Launch overhead measurement.
     Launch,
+}
+
+/// What a memory mode asks of a probe.
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+pub struct MemorySpec {
+    /// Which directions of traffic to issue.
+    pub access: MemoryAccess,
+    /// The bytes one pass moves across the interface.
+    pub bytes: u64,
+    /// Whether to measure the working set where it sits rather than walk it
+    /// across a pool until every pass finds it evicted.
+    pub resident: bool,
+}
+
+impl MemorySpec {
+    /// A probe that walks, which every mode but
+    /// [`MemoryResident`](ThroughputMode::MemoryResident) asks for.
+    pub const fn cold(access: MemoryAccess, bytes: u64) -> Self {
+        Self {
+            access,
+            bytes,
+            resident: false,
+        }
+    }
+
+    /// A probe that stays put, so what it measures is whatever holds the
+    /// working set at that size.
+    pub const fn resident(access: MemoryAccess, bytes: u64) -> Self {
+        Self {
+            access,
+            bytes,
+            resident: true,
+        }
+    }
 }
 
 impl ThroughputMode {
@@ -113,17 +167,26 @@ impl ThroughputMode {
     ///
     /// The one place the single-size variants are mapped onto their access and
     /// size, so nothing downstream has to repeat the equivalence.
-    pub const fn memory_probe(&self) -> Option<(MemoryAccess, u64)> {
+    pub const fn memory_probe(&self) -> Option<MemorySpec> {
         match self {
-            Self::Memory => Some((MemoryAccess::Copy, MemoryAccess::Copy.default_working_set())),
-            Self::MemoryRead => {
-                Some((MemoryAccess::Read, MemoryAccess::Read.default_working_set()))
-            }
-            Self::MemoryWrite => Some((
+            Self::Memory => Some(MemorySpec::cold(
+                MemoryAccess::Copy,
+                MemoryAccess::Copy.default_working_set(),
+            )),
+            Self::MemoryRead => Some(MemorySpec::cold(
+                MemoryAccess::Read,
+                MemoryAccess::Read.default_working_set(),
+            )),
+            Self::MemoryWrite => Some(MemorySpec::cold(
                 MemoryAccess::Write,
                 MemoryAccess::Write.default_working_set(),
             )),
-            Self::MemoryWorkingSet { access, bytes } => Some((*access, *bytes)),
+            Self::MemoryWorkingSet { access, bytes } => Some(MemorySpec::cold(*access, *bytes)),
+            Self::MemoryResident { access, bytes } => Some(MemorySpec {
+                access: *access,
+                bytes: *bytes,
+                resident: true,
+            }),
             Self::ComputeDirect { .. } | Self::ComputeCmma { .. } | Self::Launch => None,
         }
     }
@@ -150,6 +213,7 @@ impl ThroughputKey {
             | ThroughputMode::MemoryRead
             | ThroughputMode::MemoryWrite
             | ThroughputMode::MemoryWorkingSet { .. }
+            | ThroughputMode::MemoryResident { .. }
             | ThroughputMode::Launch => ElemType::Float(FloatKind::F32),
         }
     }
@@ -206,7 +270,8 @@ impl ThroughputValue {
             ThroughputMode::Memory
             | ThroughputMode::MemoryRead
             | ThroughputMode::MemoryWrite
-            | ThroughputMode::MemoryWorkingSet { .. } => (self.bytes_per_s(key), "bytes"),
+            | ThroughputMode::MemoryWorkingSet { .. }
+            | ThroughputMode::MemoryResident { .. } => (self.bytes_per_s(key), "bytes"),
             ThroughputMode::Launch => {
                 let dur = self.duration_per_op();
                 if dur.is_zero() {
@@ -280,6 +345,22 @@ mod tests {
         assert_eq!(
             encode(ThroughputMode::MemoryWrite),
             r#"{"mode":"MemoryWrite"}"#
+        );
+
+        // The curve variants, whose points are the bulk of any cache.
+        assert_eq!(
+            encode(ThroughputMode::MemoryWorkingSet {
+                access: MemoryAccess::Read,
+                bytes: 8192,
+            }),
+            r#"{"mode":{"MemoryWorkingSet":{"access":"Read","bytes":8192}}}"#
+        );
+        assert_eq!(
+            encode(ThroughputMode::MemoryResident {
+                access: MemoryAccess::Read,
+                bytes: 8192,
+            }),
+            r#"{"mode":{"MemoryResident":{"access":"Read","bytes":8192}}}"#
         );
 
         // And an entry written before the variant existed still reads back.

--- a/crates/cubecl-runtime/src/throughput/curve.rs
+++ b/crates/cubecl-runtime/src/throughput/curve.rs
@@ -68,6 +68,9 @@ pub struct MemoryPoint {
 #[derive(PartialEq, Clone, Debug)]
 pub struct MemoryCurve {
     access: MemoryAccess,
+    /// Which of the two curves this is, since a point means a different thing
+    /// on each and the rate is read back through its own key.
+    resident: bool,
     /// Ascending by `bytes`, deduplicated, and every rate finite and positive.
     points: Vec<MemoryPoint>,
 }
@@ -79,8 +82,23 @@ impl MemoryCurve {
     /// positive (an unsupported or failed probe), describes nothing and is
     /// dropped; duplicated working sets keep the first point.
     pub fn new(access: MemoryAccess, points: impl IntoIterator<Item = MemoryPoint>) -> Self {
+        Self::build(access, false, points)
+    }
+
+    /// Assembles a curve of working sets measured where they sit, dropping
+    /// points on the same terms as [`new`](Self::new).
+    pub fn resident(access: MemoryAccess, points: impl IntoIterator<Item = MemoryPoint>) -> Self {
+        Self::build(access, true, points)
+    }
+
+    fn build(
+        access: MemoryAccess,
+        resident: bool,
+        points: impl IntoIterator<Item = MemoryPoint>,
+    ) -> Self {
         let mut curve = Self {
             access,
+            resident,
             points: Vec::new(),
         };
 
@@ -137,12 +155,14 @@ impl MemoryCurve {
 
     /// What a point measured, in bytes moved per second.
     fn rate(&self, point: &MemoryPoint) -> f64 {
-        point.value.bytes_per_s(&ThroughputKey {
-            mode: ThroughputMode::MemoryWorkingSet {
-                access: self.access,
-                bytes: point.bytes,
-            },
-        })
+        let (access, bytes) = (self.access, point.bytes);
+        let mode = if self.resident {
+            ThroughputMode::MemoryResident { access, bytes }
+        } else {
+            ThroughputMode::MemoryWorkingSet { access, bytes }
+        };
+
+        point.value.bytes_per_s(&ThroughputKey { mode })
     }
 }
 

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -47,20 +47,50 @@ pub fn measure_memory_curve<R: Runtime>(
     client: &ComputeClient<R>,
     access: MemoryAccess,
 ) -> MemoryCurve {
-    let points = working_set_sweep(working_set_cap(client, access))
-        .into_iter()
-        .map(|bytes| {
-            let key = ThroughputKey {
-                mode: ThroughputMode::MemoryWorkingSet { access, bytes },
-            };
-
-            MemoryPoint {
-                bytes,
-                value: measure_peak_throughput::<R>(client, key),
-            }
-        });
+    let points = sweep::<R>(client, access, |bytes| ThroughputMode::MemoryWorkingSet {
+        access,
+        bytes,
+    });
 
     MemoryCurve::new(access, points)
+}
+
+/// Measure the same range of working sets where each one already sits, rather
+/// than walking it until every pass finds it evicted.
+///
+/// The ceiling for a kernel that comes back to a tile it has already touched,
+/// which against [`measure_memory_curve`] can report several hundred percent
+/// and be right to. Past the cache the two answer the same question and the
+/// curves should meet.
+///
+/// Native only, panics on WASM
+pub fn measure_resident_curve<R: Runtime>(
+    client: &ComputeClient<R>,
+    access: MemoryAccess,
+) -> MemoryCurve {
+    let points = sweep::<R>(client, access, |bytes| ThroughputMode::MemoryResident {
+        access,
+        bytes,
+    });
+
+    MemoryCurve::resident(access, points)
+}
+
+/// One measured point per size in [`working_set_sweep`], each cached exactly
+/// like the single-size probe, so a curve costs one probe per size on the
+/// first run and nothing afterwards.
+fn sweep<R: Runtime>(
+    client: &ComputeClient<R>,
+    access: MemoryAccess,
+    mode: impl Fn(u64) -> ThroughputMode,
+) -> alloc::vec::Vec<MemoryPoint> {
+    working_set_sweep(working_set_cap(client, access))
+        .into_iter()
+        .map(|bytes| MemoryPoint {
+            bytes,
+            value: measure_peak_throughput::<R>(client, ThroughputKey { mode: mode(bytes) }),
+        })
+        .collect()
 }
 
 /// The largest working set `access` can be probed at: as much as one buffer can
@@ -102,25 +132,19 @@ pub fn measure_peak_throughput<R: Runtime>(
         ThroughputMode::Memory
         | ThroughputMode::MemoryRead
         | ThroughputMode::MemoryWrite
-        | ThroughputMode::MemoryWorkingSet { .. } => {
-            // The memory modes differ only in access and working set, and
+        | ThroughputMode::MemoryWorkingSet { .. }
+        | ThroughputMode::MemoryResident { .. } => {
+            // The memory modes differ only in what they ask of the probe, and
             // `memory_probe` is the one place that mapping lives.
-            let (access, working_set) = key
+            let spec = key
                 .mode
                 .memory_probe()
                 .expect("A memory mode describes a probe");
-            let working_set = working_set.min(usize::MAX as u64) as usize;
 
-            match access {
-                MemoryAccess::Copy => {
-                    memory_direct::build_kernel(client, key, launch_config, working_set)
-                }
-                MemoryAccess::Read => {
-                    memory_read::build_kernel(client, key, launch_config, working_set)
-                }
-                MemoryAccess::Write => {
-                    memory_write::build_kernel(client, key, launch_config, working_set)
-                }
+            match spec.access {
+                MemoryAccess::Copy => memory_direct::build_kernel(client, key, launch_config, spec),
+                MemoryAccess::Read => memory_read::build_kernel(client, key, launch_config, spec),
+                MemoryAccess::Write => memory_write::build_kernel(client, key, launch_config, spec),
             }
         }
         ThroughputMode::Launch => launch_overhead::build_kernel(client, key, launch_config),

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_runtime::throughput::{KernelConfig, MemoryAccess, ThroughputKey};
+use cubecl_runtime::throughput::{KernelConfig, MemorySpec, ThroughputKey};
 
 use crate::throughput::{
     LaunchConfig,
@@ -13,13 +13,13 @@ pub fn build_kernel<R: Runtime>(
     client: &ComputeClient<R>,
     key: ThroughputKey,
     config: LaunchConfig,
-    working_set: usize,
+    spec: MemorySpec,
 ) -> KernelConfig {
     let client = client.clone();
     let dtype = key.dtype();
 
     let line_bytes = config.vector_size * dtype.size();
-    let probe = MemoryProbe::new(&client, config, line_bytes, MemoryAccess::Copy, working_set);
+    let probe = MemoryProbe::new(&client, config, line_bytes, spec);
 
     let in_handle = client.empty(probe.buffer_bytes);
     memory_probe::prime(&client, &in_handle, probe.pool_lines, config, dtype);

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -38,6 +38,7 @@ pub fn build_kernel<R: Runtime>(
                 probe.window_lines,
                 iterations,
                 probe.blocked,
+                probe.walks(),
                 dtype,
             )
         };
@@ -62,6 +63,7 @@ pub fn memory_direct_throughput<I: Numeric, N: Size>(
     window: usize,
     n_iter: usize,
     #[comptime] blocked: bool,
+    #[comptime] walks: bool,
     #[define(I)] _dtype: ElemType,
 ) {
     let len = output.len();
@@ -84,17 +86,44 @@ pub fn memory_direct_throughput<I: Numeric, N: Size>(
     // — leaving the probe reporting a bandwidth the hardware never moved.
     let mut start = 0;
     let mut wrap = 0;
+    let mut turn = 0;
+
+    // What keeps a pass with no pool to walk from being folded into the one
+    // after it: the copy carries a value no other pass stores. One add against
+    // a line moved in and back out.
+    let mut mark = Vector::<I, N>::empty();
+    let mut stamp = 0;
+    let lanes = mark.vector_size();
+    #[unroll]
+    for lane in 0..lanes {
+        mark.insert(lane, I::cast_from(0));
+    }
 
     for _ in 0..n_iter {
         for step in 0..steps {
+            // A window with no pool to walk turns inside each worker's own run
+            // instead. The addresses still move between passes, without which
+            // the compiler folds a pass that rewrites its own bytes away and
+            // the probe reports twice what the bus can carry, but a line never
+            // changes hands and so is never pulled from the cache holding it.
+            let place = if walks {
+                step
+            } else {
+                let mut turned = step + turn;
+                if turned >= steps {
+                    turned -= steps;
+                }
+                turned
+            };
+
             // Coalesced spreads one step's addresses across adjacent threads,
             // which is only fast where those threads share a real plane. A
             // CPU worker has no such neighbour, so it instead gets a run of
             // `steps` lines entirely its own.
             let base = if blocked {
-                ABSOLUTE_POS * steps + step
+                ABSOLUTE_POS * steps + place
             } else {
-                ABSOLUTE_POS + (step * stride)
+                ABSOLUTE_POS + (place * stride)
             };
 
             if base < window {
@@ -103,22 +132,35 @@ pub fn memory_direct_throughput<I: Numeric, N: Size>(
                     idx -= len;
                 }
 
-                output[idx] = input[idx];
+                output[idx] = if walks { input[idx] } else { input[idx] + mark };
             }
         }
 
-        start += window;
-        // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes. The
-        // test is whether the window starts past the end, not whether it
-        // reaches past: the index wraps, so the last position of a cycle
-        // straddles the end rather than being skipped.
-        if start >= len {
-            wrap += 1;
-            if wrap >= window {
-                wrap = 0;
+        if walks {
+            start += window;
+            // Back to the beginning, one line further along each time round,
+            // so a window that fills the whole buffer still moves between
+            // passes. The test is whether the window starts past the end, not
+            // whether it reaches past: the index wraps, so the last position
+            // of a cycle straddles the end rather than being skipped.
+            if start >= len {
+                wrap += 1;
+                if wrap >= window {
+                    wrap = 0;
+                }
+                start = wrap;
             }
-            start = wrap;
+        } else {
+            turn += 1;
+            if turn >= steps {
+                turn = 0;
+            }
+
+            stamp += 1;
+            #[unroll]
+            for lane in 0..lanes {
+                mark.insert(lane, I::cast_from(stamp));
+            }
         }
     }
 }

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, ir::ElemType};
 use cubecl_runtime::{
     server::Handle,
-    throughput::{DEFAULT_BUFFER_BYTES, MemoryAccess},
+    throughput::{DEFAULT_BUFFER_BYTES, MemorySpec},
 };
 
 use crate::throughput::LaunchConfig;
@@ -93,8 +93,7 @@ impl MemoryProbe {
         client: &ComputeClient<R>,
         config: LaunchConfig,
         line_bytes: usize,
-        access: MemoryAccess,
-        working_set: usize,
+        spec: MemorySpec,
     ) -> Self {
         let blocked = config.plane_size == 1;
         let shape = DeviceShape {
@@ -104,7 +103,7 @@ impl MemoryProbe {
             cube_count: if blocked { 1 } else { config.cube_count },
         };
 
-        Self::sized(shape, line_bytes, access, working_set, blocked)
+        Self::sized(shape, line_bytes, spec, blocked)
     }
 
     /// The geometry itself, with the device reduced to its allocation limit and
@@ -120,15 +119,9 @@ impl MemoryProbe {
     /// neither is the small-kernel behaviour the curve exists to describe: a
     /// kernel that moves little has little in flight, and that is precisely
     /// what limits it.
-    fn sized(
-        shape: DeviceShape,
-        line_bytes: usize,
-        access: MemoryAccess,
-        working_set: usize,
-        blocked: bool,
-    ) -> Self {
-        let buffers = access.buffers() as usize;
-        let window_bytes = working_set / buffers;
+    fn sized(shape: DeviceShape, line_bytes: usize, spec: MemorySpec, blocked: bool) -> Self {
+        let buffers = spec.access.buffers() as usize;
+        let window_bytes = (spec.bytes.min(usize::MAX as u64) as usize) / buffers;
 
         let cold_lines = (shape.max_alloc.min(DEFAULT_BUFFER_BYTES as usize) / line_bytes).max(1);
         let window_lines = (window_bytes / line_bytes).max(1).min(cold_lines);
@@ -139,10 +132,13 @@ impl MemoryProbe {
         // zero is such a device rather than a cacheless one, which
         // `hipDeviceProp_t::l2CacheSize` documents itself as returning, and
         // taken at face value it would pin every window.
-        let pins = shape
-            .cache_bytes
-            .filter(|cache| *cache > 0)
-            .is_some_and(|cache| window_bytes >= cache.saturating_mul(MIN_WINDOW_CACHE_MULTIPLE));
+        let pins = spec.resident
+            || shape
+                .cache_bytes
+                .filter(|cache| *cache > 0)
+                .is_some_and(|cache| {
+                    window_bytes >= cache.saturating_mul(MIN_WINDOW_CACHE_MULTIPLE)
+                });
         let pool_lines = if pins { window_lines } else { cold_lines };
 
         let cube_count = (window_lines / shape.cube_dim).clamp(1, shape.cube_count);
@@ -207,6 +203,7 @@ fn prime_buffer<I: Numeric, N: Size>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cubecl_runtime::throughput::MemoryAccess;
 
     const KB: usize = 1024;
     const MB: usize = 1024 * 1024;
@@ -222,7 +219,8 @@ mod tests {
 
     /// A probe of that device, in the 16-byte lines a `vec4` of f32 comes in.
     fn probe(working_set: usize, access: MemoryAccess) -> MemoryProbe {
-        MemoryProbe::sized(DEVICE, 16, access, working_set, false)
+        let spec = MemorySpec::cold(access, working_set as u64);
+        MemoryProbe::sized(DEVICE, 16, spec, false)
     }
 
     /// The same device, saying nothing about its cache.
@@ -231,7 +229,40 @@ mod tests {
             cache_bytes: None,
             ..DEVICE
         };
-        MemoryProbe::sized(shape, 16, access, working_set, false)
+        let spec = MemorySpec::cold(access, working_set as u64);
+        MemoryProbe::sized(shape, 16, spec, false)
+    }
+
+    /// The same device, asked where a working set already sits.
+    fn resident(working_set: usize, access: MemoryAccess) -> MemoryProbe {
+        let spec = MemorySpec::resident(access, working_set as u64);
+        MemoryProbe::sized(DEVICE, 16, spec, false)
+    }
+
+    #[test]
+    fn a_resident_window_never_walks() {
+        // Far below the cache, where a cold probe would walk furthest.
+        let small = resident(8 * KB, MemoryAccess::Read);
+        assert_eq!(small.pool_lines, small.window_lines);
+        assert_eq!(small.buffer_bytes, 8 * KB);
+        assert_eq!(small.min_iterations(), 1);
+
+        // The cold probe of the same size is the comparison being drawn.
+        assert_eq!(probe(8 * KB, MemoryAccess::Read).pool_lines, 512 * MB / 16);
+    }
+
+    #[test]
+    fn residency_is_asked_for_rather_than_deduced() {
+        // A device that reports no cache cannot tell a resident window from a
+        // cold one, so the request is the only thing that can say so.
+        let shape = DeviceShape {
+            cache_bytes: None,
+            ..DEVICE
+        };
+        let spec = MemorySpec::resident(MemoryAccess::Read, 8 * KB as u64);
+        let probe = MemoryProbe::sized(shape, 16, spec, false);
+
+        assert_eq!(probe.pool_lines, probe.window_lines);
     }
 
     #[test]
@@ -308,7 +339,8 @@ mod tests {
             cache_bytes: Some(0),
             ..DEVICE
         };
-        let probe = MemoryProbe::sized(shape, 16, MemoryAccess::Read, 256 * KB, false);
+        let spec = MemorySpec::cold(MemoryAccess::Read, 256 * KB as u64);
+        let probe = MemoryProbe::sized(shape, 16, spec, false);
 
         assert_eq!(probe.pool_lines, 512 * MB / 16);
     }
@@ -347,7 +379,8 @@ mod tests {
             max_alloc: 4 * MB,
             ..DEVICE
         };
-        let probe = MemoryProbe::sized(shape, 16, MemoryAccess::Read, 512 * MB, false);
+        let spec = MemorySpec::cold(MemoryAccess::Read, 512 * MB as u64);
+        let probe = MemoryProbe::sized(shape, 16, spec, false);
 
         assert_eq!(probe.buffer_bytes, 4 * MB);
         assert_eq!(probe.window_lines, probe.pool_lines);

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -36,6 +36,8 @@ pub struct MemoryProbe {
     /// their wrap-around from `len()`, so a buffer longer than the pool would
     /// walk them past what [`prime`] wrote.
     pub buffer_bytes: usize,
+    /// Whether the probe was asked to measure its working set where it sits.
+    pub resident: bool,
     /// Cubes to dispatch, which is [`LaunchConfig::cube_count`] unless the
     /// window is too small to give every thread a line.
     pub cube_count: usize,
@@ -67,6 +69,18 @@ struct DeviceShape {
 }
 
 impl MemoryProbe {
+    /// Whether a pass moves on rather than turning inside the run each worker
+    /// already holds.
+    ///
+    /// Only a probe asked to stay resident turns. A cold window walks even
+    /// where it is its own pool and has only a line to move by, because that
+    /// line is what its coldness rests on, and because a GPU reports twice the
+    /// write bandwidth it has when a pass stops moving, for reasons that
+    /// survived both a reordering and a per-pass stamp and are not understood.
+    pub fn walks(&self) -> bool {
+        !self.resident
+    }
+
     /// Passes a launch has to carry for the window to come back to bytes a
     /// whole pool of traffic has since evicted, which is the only thing making
     /// a window smaller than the cache cold.
@@ -144,6 +158,7 @@ impl MemoryProbe {
         let cube_count = (window_lines / shape.cube_dim).clamp(1, shape.cube_count);
 
         Self {
+            resident: spec.resident,
             pool_lines,
             window_lines,
             buffer_bytes: pool_lines * line_bytes,

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_runtime::throughput::{KernelConfig, MemoryAccess, ThroughputKey};
+use cubecl_runtime::throughput::{KernelConfig, MemorySpec, ThroughputKey};
 
 use crate::throughput::{
     LaunchConfig,
@@ -26,13 +26,13 @@ pub fn build_kernel<R: Runtime>(
     client: &ComputeClient<R>,
     key: ThroughputKey,
     config: LaunchConfig,
-    working_set: usize,
+    spec: MemorySpec,
 ) -> KernelConfig {
     let client = client.clone();
     let dtype = key.dtype();
 
     let line_bytes = config.vector_size * dtype.size();
-    let probe = MemoryProbe::new(&client, config, line_bytes, MemoryAccess::Read, working_set);
+    let probe = MemoryProbe::new(&client, config, line_bytes, spec);
 
     let in_handle = client.empty(probe.buffer_bytes);
     memory_probe::prime(&client, &in_handle, probe.pool_lines, config, dtype);

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -52,6 +52,7 @@ pub fn build_kernel<R: Runtime>(
                 probe.window_lines,
                 iterations,
                 probe.blocked,
+                probe.walks(),
                 dtype,
             )
         };
@@ -76,6 +77,7 @@ pub fn memory_read_throughput<I: Numeric, N: Size>(
     window: usize,
     n_iter: usize,
     #[comptime] blocked: bool,
+    #[comptime] walks: bool,
     #[define(I)] _dtype: ElemType,
 ) {
     let len = input.len();
@@ -114,17 +116,33 @@ pub fn memory_read_throughput<I: Numeric, N: Size>(
     // reporting the speed of adding a register to itself.
     let mut start = 0;
     let mut wrap = 0;
+    let mut turn = 0;
 
     for _ in 0..n_iter {
         for step in 0..steps {
+            // A window with no pool to walk turns inside each worker's own run
+            // instead. The addresses still move between passes, without which
+            // the compiler folds a pass that rewrites its own bytes away and
+            // the probe reports twice what the bus can carry, but a line never
+            // changes hands and so is never pulled from the cache holding it.
+            let place = if walks {
+                step
+            } else {
+                let mut turned = step + turn;
+                if turned >= steps {
+                    turned -= steps;
+                }
+                turned
+            };
+
             // Coalesced spreads one step's addresses across adjacent threads,
             // which is only fast where those threads share a real plane. A
             // CPU worker has no such neighbour, so it instead gets a run of
             // `steps` lines entirely its own.
             let base = if blocked {
-                ABSOLUTE_POS * steps + step
+                ABSOLUTE_POS * steps + place
             } else {
-                ABSOLUTE_POS + (step * stride)
+                ABSOLUTE_POS + (place * stride)
             };
 
             if base < window {
@@ -137,18 +155,25 @@ pub fn memory_read_throughput<I: Numeric, N: Size>(
             }
         }
 
-        start += window;
-        // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes. The
-        // test is whether the window starts past the end, not whether it
-        // reaches past: the index wraps, so the last position of a cycle
-        // straddles the end rather than being skipped.
-        if start >= len {
-            wrap += 1;
-            if wrap >= window {
-                wrap = 0;
+        if walks {
+            start += window;
+            // Back to the beginning, one line further along each time round,
+            // so a window that fills the whole buffer still moves between
+            // passes. The test is whether the window starts past the end, not
+            // whether it reaches past: the index wraps, so the last position
+            // of a cycle straddles the end rather than being skipped.
+            if start >= len {
+                wrap += 1;
+                if wrap >= window {
+                    wrap = 0;
+                }
+                start = wrap;
             }
-            start = wrap;
+        } else {
+            turn += 1;
+            if turn >= steps {
+                turn = 0;
+            }
         }
     }
 

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 use cubecl_core as cubecl;
-use cubecl_runtime::throughput::{KernelConfig, MemoryAccess, ThroughputKey};
+use cubecl_runtime::throughput::{KernelConfig, MemorySpec, ThroughputKey};
 
 use crate::throughput::{LaunchConfig, memory_probe::MemoryProbe};
 
@@ -20,19 +20,13 @@ pub fn build_kernel<R: Runtime>(
     client: &ComputeClient<R>,
     key: ThroughputKey,
     config: LaunchConfig,
-    working_set: usize,
+    spec: MemorySpec,
 ) -> KernelConfig {
     let client = client.clone();
     let dtype = key.dtype();
 
     let line_bytes = config.vector_size * dtype.size();
-    let probe = MemoryProbe::new(
-        &client,
-        config,
-        line_bytes,
-        MemoryAccess::Write,
-        working_set,
-    );
+    let probe = MemoryProbe::new(&client, config, line_bytes, spec);
 
     let out_handle = client.empty(probe.buffer_bytes);
 

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -42,6 +42,7 @@ pub fn build_kernel<R: Runtime>(
                 probe.window_lines,
                 iterations,
                 probe.blocked,
+                probe.walks(),
                 dtype,
             )
         };
@@ -65,6 +66,7 @@ pub fn memory_write_throughput<I: Numeric, N: Size>(
     window: usize,
     n_iter: usize,
     #[comptime] blocked: bool,
+    #[comptime] walks: bool,
     #[define(I)] _dtype: ElemType,
 ) {
     let len = output.len();
@@ -100,17 +102,34 @@ pub fn memory_write_throughput<I: Numeric, N: Size>(
     // once, leaving the probe reporting a bandwidth the hardware never moved.
     let mut start = 0;
     let mut wrap = 0;
+    let mut turn = 0;
+    let mut mark = 0;
 
     for _ in 0..n_iter {
         for step in 0..steps {
+            // A window with no pool to walk turns inside each worker's own run
+            // instead. The addresses still move between passes, without which
+            // the compiler folds a pass that rewrites its own bytes away and
+            // the probe reports twice what the bus can carry, but a line never
+            // changes hands and so is never pulled from the cache holding it.
+            let place = if walks {
+                step
+            } else {
+                let mut turned = step + turn;
+                if turned >= steps {
+                    turned -= steps;
+                }
+                turned
+            };
+
             // Coalesced spreads one step's addresses across adjacent threads,
             // which is only fast where those threads share a real plane. A
             // CPU worker has no such neighbour, so it instead gets a run of
             // `steps` lines entirely its own.
             let base = if blocked {
-                ABSOLUTE_POS * steps + step
+                ABSOLUTE_POS * steps + place
             } else {
-                ABSOLUTE_POS + (step * stride)
+                ABSOLUTE_POS + (place * stride)
             };
 
             if base < window {
@@ -123,18 +142,35 @@ pub fn memory_write_throughput<I: Numeric, N: Size>(
             }
         }
 
-        start += window;
-        // Back to the beginning, one line further along each time round, so a
-        // window that fills the whole buffer still moves between passes. The
-        // test is whether the window starts past the end, not whether it
-        // reaches past: the index wraps, so the last position of a cycle
-        // straddles the end rather than being skipped.
-        if start >= len {
-            wrap += 1;
-            if wrap >= window {
-                wrap = 0;
+        if walks {
+            start += window;
+            // Back to the beginning, one line further along each time round,
+            // so a window that fills the whole buffer still moves between
+            // passes. The test is whether the window starts past the end, not
+            // whether it reaches past: the index wraps, so the last position
+            // of a cycle straddles the end rather than being skipped.
+            if start >= len {
+                wrap += 1;
+                if wrap >= window {
+                    wrap = 0;
+                }
+                start = wrap;
             }
-            start = wrap;
+        } else {
+            turn += 1;
+            if turn >= steps {
+                turn = 0;
+            }
+
+            // A pass with no pool to walk writes the bytes the pass before it
+            // wrote, and the compiler is entitled to keep only the last of
+            // them. It cannot once no two passes store the same value, which
+            // costs one line of arithmetic against a window of stores.
+            mark += 1;
+            #[unroll]
+            for lane in 0..lanes {
+                line.insert(lane, seed + I::cast_from(mark) + I::cast_from(lane));
+            }
         }
     }
 }

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -1,7 +1,7 @@
 use cubecl::{
     ir::{ElemType, FloatKind},
     prelude::*,
-    std::throughput::{measure_memory_curve, measure_peak_throughput},
+    std::throughput::{measure_memory_curve, measure_peak_throughput, measure_resident_curve},
     throughput::{
         CmmaDims, ComputeCmmaConfig, MemoryAccess, MemoryCurve, ThroughputKey, ThroughputMode,
     },
@@ -82,21 +82,26 @@ pub fn memory_curve<R: Runtime>(device: &R::Device) {
     println!("Memory curve — {}", R::name(&client));
 
     for access in [MemoryAccess::Read, MemoryAccess::Write, MemoryAccess::Copy] {
-        let curve = measure_memory_curve::<R>(&client, access);
-        print_curve(access, &curve);
+        let cold = measure_memory_curve::<R>(&client, access);
+        let resident = measure_resident_curve::<R>(&client, access);
+        print_curve(access, &cold, &resident);
     }
 }
 
-fn print_curve(access: MemoryAccess, curve: &MemoryCurve) {
-    println!("\n  {access:?}");
+fn print_curve(access: MemoryAccess, cold: &MemoryCurve, resident: &MemoryCurve) {
+    println!("\n  {access:?}{:>16}{:>14}", "cold", "resident");
 
-    for point in curve.points() {
-        let bytes_per_s = curve.ceiling_at(point.bytes).unwrap_or(f64::NAN);
+    for point in cold.points() {
+        let rate = |curve: &MemoryCurve| match curve.ceiling_at(point.bytes) {
+            Some(bytes_per_s) => format!("{:.1} GB/s", bytes_per_s / 1e9),
+            None => String::from("N/A"),
+        };
 
         println!(
-            "    {:>10}{:>14}",
+            "    {:>10}{:>14}{:>14}",
             bytes_label(point.bytes),
-            format!("{:.1} GB/s", bytes_per_s / 1e9),
+            rate(cold),
+            rate(resident),
         );
     }
 }
@@ -162,7 +167,8 @@ fn describe(key: &ThroughputKey) -> String {
             input_dtype, cfg.accumulator_type, cfg.cmma_dims.m, cfg.cmma_dims.n, cfg.cmma_dims.k,
         ),
         ThroughputMode::ComputeDirect { .. } => key.dtype().to_string(),
-        ThroughputMode::MemoryWorkingSet { bytes, .. } => bytes_label(bytes),
+        ThroughputMode::MemoryWorkingSet { bytes, .. }
+        | ThroughputMode::MemoryResident { bytes, .. } => bytes_label(bytes),
         ThroughputMode::Memory
         | ThroughputMode::MemoryRead
         | ThroughputMode::MemoryWrite
@@ -178,14 +184,26 @@ fn mode_label(mode: &ThroughputMode) -> &'static str {
         | ThroughputMode::MemoryWorkingSet {
             access: MemoryAccess::Copy,
             ..
+        }
+        | ThroughputMode::MemoryResident {
+            access: MemoryAccess::Copy,
+            ..
         } => "memory",
         ThroughputMode::MemoryRead
         | ThroughputMode::MemoryWorkingSet {
             access: MemoryAccess::Read,
             ..
+        }
+        | ThroughputMode::MemoryResident {
+            access: MemoryAccess::Read,
+            ..
         } => "memory-read",
         ThroughputMode::MemoryWrite
         | ThroughputMode::MemoryWorkingSet {
+            access: MemoryAccess::Write,
+            ..
+        }
+        | ThroughputMode::MemoryResident {
             access: MemoryAccess::Write,
             ..
         } => "memory-write",


### PR DESCRIPTION
Stacked on #1559. Base is `fix/throughput-small-end`; the resident probe needs its iteration cap and sampling budget to mean anything.

## Why

The memory curve answers what a working set reaches *from memory*: its window walks a pool until every pass finds the bytes evicted. A kernel that comes back to a tile it has already touched is asking something else, and against the cold figure it reports several hundred percent and is right to. Nothing measured the other question.

## What it adds

`ThroughputMode::MemoryResident { access, bytes }`, the same probe without the walk. A new variant rather than a flag on `MemoryWorkingSet`, because the cache keys on the serialized mode and a flag would discard every curve anyone has already paid to measure; the existing test that pins those encodings is extended to cover both.

The geometry is free: it is the pinned path #1552 already added, so residency only decides whether to ask for it instead of waiting to be deduced from a size. `MemorySpec` carries what a mode asks of a probe, replacing the `(access, working_set)` pair threaded through the runners, which removed a parameter rather than adding a bool beside `blocked`.

## What it measures

Tower 5700X, 32 MiB L3, GB/s as cold/resident:

| | 8 KiB | 512 KiB | 8 MiB | 32 MiB | 64 MiB | 256 MiB | 512 MiB |
| --- | --- | --- | --- | --- | --- | --- | --- |
| read | 47/**585** | 44/623 | 44/524 | 44/376 | 44/**140** | 44/44 | 44/44 |
| write | 19/**512** | 19/617 | 20/416 | 20/208 | 20/34 | 20/21 | 20/20 |
| copy | 26/**910** | 25/871 | 26/524 | 26/345 | 26/46 | 26/26 | 26/26 |

The resident curve falls off a cliff between 32 and 64 MiB and this machine's L3 is 32 MiB, so the probe locates the last level cache without being told where it is. Above it the two curves converge to the printed digit, which is the check that both measure the same thing once residency stops mattering.

The GPU result is larger. CUDA, same format:

| | 512 KiB | 8 MiB | 32 MiB | 256 MiB | 512 MiB |
| --- | --- | --- | --- | --- | --- |
| read | 617/**6473** | 664/8858 | 660/**13724** | 653/3038 | 660/655 |
| copy | 482/3178 | 505/3464 | 522/3454 | 522/2931 | 521/993 |

**21x** at 32 MiB, converging to 0.8% at 512 MiB, and wgpu and vulkan agree. So a kernel working inside L2 has a ceiling near 13.7 TB/s where the cold curve says 660 GB/s, and scoring it against the cold figure prints around 2000%. Residency is not a CPU concern that GPUs are exempt from; it is larger on the GPU.

## The second commit

A probe holding its working set still has nowhere to walk, so the walk shifted it one line per pass, enough to hand the first line of each worker's run to its neighbour. The line is then pulled out of the cache already holding it once per pass, and a resident 8 KiB write measured **11.8 GB/s against 17.9 for the same bytes read cold**: slower for being in cache, which no store can be. Such a window now turns inside the run each worker owns, so addresses still move and nothing crosses between workers. That point is now 512, and copy 910 against 15.5.

Only a resident probe turns. A cold window keeps walking even where it is its own pool, because that line is what its coldness rests on, and because of the next section.

## Known and not fixed

- **A cold GPU pass that stops moving reports twice the write bandwidth the card has.** Making cold pinned windows stop walking put CUDA write at 512 MiB at 1063 to 1110 GB/s on a card that reads at 660. It survived reordering the addresses within each worker's run and stamping every pass with a distinct value, so it is not the redundant store it resembles. It is avoided rather than understood: cold windows still walk, so no path in this PR reaches it.
- **Resident write and copy do not converge on GPUs at pool-sized working sets**, 1055 and 993 against a cold 519 and 521. A 512 MiB working set claiming to be resident on a card with tens of MB of L2 is close to a contradiction, and the useful part of that curve is everything below it, but the number is wrong rather than merely uninteresting.
- **Nothing consumes the resident curve yet.** `ceiling_at` still takes only a size; deciding which curve a caller wants is the next change.

## Verification

Tower, exclusive benchmark lock, `CUBECL_THROUGHPUT_CACHE=0`, cpu / wgpu / vulkan / cuda. The cold curve is the control, since only resident probes changed: across all 208 cold points the median move against #1559 is **0.5%** and the worst is 8.0%. `cargo fmt`, `cargo clippy` and the `cubecl-runtime` and `cubecl-std` unit suites are clean, with 11 probe geometry tests including one that residency is asked for rather than deduced.
