### PR TITLE
fix(tests): floor the approx tolerance at a few ulps instead of scaling it

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/binary.rs
+++ b/crates/cubecl-core/src/runtime_tests/binary.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::approx_constant)]
 
-use core::f32;
-
 use core::fmt::Display;
 
 use crate::{self as cubecl, as_type};
@@ -10,6 +8,9 @@ use cubecl_environment::sync::LazyLock;
 use cubecl::prelude::*;
 use cubecl_runtime::server::Handle;
 use enumset::EnumSet;
+
+/// Set by reductions: they round twice per term against a reference `f16` cannot hold.
+const ULPS_ALLOWED: f32 = 32.0;
 
 #[track_caller]
 pub(crate) fn assert_equals_approx<R: Runtime, F: num_traits::Float + CubeElement + Display>(
@@ -21,8 +22,7 @@ pub(crate) fn assert_equals_approx<R: Runtime, F: num_traits::Float + CubeElemen
     let actual = client.read_one_unchecked(output);
     let actual = F::from_bytes(&actual);
 
-    // normalize to type epsilon
-    let epsilon = (epsilon / f32::EPSILON * F::epsilon().to_f32().unwrap()).max(epsilon);
+    let epsilon = epsilon.max(F::epsilon().to_f32().unwrap() * ULPS_ALLOWED);
 
     for (i, (a, e)) in actual[0..expected.len()]
         .iter()


### PR DESCRIPTION
`assert_equals_approx` scaled the caller's tolerance by the ratio of the type's epsilon to
`f32`'s. That ratio is 8192 at `f16`, so a caller's `0.001` became `8.192` and the plane tests'
`1e-5` became `0.082`, before the per-value scaling was applied on top. On a value of 72 that
allowed an absolute error of 590. `f32` was unaffected, the ratio being 1, and `f64` was
clamped by the `max`.

A narrower type needs the tolerance widened only as far as its own resolution reaches, so
the caller's relative figure now takes a floor of a few units in the last place rather than
a multiplier.

## Why 32 ULP

`test_dot` sets the floor. A reduction rounds twice per term, and at `f16` the reference it
is compared against carries digits the accumulator cannot, which reads as 0.113 on 7.76.
Everything else passes well inside it.

## Not a full fix

The per-value scaling means a large result stays loose, 2.21 on a value of 70 at `f16`, and
a reduction wants a different tolerance from a multiply, which one shared constant cannot
express. Both would want epsilons threaded per operation.

## Testing

A/B against the same tree with only this hunk reverted, comparing failure sets rather than
counts, since pre-existing failures differ by machine. **Every arm has an identical failure
set to its baseline.**

| backend | tightened | baseline |
|---|---|---|
| CUDA, RTX 4070 Ti Super | 893 passed, 1 failed | same |
| Vulkan / SPIR-V, Intel iGPU | 720 passed, 18 failed | same |
| WGSL, Intel iGPU | 498 passed, 12 failed | same |
| CPU | 757 passed, 0 failed | same |

Every row is a rerun with the branch rebased on `e390821e`. The one CUDA failure is
`tests::test_cmma_manual`, which fails on `sm_89` with `Feature '.kind::f8f6f4' not supported`.
Every Vulkan and WGSL failure is `plane_shuffle`, all 30 of them, fixed by #1564. Not one other
`assert_equals_approx` failure anywhere.

Checked on its own rather than inherited from #1562, which was verified with both changes
applied together. The tolerance moves in the direction that can newly fail, so a combined run
does not cover it.





