### PR TITLE
fix(llvm): give ue8m0 a type, and report it on the CPU backend

### DIFF
--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -68,7 +68,7 @@ fn register_supported_types(props: &mut DeviceProperties) {
         props.register_type_usage(ty, TypeUsage::all());
     }
 
-    for ty in [FloatKind::E4M3, FloatKind::E5M2] {
+    for ty in [FloatKind::E4M3, FloatKind::E5M2, FloatKind::UE8M0] {
         props.register_type_usage(
             ElemType::Float(ty),
             TypeUsage::Conversion | TypeUsage::Buffer,

--- a/crates/cubecl-llvm/src/shared/to_llvm/ty.rs
+++ b/crates/cubecl-llvm/src/shared/to_llvm/ty.rs
@@ -2,7 +2,8 @@ use super::prelude::*;
 use cubecl_core::ir::types::{
     ArrayType, AtomicType,
     scalar::{
-        Float8E4M3Type, Float8E5M2Type, Float16Type, Float32Type, Float64Type, FloatFlex32Type,
+        Float8E4M3Type, Float8E5M2Type, Float8E8M0Type, Float16Type, Float32Type, Float64Type,
+        FloatFlex32Type,
     },
 };
 use pliron::printable::Printable;
@@ -30,6 +31,7 @@ impl_cube_to_llvm_type!(FloatFlex32Type, self, ctx => FP32Type::get(ctx));
 impl_cube_to_llvm_type!(Float16Type, self, ctx => FP16Type::get(ctx));
 impl_cube_to_llvm_type!(Float8E4M3Type, self, ctx => IntegerType::get(ctx, 8, Signedness::Signless));
 impl_cube_to_llvm_type!(Float8E5M2Type, self, ctx => IntegerType::get(ctx, 8, Signedness::Signless));
+impl_cube_to_llvm_type!(Float8E8M0Type, self, ctx => IntegerType::get(ctx, 8, Signedness::Signless));
 impl_cube_to_llvm_type!(CubePointerType, self, ctx => LlvmPointerType::get(ctx, 0));
 impl_cube_to_llvm_type!(CubeVectorType, self, ctx => LlvmVectorType::get(ctx, cube_type_to_llvm(ctx, self.inner), self.vectorization as u32, VectorTypeKind::Fixed));
 impl_cube_to_llvm_type!(AtomicType, self, ctx => cube_type_to_llvm(ctx, self.inner));


### PR DESCRIPTION
A kernel holding a `ue8m0` buffer never compiles on the CPU backend. `cubecl-llvm` maps `Float8E4M3Type` and `Float8E5M2Type` onto an 8-bit integer and has no line for `Float8E8M0Type`, so conversion fails with `MissingTypeConversion("cube.ue8m0")`. That panics on the dispatch thread rather than at the call site, the launch is dropped, and the caller reads back whatever was in the output buffer.

Downstream, that is MXFP4: the format keeps its block scale in `ue8m0`, so quantizing and dequantizing on `cubecl/cpu` both no-op and every value reconstructs as zero. It is what turns [cubek](https://github.com/tracel-ai/cubek)'s `cubek-quant` CPU job red today, as `9.0 landed at 0` rather than as a compile error.

The second commit is why this was never caught here. Every `ue8m0` test in the runtime suite gates on `ue8m0::supported_uses(client).contains(TypeUsage::Conversion)`, and `cubecl-cpu` registers `E4M3` and `E5M2` only, so all of them skipped on this backend. Vulkan and CUDA both register `UE8M0` already. Among the tests it re-enables is `runtime_tests::minifloat::test_scale`, which writes exactly the buffer the missing type crashed on.

Measured on this branch, the same ten tests with and without the registration:

|                             | skips | tests that ran |
| --------------------------- | ----- | -------------- |
| without the registration    | 21    | 0              |
| with it                     | 0     | 10             |

## Verification

- `cargo test -p cubecl-cpu`: 727 passed, 0 failed, 19 ignored.
- The ten newly reachable `ue8m0` tests pass for real, with no `Unsupported, skipping` left in the output.
- `cubek-quant` on `cubecl/cpu`, with cubek's cubecl deps pointed at this branch: 48 passed, 0 failed. The two MXFP4 round-trip tests that fail on cubek `main` pass.

## Validate your PR with burn.

- [x] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [x] Fix any broken tests or compilation errors in cubek. Nothing to fix: this repairs cubek `main` as it stands, and needs no change there.
- [ ] Submit a PR in cubek with your fixes and link it here. Not applicable, no cubek change is needed.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
