### PR TITLE
fix(cpp): green the cubecl-cuda suite

### DIFF
--- a/crates/cubecl-cpp/src/cuda/convert.rs
+++ b/crates/cubecl-cpp/src/cuda/convert.rs
@@ -135,10 +135,27 @@ cuda_op_with_out!(CastOp, |op, ctx| {
         cast_half_to_minifloat(ctx, input, out_ty)
     } else if out_ty.is_tfloat32(ctx) {
         format!("nvcuda::wmma::__float_to_tf32({})", input.name(ctx))
+    } else if crosses_half_kinds(ctx, input, out_ty) {
+        format!("{}(float({}))", out_ty.to_cpp(ctx), input.name(ctx))
     } else {
         format!("{}({})", out_ty.to_cpp(ctx), input.name(ctx))
     }
 });
+
+/// Whether a cast goes between the two 16-bit float kinds, which is the one
+/// pair CUDA will not construct directly.
+///
+/// `__half` and `__nv_bfloat16` declare no constructor from each other, and
+/// each converts implicitly to `float` and to every integer width, so
+/// `__nv_bfloat16(h)` is ambiguous across seven candidates rather than simply
+/// absent — the error names the constructors instead of the missing one, which
+/// is why it reads as an overload problem. Naming the `float` hop resolves it
+/// and costs no accuracy: f32 holds either kind exactly, so the only rounding
+/// is the one into the destination that a direct cast would also do.
+fn crosses_half_kinds(ctx: &Context, input: Value, out_ty: TypeHandle) -> bool {
+    (input.is_float16(ctx) && out_ty.is_bfloat16(ctx))
+        || (input.is_bfloat16(ctx) && out_ty.is_float16(ctx))
+}
 
 // Cast from minifloat to half/bf16. Could be made more generic, but a simple mapping is easier
 // to understand. The naming is very inconsistent (i.e. halfraw2 vs bf162raw)

--- a/crates/cubecl-cpp/src/cuda/mod.rs
+++ b/crates/cubecl-cpp/src/cuda/mod.rs
@@ -12,6 +12,7 @@ pub mod ptx;
 pub mod signature;
 pub mod tma;
 pub mod ty;
+pub mod unary;
 
 use dialect::*;
 pub use mma::manual::{supported_mma_combinations, supported_scaled_mma_combinations};

--- a/crates/cubecl-cpp/src/cuda/unary.rs
+++ b/crates/cubecl-cpp/src/cuda/unary.rs
@@ -1,0 +1,24 @@
+use cubecl_core::ir::{dialect::math::TanhOp, prelude::*};
+
+use crate::{
+    shared::CompilationOptions,
+    shared::ty::TypedExtCPP,
+    shared::unary::{lower_target_unop, tanh_via_f32},
+    target::Cuda,
+};
+
+// `htanh`/`h2tanh` reach the hardware `tanh.approx.f16`, which is worth having
+// over an f32 round trip — but the intrinsics only appear in the CUDA 12.8
+// headers, and the instruction they lower to needs sm_75. `fast_tanh` carries
+// both conditions. Where either is missing, half precision `tanh` is computed
+// in f32 the way it always is on HIP.
+//
+// This runs before the packing pass, so a half pair that would have become
+// `h2tanh` is already f32 arithmetic by the time packing looks at it.
+lower_target_unop!(TanhOp, tanh_via_f32, Cuda, |op, ctx| {
+    op.get_result(ctx).is_half(ctx)
+        && !ctx
+            .aux_ty::<CompilationOptions>()
+            .supports_features
+            .fast_tanh
+});

