### PR TITLE
fix(cpp): lower CUDA complex casts with cuComplex helpers

### DIFF
--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -128,15 +128,38 @@ fn vectorized(ctx: &Context, scalar: TypeHandle, vector_size: usize) -> TypeHand
 
 cuda_op_with_out!(CastOp, |op, ctx| {
     let input = op.input(ctx);
+    let input_name = input.name(ctx);
     let out_ty = op.get_result(ctx).get_type(ctx);
-    if input.is_fp8_fp6_fp4(ctx) || input.is_packed_fp6_fp8_fp4(ctx) {
+    let out_scalar = out_ty.scalar_ty(ctx).deref(ctx);
+
+    if out_scalar.is::<Complex32Type>() {
+        if input.is_complex(ctx) {
+            format!("make_cuFloatComplex({input_name}.x, {input_name}.y)")
+        } else {
+            format!("make_cuFloatComplex({input_name}, 0.0f)")
+        }
+    } else if out_scalar.is::<Complex64Type>() {
+        if input.is_complex(ctx) {
+            format!("make_cuDoubleComplex({input_name}.x, {input_name}.y)")
+        } else {
+            format!("make_cuDoubleComplex({input_name}, 0.0)")
+        }
+    } else if input.is_complex(ctx) {
+        if out_ty.is_tfloat32(ctx) {
+            format!("nvcuda::wmma::__float_to_tf32({input_name}.x)")
+        } else if out_ty.is_bool(ctx) {
+            format!("({input_name}.x != 0 || {input_name}.y != 0)")
+        } else {
+            format!("{}({input_name}.x)", out_ty.to_cpp(ctx))
+        }
+    } else if input.is_fp8_fp6_fp4(ctx) || input.is_packed_fp6_fp8_fp4(ctx) {
         cast_minifloat_to_half(ctx, input)
     } else if out_ty.is_fp8_fp6_fp4(ctx) || out_ty.is_packed_fp6_fp8_fp4(ctx) {
         cast_half_to_minifloat(ctx, input, out_ty)
     } else if out_ty.is_tfloat32(ctx) {
-        format!("nvcuda::wmma::__float_to_tf32({})", input.name(ctx))
+        format!("nvcuda::wmma::__float_to_tf32({input_name})")
     } else {
-        format!("{}({})", out_ty.to_cpp(ctx), input.name(ctx))
+        format!("{}({input_name})", out_ty.to_cpp(ctx))
     }
 });
 
@@ -202,4 +225,82 @@ fn fp8_source_prefix(ctx: &Context, input: Value) -> &'static str {
         Float64Type => "double",;
         _ => unsupported()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        shared::operation::OpToCPP,
+        target::{CtxTarget, Target},
+    };
+    use cubecl_core::ir::{ComplexKind, ConstantValue, ElemType, FloatKind, UIntKind};
+    use pliron::builtin::ops::ConstantOp;
+
+    fn cast(input: ConstantValue, input_ty: ElemType, output_ty: ElemType) -> String {
+        let mut ctx = Context::new();
+        ctx.set_target(Target::Cuda);
+        let input_attr = input.as_attribute(&ctx, input_ty);
+        let input = ConstantOp::new(&mut ctx, input_attr).get_result(&ctx);
+        let input_name = input.name(&ctx).to_string();
+        let output_ty = output_ty.to_type(&ctx);
+        let op = CastOp::new(&mut ctx, output_ty, input);
+        let cpp = OpToCPP::<Cuda>::to_cpp(&op, &ctx);
+        cpp.split_once(" = ")
+            .unwrap()
+            .1
+            .replace(&input_name, "input")
+    }
+
+    #[test]
+    fn complex_casts_use_cucomplex_components_and_constructors() {
+        assert_eq!(
+            cast(
+                ConstantValue::UInt(0),
+                UIntKind::U32.into(),
+                ComplexKind::C64.into()
+            ),
+            "make_cuDoubleComplex(input, 0.0);\n"
+        );
+        assert_eq!(
+            cast(
+                ConstantValue::Float(1.0),
+                FloatKind::F64.into(),
+                ComplexKind::C32.into()
+            ),
+            "make_cuFloatComplex(input, 0.0f);\n"
+        );
+        assert_eq!(
+            cast(
+                ConstantValue::Complex(1.0, 2.0),
+                ComplexKind::C64.into(),
+                ComplexKind::C32.into()
+            ),
+            "make_cuFloatComplex(input.x, input.y);\n"
+        );
+        assert_eq!(
+            cast(
+                ConstantValue::Complex(1.0, 2.0),
+                ComplexKind::C32.into(),
+                ComplexKind::C64.into()
+            ),
+            "make_cuDoubleComplex(input.x, input.y);\n"
+        );
+        assert_eq!(
+            cast(
+                ConstantValue::Complex(1.0, 2.0),
+                ComplexKind::C32.into(),
+                FloatKind::F64.into()
+            ),
+            "double(input.x);\n"
+        );
+        assert_eq!(
+            cast(
+                ConstantValue::Complex(0.0, 1.0),
+                ComplexKind::C32.into(),
+                ElemType::Bool
+            ),
+            "(input.x != 0 || input.y != 0);\n"
+        );
+    }
 }

