### PR TITLE
fix(core): pin a scalar's WithScalar to itself

### DIFF
--- a/crates/cubecl-core/src/frontend/element/cube_elem.rs
+++ b/crates/cubecl-core/src/frontend/element/cube_elem.rs
@@ -100,7 +100,7 @@ impl<T: CubePrimitive> CubePrimitiveExpand for NativeExpand<T> {
 /// **not** for `Vector` or non-standard primitives like `Barrier`. Alternatively, treat these as
 /// types that can be stored in a [`Vector`]
 pub trait Scalar:
-    CubePrimitive<Scalar = Self, Size = Const<1>>
+    CubePrimitive<Scalar = Self, Size = Const<1>, WithScalar<Self> = Self>
     + Default
     + IntoRuntime
     + Debug


### PR DESCRIPTION
Every `Scalar` implementor already defines `WithScalar<S> = S`. The types that map it
elsewhere, `Vector`, `Atomic` and `NativeExpand`, are not scalars. `Scalar` pins
`Scalar = Self` and `Size = Const<1>` in the same position already.

Without it, code generic over `Numeric` or `Float` cannot apply an operator to its own
element type: the result is an opaque `T::WithScalar<T>` with no operators on it. #1300
generalized the associated type for the container types and the scalar side was never
pinned back down.

## Testing

`cargo check --workspace --all-targets` clean here. Downstream, it fixes 20 errors in
cubek-tile with no cubek changes at all; the alternative was a `WithScalar<T> = T` bound
spreading through 71 generic sites in that crate alone.
