### PR TITLE
test(runtime): coordinate the profile tests with the refusal toggle

### DIFF
--- a/crates/cubecl-runtime/tests/integration_test.rs
+++ b/crates/cubecl-runtime/tests/integration_test.rs
@@ -334,6 +334,7 @@ fn autotune_short_circuit_disabled_benchmarks_all() {
 /// the *original* panic (the issue's symptom), instead of an opaque `CallError`.
 #[test_log::test]
 #[cfg(feature = "std")]
+#[serial_test::parallel]
 fn profile_reraises_panic_from_profiled_closure() {
     let client = test_client(&DummyDevice);
 
@@ -356,6 +357,7 @@ fn profile_reraises_panic_from_profiled_closure() {
 /// `unwrap_or_resume` swap turning a normal result into a panic).
 #[test_log::test]
 #[cfg(feature = "std")]
+#[serial_test::parallel]
 fn profile_returns_ok_on_success() {
     let client = test_client(&DummyDevice);
 


### PR DESCRIPTION
`profile_returns_ok_on_success` fails intermittently in CI, with a message set by a different test:

```
a successful profiled closure must return Ok: An execution error happened during profiling
Caused by:
  this test server was told to refuse profiles
```

`REFUSE_PROFILES` is a process-wide `AtomicBool`. #1573 introduced it together with `a_refused_profile_degrades_to_an_untimed_launch`, which flips it on, runs, and flips it off, and is marked `#[serial_test::serial]`.

The two tests that call `profile` come from #1376, two months earlier, and carry no `serial_test` attribute at all. That was correct when they were written, since the flag did not exist. `serial_test` only excludes tests marked `serial` or `parallel`, so an unmarked test runs freely inside the window where profiles are refused, and a test asserting that profiling succeeds fails with the refusal.

Marking both readers `#[serial_test::parallel]` closes it. `exclusive_stays_recoverable_on_task_panic` goes through `exclusive` rather than `profile`, so it is left alone, as are the two allocation tests.

Seen on #1559, where the only difference from a passing run is a rebase onto a main that contains #1573. I could not reproduce it locally in 25 runs of the unpatched tree, so this rests on the mechanism and the CI panic rather than on a local reproduction: the window is narrower on a machine that is faster and less loaded than a runner.