--- a/crates/cubecl-ir/src/value.rs
+++ b/crates/cubecl-ir/src/value.rs
@@ -303,16 +303,16 @@ impl ConstantValue {
         }
     }
 
-    /// Returns the value of the variable as a bool.
+    /// Returns the scalar's truthiness.
     ///
-    /// It will panic if the scalar isn't a bool.
+    /// Complex values are true when either component is nonzero.
     pub fn as_bool(&self) -> bool {
         match self {
             ConstantValue::UInt(val) => *val != 0,
             ConstantValue::Int(val) => *val != 0,
             ConstantValue::Float(val) => *val != 0.,
             ConstantValue::Bool(val) => *val,
-            ConstantValue::Complex(_, _) => panic!("Complex constants can't be converted to bool"),
+            ConstantValue::Complex(re, im) => *re != 0. || *im != 0.,
         }
     }
 
@@ -357,35 +357,40 @@ impl ConstantValue {
     }
 
     pub fn cast_to(&self, other: impl Into<Type>) -> ConstantValue {
+        let real = match self {
+            ConstantValue::Complex(re, _) => ConstantValue::Float(*re),
+            value => *value,
+        };
+
         match other.into().elem_type() {
-            ElemType::Index => self.as_u64().into(),
+            ElemType::Index => real.as_u64().into(),
             ElemType::Float(kind) => match kind {
-                FloatKind::E2M1 => e2m1::from_f64(self.as_f64()).to_f64(),
-                FloatKind::E2M1x2 => e2m1::from_f64(self.as_f64()).to_f64(),
+                FloatKind::E2M1 => e2m1::from_f64(real.as_f64()).to_f64(),
+                FloatKind::E2M1x2 => e2m1::from_f64(real.as_f64()).to_f64(),
                 FloatKind::E2M3 | FloatKind::E3M2 => {
                     unimplemented!("FP6 constants not yet supported")
                 }
-                FloatKind::E4M3 => e4m3::from_f64(self.as_f64()).to_f64(),
-                FloatKind::E5M2 => e5m2::from_f64(self.as_f64()).to_f64(),
-                FloatKind::UE8M0 => ue8m0::from_f64(self.as_f64()).to_f64(),
-                FloatKind::F16 => half::f16::from_f64(self.as_f64()).to_f64(),
-                FloatKind::BF16 => half::bf16::from_f64(self.as_f64()).to_f64(),
-                FloatKind::Flex32 | FloatKind::TF32 | FloatKind::F32 => self.as_f64() as f32 as f64,
-                FloatKind::F64 => self.as_f64(),
+                FloatKind::E4M3 => e4m3::from_f64(real.as_f64()).to_f64(),
+                FloatKind::E5M2 => e5m2::from_f64(real.as_f64()).to_f64(),
+                FloatKind::UE8M0 => ue8m0::from_f64(real.as_f64()).to_f64(),
+                FloatKind::F16 => half::f16::from_f64(real.as_f64()).to_f64(),
+                FloatKind::BF16 => half::bf16::from_f64(real.as_f64()).to_f64(),
+                FloatKind::Flex32 | FloatKind::TF32 | FloatKind::F32 => real.as_f64() as f32 as f64,
+                FloatKind::F64 => real.as_f64(),
             }
             .into(),
             ElemType::Int(kind) => match kind {
-                IntKind::I8 => self.as_i64() as i8 as i64,
-                IntKind::I16 => self.as_i64() as i16 as i64,
-                IntKind::I32 => self.as_i64() as i32 as i64,
-                IntKind::I64 => self.as_i64(),
+                IntKind::I8 => real.as_i64() as i8 as i64,
+                IntKind::I16 => real.as_i64() as i16 as i64,
+                IntKind::I32 => real.as_i64() as i32 as i64,
+                IntKind::I64 => real.as_i64(),
             }
             .into(),
             ElemType::UInt(kind) => match kind {
-                UIntKind::U8 => self.as_u64() as u8 as u64,
-                UIntKind::U16 => self.as_u64() as u16 as u64,
-                UIntKind::U32 => self.as_u64() as u32 as u64,
-                UIntKind::U64 => self.as_u64(),
+                UIntKind::U8 => real.as_u64() as u8 as u64,
+                UIntKind::U16 => real.as_u64() as u16 as u64,
+                UIntKind::U32 => real.as_u64() as u32 as u64,
+                UIntKind::U64 => real.as_u64(),
             }
             .into(),
             ElemType::Complex(kind) => {
@@ -437,5 +442,26 @@ impl Display for ExpandValue {
 impl From<&ExpandValue> for ExpandValue {
     fn from(value: &ExpandValue) -> Self {
         *value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn complex_casts_use_the_real_component_except_for_bool() {
+        let value = ConstantValue::Complex(3.5, 2.0);
+        assert_eq!(value.cast_to(FloatKind::F64), ConstantValue::Float(3.5));
+        assert_eq!(value.cast_to(IntKind::I32), ConstantValue::Int(3));
+        assert_eq!(value.cast_to(UIntKind::U32), ConstantValue::UInt(3));
+        assert_eq!(
+            ConstantValue::Complex(0.0, 1.0).cast_to(ElemType::Bool),
+            ConstantValue::Bool(true)
+        );
+        assert_eq!(
+            ConstantValue::Complex(0.0, 0.0).cast_to(ElemType::Bool),
+            ConstantValue::Bool(false)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes CUDA lowering for casts involving `c32` and `c64` values.

CUDA complex types are C structs without converting constructors, so generic output such as `cuDoubleComplex(uint32(0))` is rejected by NVRTC. Complex casts now:

- construct `c32` and `c64` with `make_cuFloatComplex` / `make_cuDoubleComplex`
- convert complex precision component by component
- use the real component for numeric scalar casts
- treat a complex value as true when either component is nonzero

Constant folding now follows the same real-component and truthiness semantics as CUDA code generation.

Follow-up to #1300.

## Validation

- `cargo xtask validate`
- `cargo test -p cubecl-cuda complex_ -- --nocapture` (46 passed on NVIDIA A100)
- focused C++ emission tests for scalar-to-complex, `c32`/`c64`, complex-to-real, and complex-to-bool casts
- focused IR tests for constant complex casts

## Validate your PR with burn

- [x] Created a validation branch in the [cubek repo](https://github.com/Tracel-AI/cubek)
- [x] Updated cubek's main `Cargo.toml` with this PR hash
- [x] Fixed any broken tests or compilation errors in cubek
- [x] Submitted tracel-ai/cubek#586
- [x] Created a validation branch in the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Updated Burn's main `Cargo.toml` with this PR and cubek PR hashes
- [x] Fixed compilation errors caused by newer CubeCL APIs
- [x] Submitted tracel-ai/burn#5541
