### PR TITLE
Add fine-grained memory clobbers for `gpu_asm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "itertools 0.15.0",
  "num",
  "num-traits",
+ "paste",
  "pliron",
  "pliron-spirv",
  "portable-atomic",

--- a/crates/cubecl-core/src/frontend/asm.rs
+++ b/crates/cubecl-core/src/frontend/asm.rs
@@ -2,7 +2,7 @@ use alloc::{string::String, vec::Vec};
 
 use cubecl_ir::{
     AddressSpace, Scope,
-    dialect::{InlineAsmOp, OperationPtrExt},
+    dialect::{InlineAsmOp, MemoryClobbers, OperationPtrExt},
     interfaces::TypeExt,
 };
 use pliron::{op::Op, r#type::Typed, value::Value};
@@ -114,25 +114,29 @@ impl BuildAsmExpand {
             .iter()
             .map(|it| it.get_type(ctx).as_ptr(ctx).inner)
             .collect();
+        let memory_clobbers = if self.nomem {
+            MemoryClobbers::Nomem
+        } else if self.readonly {
+            MemoryClobbers::Readonly
+        } else if self.explicit_mem {
+            MemoryClobbers::Explicit {
+                reads_spaces: self.reads_spaces.into(),
+                writes_spaces: self.writes_spaces.into(),
+            }
+        } else {
+            MemoryClobbers::ReadWrite
+        };
         let op = InlineAsmOp::new(
             ctx,
             result_types,
             self.out_specs,
             self.asm,
+            memory_clobbers,
             self.in_values,
             self.in_specs,
         );
         if self.pure {
             op.set_pure(ctx);
-        }
-        if self.nomem {
-            op.set_nomem(ctx);
-        }
-        if self.explicit_mem {
-            op.set_explicit_mem(ctx);
-        }
-        if self.readonly {
-            op.set_readonly(ctx);
         }
         scope.register(&op);
         // Store results back to out expand values

--- a/crates/cubecl-core/src/frontend/asm.rs
+++ b/crates/cubecl-core/src/frontend/asm.rs
@@ -1,7 +1,7 @@
 use alloc::{string::String, vec::Vec};
 
 use cubecl_ir::{
-    Scope,
+    AddressSpace, Scope,
     dialect::{InlineAsmOp, OperationPtrExt},
     interfaces::TypeExt,
 };
@@ -9,14 +9,21 @@ use pliron::{op::Op, r#type::Typed, value::Value};
 
 use crate::frontend::{HasValue, assign};
 
+pub use cubecl_ir::dialect::{InputKind, InputSpec, RegSpec};
+
 #[derive(Default)]
 pub struct BuildAsmExpand {
     asm: String,
     out_values: Vec<Value>,
+    out_specs: Vec<RegSpec>,
     in_values: Vec<Value>,
+    in_specs: Vec<InputSpec>,
     pure: bool,
     nomem: bool,
+    explicit_mem: bool,
     readonly: bool,
+    reads_spaces: Vec<AddressSpace>,
+    writes_spaces: Vec<AddressSpace>,
 }
 
 impl BuildAsmExpand {
@@ -30,15 +37,23 @@ impl BuildAsmExpand {
     // Takes by reference because of syntax reasons, since normal Rust allows immutables that are
     // uninitialized and only assigned once (i.e. as the output for an assembly macro).
     // We also only assign once, so reference gives the correct semantics.
-    pub fn push_output<T: HasValue>(mut self, scope: &Scope, output: &T) -> Self {
+    pub fn push_output<T: HasValue>(mut self, scope: &Scope, output: &T, spec: RegSpec) -> Self {
         let value = output.value(scope);
         self.out_values.push(value);
+        self.out_specs.push(spec);
         self
     }
 
-    pub fn push_input<T: HasValue>(mut self, scope: &Scope, input: T) -> Self {
+    pub fn push_input<T: HasValue>(
+        mut self,
+        scope: &Scope,
+        input: T,
+        kind: InputKind,
+        spec: RegSpec,
+    ) -> Self {
         let value = input.value(scope);
         self.in_values.push(value);
+        self.in_specs.push(InputSpec::new(kind, spec));
         self
     }
 
@@ -52,8 +67,43 @@ impl BuildAsmExpand {
         self
     }
 
+    pub fn explicit_mem(mut self) -> Self {
+        self.explicit_mem = true;
+        self
+    }
+
     pub fn readonly(mut self) -> Self {
         self.readonly = true;
+        self
+    }
+
+    pub fn reads_local(mut self) -> Self {
+        self.reads_spaces.push(AddressSpace::Local);
+        self
+    }
+
+    pub fn reads_shared(mut self) -> Self {
+        self.reads_spaces.push(AddressSpace::Shared);
+        self
+    }
+
+    pub fn reads_global(mut self) -> Self {
+        self.reads_spaces.push(AddressSpace::Global(0));
+        self
+    }
+
+    pub fn writes_local(mut self) -> Self {
+        self.writes_spaces.push(AddressSpace::Local);
+        self
+    }
+
+    pub fn writes_shared(mut self) -> Self {
+        self.writes_spaces.push(AddressSpace::Shared);
+        self
+    }
+
+    pub fn writes_global(mut self) -> Self {
+        self.writes_spaces.push(AddressSpace::Global(0));
         self
     }
 
@@ -64,12 +114,22 @@ impl BuildAsmExpand {
             .iter()
             .map(|it| it.get_type(ctx).as_ptr(ctx).inner)
             .collect();
-        let op = InlineAsmOp::new(ctx, result_types, self.asm, self.in_values);
+        let op = InlineAsmOp::new(
+            ctx,
+            result_types,
+            self.out_specs,
+            self.asm,
+            self.in_values,
+            self.in_specs,
+        );
         if self.pure {
             op.set_pure(ctx);
         }
         if self.nomem {
             op.set_nomem(ctx);
+        }
+        if self.explicit_mem {
+            op.set_explicit_mem(ctx);
         }
         if self.readonly {
             op.set_readonly(ctx);

--- a/crates/cubecl-core/src/runtime_tests/barrier.rs
+++ b/crates/cubecl-core/src/runtime_tests/barrier.rs
@@ -1,4 +1,4 @@
-use crate::{self as cubecl, as_bytes};
+use crate::{self as cubecl, as_bytes, frontend::barrier::copy_async};
 use alloc::vec::Vec;
 use barrier::Barrier;
 use cubecl::prelude::*;
@@ -6,7 +6,7 @@ use cubecl_ir::OpaqueType;
 use num_traits::Zero;
 
 #[cube(launch)]
-pub fn async_copy_test<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut [Vector<F, N>]) {
+pub fn async_memcpy_test<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut [Vector<F, N>]) {
     let barrier = Barrier::local();
     let mut smem = Shared::new_slice(1usize);
 
@@ -19,7 +19,7 @@ pub fn async_copy_test<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut [
     output[0] = smem[0];
 }
 
-pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(client: ComputeClient<R>) {
+pub fn test_async_memcpy<R: Runtime, F: Float + CubeElement>(client: ComputeClient<R>) {
     if !client.properties().supports_type(OpaqueType::Barrier) {
         // We can't execute the test, skip.
         return;
@@ -29,7 +29,7 @@ pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(client: ComputeClient
     let output = client.empty(core::mem::size_of::<F>());
 
     unsafe {
-        async_copy_test::launch::<F, R>(
+        async_memcpy_test::launch::<F, R>(
             &client,
             CubeCount::Static(1, 1, 1),
             CubeDim::new_1d(1),
@@ -43,6 +43,51 @@ pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(client: ComputeClient
     let actual = F::from_bytes(&actual);
 
     assert_eq!(actual[0], F::new(2.0));
+}
+
+#[cube(launch)]
+pub fn async_copy_test<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut [Vector<F, N>]) {
+    let elected = plane_elect();
+    let barrier = Barrier::shared(1u32, elected);
+    // Align to 16 to avoid any issues with misaligned pointers
+    let mut smem = Shared::new_aligned_slice(2usize, 16usize);
+
+    if elected {
+        let source = &input[2..4];
+        let destination = &mut smem[..2];
+        copy_async(source, destination, 2u32);
+
+        barrier.commit_copy_async();
+        barrier.arrive_and_wait();
+        output[0] = smem[0];
+        output[1] = smem[1];
+    }
+}
+
+pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(client: ComputeClient<R>) {
+    if !client.properties().features.copy_async {
+        // We can't execute the test, skip.
+        return;
+    }
+
+    let input = client.create_from_slice(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
+    let output = client.empty(core::mem::size_of::<F>() * 2);
+
+    unsafe {
+        async_copy_test::launch::<F, R>(
+            &client,
+            CubeCount::Static(1, 1, 1),
+            CubeDim::new_1d(1),
+            1,
+            BufferArg::from_raw_parts(input, 5),
+            BufferArg::from_raw_parts(output.clone(), 2),
+        )
+    };
+
+    let actual = client.read_one_unchecked(output);
+    let actual = F::from_bytes(&actual);
+
+    assert_eq!(actual, [F::new(2.0), F::new(3.0)]);
 }
 
 #[cube(launch)]
@@ -233,6 +278,14 @@ macro_rules! testgen_barrier {
         fn test_barrier_async_copy() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::barrier::test_async_copy::<TestRuntime, FloatType>(client);
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_barrier_async_memcpy() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::barrier::test_async_memcpy::<TestRuntime, FloatType>(
+                client,
+            );
         }
 
         #[$crate::runtime_tests::test_log::test]

--- a/crates/cubecl-cpp/src/cuda/plane.rs
+++ b/crates/cubecl-cpp/src/cuda/plane.rs
@@ -4,10 +4,7 @@ use cubecl_core::{
     prelude::*,
 };
 use pliron::{
-    builtin::{
-        attributes::UnitAttr,
-        types::{IntegerType, Signedness},
-    },
+    builtin::types::{IntegerType, Signedness},
     derive::op_interface_impl,
     value::Value,
 };
@@ -80,7 +77,6 @@ impl LowerOp<Cuda> for ElectOp {
                 "selp.b32 $0, 1, 0, %%px;"
             };
             let op = InlinePtxOp::new_volatile(ctx, Some(u32), ptx, vec![]);
-            op.set_attr_cuda_inline_ptx_nomem(ctx, UnitAttr::new());
             scope.register(&op);
             let cast = cast_value(scope, op.result(ctx).unwrap(), BoolType::get(ctx).into());
             vec![cast]

--- a/crates/cubecl-cpp/src/cuda/plane.rs
+++ b/crates/cubecl-cpp/src/cuda/plane.rs
@@ -4,7 +4,10 @@ use cubecl_core::{
     prelude::*,
 };
 use pliron::{
-    builtin::types::{IntegerType, Signedness},
+    builtin::{
+        attributes::UnitAttr,
+        types::{IntegerType, Signedness},
+    },
     derive::op_interface_impl,
     value::Value,
 };
@@ -77,6 +80,7 @@ impl LowerOp<Cuda> for ElectOp {
                 "selp.b32 $0, 1, 0, %%px;"
             };
             let op = InlinePtxOp::new_volatile(ctx, Some(u32), ptx, vec![]);
+            op.set_attr_cuda_inline_ptx_nomem(ctx, UnitAttr::new());
             scope.register(&op);
             let cast = cast_value(scope, op.result(ctx).unwrap(), BoolType::get(ctx).into());
             vec![cast]

--- a/crates/cubecl-cpp/src/cuda/ptx/asm.rs
+++ b/crates/cubecl-cpp/src/cuda/ptx/asm.rs
@@ -3,8 +3,8 @@ use core::{cell::Ref, fmt::Display};
 use cubecl_core::{
     frontend::InputKind,
     ir::{
-        AddressSpaceVecAttr, AddressType, Scope,
-        dialect::{InlineAsmOp, InputSpecVecAttr},
+        AddressType, Scope,
+        dialect::{InlineAsmOp, InputSpecVecAttr, MemoryClobbers, MemoryClobbersAttr},
         interfaces::{MemoryEffect, MemoryEffects, TypedExt},
         prelude::*,
         types::VectorType,
@@ -35,18 +35,13 @@ use crate::{
     attr($cuda_inline_ptx_ptx, $StringAttr) ` : ` types(CharSpace(`,`)) ` : ` operands(CharSpace(`,`))
     opt_attr($cuda_inline_ptx_clobbers, $VecAttr)
     opt_attr($cuda_inline_ptx_in_spec, $InputSpecVecAttr, label($in_spec))
-    opt_attr($cuda_inline_ptx_reads_spaces, $AddressSpaceVecAttr, label($reads_spaces))
-    opt_attr($cuda_inline_ptx_writes_spaces, $AddressSpaceVecAttr, label($writes_spaces))",
+    opt_attr($cuda_inline_ptx_memory_clobbers, $MemoryClobbersAttr, label($memory_clobbers))",
     attributes = (
         cuda_inline_ptx_ptx: StringAttr,
         cuda_inline_ptx_volatile: UnitAttr,
         cuda_inline_ptx_clobbers: VecAttr,
-        cuda_inline_ptx_nomem: UnitAttr,
-        cuda_inline_ptx_explicit_mem: UnitAttr,
-        cuda_inline_ptx_readonly: UnitAttr,
+        cuda_inline_ptx_memory_clobbers: MemoryClobbersAttr,
         cuda_inline_ptx_in_spec: InputSpecVecAttr,
-        cuda_inline_ptx_reads_spaces: AddressSpaceVecAttr,
-        cuda_inline_ptx_writes_spaces: AddressSpaceVecAttr,
     ),
     verifier = "succ"
 )]
@@ -69,6 +64,7 @@ impl InlinePtxOp {
         );
         let op = Self { op };
         op.set_attr_cuda_inline_ptx_ptx(ctx, ptx.to_string().into());
+        op.set_attr_cuda_inline_ptx_memory_clobbers(ctx, MemoryClobbers::Nomem.into());
         op
     }
 
@@ -80,6 +76,7 @@ impl InlinePtxOp {
     ) -> Self {
         let op = Self::new(ctx, result_ty, ptx, inputs);
         op.set_attr_cuda_inline_ptx_volatile(ctx, UnitAttr::new());
+        op.set_attr_cuda_inline_ptx_memory_clobbers(ctx, MemoryClobbers::Nomem.into());
         op
     }
 
@@ -133,48 +130,43 @@ impl SideEffects for InlinePtxOp {
 #[op_interface_impl]
 impl MemoryEffects for InlinePtxOp {
     fn memory_effects(&self, ctx: &Context) -> Vec<MemoryEffect> {
-        if self.get_attr_cuda_inline_ptx_nomem(ctx).is_some() {
-            vec![]
-        } else if self.get_attr_cuda_inline_ptx_readonly(ctx).is_some() {
-            vec![MemoryEffect::ReadAll]
-        } else if self.get_attr_cuda_inline_ptx_explicit_mem(ctx).is_some() {
-            let mut out = vec![];
-            for space in self
-                .get_attr_cuda_inline_ptx_reads_spaces(ctx)
-                .map(|it| it.0.clone())
-                .unwrap_or_default()
-            {
-                out.push(MemoryEffect::ReadAllInSpace(space));
-            }
-            for space in self
-                .get_attr_cuda_inline_ptx_writes_spaces(ctx)
-                .map(|it| it.0.clone())
-                .unwrap_or_default()
-            {
-                out.push(MemoryEffect::WriteAllInSpace(space));
-            }
-            let in_specs = self
-                .get_attr_cuda_inline_ptx_in_spec(ctx)
-                .map(|it| it.0.clone())
-                .unwrap_or_default();
-            for (value, spec) in self.inputs(ctx).into_iter().zip(in_specs) {
-                match spec.kind {
-                    InputKind::MemIn => {
-                        out.push(MemoryEffect::Read(value));
-                    }
-                    InputKind::MemOut => {
-                        out.push(MemoryEffect::Write(value));
-                    }
-                    InputKind::MemInout => {
-                        out.push(MemoryEffect::Read(value));
-                        out.push(MemoryEffect::Write(value));
-                    }
-                    InputKind::In => {}
+        match &self
+            .get_attr_cuda_inline_ptx_memory_clobbers(ctx)
+            .unwrap()
+            .0
+        {
+            MemoryClobbers::Nomem => vec![],
+            MemoryClobbers::Readonly => vec![MemoryEffect::ReadAll],
+            MemoryClobbers::Explicit {
+                reads_spaces,
+                writes_spaces,
+            } => {
+                let mut out = vec![];
+                for space in reads_spaces.0.iter() {
+                    out.push(MemoryEffect::ReadAllInSpace(*space));
                 }
+                for space in writes_spaces.0.iter() {
+                    out.push(MemoryEffect::WriteAllInSpace(*space));
+                }
+                let specs = self.get_attr_cuda_inline_ptx_in_spec(ctx).unwrap();
+                for (value, spec) in self.inputs(ctx).into_iter().zip(specs.0.iter()) {
+                    match spec.kind {
+                        InputKind::MemIn => {
+                            out.push(MemoryEffect::Read(value));
+                        }
+                        InputKind::MemOut => {
+                            out.push(MemoryEffect::Write(value));
+                        }
+                        InputKind::MemInout => {
+                            out.push(MemoryEffect::Read(value));
+                            out.push(MemoryEffect::Write(value));
+                        }
+                        InputKind::In => {}
+                    }
+                }
+                out
             }
-            out
-        } else {
-            vec![MemoryEffect::ReadAll, MemoryEffect::WriteAll]
+            MemoryClobbers::ReadWrite => vec![MemoryEffect::ReadAll, MemoryEffect::WriteAll],
         }
     }
 }
@@ -337,31 +329,23 @@ impl LowerOp<Cuda> for InlineAsmOp {
             .opt_result(ctx)
             .map(|res| res.get_type(ctx));
         let inline_ptx = InlinePtxOp::new(ctx, results, ptx, inputs);
+        let mem_clobbers = self.memory_clobbers(ctx).clone();
         if !self.pure(ctx) {
             inline_ptx.set_attr_cuda_inline_ptx_volatile(ctx, UnitAttr::new());
         }
-        if self.readonly(ctx) {
-            inline_ptx.set_attr_cuda_inline_ptx_readonly(ctx, UnitAttr::new());
+        match &mem_clobbers {
+            MemoryClobbers::Nomem => {}
+            MemoryClobbers::Readonly
+            | MemoryClobbers::Explicit { .. }
+            | MemoryClobbers::ReadWrite => {
+                inline_ptx.set_attr_cuda_inline_ptx_clobbers(
+                    ctx,
+                    VecAttr(vec![Box::new(StringAttr::new("memory".into()))]),
+                );
+            }
         }
-        if self.nomem(ctx) {
-            inline_ptx.set_attr_cuda_inline_ptx_nomem(ctx, UnitAttr::new());
-        } else {
-            inline_ptx.set_attr_cuda_inline_ptx_clobbers(
-                ctx,
-                VecAttr(vec![Box::new(StringAttr::new("memory".into()))]),
-            );
-        }
-        if self.explicit_mem(ctx) {
-            inline_ptx.set_attr_cuda_inline_ptx_explicit_mem(ctx, UnitAttr::new());
-            inline_ptx.set_attr_cuda_inline_ptx_clobbers(
-                ctx,
-                VecAttr(vec![Box::new(StringAttr::new("memory".into()))]),
-            );
-        }
-
+        inline_ptx.set_attr_cuda_inline_ptx_memory_clobbers(ctx, mem_clobbers.into());
         inline_ptx.set_attr_cuda_inline_ptx_in_spec(ctx, self.in_specs(ctx).into());
-        inline_ptx.set_attr_cuda_inline_ptx_reads_spaces(ctx, self.reads_spaces(ctx).into());
-        inline_ptx.set_attr_cuda_inline_ptx_writes_spaces(ctx, self.writes_spaces(ctx).into());
 
         inline_ptx
             .get_operation()

--- a/crates/cubecl-cpp/src/cuda/ptx/asm.rs
+++ b/crates/cubecl-cpp/src/cuda/ptx/asm.rs
@@ -1,7 +1,14 @@
 use core::{cell::Ref, fmt::Display};
 
-use cubecl_core::ir::{
-    AddressType, Scope, dialect::InlineAsmOp, interfaces::TypedExt, prelude::*, types::VectorType,
+use cubecl_core::{
+    frontend::InputKind,
+    ir::{
+        AddressSpaceVecAttr, AddressType, Scope,
+        dialect::{InlineAsmOp, InputSpecVecAttr},
+        interfaces::{MemoryEffect, MemoryEffects, TypedExt},
+        prelude::*,
+        types::VectorType,
+    },
 };
 use itertools::Itertools;
 use pliron::{
@@ -26,8 +33,21 @@ use crate::{
     name = "cuda.inline_ptx",
     format = "opt_attr($cuda_inline_ptx_volatile, $UnitAttr, label($volatile))
     attr($cuda_inline_ptx_ptx, $StringAttr) ` : ` types(CharSpace(`,`)) ` : ` operands(CharSpace(`,`))
-    opt_attr($cuda_inline_ptx_clobbers, $VecAttr)",
-    attributes = (cuda_inline_ptx_ptx: StringAttr, cuda_inline_ptx_volatile: UnitAttr, cuda_inline_ptx_clobbers: VecAttr),
+    opt_attr($cuda_inline_ptx_clobbers, $VecAttr)
+    opt_attr($cuda_inline_ptx_in_spec, $InputSpecVecAttr, label($in_spec))
+    opt_attr($cuda_inline_ptx_reads_spaces, $AddressSpaceVecAttr, label($reads_spaces))
+    opt_attr($cuda_inline_ptx_writes_spaces, $AddressSpaceVecAttr, label($writes_spaces))",
+    attributes = (
+        cuda_inline_ptx_ptx: StringAttr,
+        cuda_inline_ptx_volatile: UnitAttr,
+        cuda_inline_ptx_clobbers: VecAttr,
+        cuda_inline_ptx_nomem: UnitAttr,
+        cuda_inline_ptx_explicit_mem: UnitAttr,
+        cuda_inline_ptx_readonly: UnitAttr,
+        cuda_inline_ptx_in_spec: InputSpecVecAttr,
+        cuda_inline_ptx_reads_spaces: AddressSpaceVecAttr,
+        cuda_inline_ptx_writes_spaces: AddressSpaceVecAttr,
+    ),
     verifier = "succ"
 )]
 pub struct InlinePtxOp;
@@ -73,6 +93,17 @@ impl InlinePtxOp {
         }
     }
 
+    pub fn clobbers(&self, ctx: &Context) -> Vec<String> {
+        let clobbers = self
+            .get_attr_cuda_inline_ptx_clobbers(ctx)
+            .map(|it| it.0.clone())
+            .unwrap_or_default();
+        clobbers
+            .into_iter()
+            .map(|it| (*it.downcast::<StringAttr>().unwrap()).into())
+            .collect()
+    }
+
     pub fn raw_ptx<'a>(&self, ctx: &'a Context) -> Ref<'a, str> {
         Ref::map(self.get_attr_cuda_inline_ptx_ptx(ctx).unwrap(), |it| {
             it.as_str()
@@ -96,6 +127,55 @@ impl InlinePtxOp {
 impl SideEffects for InlinePtxOp {
     fn has_side_effects(&self, ctx: &Context) -> bool {
         self.get_attr_cuda_inline_ptx_volatile(ctx).is_some()
+    }
+}
+
+#[op_interface_impl]
+impl MemoryEffects for InlinePtxOp {
+    fn memory_effects(&self, ctx: &Context) -> Vec<MemoryEffect> {
+        if self.get_attr_cuda_inline_ptx_nomem(ctx).is_some() {
+            vec![]
+        } else if self.get_attr_cuda_inline_ptx_readonly(ctx).is_some() {
+            vec![MemoryEffect::ReadAll]
+        } else if self.get_attr_cuda_inline_ptx_explicit_mem(ctx).is_some() {
+            let mut out = vec![];
+            for space in self
+                .get_attr_cuda_inline_ptx_reads_spaces(ctx)
+                .map(|it| it.0.clone())
+                .unwrap_or_default()
+            {
+                out.push(MemoryEffect::ReadAllInSpace(space));
+            }
+            for space in self
+                .get_attr_cuda_inline_ptx_writes_spaces(ctx)
+                .map(|it| it.0.clone())
+                .unwrap_or_default()
+            {
+                out.push(MemoryEffect::WriteAllInSpace(space));
+            }
+            let in_specs = self
+                .get_attr_cuda_inline_ptx_in_spec(ctx)
+                .map(|it| it.0.clone())
+                .unwrap_or_default();
+            for (value, spec) in self.inputs(ctx).into_iter().zip(in_specs) {
+                match spec.kind {
+                    InputKind::MemIn => {
+                        out.push(MemoryEffect::Read(value));
+                    }
+                    InputKind::MemOut => {
+                        out.push(MemoryEffect::Write(value));
+                    }
+                    InputKind::MemInout => {
+                        out.push(MemoryEffect::Read(value));
+                        out.push(MemoryEffect::Write(value));
+                    }
+                    InputKind::In => {}
+                }
+            }
+            out
+        } else {
+            vec![MemoryEffect::ReadAll, MemoryEffect::WriteAll]
+        }
     }
 }
 
@@ -200,7 +280,7 @@ fn insert_placeholders(
 ) -> String {
     let pat = format!("${plir_idx}");
     if !ptx.contains(&pat) {
-        panic!("Tried substituting argument {pat} in PTX, but it wasn't found.")
+        panic!("Tried substituting argument {pat} in PTX string {ptx:?}, but it wasn't found.")
     }
     let substitute = if ty.deref(ctx).is::<VectorType>() {
         let vec = ty.vector_size(ctx);
@@ -260,12 +340,29 @@ impl LowerOp<Cuda> for InlineAsmOp {
         if !self.pure(ctx) {
             inline_ptx.set_attr_cuda_inline_ptx_volatile(ctx, UnitAttr::new());
         }
-        if !self.nomem(ctx) {
+        if self.readonly(ctx) {
+            inline_ptx.set_attr_cuda_inline_ptx_readonly(ctx, UnitAttr::new());
+        }
+        if self.nomem(ctx) {
+            inline_ptx.set_attr_cuda_inline_ptx_nomem(ctx, UnitAttr::new());
+        } else {
             inline_ptx.set_attr_cuda_inline_ptx_clobbers(
                 ctx,
                 VecAttr(vec![Box::new(StringAttr::new("memory".into()))]),
             );
         }
+        if self.explicit_mem(ctx) {
+            inline_ptx.set_attr_cuda_inline_ptx_explicit_mem(ctx, UnitAttr::new());
+            inline_ptx.set_attr_cuda_inline_ptx_clobbers(
+                ctx,
+                VecAttr(vec![Box::new(StringAttr::new("memory".into()))]),
+            );
+        }
+
+        inline_ptx.set_attr_cuda_inline_ptx_in_spec(ctx, self.in_specs(ctx).into());
+        inline_ptx.set_attr_cuda_inline_ptx_reads_spaces(ctx, self.reads_spaces(ctx).into());
+        inline_ptx.set_attr_cuda_inline_ptx_writes_spaces(ctx, self.writes_spaces(ctx).into());
+
         inline_ptx
             .get_operation()
             .insert_before(ctx, self.get_operation());

--- a/crates/cubecl-cpp/src/cuda/ptx/copy_async.rs
+++ b/crates/cubecl-cpp/src/cuda/ptx/copy_async.rs
@@ -24,7 +24,7 @@ pub fn cp_async_global_to_shared(
     let smem = generic_to_shared::<u32>(smem);
     gpu_asm!(
         "cp.async.{cache}.shared::cta.global [{}], [{}], {size}, {size};",
-        in(_) smem, in(_) src, size = const copy_size
+        mem_out(_) smem, mem_in(_) src, size = const copy_size, options(explicit_mem)
     );
 }
 
@@ -39,14 +39,14 @@ pub fn cp_async_global_to_shared_checked(
     let smem = generic_to_shared::<u32>(smem);
     gpu_asm!(
         "cp.async.{cache}.shared::cta.global [{}], [{}], {copy_size}, {len};",
-        in(_) smem, in(_) src, len = in(_) src_size
+        mem_out(_) smem, mem_in(_) src, len = in(_) src_size, options(explicit_mem)
     );
 }
 
 #[cube]
 pub fn commit_copy_async(bar: &Barrier) {
     let bar_handle = barrier_native_handle(bar);
-    gpu_asm!("cp.async.mbarrier.arrive.shared::cta.b64 [{}];", in(_) bar_handle);
+    gpu_asm!("cp.async.mbarrier.arrive.shared::cta.b64 [{}];", mem_inout(_) bar_handle, options(explicit_mem));
 }
 
 #[op_interface_impl]

--- a/crates/cubecl-cpp/src/cuda/ptx/mma.rs
+++ b/crates/cubecl-cpp/src/cuda/ptx/mma.rs
@@ -103,7 +103,7 @@ fn ldmatrix(
     let out: Vector<u32, NCD>;
     gpu_asm!(
         "ldmatrix.sync.aligned.m8n8.x{num}{transpose}.shared::cta.b16 {out}, [{addr}];",
-        out = out(_) out, addr = in(_) row_addr, options(readonly),
+        out = out(_) out, addr = mem_in(_) row_addr, options(explicit_mem),
     );
     out
 }
@@ -119,7 +119,7 @@ fn stmatrix(
 
     gpu_asm!(
         "stmatrix.sync.aligned.m8n8.x{num}{transpose}.shared::cta.b16 [{addr}], {val};",
-        addr = in(_) row_addr, val = in(_) value,
+        addr = mem_out(_) row_addr, val = in(_) value, options(explicit_mem),
     );
 }
 

--- a/crates/cubecl-cpp/src/cuda/ptx/mod.rs
+++ b/crates/cubecl-cpp/src/cuda/ptx/mod.rs
@@ -4,7 +4,7 @@ use cubecl_core::{
     intrinsic,
     ir::{
         AddressSpace,
-        interfaces::TypeExt,
+        interfaces::{TypeExt, aliasing::AliasingOp},
         prelude::*,
         types::{
             PointerType,
@@ -41,6 +41,13 @@ pub struct GenericToSharedOp {
     ptr: Value,
 }
 
+#[op_interface_impl]
+impl AliasingOp for GenericToSharedOp {
+    fn source_ptr(&self, ctx: &Context) -> Option<Value> {
+        Some(self.ptr(ctx))
+    }
+}
+
 cuda_op_with_out!(GenericToSharedOp, |op, ctx| {
     let ptr = op.ptr(ctx).name(ctx);
     format!("__cvta_generic_to_shared({ptr})")
@@ -65,6 +72,13 @@ pub fn generic_to_shared<T: CubePrimitive>(ptr: *const T) -> u32 {
 #[op_interfaces(OperandNOfType<0, PointerType>)]
 pub struct BarrierNativeHandleOp {
     bar_ptr: Value,
+}
+
+#[op_interface_impl]
+impl AliasingOp for BarrierNativeHandleOp {
+    fn source_ptr(&self, ctx: &Context) -> Option<Value> {
+        Some(self.bar_ptr(ctx))
+    }
 }
 
 impl Verify for BarrierNativeHandleOp {

--- a/crates/cubecl-cpp/src/cuda/ptx/tma_load_im2col.rs
+++ b/crates/cubecl-cpp/src/cuda/ptx/tma_load_im2col.rs
@@ -21,12 +21,13 @@ pub fn tma_load_im2col_3d(
     let smem = generic_to_shared::<u32>(smem);
     let descriptor_address = tensor_map_address(tensor_map);
     let (n, w, c) = pos;
+    // Note: tensor maps are opaque descriptors not pointers, so memory effects don't apply
     gpu_asm!(
         "cp.async.bulk.tensor.3d.shared::cluster.global.im2col.mbarrier::complete_tx::bytes ",
         "[{smem}], [{tensor_map}, {{{c}, {w}, {n}}}], [{bar}], {{{offs_w}}};",
-        smem = in(_) smem, tensor_map = in(_) descriptor_address,
+        smem = mem_out(_) smem, tensor_map = in(_) descriptor_address,
         c = in(_) c, w = in(_) w, n = in(_) n, offs_w = in(_) offset,
-        bar = in(_) bar_handle,
+        bar = mem_inout(_) bar_handle, options(explicit_mem)
     );
 }
 
@@ -43,13 +44,14 @@ pub fn tma_load_im2col_4d(
     let descriptor_address = tensor_map_address(tensor_map);
     let (n, h, w, c) = pos;
     let (offs_h, offs_w) = offset;
+    // Note: tensor maps are opaque descriptors not pointers, so memory effects don't apply
     gpu_asm!(
         "cp.async.bulk.tensor.4d.shared::cluster.global.im2col.mbarrier::complete_tx::bytes ",
         "[{smem}], [{tensor_map}, {{{c}, {w}, {h}, {n}}}], [{bar}], {{{offs_w}, {offs_h}}};",
-        smem = in(_) smem, tensor_map = in(_) descriptor_address,
+        smem = mem_out(_) smem, tensor_map = in(_) descriptor_address,
         c = in(_) c, w = in(_) w, h = in(_) h, n = in(_) n,
         offs_w = in(_) offs_w, offs_h = in(_) offs_h,
-        bar = in(_) bar_handle,
+        bar = mem_inout(_) bar_handle, options(explicit_mem),
     );
 }
 
@@ -66,13 +68,14 @@ pub fn tma_load_im2col_5d(
     let descriptor_address = tensor_map_address(tensor_map);
     let (n, d, h, w, c) = pos;
     let (offs_d, offs_h, offs_w) = offset;
+    // Note: tensor maps are opaque descriptors not pointers, so memory effects don't apply
     gpu_asm!(
         "cp.async.bulk.tensor.5d.shared::cluster.global.im2col.mbarrier::complete_tx::bytes ",
         "[{smem}], [{tensor_map}, {{{c}, {w}, {h}, {d}, {n}}}], [{bar}], {{{offs_w}, {offs_h}, {offs_d}}};",
-        smem = in(_) smem, tensor_map = in(_) descriptor_address,
+        smem = in(mem_out) smem, tensor_map = in(_) descriptor_address,
         c = in(_) c, w = in(_) w, h = in(_) h, d = in(_) d, n = in(_) n,
         offs_w = in(_) offs_w, offs_h = in(_) offs_h, offs_d = in(_) offs_d,
-        bar = in(_) bar_handle,
+        bar = in(mem_inout) bar_handle, options(explicit_mem)
     );
 }
 

--- a/crates/cubecl-cpu/Cargo.toml
+++ b/crates/cubecl-cpu/Cargo.toml
@@ -68,6 +68,7 @@ sysinfo = { workspace = true }
 libc = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+bytemuck = { workspace = true }
 winapi = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cubecl-ir/Cargo.toml
+++ b/crates/cubecl-ir/Cargo.toml
@@ -49,6 +49,7 @@ internment = { workspace = true, features = ["intern", "serde"] }
 itertools = { workspace = true }
 num = { workspace = true }
 num-traits = { workspace = true }
+paste = { workspace = true }
 serde = { workspace = true, optional = true, features = ["rc"] }
 smallvec = { workspace = true }
 spin = { workspace = true }

--- a/crates/cubecl-ir/src/attributes/mod.rs
+++ b/crates/cubecl-ir/src/attributes/mod.rs
@@ -82,6 +82,28 @@ macro_rules! ext_attribute {
     };
 }
 
+#[macro_export]
+macro_rules! typed_vec_attr {
+    ($ty: ty, $name: literal) => {
+        paste::paste! {
+             /// A vector of other attributes.
+            #[pliron::derive::pliron_attr(
+                name = $name,
+                format = "`[` vec($0, CharSpace(`,`)) `]`",
+                verifier = "succ"
+            )]
+            #[derive(PartialEq, Eq, Clone, Debug, Hash, Default, derive_more::From)]
+            pub struct [<$ty VecAttr>](pub Vec<$ty>);
+
+            impl [<$ty VecAttr>] {
+                pub fn new(value: alloc::vec::Vec<$ty>) -> Self {
+                    [<$ty VecAttr>](value)
+                }
+            }
+        }
+    };
+}
+
 /// A zero-value attribute, used for zero-initializing arbitrary types with whatever "zero" means
 /// for it. Arrays get all fields zero-initialized, floats and ints initialize to zero, booleans
 /// to false, etc.

--- a/crates/cubecl-ir/src/dialect/asm.rs
+++ b/crates/cubecl-ir/src/dialect/asm.rs
@@ -1,20 +1,66 @@
 use core::cell::Ref;
 use std::string::String;
 
+use derive_new::new;
 use pliron::{
     builtin::attributes::{StringAttr, UnitAttr},
     opts::dce::SideEffects,
 };
 
 use crate::{
-    CanMaterialize,
+    AddressSpace, AddressSpaceVecAttr, CanMaterialize,
     interfaces::{MemoryEffect, MemoryEffects},
     prelude::*,
+    typed_vec_attr,
 };
+
+#[format]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub enum InputKind {
+    /// Regular input
+    In,
+    /// Input that reads memory through the value
+    MemIn,
+    /// Input that writes memory through the value.
+    MemOut,
+    /// Input that reads and writes memory through the value.
+    MemInout,
+}
+
+#[pliron_attr(name = "asm.reg_class", format, verifier = "succ")]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub enum RegSpec {
+    /// Default register class for the type
+    Inferred,
+    /// Custom class mainly for CPU (i.e. `xmm_reg`)
+    Class(String),
+    /// Explicit register mainly for CPU (i.e. `"ax"`)
+    Explicit(String),
+}
+
+#[pliron_attr(name = "asm.input_spec", format, verifier = "succ")]
+#[derive(PartialEq, Eq, Hash, Clone, Debug, new)]
+pub struct InputSpec {
+    pub kind: InputKind,
+    pub class: RegSpec,
+}
+
+typed_vec_attr!(RegSpec, "asm.reg_specs");
+typed_vec_attr!(InputSpec, "asm.input_specs");
 
 #[pliron_op(name = "cube.asm",
     format,
-    attributes = (cube_asm_asm: StringAttr, cube_asm_pure: UnitAttr, cube_asm_nomem: UnitAttr, cube_asm_readonly: UnitAttr),
+    attributes = (
+        cube_asm_asm: StringAttr,
+        cube_asm_pure: UnitAttr,
+        cube_asm_nomem: UnitAttr,
+        cube_asm_explicit_mem: UnitAttr,
+        cube_asm_readonly: UnitAttr,
+        cube_asm_out_spec: RegSpecVecAttr,
+        cube_asm_in_spec: InputSpecVecAttr,
+        cube_asm_reads_spaces: AddressSpaceVecAttr,
+        cube_asm_writes_spaces: AddressSpaceVecAttr,
+    ),
     verifier = "succ"
 )]
 #[op_traits(CanMaterialize)]
@@ -24,8 +70,10 @@ impl InlineAsmOp {
     pub fn new(
         ctx: &mut Context,
         result_types: Vec<TypeHandle>,
+        out_spec: Vec<RegSpec>,
         asm: String,
         arguments: Vec<Value>,
+        in_spec: Vec<InputSpec>,
     ) -> Self {
         let op = Operation::new(
             ctx,
@@ -37,6 +85,10 @@ impl InlineAsmOp {
         );
         let this = Self { op };
         this.set_attr_cube_asm_asm(ctx, asm.into());
+        this.set_attr_cube_asm_out_spec(ctx, out_spec.into());
+        this.set_attr_cube_asm_in_spec(ctx, in_spec.into());
+        this.set_attr_cube_asm_reads_spaces(ctx, Default::default());
+        this.set_attr_cube_asm_writes_spaces(ctx, Default::default());
         this
     }
 
@@ -68,12 +120,44 @@ impl InlineAsmOp {
         self.set_attr_cube_asm_nomem(ctx, UnitAttr::new());
     }
 
+    pub fn explicit_mem(&self, ctx: &Context) -> bool {
+        self.get_attr_cube_asm_explicit_mem(ctx).is_some()
+    }
+
+    pub fn set_explicit_mem(&self, ctx: &Context) {
+        self.set_attr_cube_asm_explicit_mem(ctx, UnitAttr::new());
+    }
+
     pub fn readonly(&self, ctx: &Context) -> bool {
         self.get_attr_cube_asm_readonly(ctx).is_some()
     }
 
     pub fn set_readonly(&self, ctx: &Context) {
         self.set_attr_cube_asm_readonly(ctx, UnitAttr::new());
+    }
+
+    pub fn reads_spaces(&self, ctx: &Context) -> Vec<AddressSpace> {
+        self.get_attr_cube_asm_reads_spaces(ctx).unwrap().0.clone()
+    }
+
+    pub fn set_reads_spaces(&self, ctx: &Context, spaces: Vec<AddressSpace>) {
+        self.set_attr_cube_asm_reads_spaces(ctx, spaces.into());
+    }
+
+    pub fn writes_spaces(&self, ctx: &Context) -> Vec<AddressSpace> {
+        self.get_attr_cube_asm_writes_spaces(ctx).unwrap().0.clone()
+    }
+
+    pub fn set_writes_spaces(&self, ctx: &Context, spaces: Vec<AddressSpace>) {
+        self.set_attr_cube_asm_writes_spaces(ctx, spaces.into());
+    }
+
+    pub fn out_specs(&self, ctx: &Context) -> Vec<RegSpec> {
+        self.get_attr_cube_asm_out_spec(ctx).unwrap().0.clone()
+    }
+
+    pub fn in_specs(&self, ctx: &Context) -> Vec<InputSpec> {
+        self.get_attr_cube_asm_in_spec(ctx).unwrap().0.clone()
     }
 }
 
@@ -91,6 +175,30 @@ impl MemoryEffects for InlineAsmOp {
             vec![]
         } else if self.readonly(ctx) {
             vec![MemoryEffect::ReadAll]
+        } else if self.explicit_mem(ctx) {
+            let mut out = vec![];
+            for space in self.reads_spaces(ctx) {
+                out.push(MemoryEffect::ReadAllInSpace(space));
+            }
+            for space in self.writes_spaces(ctx) {
+                out.push(MemoryEffect::WriteAllInSpace(space));
+            }
+            for (value, spec) in self.inputs(ctx).into_iter().zip(self.in_specs(ctx)) {
+                match spec.kind {
+                    InputKind::MemIn => {
+                        out.push(MemoryEffect::Read(value));
+                    }
+                    InputKind::MemOut => {
+                        out.push(MemoryEffect::Write(value));
+                    }
+                    InputKind::MemInout => {
+                        out.push(MemoryEffect::Read(value));
+                        out.push(MemoryEffect::Write(value));
+                    }
+                    InputKind::In => {}
+                }
+            }
+            out
         } else {
             vec![MemoryEffect::ReadAll, MemoryEffect::WriteAll]
         }

--- a/crates/cubecl-ir/src/dialect/asm.rs
+++ b/crates/cubecl-ir/src/dialect/asm.rs
@@ -1,6 +1,7 @@
 use core::cell::Ref;
 use std::string::String;
 
+use derive_more::From;
 use derive_new::new;
 use pliron::{
     builtin::attributes::{StringAttr, UnitAttr},
@@ -8,7 +9,7 @@ use pliron::{
 };
 
 use crate::{
-    AddressSpace, AddressSpaceVecAttr, CanMaterialize,
+    AddressSpaceVecAttr, CanMaterialize,
     interfaces::{MemoryEffect, MemoryEffects},
     prelude::*,
     typed_vec_attr,
@@ -48,18 +49,30 @@ pub struct InputSpec {
 typed_vec_attr!(RegSpec, "asm.reg_specs");
 typed_vec_attr!(InputSpec, "asm.input_specs");
 
+#[pliron_attr(name = "asm.memory_clobbers", format, verifier = "succ")]
+#[derive(PartialEq, Eq, Hash, Clone, Debug, From)]
+pub struct MemoryClobbersAttr(pub MemoryClobbers);
+
+#[format]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub enum MemoryClobbers {
+    Nomem,
+    Readonly,
+    Explicit {
+        reads_spaces: AddressSpaceVecAttr,
+        writes_spaces: AddressSpaceVecAttr,
+    },
+    ReadWrite,
+}
+
 #[pliron_op(name = "cube.asm",
     format,
     attributes = (
         cube_asm_asm: StringAttr,
         cube_asm_pure: UnitAttr,
-        cube_asm_nomem: UnitAttr,
-        cube_asm_explicit_mem: UnitAttr,
-        cube_asm_readonly: UnitAttr,
+        cube_asm_memory_clobbers: MemoryClobbersAttr,
         cube_asm_out_spec: RegSpecVecAttr,
         cube_asm_in_spec: InputSpecVecAttr,
-        cube_asm_reads_spaces: AddressSpaceVecAttr,
-        cube_asm_writes_spaces: AddressSpaceVecAttr,
     ),
     verifier = "succ"
 )]
@@ -72,6 +85,7 @@ impl InlineAsmOp {
         result_types: Vec<TypeHandle>,
         out_spec: Vec<RegSpec>,
         asm: String,
+        memory_clobbers: MemoryClobbers,
         arguments: Vec<Value>,
         in_spec: Vec<InputSpec>,
     ) -> Self {
@@ -85,10 +99,9 @@ impl InlineAsmOp {
         );
         let this = Self { op };
         this.set_attr_cube_asm_asm(ctx, asm.into());
+        this.set_attr_cube_asm_memory_clobbers(ctx, memory_clobbers.into());
         this.set_attr_cube_asm_out_spec(ctx, out_spec.into());
         this.set_attr_cube_asm_in_spec(ctx, in_spec.into());
-        this.set_attr_cube_asm_reads_spaces(ctx, Default::default());
-        this.set_attr_cube_asm_writes_spaces(ctx, Default::default());
         this
     }
 
@@ -112,44 +125,11 @@ impl InlineAsmOp {
         self.set_attr_cube_asm_pure(ctx, UnitAttr::new());
     }
 
-    pub fn nomem(&self, ctx: &Context) -> bool {
-        self.get_attr_cube_asm_nomem(ctx).is_some()
-    }
-
-    pub fn set_nomem(&self, ctx: &Context) {
-        self.set_attr_cube_asm_nomem(ctx, UnitAttr::new());
-    }
-
-    pub fn explicit_mem(&self, ctx: &Context) -> bool {
-        self.get_attr_cube_asm_explicit_mem(ctx).is_some()
-    }
-
-    pub fn set_explicit_mem(&self, ctx: &Context) {
-        self.set_attr_cube_asm_explicit_mem(ctx, UnitAttr::new());
-    }
-
-    pub fn readonly(&self, ctx: &Context) -> bool {
-        self.get_attr_cube_asm_readonly(ctx).is_some()
-    }
-
-    pub fn set_readonly(&self, ctx: &Context) {
-        self.set_attr_cube_asm_readonly(ctx, UnitAttr::new());
-    }
-
-    pub fn reads_spaces(&self, ctx: &Context) -> Vec<AddressSpace> {
-        self.get_attr_cube_asm_reads_spaces(ctx).unwrap().0.clone()
-    }
-
-    pub fn set_reads_spaces(&self, ctx: &Context, spaces: Vec<AddressSpace>) {
-        self.set_attr_cube_asm_reads_spaces(ctx, spaces.into());
-    }
-
-    pub fn writes_spaces(&self, ctx: &Context) -> Vec<AddressSpace> {
-        self.get_attr_cube_asm_writes_spaces(ctx).unwrap().0.clone()
-    }
-
-    pub fn set_writes_spaces(&self, ctx: &Context, spaces: Vec<AddressSpace>) {
-        self.set_attr_cube_asm_writes_spaces(ctx, spaces.into());
+    pub fn memory_clobbers<'a>(&self, ctx: &'a Context) -> Ref<'a, MemoryClobbers> {
+        Ref::map(
+            self.get_attr_cube_asm_memory_clobbers(ctx).unwrap(),
+            |attr| &attr.0,
+        )
     }
 
     pub fn out_specs(&self, ctx: &Context) -> Vec<RegSpec> {
@@ -171,36 +151,38 @@ impl SideEffects for InlineAsmOp {
 #[op_interface_impl]
 impl MemoryEffects for InlineAsmOp {
     fn memory_effects(&self, ctx: &Context) -> Vec<MemoryEffect> {
-        if self.nomem(ctx) {
-            vec![]
-        } else if self.readonly(ctx) {
-            vec![MemoryEffect::ReadAll]
-        } else if self.explicit_mem(ctx) {
-            let mut out = vec![];
-            for space in self.reads_spaces(ctx) {
-                out.push(MemoryEffect::ReadAllInSpace(space));
-            }
-            for space in self.writes_spaces(ctx) {
-                out.push(MemoryEffect::WriteAllInSpace(space));
-            }
-            for (value, spec) in self.inputs(ctx).into_iter().zip(self.in_specs(ctx)) {
-                match spec.kind {
-                    InputKind::MemIn => {
-                        out.push(MemoryEffect::Read(value));
-                    }
-                    InputKind::MemOut => {
-                        out.push(MemoryEffect::Write(value));
-                    }
-                    InputKind::MemInout => {
-                        out.push(MemoryEffect::Read(value));
-                        out.push(MemoryEffect::Write(value));
-                    }
-                    InputKind::In => {}
+        match &*self.memory_clobbers(ctx) {
+            MemoryClobbers::Nomem => vec![],
+            MemoryClobbers::Readonly => vec![MemoryEffect::ReadAll],
+            MemoryClobbers::Explicit {
+                reads_spaces,
+                writes_spaces,
+            } => {
+                let mut out = vec![];
+                for space in reads_spaces.0.iter() {
+                    out.push(MemoryEffect::ReadAllInSpace(*space));
                 }
+                for space in writes_spaces.0.iter() {
+                    out.push(MemoryEffect::WriteAllInSpace(*space));
+                }
+                for (value, spec) in self.inputs(ctx).into_iter().zip(self.in_specs(ctx)) {
+                    match spec.kind {
+                        InputKind::MemIn => {
+                            out.push(MemoryEffect::Read(value));
+                        }
+                        InputKind::MemOut => {
+                            out.push(MemoryEffect::Write(value));
+                        }
+                        InputKind::MemInout => {
+                            out.push(MemoryEffect::Read(value));
+                            out.push(MemoryEffect::Write(value));
+                        }
+                        InputKind::In => {}
+                    }
+                }
+                out
             }
-            out
-        } else {
-            vec![MemoryEffect::ReadAll, MemoryEffect::WriteAll]
+            MemoryClobbers::ReadWrite => vec![MemoryEffect::ReadAll, MemoryEffect::WriteAll],
         }
     }
 }

--- a/crates/cubecl-ir/src/interfaces/mod.rs
+++ b/crates/cubecl-ir/src/interfaces/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ConstantValue, ElemType,
+    AddressSpace, ConstantValue, ElemType,
     dialect::synchronization::SyncScope,
     prelude::*,
     types::{AtomicType, PointerType, VectorType, scalar::*},
@@ -167,6 +167,8 @@ pub(crate) use synchronizes;
 pub enum MemoryEffect {
     Read(Value),
     Write(Value),
+    ReadAllInSpace(AddressSpace),
+    WriteAllInSpace(AddressSpace),
     ReadAll,
     WriteAll,
 }

--- a/crates/cubecl-ir/src/type.rs
+++ b/crates/cubecl-ir/src/type.rs
@@ -1,8 +1,9 @@
 use super::{ConstantValue, ExpandValue};
 use crate::{
-    AddressType, ContextExt, Scope, TypeHash,
+    AddressType, ContextExt, Scope, TypeHash, typed_vec_attr,
     types::{scalar::*, spirv::ClampMode},
 };
+use alloc::vec::Vec;
 use core::fmt::Display;
 use cubecl_common::{
     e2m1, e2m1x2, e2m3, e3m2, e4m3, e5m2, flex32,
@@ -422,6 +423,8 @@ pub enum AddressSpace {
     Shared,
     Local,
 }
+
+typed_vec_attr!(AddressSpace, "cube.address_spaces");
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, TypeHash, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/cubecl-macros/src/generate/asm.rs
+++ b/crates/cubecl-macros/src/generate/asm.rs
@@ -1,9 +1,12 @@
 use itertools::Itertools;
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{ToTokens, quote};
 
 use crate::{
-    parse::asm::{AsmArgs, AsmExpression, DirSpec, FormatString, RegOperandBody},
+    parse::asm::{
+        AsmArgs, AsmExpression, DirSpec, DualDirSpec, DualDirSpecExpression, FormatString,
+        RegOperandBody, RegOperandKind, RegSpec,
+    },
     paths::prelude_type,
     scope::Context,
 };
@@ -16,22 +19,68 @@ impl AsmExpression {
         let inputs = self
             .inputs
             .iter()
-            .map(|it| it.to_tokens(ctx))
+            .map(|(expr, spec)| {
+                let expr = expr.to_tokens(ctx);
+                let spec = match spec {
+                    RegOperandKind::DirSpec(dir, reg) => quote![#dir, #reg],
+                    RegOperandKind::DualDirSpec(dir, reg) => quote![#dir, #reg],
+                };
+                quote![#expr, #spec]
+            })
             .collect::<Vec<_>>();
         let outputs = self
             .outputs
             .iter()
-            .map(|it| it.to_tokens(ctx))
+            .map(|(expr, spec)| {
+                let expr = expr.to_tokens(ctx);
+                quote![&#expr, #spec]
+            })
             .collect::<Vec<_>>();
         let options = &self.options;
 
         quote! {{
             #builder::new(#asm)
             #(.push_input(scope, #inputs))*
-            #(.push_output(scope, &#outputs))*
+            #(.push_output(scope, #outputs))*
             #(.#options())*
             .register(scope)
         }}
+    }
+}
+
+impl ToTokens for RegSpec {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let reg_spec = prelude_type("RegSpec");
+        tokens.extend(match self {
+            RegSpec::Inferred(_) => quote![#reg_spec::Inferred],
+            RegSpec::Class(ident) => {
+                let name = ident.to_string();
+                quote![#reg_spec::Class(#name.into())]
+            }
+            RegSpec::Explicit(name) => quote![#reg_spec::Explicit(#name.into())],
+        });
+    }
+}
+
+impl ToTokens for DirSpec {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let kind = prelude_type("InputKind");
+        tokens.extend(match self {
+            DirSpec::In(_) => quote![#kind::In],
+            DirSpec::MemIn(_) => quote![#kind::MemIn],
+            DirSpec::MemOut(_) => quote![#kind::MemOut],
+            DirSpec::Lateout(_) | DirSpec::Out(_) => unreachable!(),
+        });
+    }
+}
+
+impl ToTokens for DualDirSpec {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let kind = prelude_type("InputKind");
+        tokens.extend(match self {
+            DualDirSpec::MemInout(_) => quote![#kind::MemInout],
+            DualDirSpec::Inout(_) | DualDirSpec::Inlateout(_) => unreachable!(),
+        });
     }
 }
 
@@ -57,7 +106,7 @@ impl AsmArgs {
             match reg.body {
                 RegOperandBody::DirSpec(dir_spec, ..) => {
                     let placeholder = match dir_spec {
-                        DirSpec::In(_) => {
+                        DirSpec::In(_) | DirSpec::MemIn(_) | DirSpec::MemOut(_) => {
                             let placeholder = format!("${in_idx}");
                             in_idx += 1;
                             placeholder
@@ -74,8 +123,22 @@ impl AsmArgs {
                     };
                     fmt_args.push(fmt_arg);
                 }
-                RegOperandBody::DualDirSpec(..) => {
-                    panic!("inout params not yet supported")
+                RegOperandBody::DualDirSpec(dir_spec, ..) => {
+                    let placeholder = match dir_spec {
+                        DualDirSpec::MemInout(_) => {
+                            let placeholder = format!("${in_idx}");
+                            in_idx += 1;
+                            placeholder
+                        }
+                        DualDirSpec::Inout(_) | DualDirSpec::Inlateout(_) => {
+                            panic!("inout params not yet supported")
+                        }
+                    };
+                    let fmt_arg = match reg.param_name {
+                        Some(name) => quote![#name = #placeholder],
+                        None => quote![#placeholder],
+                    };
+                    fmt_args.push(fmt_arg);
                 }
                 RegOperandBody::Const(expr) => match reg.param_name {
                     Some(name) => fmt_args.push(quote![#name = #expr]),
@@ -103,13 +166,23 @@ pub fn generate_asm_unexpanded(tokens: TokenStream) -> syn::Result<TokenStream> 
     for reg in registers {
         match reg.body {
             RegOperandBody::DirSpec(dir_spec, _, expr) => match dir_spec {
-                DirSpec::In(_) => {
+                DirSpec::In(_) | DirSpec::MemIn(_) | DirSpec::MemOut(_) => {
                     inputs.push(expr);
                 }
                 DirSpec::Out(_) | DirSpec::Lateout(_) => {
                     outputs.push(expr);
                 }
             },
+            RegOperandBody::DualDirSpec(dir_spec, _, DualDirSpecExpression::Single(expr)) => {
+                match dir_spec {
+                    DualDirSpec::MemInout(_) => {
+                        inputs.push(expr);
+                    }
+                    DualDirSpec::Inout(_) | DualDirSpec::Inlateout(_) => {
+                        unimplemented!("inout params not yet supported")
+                    }
+                }
+            }
             RegOperandBody::DualDirSpec(..) => {
                 unimplemented!("inout params not yet supported")
             }

--- a/crates/cubecl-macros/src/parse/asm.rs
+++ b/crates/cubecl-macros/src/parse/asm.rs
@@ -21,7 +21,10 @@ mod kw {
 
     syn::custom_keyword!(pure);
     syn::custom_keyword!(nomem);
+    syn::custom_keyword!(explicit_mem);
     syn::custom_keyword!(readonly);
+    syn::custom_keyword!(reads_address_space);
+    syn::custom_keyword!(writes_address_space);
     syn::custom_keyword!(preserves_flags);
     syn::custom_keyword!(noreturn);
     syn::custom_keyword!(nostack);
@@ -33,6 +36,16 @@ mod kw {
     syn::custom_keyword!(inlateout);
     syn::custom_keyword!(sym);
     syn::custom_keyword!(label);
+
+    // Address spaces
+    syn::custom_keyword!(global);
+    syn::custom_keyword!(shared);
+    syn::custom_keyword!(local);
+
+    // Memory registers
+    syn::custom_keyword!(mem_in);
+    syn::custom_keyword!(mem_out);
+    syn::custom_keyword!(mem_inout);
 }
 
 macro_rules! peek_select {
@@ -93,8 +106,14 @@ pub enum AsmOption {
     Pure(kw::pure),
     #[display("nomem")]
     Nomem(kw::nomem),
+    #[display("explicit_mem")]
+    ExplicitMem(kw::explicit_mem),
     #[display("readonly")]
     Readonly(kw::readonly),
+    #[display("reads_{_1}")]
+    ReadsAddressSpace(kw::reads_address_space, AddressSpace),
+    #[display("writes_{_1}")]
+    WritesAddressSpace(kw::writes_address_space, AddressSpace),
     #[display("preserves_flags")]
     PreservesFlags(kw::preserves_flags),
     #[display("noreturn")]
@@ -110,13 +129,26 @@ impl AsmOption {
         match self {
             AsmOption::Pure(kw) => kw.span(),
             AsmOption::Nomem(kw) => kw.span(),
+            AsmOption::ExplicitMem(kw) => kw.span(),
             AsmOption::Readonly(kw) => kw.span(),
+            AsmOption::ReadsAddressSpace(kw, _) => kw.span(),
+            AsmOption::WritesAddressSpace(kw, _) => kw.span(),
             AsmOption::PreservesFlags(kw) => kw.span(),
             AsmOption::Noreturn(kw) => kw.span(),
             AsmOption::Nostack(kw) => kw.span(),
             AsmOption::Raw(kw) => kw.span(),
         }
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Display)]
+pub enum AddressSpace {
+    #[display("global")]
+    Global(kw::global),
+    #[display("shared")]
+    Shared(kw::shared),
+    #[display("local")]
+    Local(kw::local),
 }
 
 #[derive(Clone)]
@@ -135,6 +167,12 @@ pub enum RegOperandBody {
     Label(kw::label, syn::Block),
 }
 
+#[derive(Clone, Debug)]
+pub enum RegOperandKind {
+    DirSpec(DirSpec, RegSpec),
+    DualDirSpec(DualDirSpec, RegSpec),
+}
+
 #[derive(Clone)]
 #[allow(unused, reason = "not supported, but want to parse it")]
 pub enum DualDirSpecExpression {
@@ -142,8 +180,8 @@ pub enum DualDirSpecExpression {
     Pair(Expr, Expr),
 }
 
-#[derive(Clone)]
-#[allow(unused, reason = "not supported, but want to parse it")]
+#[derive(Clone, Debug)]
+#[allow(unused, reason = "parsing")]
 pub enum RegSpec {
     Class(Ident),
     Inferred(Token![_]),
@@ -154,14 +192,30 @@ pub enum RegSpec {
 #[allow(unused, reason = "parsing")]
 pub enum DirSpec {
     In(token::In),
+    MemIn(kw::mem_in),
     Out(kw::out),
+    MemOut(kw::mem_out),
     Lateout(kw::lateout),
+}
+
+impl DirSpec {
+    pub fn span(&self) -> Span {
+        match self {
+            DirSpec::In(kw) => kw.span(),
+            DirSpec::MemIn(kw) => kw.span(),
+            DirSpec::Out(kw) => kw.span(),
+            DirSpec::MemOut(kw) => kw.span(),
+            DirSpec::Lateout(kw) => kw.span(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Display)]
 pub enum DualDirSpec {
     #[display("inout")]
     Inout(kw::inout),
+    #[display("mem_inout")]
+    MemInout(kw::mem_inout),
     #[display("inlateout")]
     Inlateout(kw::inlateout),
 }
@@ -169,8 +223,9 @@ pub enum DualDirSpec {
 impl DualDirSpec {
     pub fn span(&self) -> Span {
         match self {
-            DualDirSpec::Inout(inout) => inout.span(),
-            DualDirSpec::Inlateout(inlateout) => inlateout.span(),
+            DualDirSpec::Inout(kw) => kw.span(),
+            DualDirSpec::MemInout(kw) => kw.span(),
+            DualDirSpec::Inlateout(kw) => kw.span(),
         }
     }
 }
@@ -282,13 +337,30 @@ impl Parse for AsmOption {
         peek_select!(input, {
             kw::pure => Ok(AsmOption::Pure(input.parse()?)),
             kw::nomem => Ok(AsmOption::Nomem(input.parse()?)),
+            kw::explicit_mem => Ok(AsmOption::ExplicitMem(input.parse()?)),
             kw::readonly => Ok(AsmOption::Readonly(input.parse()?)),
+            kw::reads_address_space => Ok(AsmOption::ReadsAddressSpace(input.parse()?, input.parse()?)),
+            kw::writes_address_space => Ok(AsmOption::WritesAddressSpace(input.parse()?, input.parse()?)),
             kw::preserves_flags => Ok(AsmOption::PreservesFlags(input.parse()?)),
             kw::noreturn => Ok(AsmOption::Noreturn(input.parse()?)),
             kw::nostack => Ok(AsmOption::Nostack(input.parse()?)),
             kw::raw => Ok(AsmOption::Raw(input.parse()?));
             _ => {
                 Err(syn::Error::new(input.span(), "expected asm option"))
+            },
+        })
+    }
+}
+
+// AddressSpace -> global | shared | local
+impl Parse for AddressSpace {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        peek_select!(input, {
+            kw::global => Ok(AddressSpace::Global(input.parse()?)),
+            kw::shared => Ok(AddressSpace::Shared(input.parse()?)),
+            kw::local => Ok(AddressSpace::Local(input.parse()?));
+            _ => {
+                Err(syn::Error::new(input.span(), "expected global, shared or local"))
             },
         })
     }
@@ -328,7 +400,27 @@ impl Parse for RegOperandBody {
                     input.parse()?,
                 ))
             },
+            kw::mem_in => {
+                let dir = input.parse()?;
+                let content;
+                syn::parenthesized!(content in input);
+                Ok(RegOperandBody::DirSpec(
+                    dir,
+                    content.parse()?,
+                    input.parse()?,
+                ))
+            },
             kw::out => {
+                let dir = input.parse()?;
+                let content;
+                syn::parenthesized!(content in input);
+                Ok(RegOperandBody::DirSpec(
+                    dir,
+                    content.parse()?,
+                    input.parse()?,
+                ))
+            },
+            kw::mem_out => {
                 let dir = input.parse()?;
                 let content;
                 syn::parenthesized!(content in input);
@@ -349,6 +441,16 @@ impl Parse for RegOperandBody {
                 ))
             },
             kw::inout => {
+                let dir = input.parse()?;
+                let content;
+                syn::parenthesized!(content in input);
+                 Ok(RegOperandBody::DualDirSpec(
+                    dir,
+                    content.parse()?,
+                    input.parse()?,
+                ))
+            },
+            kw::mem_inout => {
                 let dir = input.parse()?;
                 let content;
                 syn::parenthesized!(content in input);
@@ -395,40 +497,41 @@ impl Parse for DualDirSpecExpression {
 // RegSpec → RegisterClass | ExplicitRegister
 impl Parse for RegSpec {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        if input.peek(LitStr) {
-            Ok(RegSpec::Explicit(input.parse()?))
-        } else if input.peek(Token![_]) {
-            Ok(RegSpec::Inferred(input.parse()?))
-        } else {
-            Ok(RegSpec::Class(input.parse()?))
-        }
+        peek_select!(input, {
+            token::Underscore => input.parse().map(RegSpec::Inferred),
+            LitStr =>  input.parse().map(RegSpec::Explicit);
+            _ => input.parse().map(RegSpec::Class),
+        })
     }
 }
 
-// DirSpec → in | out | lateout
+// DirSpec → in | mem_in | out | mem_out | lateout
 impl Parse for DirSpec {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         peek_select!(input, {
             token::In => input.parse().map(DirSpec::In),
+            kw::mem_in => input.parse().map(DirSpec::MemIn),
             kw::out => input.parse().map(DirSpec::Out),
+            kw::mem_out => input.parse().map(DirSpec::MemOut),
             kw::lateout => input.parse().map(DirSpec::Lateout);
             _ => Err(syn::Error::new(
                 input.span(),
-                "expected `in`, `out`, or `lateout`",
+                "expected `in`, `mem_in`, `out`, `mem_out` or `lateout`",
             )),
         })
     }
 }
 
-// DualDirSpec → inout | inlateout
+// DualDirSpec → inout | mem_inout | inlateout
 impl Parse for DualDirSpec {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         peek_select!(input, {
             kw::inout => input.parse().map(DualDirSpec::Inout),
+            kw::mem_inout => input.parse().map(DualDirSpec::MemInout),
             kw::inlateout => input.parse().map(DualDirSpec::Inlateout);
             _ => Err(syn::Error::new(
                 input.span(),
-                "expected `inout` or `inlateout`",
+                "expected `inout`, `mem_inout` or `inlateout`",
             )),
         })
     }
@@ -465,7 +568,7 @@ impl AsmArgs {
                     ))?;
                 }
                 AsmOperand::AsmOptions(options) => options.validate(self)?,
-                AsmOperand::RegOperand(reg) => reg.validate()?,
+                AsmOperand::RegOperand(reg) => reg.validate(self)?,
             }
         }
         Ok(())
@@ -483,10 +586,14 @@ impl AsmArgs {
 
     pub fn out_registers(&self) -> impl Iterator<Item = RegOperand> {
         self.registers().into_iter().filter(|it| match &it.body {
-            RegOperandBody::DirSpec(dir, _, _) => {
-                matches!(dir, DirSpec::Out(_) | DirSpec::Lateout(_))
-            }
-            RegOperandBody::DualDirSpec(..) => true,
+            RegOperandBody::DirSpec(dir, ..) => match dir {
+                DirSpec::In(_) | DirSpec::MemIn(_) | DirSpec::MemOut(_) => false,
+                DirSpec::Out(_) | DirSpec::Lateout(_) => true,
+            },
+            RegOperandBody::DualDirSpec(dir, ..) => match dir {
+                DualDirSpec::MemInout(_) => false,
+                DualDirSpec::Inout(_) | DualDirSpec::Inlateout(_) => true,
+            },
             _ => false,
         })
     }
@@ -518,7 +625,66 @@ impl AsmOptions {
                         ))?;
                     }
                 }
-                AsmOption::Nomem(_) | AsmOption::Readonly(_) => {}
+                AsmOption::Nomem(token) => {
+                    let has_conflict = self
+                        .options
+                        .iter()
+                        .any(|it| matches!(it, AsmOption::Readonly(_) | AsmOption::ExplicitMem(_)));
+                    if has_conflict {
+                        Err(syn::Error::new(
+                            token.span(),
+                            "`nomem` cannot be combined with `readonly` or `explicit_mem`",
+                        ))?;
+                    }
+                }
+                AsmOption::ExplicitMem(token) => {
+                    let has_conflict = self
+                        .options
+                        .iter()
+                        .any(|it| matches!(it, AsmOption::Readonly(_) | AsmOption::Nomem(_)));
+                    if has_conflict {
+                        Err(syn::Error::new(
+                            token.span(),
+                            "`explicit_mem` cannot be combined with `readonly` or `nomem`",
+                        ))?;
+                    }
+                }
+                AsmOption::Readonly(token) => {
+                    let has_conflict = self
+                        .options
+                        .iter()
+                        .any(|it| matches!(it, AsmOption::ExplicitMem(_) | AsmOption::Nomem(_)));
+                    if has_conflict {
+                        Err(syn::Error::new(
+                            token.span(),
+                            "`readonly` cannot be combined with `explicit_mem` or `nomem`",
+                        ))?;
+                    }
+                }
+                AsmOption::ReadsAddressSpace(token, ..) => {
+                    let has_explicit = self
+                        .options
+                        .iter()
+                        .any(|it| matches!(it, AsmOption::ExplicitMem(_)));
+                    if !has_explicit {
+                        Err(syn::Error::new(
+                            token.span(),
+                            "`reads_address_space` requires `explicit_mem`",
+                        ))?;
+                    }
+                }
+                AsmOption::WritesAddressSpace(token, ..) => {
+                    let has_explicit = self
+                        .options
+                        .iter()
+                        .any(|it| matches!(it, AsmOption::ExplicitMem(_)));
+                    if !has_explicit {
+                        Err(syn::Error::new(
+                            token.span(),
+                            "`writes_address_space` requires `explicit_mem`",
+                        ))?;
+                    }
+                }
                 unsupported @ (AsmOption::PreservesFlags(_)
                 | AsmOption::Noreturn(_)
                 | AsmOption::Nostack(_)
@@ -533,24 +699,59 @@ impl AsmOptions {
 }
 
 impl RegOperand {
-    pub fn validate(&self) -> syn::Result<()> {
+    pub fn validate(&self, args: &AsmArgs) -> syn::Result<()> {
         match &self.body {
             RegOperandBody::DirSpec(dir, ..) => {
                 // Maybe validate register class, leave for now since it's ignored. I wish there was
                 // `compile_warning!()`...
-                if let DirSpec::Lateout(token) = dir {
-                    Err(syn::Error::new_spanned(
-                        token,
-                        "`lateout` direction is currently not supported",
-                    ))?;
+                match dir {
+                    DirSpec::MemIn(_) | DirSpec::MemOut(_) => {
+                        let opts = args.operands.iter().filter_map(|opd| match &opd.operand {
+                            AsmOperand::AsmOptions(asm_options) => Some(asm_options.options.iter()),
+                            _ => None,
+                        });
+                        let is_explicit = opts
+                            .flatten()
+                            .any(|opt| matches!(opt, AsmOption::ExplicitMem(_)));
+                        if !is_explicit {
+                            Err(syn::Error::new(
+                                dir.span(),
+                                "`mem_*` register directions require `explicit_mem`",
+                            ))?;
+                        }
+                    }
+                    DirSpec::Lateout(kw) => {
+                        Err(syn::Error::new_spanned(
+                            kw,
+                            "`lateout` direction is currently not supported",
+                        ))?;
+                    }
+                    DirSpec::In(..) | DirSpec::Out(..) => {}
                 }
             }
-            RegOperandBody::DualDirSpec(dir, ..) => {
-                Err(syn::Error::new(
-                    dir.span(),
-                    format!("`{}` direction is currently not supported", dir),
-                ))?;
-            }
+            RegOperandBody::DualDirSpec(dir, ..) => match dir {
+                DualDirSpec::MemInout(_) => {
+                    let opts = args.operands.iter().filter_map(|opd| match &opd.operand {
+                        AsmOperand::AsmOptions(asm_options) => Some(asm_options.options.iter()),
+                        _ => None,
+                    });
+                    let is_explicit = opts
+                        .flatten()
+                        .any(|opt| matches!(opt, AsmOption::ExplicitMem(_)));
+                    if !is_explicit {
+                        Err(syn::Error::new(
+                            dir.span(),
+                            "`mem_*` register directions require `explicit_mem`",
+                        ))?;
+                    }
+                }
+                DualDirSpec::Inout(_) | DualDirSpec::Inlateout(_) => {
+                    Err(syn::Error::new(
+                        dir.span(),
+                        format!("`{}` direction is currently not supported", dir),
+                    ))?;
+                }
+            },
             RegOperandBody::Const(_) => {}
             RegOperandBody::Sym(keyword, ..) => {
                 Err(syn::Error::new(
@@ -573,8 +774,8 @@ impl RegOperand {
 pub struct AsmExpression {
     /// `format!()` call with the args already filled in for simplicity
     pub asm: TokenStream,
-    pub outputs: Vec<Expression>,
-    pub inputs: Vec<Expression>,
+    pub outputs: Vec<(Expression, RegSpec)>,
+    pub inputs: Vec<(Expression, RegOperandKind)>,
     pub options: Vec<Ident>,
 }
 
@@ -599,19 +800,30 @@ pub fn parse_asm_call(ctx: &mut Context, tokens: TokenStream) -> syn::Result<Asm
 
     for reg in registers {
         match reg.body {
-            RegOperandBody::DirSpec(dir_spec, _, expr) => {
+            RegOperandBody::DirSpec(dir_spec, reg, expr) => {
                 let expr = Expression::from_expr(expr, ctx)?;
                 match dir_spec {
-                    DirSpec::In(_) => {
-                        inputs.push(expr);
+                    dir @ (DirSpec::In(_) | DirSpec::MemIn(_) | DirSpec::MemOut(_)) => {
+                        inputs.push((expr, RegOperandKind::DirSpec(dir, reg)));
                     }
                     DirSpec::Out(_) | DirSpec::Lateout(_) => {
-                        outputs.push(expr);
+                        outputs.push((expr, reg));
+                    }
+                }
+            }
+            RegOperandBody::DualDirSpec(dir_spec, reg, DualDirSpecExpression::Single(expr)) => {
+                let expr = Expression::from_expr(expr, ctx)?;
+                match dir_spec {
+                    dir @ DualDirSpec::MemInout(_) => {
+                        inputs.push((expr, RegOperandKind::DualDirSpec(dir, reg)));
+                    }
+                    DualDirSpec::Inout(_) | DualDirSpec::Inlateout(_) => {
+                        unimplemented!();
                     }
                 }
             }
             RegOperandBody::DualDirSpec(..) => {
-                unimplemented!()
+                unimplemented!();
             }
             RegOperandBody::Const(..) => {}
             RegOperandBody::Sym(..) | RegOperandBody::Label(..) => unimplemented!(),

--- a/crates/cubecl-opt/src/analyses/pointer_source.rs
+++ b/crates/cubecl-opt/src/analyses/pointer_source.rs
@@ -186,8 +186,17 @@ impl Analysis for GlobalVisibility {
                                 MemoryEffect::Write(affects) => state.check_write(ctx, affects),
                                 // Inline asm: it names no pointer, so it can
                                 // touch any buffer the kernel holds.
+                                MemoryEffect::ReadAllInSpace(AddressSpace::Global(_)) => {
+                                    state.read_all();
+                                }
+                                MemoryEffect::WriteAllInSpace(AddressSpace::Global(_)) => {
+                                    state.write_all();
+                                }
                                 MemoryEffect::ReadAll => state.read_all(),
                                 MemoryEffect::WriteAll => state.write_all(),
+                                // Not affecting global
+                                MemoryEffect::ReadAllInSpace(_)
+                                | MemoryEffect::WriteAllInSpace(_) => {}
                             }
                         }
                     }

--- a/crates/cubecl-opt/tests/visibility.rs
+++ b/crates/cubecl-opt/tests/visibility.rs
@@ -13,6 +13,7 @@ use cubecl_ir::{
         ATTR_BUFFER_BINDING, ATTR_BUFFER_IO, BufferBindingAttr, BufferIOAttr, FuncInterface,
     },
     dialect::{
+        RegSpec,
         asm::InlineAsmOp,
         memory::{IndexOp, LoadOp, StoreOp},
     },
@@ -136,7 +137,9 @@ fn an_untraceable_global_pointer_is_attributed_by_its_type() {
         let asm = InlineAsmOp::new(
             ctx,
             vec![ptr_ty.to_handle()],
+            vec![RegSpec::Inferred],
             "mystery_pointer".into(),
+            vec![],
             vec![],
         );
         asm.set_nomem(ctx);
@@ -173,7 +176,14 @@ fn inline_asm_reaches_every_buffer() {
     let _a = global(&scope, 0);
     let _b = global(&scope, 1);
 
-    let asm = InlineAsmOp::new(scope.ctx_mut(), vec![], "who_knows".into(), vec![]);
+    let asm = InlineAsmOp::new(
+        scope.ctx_mut(),
+        vec![],
+        vec![],
+        "who_knows".into(),
+        vec![],
+        vec![],
+    );
     scope.register(&asm);
 
     let visibility = visibility(scope);
@@ -196,7 +206,14 @@ fn readonly_inline_asm_marks_reads_only() {
     let scope = kernel();
     let _a = global(&scope, 0);
 
-    let asm = InlineAsmOp::new(scope.ctx_mut(), vec![], "observer".into(), vec![]);
+    let asm = InlineAsmOp::new(
+        scope.ctx_mut(),
+        vec![],
+        vec![],
+        "observer".into(),
+        vec![],
+        vec![],
+    );
     asm.set_readonly(scope.ctx_mut());
     scope.register(&asm);
 

--- a/crates/cubecl-opt/tests/visibility.rs
+++ b/crates/cubecl-opt/tests/visibility.rs
@@ -13,7 +13,7 @@ use cubecl_ir::{
         ATTR_BUFFER_BINDING, ATTR_BUFFER_IO, BufferBindingAttr, BufferIOAttr, FuncInterface,
     },
     dialect::{
-        RegSpec,
+        MemoryClobbers, RegSpec,
         asm::InlineAsmOp,
         memory::{IndexOp, LoadOp, StoreOp},
     },
@@ -134,16 +134,15 @@ fn an_untraceable_global_pointer_is_attributed_by_its_type() {
         let ctx = scope.ctx_mut();
         let inner = IndexType::get(ctx);
         let ptr_ty = PointerType::get(ctx, inner.into(), AddressSpace::Global(1));
-        let asm = InlineAsmOp::new(
+        InlineAsmOp::new(
             ctx,
             vec![ptr_ty.to_handle()],
             vec![RegSpec::Inferred],
             "mystery_pointer".into(),
+            MemoryClobbers::Nomem,
             vec![],
             vec![],
-        );
-        asm.set_nomem(ctx);
-        asm
+        )
     };
     scope.register(&ptr);
     let ptr = ptr.results(scope.ctx())[0];
@@ -181,6 +180,7 @@ fn inline_asm_reaches_every_buffer() {
         vec![],
         vec![],
         "who_knows".into(),
+        MemoryClobbers::ReadWrite,
         vec![],
         vec![],
     );
@@ -211,10 +211,10 @@ fn readonly_inline_asm_marks_reads_only() {
         vec![],
         vec![],
         "observer".into(),
+        MemoryClobbers::Readonly,
         vec![],
         vec![],
     );
-    asm.set_readonly(scope.ctx_mut());
     scope.register(&asm);
 
     let visibility = visibility(scope);


### PR DESCRIPTION
Adds memory args for `gpu_asm!` so buffers can be properly marked and we don't need to clobber all address spaces when pointers can be traced. The new syntax is custom, it adds `mem_in`, `mem_out` and `mem_inout` directions, as well as the new `explicit_mem` option to disable the default clobber while still marking the op as having memory effects (i.e. for generating the `"memory"` clobber in C++).

Adds `MemoryEffects` implementation for inline PTX, it was missing that before and this caused correctness issues in the buffer visibility analysis.