### PR TITLE
fix(ir): an scf.if reports its condition as its result to SCCP

### DIFF
--- a/crates/cubecl-ir/src/dialect/scf.rs
+++ b/crates/cubecl-ir/src/dialect/scf.rs
@@ -90,12 +90,27 @@ impl IfOp {
 
 #[op_interface_impl]
 impl ConstFoldInterface for IfOp {
+    /// One entry per *result*, and an `IfOp`'s results are what its taken branch yields — never
+    /// its condition. Returning the operands verbatim mapped the condition onto result 0, so
+    /// `if true { yield x } else { yield false }` published "result 0 is constant true" into the
+    /// lattice. Nothing checks that claim against the branch, so the next `IfOp` down a guard
+    /// chain saw a constant-true condition and [`fold_in_place`](Self::fold_in_place) inlined its
+    /// `then` block unconditionally, dropping its own guard — and the one after that, for as long
+    /// as the chain ran. A bounds test written as an accumulating chain (`in_bounds = in_bounds
+    /// && this_axis_in_bounds`) collapsed to its innermost term, which is how a padded
+    /// convolution came to read outside its input.
+    ///
+    /// The yielded values' constness is not knowable from `operand_attrs` — those are the
+    /// operands, and the yields live in the regions — so nothing is claimed here. A constant
+    /// condition still folds, in `fold_in_place`, which SCCP calls off the operand lattice rather
+    /// than off this; the yielded value then reaches its uses as an ordinary SSA forward and
+    /// carries whatever constness it actually has.
     fn check_fold(
         &self,
-        _ctx: &Context,
-        operand_attrs: &[Option<AttrObj>],
+        ctx: &Context,
+        _operand_attrs: &[Option<AttrObj>],
     ) -> Vec<Option<AttrObj>> {
-        operand_attrs.to_vec()
+        vec![None; self.results(ctx).len()]
     }
 
     fn fold_in_place(


### PR DESCRIPTION
`ConstFoldInterface::check_fold` returns one entry per *result*. `IfOp` returned `operand_attrs.to_vec()`, and an `IfOp`'s only operand is its condition, so the condition's constness was published as result 0's.

Nothing checks that claim against the branch. `if true { yield x } else { yield false }` therefore entered the lattice as "result 0 is constant true", and the next `IfOp` down a chain saw a constant-true condition: `fold_in_place` inlined its `then` block unconditionally, dropped its own guard, and handed the same false claim to the one after it.

That is fatal to a guard written as an accumulator — `in_bounds = in_bounds && this_axis_in_bounds`, which is how the tile DSL emits a bounds test. The chain collapsed to its innermost term. In a padded convolution the emitted SPIR-V kept `h >= 0` only to clamp the index to zero and carried no `h < shape` check at all, so a tap outside the input read element 0 instead of masking, and a tap further out read off the end of the buffer — wrong results, then a GPUVM fault and a lost device. WGSL was unaffected: it does not run this pipeline.

Claim nothing here instead. The yielded values' constness is not knowable from `operand_attrs` — those are the operands, and the yields live in the regions. A constant condition still folds, in `fold_in_place`, which SCCP calls off the operand lattice rather than off `check_fold`; the yielded value then reaches its uses as an ordinary SSA forward and carries whatever constness it actually has.

Verified on Vulkan (radv, gfx1151) against cubek b93b3f1:
  - cubek-convolution depthwise:  1 passed / 6 failed  ->  7 passed
  - cubek-tile (vulkan):        172 passed / 30 failed -> 190 passed
  - burn conv2d_groups autodiff:  9 failed + device loss -> 12 passed

No test is added: cubecl has no harness for driving a pass pipeline over hand-built IR, and the behaviour is already covered by cubek's `conv1d_padded_underflow_masks_to_zero` and its depthwise suite.