### PR TITLE
fix(plane): document the shuffle up and down boundary as undefined

### DIFF
--- a/crates/cubecl-core/src/frontend/plane.rs
+++ b/crates/cubecl-core/src/frontend/plane.rs
@@ -159,10 +159,11 @@ pub mod plane_shuffle_xor {
 
 /// Perform a shuffle up operation across the plane.
 /// Each unit reads the value from a unit with a lower lane ID (`current_id` - delta).
-/// Units with `lane_id` < delta will read from themselves (no change).
+/// What a unit with `lane_id` < delta reads is undefined and differs by backend, so mask
+/// those units at the call site.
 ///
 /// # Example
-/// For delta=1: `[a, b, c, d] -> [a, a, b, c]`
+/// For delta=1, reading `?` for the undefined unit: `[a, b, c, d] -> [?, a, b, c]`
 #[allow(unused_variables)]
 pub fn plane_shuffle_up<E: CubePrimitive>(value: E, delta: u32) -> E {
     unexpanded!()
@@ -187,10 +188,11 @@ pub mod plane_shuffle_up {
 
 /// Perform a shuffle down operation across the plane.
 /// Each unit reads the value from a unit with a higher lane ID (`current_id` + delta).
-/// Units at the end will read from themselves if (`lane_id` + delta >= `plane_dim`).
+/// What a unit reads when `lane_id` + delta >= `plane_dim` is undefined and differs by
+/// backend, so mask those units at the call site.
 ///
 /// # Example
-/// For delta=1: `[a, b, c, d] -> [b, c, d, d]`
+/// For delta=1, reading `?` for the undefined unit: `[a, b, c, d] -> [b, c, d, ?]`
 #[allow(unused_variables)]
 pub fn plane_shuffle_down<E: CubePrimitive>(value: E, delta: u32) -> E {
     unexpanded!()

--- a/crates/cubecl-core/src/frontend/plane.rs
+++ b/crates/cubecl-core/src/frontend/plane.rs
@@ -159,11 +159,11 @@ pub mod plane_shuffle_xor {
 
 /// Perform a shuffle up operation across the plane.
 /// Each unit reads the value from a unit with a lower lane ID (`current_id` - delta).
-/// What a unit with `lane_id` < delta reads is undefined and differs by backend, so mask
-/// those units at the call site.
+/// A unit with `lane_id` < delta reads an indeterminate value that differs by backend, so
+/// mask those units at the call site.
 ///
 /// # Example
-/// For delta=1, reading `?` for the undefined unit: `[a, b, c, d] -> [?, a, b, c]`
+/// For delta=1, writing `?` for the indeterminate read: `[a, b, c, d] -> [?, a, b, c]`
 #[allow(unused_variables)]
 pub fn plane_shuffle_up<E: CubePrimitive>(value: E, delta: u32) -> E {
     unexpanded!()
@@ -188,11 +188,11 @@ pub mod plane_shuffle_up {
 
 /// Perform a shuffle down operation across the plane.
 /// Each unit reads the value from a unit with a higher lane ID (`current_id` + delta).
-/// What a unit reads when `lane_id` + delta >= `plane_dim` is undefined and differs by
-/// backend, so mask those units at the call site.
+/// A unit whose `lane_id` + delta >= `plane_dim` reads an indeterminate value that differs
+/// by backend, so mask those units at the call site.
 ///
 /// # Example
-/// For delta=1, reading `?` for the undefined unit: `[a, b, c, d] -> [b, c, d, ?]`
+/// For delta=1, writing `?` for the indeterminate read: `[a, b, c, d] -> [b, c, d, ?]`
 #[allow(unused_variables)]
 pub fn plane_shuffle_down<E: CubePrimitive>(value: E, delta: u32) -> E {
     unexpanded!()

--- a/crates/cubecl-core/src/runtime_tests/plane.rs
+++ b/crates/cubecl-core/src/runtime_tests/plane.rs
@@ -140,7 +140,9 @@ pub fn kernel_shuffle_up<F: Float, N: Size>(output: &mut Tensor<Vector<F, N>>) {
     let val = output[UNIT_POS as usize];
     let val2 = plane_shuffle_up(val, 1);
 
-    output[UNIT_POS as usize] = val2;
+    if UNIT_POS_PLANE >= 1 {
+        output[UNIT_POS as usize] = val2;
+    }
 }
 
 #[cube(launch)]
@@ -148,7 +150,9 @@ pub fn kernel_shuffle_down<F: Float, N: Size>(output: &mut Tensor<Vector<F, N>>)
     let val = output[UNIT_POS as usize];
     let val2 = plane_shuffle_down(val, 1);
 
-    output[UNIT_POS as usize] = val2;
+    if UNIT_POS_PLANE + 1 < PLANE_DIM {
+        output[UNIT_POS as usize] = val2;
+    }
 }
 
 pub fn test_plane_sum<
@@ -776,14 +780,13 @@ pub fn test_plane_shuffle_up<
     client: ComputeClient<TestRuntime>,
     vectorization: VectorSize,
 ) {
-    let plane_size = 32;
+    let plane_size = client.properties().hardware.plane_size_max;
     let input: Vec<f32> = (0..plane_size * vectorization as u32)
         .map(|x| x as f32)
         .collect();
     let mut expected = input.clone();
 
-    // Shuffle up with delta=1: lane i gets value from lane (i - 1)
-    // Lane 0 stays the same, lanes 1..31 shift down
+    // Unit 0 is undefined, so the kernel leaves it alone and it keeps its input.
     for lane in 1..plane_size as usize {
         for v in 0..vectorization {
             expected[lane * vectorization + v] = input[(lane - 1) * vectorization + v];
@@ -822,8 +825,7 @@ pub fn test_plane_shuffle_down<
         .collect();
     let mut expected = input.clone();
 
-    // Shuffle down with delta=1: lane i gets value from lane (i + 1)
-    // Lanes 0..30 shift up, lane 31 stays the same
+    // The last unit is undefined, so the kernel leaves it alone and it keeps its input.
     for lane in 0..(plane_size - 1) as usize {
         for v in 0..vectorization {
             expected[lane * vectorization + v] = input[(lane + 1) * vectorization + v];

--- a/crates/cubecl-core/src/runtime_tests/plane.rs
+++ b/crates/cubecl-core/src/runtime_tests/plane.rs
@@ -786,7 +786,7 @@ pub fn test_plane_shuffle_up<
         .collect();
     let mut expected = input.clone();
 
-    // Unit 0 is undefined, so the kernel leaves it alone and it keeps its input.
+    // Unit 0's read is indeterminate, so the kernel skips its write and it keeps its input.
     for lane in 1..plane_size as usize {
         for v in 0..vectorization {
             expected[lane * vectorization + v] = input[(lane - 1) * vectorization + v];
@@ -825,7 +825,7 @@ pub fn test_plane_shuffle_down<
         .collect();
     let mut expected = input.clone();
 
-    // The last unit is undefined, so the kernel leaves it alone and it keeps its input.
+    // The last unit's read is indeterminate, so the kernel skips its write and it keeps its input.
     for lane in 0..(plane_size - 1) as usize {
         for v in 0..vectorization {
             expected[lane * vectorization + v] = input[(lane + 1) * vectorization + v];


### PR DESCRIPTION
`plane_shuffle_up` documented that units with `lane_id` < delta read from themselves,
`[a, b, c, d] -> [a, a, b, c]`, and `plane_shuffle_down` the same at the far end. Two of the
four backends do not do that, and the tests asserting it fail on every non NVIDIA device.

| backend | emits | out of range unit |
| --- | --- | --- |
| CUDA | `__shfl_up_sync(__activemask(), v, d)` | own value, matches the doc |
| HIP | `__shfl_up(v, d)` | own value, matches the doc |
| SPIR-V | `OpGroupNonUniformShuffleUp` | **spec says undefined** |
| WGSL | `subgroupShuffleUp(v, d)` | **spec leaves it indeterminate** |
| Metal | `simd_shuffle_up(v, d)` | **undefined**, untested for lack of hardware |

Note `cubecl-cpp` is split here: CUDA and HIP clamp, Metal does not. Those three backends
emit the intrinsic bare. AMD and Intel wrap to the far end of the plane,
which the specs permit; NVIDIA happens to return the own value, so the promise held only
there. The failures are exactly that wrap: `shuffle_up` at unit 0 returns the last unit's
value, `shuffle_down` at the last unit returns unit 0's.

## Why document rather than guarantee

Guaranteeing the clamp means a compare and a select on every shuffle in both backends, to
serve nobody. The only caller of these two ops in the tree is the C++ scan polyfill, and it
already masks the boundary itself with `if UNIT_POS_PLANE >= offset`, because a scan needs
that mask for its own correctness regardless. SPIR-V and WGSL never reach that polyfill
anyway: their scans map to `GroupNonUniformIAdd` and `FAdd` with `InclusiveScan` and
`ExclusiveScan`, which is why the scan tests pass on AMD and Intel while these do not.

So the contract moves to match the two specs, and the docs name the divergence rather than
promising something only CUDA and HIP deliver.

## Tests

The kernels skip the write where the shuffle is undefined, the same idiom the scan polyfill
uses, so the undefined unit keeps its input. The expected values did not need to change.

```rust
let val2 = plane_shuffle_up(val, 1);
if UNIT_POS_PLANE >= 1 {
    output[UNIT_POS as usize] = val2;
}
```

`test_plane_shuffle_up` also hardcoded a plane size of 32 while `test_plane_shuffle_down`
queried `plane_size_max`, so on a 64 wide wave the two covered different things. It now
queries too, which makes `PLANE_DIM` meaningful in the shuffle down guard.

Both tests still assume one plane spans the whole cube, that `PLANE_DIM` equals
`plane_size_max` at runtime. On WGSL that value is `adapter_info.subgroup_max_size`, so a
driver picking a narrower subgroup would split the cube in two and fail on an interior
boundary unit rather than the one the guard skips. That is pre-existing in the down test and
this hands it to the up test as well. Out of scope here, but named so a future red run has
its explanation.

## Verified

Where the shuffle tests were failing: Intel iGPU 12 and 18 failures on WGSL and SPIR-V, now
24 and 36 passing; AMD RX 7600 the same 12 and 18, now 89 and 133 passing.

Where they already passed, whole suites run with and without the change on the same machine:
RTX 4070 Ti gives WGSL 484, Vulkan 708 and CUDA 860 with one failure, AMD HIP gives 89, CPU
gives 133. Every arm has an identical failure set to its baseline. The one CUDA failure is
`tests::test_cmma_manual`, unrelated and present either way.

CUDA and HIP are where the old wording actually held, so they are the two that could have
regressed. Neither did, which is expected: their shuffle already returns the unit's own
value, so skipping the write stores the same thing.

Worth a second opinion from whoever owns the plane API, since this is a contract change even
though no in tree caller depends on the old wording.
