### PR TITLE
chore(miri): rename the fetch_update deprecrated method to remove miri warnings

### DIFF
--- a/crates/cubecl-environment/src/stream/policy.rs
+++ b/crates/cubecl-environment/src/stream/policy.rs
@@ -69,7 +69,7 @@ pub fn policy() -> StreamPolicy {
 /// wins over configuration.
 #[doc(hidden)]
 pub fn set_policy_from_config(policy: StreamPolicy) {
-    let _ = POLICY.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+    let _ = POLICY.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
         if current & SET_BY_USER != 0 {
             None
         } else {


### PR DESCRIPTION
The name replacement is what the miri test warnings to the new function was so behavior should stay the same.