### PR TITLE
fix(cpp): an accumulator fragment names no layout

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/cmma.rs
+++ b/crates/cubecl-core/src/runtime_tests/cmma.rs
@@ -483,8 +483,8 @@ pub fn test_simple_1_vectorized_offset<R: Runtime>(
 #[cube(launch)]
 /// Executes Out = Lhs @ Rhs.T with the accumulator declaring a layout.
 ///
-/// Every other kernel here leaves it [`Undefined`](cmma::MatrixLayout::Undefined),
-/// which is the only value the C++ backends used to emit correctly.
+/// An accumulator's layout is its own and never reaches the product, so declaring
+/// one must compile and change nothing.
 pub fn kernel_accumulator_row_major(lhs: &[f16], rhs: &[f16], out: &mut [f32]) {
     let a = cmma::Matrix::<f16>::from_slice(
         cmma::MatrixIdent::A,
@@ -552,8 +552,6 @@ pub fn test_accumulator_row_major<R: Runtime>(client: ComputeClient<R>, cube_dim
     let actual = client.read_one_unchecked(out);
     let actual = f32::from_bytes(&actual);
 
-    // The layout is the accumulator's own, not the operands', so stating it
-    // changes nothing about the product.
     assert_eq!(test_simple_1_expected(), actual);
 }
 

--- a/crates/cubecl-core/src/runtime_tests/cmma.rs
+++ b/crates/cubecl-core/src/runtime_tests/cmma.rs
@@ -480,6 +480,83 @@ pub fn test_simple_1_vectorized_offset<R: Runtime>(
     );
 }
 
+#[cube(launch)]
+/// Executes Out = Lhs @ Rhs.T with the accumulator declaring a layout.
+///
+/// Every other kernel here leaves it [`Undefined`](cmma::MatrixLayout::Undefined),
+/// which is the only value the C++ backends used to emit correctly.
+pub fn kernel_accumulator_row_major(lhs: &[f16], rhs: &[f16], out: &mut [f32]) {
+    let a = cmma::Matrix::<f16>::from_slice(
+        cmma::MatrixIdent::A,
+        16usize,
+        16usize,
+        16usize,
+        cmma::MatrixLayout::RowMajor,
+        lhs,
+        16,
+    );
+    let b = cmma::Matrix::<f16>::from_slice(
+        cmma::MatrixIdent::B,
+        16usize,
+        16usize,
+        16usize,
+        cmma::MatrixLayout::ColMajor,
+        rhs,
+        16,
+    );
+    let c = cmma::Matrix::<f32>::from_value(
+        cmma::MatrixIdent::Accumulator,
+        16usize,
+        16usize,
+        16usize,
+        cmma::MatrixLayout::RowMajor,
+        0.0,
+    );
+
+    cmma::execute(&a, &b, &c, &c);
+
+    cmma::store(out, &c, 16, cmma::MatrixLayout::RowMajor);
+}
+
+pub fn test_accumulator_row_major<R: Runtime>(client: ComputeClient<R>, cube_dimensions: CubeDim) {
+    if !client.features().matmul.cmma.contains(&MmaConfig {
+        a_type: ElemType::Float(FloatKind::F16),
+        b_type: ElemType::Float(FloatKind::F16),
+        cd_type: ElemType::Float(FloatKind::F32),
+        m: 16,
+        k: 16,
+        n: 16,
+    }) {
+        // We can't execute the test, skip.
+        return;
+    }
+
+    let lhs: Vec<f16> = (0..256).map(|i| f16::from_f32(i as f32)).collect();
+    let rhs: Vec<f16> = (0..256).map(|i| f16::from_f32((i % 8) as f32)).collect();
+
+    let lhs = client.create_from_slice(f16::as_bytes(&lhs));
+    let rhs = client.create_from_slice(f16::as_bytes(&rhs));
+    let out = client.empty(core::mem::size_of::<f32>() * 256);
+
+    unsafe {
+        kernel_accumulator_row_major::launch(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            cube_dimensions,
+            BufferArg::from_raw_parts(lhs, 256),
+            BufferArg::from_raw_parts(rhs, 256),
+            BufferArg::from_raw_parts(out.clone(), 256),
+        )
+    };
+
+    let actual = client.read_one_unchecked(out);
+    let actual = f32::from_bytes(&actual);
+
+    // The layout is the accumulator's own, not the operands', so stating it
+    // changes nothing about the product.
+    assert_eq!(test_simple_1_expected(), actual);
+}
+
 pub fn test_simple_1<R: Runtime>(client: ComputeClient<R>, cube_dimensions: CubeDim) {
     if !client.features().matmul.cmma.contains(&MmaConfig {
         a_type: ElemType::Float(FloatKind::F16),
@@ -1741,6 +1818,16 @@ macro_rules! testgen_cmma {
             let client = TestRuntime::client(&Default::default());
             let cube_dimensions = cube_dim::<TestRuntime>(&client);
             cubecl_core::runtime_tests::cmma::test_simple_1_vectorized_offset::<TestRuntime>(
+                client,
+                cube_dimensions,
+            );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_cmma_accumulator_row_major() {
+            let client = TestRuntime::client(&Default::default());
+            let cube_dimensions = cube_dim::<TestRuntime>(&client);
+            cubecl_core::runtime_tests::cmma::test_accumulator_row_major::<TestRuntime>(
                 client,
                 cube_dimensions,
             );

--- a/crates/cubecl-cpp/src/shared/mma.rs
+++ b/crates/cubecl-cpp/src/shared/mma.rs
@@ -84,13 +84,16 @@ pub mod wmma_api_base {
             MatrixIdent::Accumulator => format!("{ns}::accumulator"),
         };
         let MatrixShape { m, n, k } = ty.shape;
-        // An accumulator fragment naming a layout is a type that does not exist.
+        // The layout-free fragment specialization exists for the accumulator and for nothing else.
         let layout = match (ty.ident, ty.layout) {
-            (MatrixIdent::Accumulator, _) | (_, MatrixLayout::Undefined) => {
+            (MatrixIdent::Accumulator, _) => {
                 return format!("{ns}::fragment<{ident}, {m}, {n}, {k}, {elem}>");
             }
             (_, MatrixLayout::ColMajor) => format!("{ns}::col_major"),
             (_, MatrixLayout::RowMajor) => format!("{ns}::row_major"),
+            (_, MatrixLayout::Undefined) => {
+                panic!("An A or B fragment names the layout of the data it is loaded from.")
+            }
         };
         format!("{ns}::fragment<{ident}, {m}, {n}, {k}, {elem}, {layout}>")
     }

--- a/crates/cubecl-cpp/src/shared/mma.rs
+++ b/crates/cubecl-cpp/src/shared/mma.rs
@@ -84,12 +84,13 @@ pub mod wmma_api_base {
             MatrixIdent::Accumulator => format!("{ns}::accumulator"),
         };
         let MatrixShape { m, n, k } = ty.shape;
-        let layout = match ty.layout {
-            MatrixLayout::ColMajor => format!("{ns}::col_major"),
-            MatrixLayout::RowMajor => format!("{ns}::row_major"),
-            MatrixLayout::Undefined => {
+        // An accumulator fragment naming a layout is a type that does not exist.
+        let layout = match (ty.ident, ty.layout) {
+            (MatrixIdent::Accumulator, _) | (_, MatrixLayout::Undefined) => {
                 return format!("{ns}::fragment<{ident}, {m}, {n}, {k}, {elem}>");
             }
+            (_, MatrixLayout::ColMajor) => format!("{ns}::col_major"),
+            (_, MatrixLayout::RowMajor) => format!("{ns}::row_major"),
         };
         format!("{ns}::fragment<{ident}, {m}, {n}, {k}, {elem}, {layout}>")
     }


### PR DESCRIPTION
`compile_matrix` chose the layout from `MatrixLayout` alone, so an accumulator declared with one was emitted as a fragment specialization that does not exist. nvrtc reports an incomplete type, and every use of the fragment fails to resolve after it.

Reached from the tiled Cmma matmul on CUDA, and from rocWMMA on HIP, which share the emitter. Every cmma runtime test declared its accumulator undefined, which is the one value the old match handled.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
