### PR TITLE
fix(llvm): name overloaded intrinsics for the type they are overloaded on

### DIFF
--- a/crates/cubecl-llvm/src/shared/to_llvm/math.rs
+++ b/crates/cubecl-llvm/src/shared/to_llvm/math.rs
@@ -19,8 +19,12 @@ macro_rules! lower_unary_intrinsic_arith {
                 let res_ty = cube_type_to_llvm(ctx, self.get_result(ctx).get_type(ctx));
                 let intrinsic_type = FuncType::get(ctx, res_ty, vec![elem_ty], false);
 
+                let mut llvm_op = $llvm_op.to_string();
+                llvm_op.push('.');
+                llvm_op.push_str(llvm_mangled_ty(ctx, elem_ty).as_str());
+
                 let op =
-                    llvm::CallIntrinsicOp::new(ctx, $llvm_op.into(), intrinsic_type, vec![input]);
+                    llvm::CallIntrinsicOp::new(ctx, llvm_op.into(), intrinsic_type, vec![input]);
 
                 rewriter.insert_op(ctx, &op);
                 rewriter.replace_operation_with_values(
@@ -465,8 +469,11 @@ impl ToLLVMDialect for FmaOp {
         let res_ty = cube_type_to_llvm(ctx, self.get_result(ctx).get_type(ctx));
         let intrinsic_type = FuncType::get(ctx, res_ty, vec![a_ty, b_ty, c_ty], false);
 
-        let op =
-            llvm::CallIntrinsicOp::new(ctx, "llvm.fmuladd".into(), intrinsic_type, vec![a, b, c]);
+        let mut llvm_op = "llvm.fmuladd".to_string();
+        llvm_op.push('.');
+        llvm_op.push_str(llvm_mangled_ty(ctx, a_ty).as_str());
+
+        let op = llvm::CallIntrinsicOp::new(ctx, llvm_op.into(), intrinsic_type, vec![a, b, c]);
 
         rewriter.insert_op(ctx, &op);
         rewriter.replace_operation_with_values(ctx, self.get_operation(), vec![op.get_result(ctx)]);


### PR DESCRIPTION
`cubek-interpolate` segfaults on the CPU backend, and cubek's `main` has been red since it
took a rev containing #1550. Bisected to that commit, but this is the bug it exposed rather
than a fault in it.

## What

`llvm.fmuladd` and every intrinsic from `lower_unary_intrinsic_arith!` are emitted without a
type suffix, so a declaration reads:

```llvm
declare float @llvm.fmuladd(float, float, float)
```

That is not the intrinsic. An overloaded one is identified by its mangled name,
`@llvm.fmuladd.f32`. pliron-llvm builds the declaration with `llvm_add_function` from the
name alone rather than `getOrInsertDeclaration`, and says in a comment that it cannot work
out the overloaded types from the name and arguments. Here they are known, and
`llvm_mangled_ty` already spells them, which is how the binary macro and `llvm.is.fpclass`
have always named theirs.

## Why it crashes

`IPSCCP` runs `FunctionSpecializer`, which costs every instruction in a candidate block, and
reading an intrinsic that is not one walks off the end of `IntrinsicCostAttributes`:

```
#0 llvm::IntrinsicCostAttributes::IntrinsicCostAttributes(...)
#1 llvm::TargetTransformInfoImplCRTPBase<llvm::X86TTIImpl>::getInstructionCost(...)
#2 llvm::CodeMetrics::analyzeBasicBlock(...)
#3 llvm::FunctionSpecializer::run()
#4 runIPSCCP(...)
```

Reaching it needs a specialization candidate, which is why `llvm.floor` and `llvm.fabs` have
carried the same defect harmlessly for a long time. #1550 put twenty-nine `fmuladd` calls
into a bicubic kernel and found one.

## Verified

On the CPU backend: 727 cubecl tests, and roughly 1700 across cubek's twelve crates.
`cubek-interpolate` goes from a segfaulting binary to 81 passing. The two `cubek-quant` fp4
failures that remain are unrelated to this and fail identically without it.

## Not in this PR

`LLVMRunPasses` is handed a null `TargetMachine`, so the pipeline costs its instructions
against a null model and decides what to inline and vectorize for no particular target.
Attaching a real one changes the backtrace frame above from `NoTTIImpl` to `X86TTIImpl` but
does not fix this crash. Separate change.