--- a/crates/cubecl-cpp/src/hip/unary.rs
+++ b/crates/cubecl-cpp/src/hip/unary.rs
@@ -1,18 +1,13 @@
-use cubecl_core::{
-    self as cubecl,
-    ir::{dialect::math::TanhOp, prelude::*},
-    prelude::*,
+use cubecl_core::ir::{dialect::math::TanhOp, prelude::*};
+
+use crate::{
+    shared::ty::TypedExtCPP,
+    shared::unary::{lower_target_unop, tanh_via_f32},
+    target::Hip,
 };
 
-use crate::{shared::ty::TypedExtCPP, shared::unary::lower_target_unop, target::Hip};
-
-// HIP's fp16 headers don't provide `htanh`/`h2tanh` like CUDA does, so half precision `tanh` has
-// to be computed in f32.
+// HIP's fp16 headers don't provide `htanh`/`h2tanh`, so half precision `tanh` has to be computed
+// in f32.
 lower_target_unop!(TanhOp, tanh_via_f32, Hip, |op, ctx| op
     .get_result(ctx)
     .is_half(ctx));
-
-#[cube]
-fn tanh_via_f32<T: Float, N: Size>(input: Vector<T, N>) -> Vector<T, N> {
-    Vector::cast_from(Vector::<f32, N>::cast_from(input).tanh())
-}

--- a/crates/cubecl-cpp/src/shared/binary.rs
+++ b/crates/cubecl-cpp/src/shared/binary.rs
@@ -307,9 +307,16 @@ unrolling!(PowfOp);
 no_half!(PowfOp);
 
 shared_op_with_out!(PowiOp, |op, ctx| {
-    let lhs = op.lhs(ctx);
+    let lhs = op.lhs(ctx).name(ctx);
     let rhs = op.rhs(ctx).name(ctx);
-    format!("pow({}, {rhs})", lhs.name(ctx))
+    // The exponent is cast to the base's type rather than left as an integer:
+    // `pow(float, int)` picks the `powif`/`powi` overload, which the C-family
+    // math headers declare but leave to libdevice. NVRTC does not link it, so
+    // the call survives to ptxas as an unresolved extern. `pow` with an
+    // integral floating-point exponent is exact for a negative base, which is
+    // the case the integer overload existed to serve.
+    let elem = op.get_result(ctx).get_type(ctx).to_cpp(ctx);
+    format!("pow({lhs}, ({elem}){rhs})")
 });
 unrolling!(PowiOp);
 no_half!(PowiOp);

--- a/crates/cubecl-cpp/src/shared/unary.rs
+++ b/crates/cubecl-cpp/src/shared/unary.rs
@@ -307,6 +307,15 @@ fn trailing_zeros<T: Int, N: Size>(input: Vector<T, N>) -> Vector<u32, N> {
     select_many(input.equal(&Vector::zero()), bits, out)
 }
 
+/// Half precision `tanh` where the target has no native half version.
+///
+/// f32 holds f16 and bf16 exactly, so the only rounding is the one back into
+/// the half type.
+#[cube]
+pub(crate) fn tanh_via_f32<T: Float, N: Size>(input: Vector<T, N>) -> Vector<T, N> {
+    Vector::cast_from(Vector::<f32, N>::cast_from(input).tanh())
+}
+
 #[cube]
 fn cast_f16_bf16<T: Scalar, N: Size>(input: Vector<T, N>) -> Vector<bf16, N> {
     Vector::<bf16, N>::cast_from(Vector::<f32, N>::cast_from(input))


### PR DESCRIPTION
Seven tests in `cubecl-cuda` failed on an RTX 3070 (sm_86, CUDA 12.0 toolkit). All seven were compile failures in the generated CUDA C++, so the kernels never ran and nothing was numerically wrong. Three independent causes.

`powi` emitted `pow(base, exponent)` with the exponent left an `int32_t`. Overload resolution picks `pow(float, int)`, which lowers to the libdevice externs `powif`/`powi`. NVRTC does not inline those and nothing links libdevice, so the call reached ptxas as `Unresolved extern function '_Z5powiffi'` on every float type. Casting the exponent to the base's type takes the ordinary overload; `pow` is exact for a negative base raised to an integral exponent, the case the integer overload served.

Casting between `__half` and `__nv_bfloat16` emitted the constructor directly. Neither declares a constructor from the other and both convert implicitly to `float` and to every integer width, so the call is ambiguous across seven candidates. The fp8 -> bf16 path reached it through its `__half` intermediate. Naming the `float` hop resolves it at no cost in accuracy, f32 holding either kind exactly. Both scalar directions are covered; the packed `__half2`/`__nv_bfloat162` pair fails the same way but `CastOp` is not `packable!`, so codegen cannot reach it.

Half `tanh` emitted `htanh`, and a half pair `h2tanh`. Those arrived in the CUDA 12.8 headers and lower to `tanh.approx.f16`, which needs sm_75. `CompilationOptions::supports_features::fast_tanh` already carried both conditions and was set correctly, but nothing read it. Give it a reader: a CUDA lowering that computes half `tanh` in f32 when the flag is clear, mirroring the one HIP has always had. It runs before the packing pass, so a half pair is f32 arithmetic before packing could reach for `h2tanh`. `tanh_via_f32` moves to `shared::unary` rather than being written twice; HIP now takes it from there.

The tanh gate was checked in both directions on the 12.0 toolkit: as written it takes the f32 path and passes, and forcing `fast_tanh` on brings back `htanh` and the original failure, so a 12.8+ toolkit on sm_75+ keeps the native path.

cubecl-cuda: 937 passed / 7 failed -> 944 passed / 0 failed, plus the five graph tests. The `powi` change is in `shared`, so it reaches HIP, which was already working there; the emitted form is equivalent and compiles, but no AMD device was available to run it.