### PR TITLE
fix: stop advertising tensor cores on dies that have none

### DIFF
--- a/crates/cubecl-cpp/src/cuda/arch.rs
+++ b/crates/cubecl-cpp/src/cuda/arch.rs
@@ -15,11 +15,13 @@ impl CudaArchitecture {
     /// Turing has tensor cores and every Turing that does shipped under another brand, so the
     /// two coincide exactly at 7.5. The professional TU117 parts (T400 to T1000) are not caught.
     pub fn has_tensor_cores(version: u32, name: &str) -> bool {
-        // Tensor cores arrive with Volta.
-        if version < 70 {
-            return false;
+        match version {
+            // Tensor cores arrive with Volta.
+            ..70 => false,
+            // The GTX-branded Turings are the only later dies without them.
+            75 => !name.to_uppercase().contains("GTX"),
+            _ => true,
         }
-        !(version == 75 && name.to_uppercase().contains("GTX"))
     }
 }
 
@@ -59,6 +61,8 @@ mod tests {
             52,
             "NVIDIA GeForce GTX 980"
         ));
+        // Volta itself has them: the boundary is inclusive.
+        assert!(CudaArchitecture::has_tensor_cores(70, "Tesla V100-SXM2"));
     }
 
     #[test]

--- a/crates/cubecl-cpp/src/cuda/arch.rs
+++ b/crates/cubecl-cpp/src/cuda/arch.rs
@@ -5,26 +5,17 @@ use crate::shared::Architecture;
 #[derive(Debug)]
 pub struct CudaArchitecture {
     pub version: u32,
-    /// Whether this die has tensor cores, which its compute capability does not say.
-    ///
-    /// TU116 and TU117 report 7.5 exactly like every other Turing and ship without them, so a
-    /// version check alone advertises CMMA on a GTX 1660. The kernel then compiles, runs on
-    /// the ordinary FP16 pipeline at about a fiftieth of the rate, and reports a number that
-    /// looks comparable to one from a card that has the hardware.
+    /// Compute capability cannot say this: TU116 and TU117 report 7.5 like every other
+    /// Turing, and `mma.sync` still runs on them, on the FP16 pipeline at a fiftieth the rate.
     pub tensor_cores: bool,
 }
 
 impl CudaArchitecture {
-    /// Decided by the marketing name, because CUDA exposes no attribute for it: there is no
-    /// device property, and both dies share their compute capability with Turings that do have
-    /// tensor cores.
-    ///
-    /// No GTX-branded Turing has them. Every Turing that does shipped as RTX, Titan RTX,
-    /// Quadro RTX or Tesla, so the absence of tensor cores and the GTX brand coincide exactly
-    /// on 7.5. The professional TU117 parts, T400 through T1000, also lack them and are not
-    /// caught here; they keep reporting what they report today rather than being guessed at.
+    /// Decided by the marketing name because CUDA exposes no attribute for it. No GTX-branded
+    /// Turing has tensor cores and every Turing that does shipped under another brand, so the
+    /// two coincide exactly at 7.5. The professional TU117 parts (T400 to T1000) are not caught.
     pub fn has_tensor_cores(version: u32, name: &str) -> bool {
-        // Volta brought them; nothing before it has any.
+        // Tensor cores arrive with Volta.
         if version < 70 {
             return false;
         }
@@ -38,7 +29,6 @@ mod tests {
 
     #[test]
     fn turing_without_tensor_cores_is_told_apart_from_turing_with_them() {
-        // Same compute capability, opposite answers. This is the whole reason the name is read.
         assert!(!CudaArchitecture::has_tensor_cores(
             75,
             "NVIDIA GeForce GTX 1660 SUPER"
@@ -51,12 +41,11 @@ mod tests {
 
     #[test]
     fn the_gtx_exception_applies_only_to_turing() {
-        // A GTX at another compute capability is not a Turing and is not what this excludes.
         assert!(CudaArchitecture::has_tensor_cores(
             80,
             "NVIDIA A100-GTX-ish"
         ));
-        // And Tesla T4 is TU104: 7.5, tensor cores, no GTX in the name.
+        // Tesla T4 is TU104: 7.5 with tensor cores, no GTX in the name.
         assert!(CudaArchitecture::has_tensor_cores(75, "Tesla T4"));
     }
 
@@ -72,8 +61,6 @@ mod tests {
         ));
     }
 
-    /// A driver that will not name the device leaves the old behaviour rather than guessing a
-    /// card has no tensor cores, which would silently disable CMMA on hardware that has them.
     #[test]
     fn an_unnamed_device_keeps_what_its_version_says() {
         assert!(CudaArchitecture::has_tensor_cores(

--- a/crates/cubecl-cpp/src/cuda/arch.rs
+++ b/crates/cubecl-cpp/src/cuda/arch.rs
@@ -5,6 +5,82 @@ use crate::shared::Architecture;
 #[derive(Debug)]
 pub struct CudaArchitecture {
     pub version: u32,
+    /// Whether this die has tensor cores, which its compute capability does not say.
+    ///
+    /// TU116 and TU117 report 7.5 exactly like every other Turing and ship without them, so a
+    /// version check alone advertises CMMA on a GTX 1660. The kernel then compiles, runs on
+    /// the ordinary FP16 pipeline at about a fiftieth of the rate, and reports a number that
+    /// looks comparable to one from a card that has the hardware.
+    pub tensor_cores: bool,
+}
+
+impl CudaArchitecture {
+    /// Decided by the marketing name, because CUDA exposes no attribute for it: there is no
+    /// device property, and both dies share their compute capability with Turings that do have
+    /// tensor cores.
+    ///
+    /// No GTX-branded Turing has them. Every Turing that does shipped as RTX, Titan RTX,
+    /// Quadro RTX or Tesla, so the absence of tensor cores and the GTX brand coincide exactly
+    /// on 7.5. The professional TU117 parts, T400 through T1000, also lack them and are not
+    /// caught here; they keep reporting what they report today rather than being guessed at.
+    pub fn has_tensor_cores(version: u32, name: &str) -> bool {
+        // Volta brought them; nothing before it has any.
+        if version < 70 {
+            return false;
+        }
+        !(version == 75 && name.to_uppercase().contains("GTX"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CudaArchitecture;
+
+    #[test]
+    fn turing_without_tensor_cores_is_told_apart_from_turing_with_them() {
+        // Same compute capability, opposite answers. This is the whole reason the name is read.
+        assert!(!CudaArchitecture::has_tensor_cores(
+            75,
+            "NVIDIA GeForce GTX 1660 SUPER"
+        ));
+        assert!(CudaArchitecture::has_tensor_cores(
+            75,
+            "NVIDIA GeForce RTX 2060"
+        ));
+    }
+
+    #[test]
+    fn the_gtx_exception_applies_only_to_turing() {
+        // A GTX at another compute capability is not a Turing and is not what this excludes.
+        assert!(CudaArchitecture::has_tensor_cores(
+            80,
+            "NVIDIA A100-GTX-ish"
+        ));
+        // And Tesla T4 is TU104: 7.5, tensor cores, no GTX in the name.
+        assert!(CudaArchitecture::has_tensor_cores(75, "Tesla T4"));
+    }
+
+    #[test]
+    fn nothing_before_volta_has_them() {
+        assert!(!CudaArchitecture::has_tensor_cores(
+            61,
+            "NVIDIA GeForce GTX 1080"
+        ));
+        assert!(!CudaArchitecture::has_tensor_cores(
+            52,
+            "NVIDIA GeForce GTX 980"
+        ));
+    }
+
+    /// A driver that will not name the device leaves the old behaviour rather than guessing a
+    /// card has no tensor cores, which would silently disable CMMA on hardware that has them.
+    #[test]
+    fn an_unnamed_device_keeps_what_its_version_says() {
+        assert!(CudaArchitecture::has_tensor_cores(
+            75,
+            "unknown CUDA device"
+        ));
+    }
 }
 
 impl Display for CudaArchitecture {
@@ -19,7 +95,7 @@ impl Architecture for CudaArchitecture {
     }
 
     fn is_wmma_capable(&self) -> bool {
-        true
+        self.tensor_cores
     }
 
     fn is_mfma_capable(&self) -> bool {

--- a/crates/cubecl-cpp/src/cuda/mma/cuda_compiler.rs
+++ b/crates/cubecl-cpp/src/cuda/mma/cuda_compiler.rs
@@ -10,7 +10,7 @@ pub(super) fn supported_cmma_combinations_wmma(
     arch: &CudaArchitecture,
 ) -> SupportedMmaCombinations {
     let mut result: SupportedMmaCombinations = vec![];
-    if arch.get_version() >= WMMA_MINIMUM_VERSION {
+    if arch.get_version() >= WMMA_MINIMUM_VERSION && arch.tensor_cores {
         let tdims = vec![(16, 16, 16), (32, 8, 16), (8, 32, 16)];
         // Types fully supported.
         let types = vec![

--- a/crates/cubecl-cpp/src/cuda/mma/ptx_wmma_compiler.rs
+++ b/crates/cubecl-cpp/src/cuda/mma/ptx_wmma_compiler.rs
@@ -327,7 +327,7 @@ fn format_reg_and_inc(count: &mut u8) -> String {
 
 pub(super) fn supported_cmma_combinations_ptx(arch: &CudaArchitecture) -> SupportedMmaCombinations {
     let mut result: SupportedMmaCombinations = vec![];
-    if arch.get_version() >= WMMA_MINIMUM_VERSION {
+    if arch.get_version() >= WMMA_MINIMUM_VERSION && arch.tensor_cores {
         // Types fully supported.
         let types = vec![
             (

--- a/crates/cubecl-cpp/src/hip/arch.rs
+++ b/crates/cubecl-cpp/src/hip/arch.rs
@@ -12,7 +12,7 @@ impl Architecture for AMDArchitecture {
     fn is_wmma_capable(&self) -> bool {
         matches!(
             self,
-            AMDArchitecture::GFX10 | AMDArchitecture::GFX11 | AMDArchitecture::GFX12
+            AMDArchitecture::GFX103 | AMDArchitecture::GFX11 | AMDArchitecture::GFX12
         )
     }
 

--- a/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
+++ b/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
@@ -80,7 +80,7 @@ pub(super) fn supported_wmma_combinations_rocwmma(
                 )
                 .collect()
         }
-        AMDArchitecture::GFX10 | AMDArchitecture::GFX11 => {
+        AMDArchitecture::GFX103 | AMDArchitecture::GFX11 => {
             // For gfx11 the supported tile dimensions are always the same
             //                                   m   n   k
             let tdims = vec![(16, 16, 16), (16, 16, 32)];

--- a/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
+++ b/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
@@ -338,8 +338,7 @@ pub(super) fn supported_wmma_combinations_rocwmma(
                 ),
             ]
         }
-        // RDNA1 has no WMMA instructions at all: they arrive with RDNA3, and rocWMMA does
-        // not target gfx101x. Grouped with the unknown case because the answer is the same.
+        // RDNA1 has no WMMA instructions; they arrive with RDNA3.
         AMDArchitecture::GFX101 | AMDArchitecture::Other => vec![],
     };
     combinations

--- a/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
+++ b/crates/cubecl-cpp/src/hip/mma/rocwmma_compiler.rs
@@ -338,7 +338,9 @@ pub(super) fn supported_wmma_combinations_rocwmma(
                 ),
             ]
         }
-        AMDArchitecture::Other => vec![],
+        // RDNA1 has no WMMA instructions at all: they arrive with RDNA3, and rocWMMA does
+        // not target gfx101x. Grouped with the unknown case because the answer is the same.
+        AMDArchitecture::GFX101 | AMDArchitecture::Other => vec![],
     };
     combinations
         .into_iter()

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -80,10 +80,8 @@ impl DeviceService for CudaServer {
         // Querying texture row align is a heuristic, but also not guaranteed to be the same.
         let mem_alignment = 512;
 
-        // Read before the architecture rather than only for display, because whether this die
-        // has tensor cores is not in any attribute and the name is the only thing that says so.
-        // A driver that declines to name its device is not a reason to fail initialization; it
-        // costs the tensor-core exception, which leaves the old behaviour.
+        // The name is the only signal for tensor cores. A driver that declines to give one
+        // costs only the tensor-core exception, never initialization.
         let device_name = cudarc::driver::result::device::get_name(device_ptr)
             .unwrap_or_else(|_| "unknown CUDA device".to_string());
 

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -80,9 +80,17 @@ impl DeviceService for CudaServer {
         // Querying texture row align is a heuristic, but also not guaranteed to be the same.
         let mem_alignment = 512;
 
+        // Read before the architecture rather than only for display, because whether this die
+        // has tensor cores is not in any attribute and the name is the only thing that says so.
+        // A driver that declines to name its device is not a reason to fail initialization; it
+        // costs the tensor-core exception, which leaves the old behaviour.
+        let device_name = cudarc::driver::result::device::get_name(device_ptr)
+            .unwrap_or_else(|_| "unknown CUDA device".to_string());
+
         // Ask the wmma compiler for its supported combinations
         let arch = CudaArchitecture {
             version: arch_version,
+            tensor_cores: CudaArchitecture::has_tensor_cores(arch_version, &device_name),
         };
         let supported_cmma_combinations = CudaCmmaCompiler::Cpp.supported_cmma_combinations(&arch);
         let supported_mma_combinations = cuda::supported_mma_combinations(&arch);
@@ -177,10 +185,6 @@ impl DeviceService for CudaServer {
         // the compilation namespace and the identity. Built once and shared
         // with `CudaContext` below, so the two cannot disagree.
         let fingerprint = format!("ptx_sm{arch_version}");
-        // Display only, and a driver that declines to name its device is not a
-        // reason to fail initialization.
-        let device_name = cudarc::driver::result::device::get_name(device_ptr)
-            .unwrap_or_else(|_| "unknown CUDA device".to_string());
 
         let mut device_props = DeviceProperties::new(
             Default::default(),

--- a/crates/cubecl-ir/src/amd.rs
+++ b/crates/cubecl-ir/src/amd.rs
@@ -34,8 +34,7 @@ pub enum AMDArchitecture {
     GFX11,
     // gfx1030 through gfx1036 (RDNA2)
     GFX103,
-    // gfx1010 through gfx1013 (RDNA1). Wave32 like the RDNA generations after it, and the
-    // only one of them with no WMMA at all: the instructions arrive with RDNA3.
+    // gfx1010 through gfx1013 (RDNA1): wave32, but no WMMA, which arrives with RDNA3
     GFX101,
     // CDNA
     GFX908,
@@ -166,8 +165,6 @@ mod tests {
             ("gfx1201", Some(32), Some(AmdWmma::Rdna4)),
             ("gfx1100", Some(32), Some(AmdWmma::Rdna3)),
             ("gfx1030", Some(32), None),
-            // RDNA1. Wave32 like RDNA2, and no WMMA: the instructions arrive with RDNA3, so a
-            // prefix match that folded it into gfx103 advertised tensor ops it does not have.
             ("gfx1010", Some(32), None),
             ("gfx90a", Some(64), None),
             ("gfx942", Some(64), None),
@@ -178,19 +175,14 @@ mod tests {
         }
     }
 
-    /// RDNA1 and RDNA2 differ in what they can do, not in how wide their waves are, and a
-    /// prefix match on "gfx10" answered for both. The families are what the WMMA tables key
-    /// off, so folding them together advertised tensor operations RDNA1 has none of.
     #[test]
     fn rdna1_is_not_rdna2() {
         assert_eq!(GfxArch::parse("gfx1010").family(), AMDArchitecture::GFX101);
         assert_eq!(GfxArch::parse("gfx1012").family(), AMDArchitecture::GFX101);
         assert_eq!(GfxArch::parse("gfx1030").family(), AMDArchitecture::GFX103);
         assert_eq!(GfxArch::parse("gfx1032").family(), AMDArchitecture::GFX103);
-        // Both are wave32, which is why the fold went unnoticed.
         assert_eq!(GfxArch::parse("gfx1010").plane_dim(), Some(32));
         assert_eq!(GfxArch::parse("gfx1030").plane_dim(), Some(32));
-        // And neither has WMMA, which arrives with RDNA3.
         assert_eq!(GfxArch::parse("gfx1010").wmma(), None);
     }
 

--- a/crates/cubecl-ir/src/amd.rs
+++ b/crates/cubecl-ir/src/amd.rs
@@ -34,6 +34,9 @@ pub enum AMDArchitecture {
     GFX11,
     // gfx1030 through gfx1036 (RDNA2)
     GFX103,
+    // gfx1010 through gfx1013 (RDNA1). Wave32 like the RDNA generations after it, and the
+    // only one of them with no WMMA at all: the instructions arrive with RDNA3.
+    GFX101,
     // CDNA
     GFX908,
     GFX90A,
@@ -58,7 +61,10 @@ impl AMDArchitecture {
     /// CDNA runs wave64 (gfx9 and gfx940+) and RDNA wave32 (gfx10, gfx11, gfx12).
     pub fn plane_dim(&self) -> Option<u32> {
         match self {
-            AMDArchitecture::GFX103 | AMDArchitecture::GFX11 | AMDArchitecture::GFX12 => Some(32),
+            AMDArchitecture::GFX101
+            | AMDArchitecture::GFX103
+            | AMDArchitecture::GFX11
+            | AMDArchitecture::GFX12 => Some(32),
             AMDArchitecture::GFX908 | AMDArchitecture::GFX90A | AMDArchitecture::GFX94 => Some(64),
             AMDArchitecture::Other => None,
         }
@@ -70,8 +76,10 @@ impl AMDArchitecture {
             Ok(AMDArchitecture::GFX12)
         } else if norm.starts_with("gfx11") {
             Ok(AMDArchitecture::GFX11)
-        } else if norm.starts_with("gfx10") {
+        } else if norm.starts_with("gfx103") {
             Ok(AMDArchitecture::GFX103)
+        } else if norm.starts_with("gfx101") {
+            Ok(AMDArchitecture::GFX101)
         } else if norm == "gfx908" {
             Ok(AMDArchitecture::GFX908)
         } else if norm == "gfx90a" {
@@ -158,6 +166,9 @@ mod tests {
             ("gfx1201", Some(32), Some(AmdWmma::Rdna4)),
             ("gfx1100", Some(32), Some(AmdWmma::Rdna3)),
             ("gfx1030", Some(32), None),
+            // RDNA1. Wave32 like RDNA2, and no WMMA: the instructions arrive with RDNA3, so a
+            // prefix match that folded it into gfx103 advertised tensor ops it does not have.
+            ("gfx1010", Some(32), None),
             ("gfx90a", Some(64), None),
             ("gfx942", Some(64), None),
         ] {
@@ -165,6 +176,22 @@ mod tests {
             assert_eq!(gfx.plane_dim(), plane_dim, "{name}");
             assert_eq!(gfx.wmma(), wmma, "{name}");
         }
+    }
+
+    /// RDNA1 and RDNA2 differ in what they can do, not in how wide their waves are, and a
+    /// prefix match on "gfx10" answered for both. The families are what the WMMA tables key
+    /// off, so folding them together advertised tensor operations RDNA1 has none of.
+    #[test]
+    fn rdna1_is_not_rdna2() {
+        assert_eq!(GfxArch::parse("gfx1010").family(), AMDArchitecture::GFX101);
+        assert_eq!(GfxArch::parse("gfx1012").family(), AMDArchitecture::GFX101);
+        assert_eq!(GfxArch::parse("gfx1030").family(), AMDArchitecture::GFX103);
+        assert_eq!(GfxArch::parse("gfx1032").family(), AMDArchitecture::GFX103);
+        // Both are wave32, which is why the fold went unnoticed.
+        assert_eq!(GfxArch::parse("gfx1010").plane_dim(), Some(32));
+        assert_eq!(GfxArch::parse("gfx1030").plane_dim(), Some(32));
+        // And neither has WMMA, which arrives with RDNA3.
+        assert_eq!(GfxArch::parse("gfx1010").wmma(), None);
     }
 
     /// An architecture the table has never heard of reports no width rather than guessing

--- a/crates/cubecl-ir/src/amd.rs
+++ b/crates/cubecl-ir/src/amd.rs
@@ -32,8 +32,8 @@ pub enum AMDArchitecture {
     GFX12,
     // gfx1100, gfx1101, gfx1102
     GFX11,
-    // gfx1030, gfx1031, gfx1032
-    GFX10,
+    // gfx1030 through gfx1036 (RDNA2)
+    GFX103,
     // CDNA
     GFX908,
     GFX90A,
@@ -58,7 +58,7 @@ impl AMDArchitecture {
     /// CDNA runs wave64 (gfx9 and gfx940+) and RDNA wave32 (gfx10, gfx11, gfx12).
     pub fn plane_dim(&self) -> Option<u32> {
         match self {
-            AMDArchitecture::GFX10 | AMDArchitecture::GFX11 | AMDArchitecture::GFX12 => Some(32),
+            AMDArchitecture::GFX103 | AMDArchitecture::GFX11 | AMDArchitecture::GFX12 => Some(32),
             AMDArchitecture::GFX908 | AMDArchitecture::GFX90A | AMDArchitecture::GFX94 => Some(64),
             AMDArchitecture::Other => None,
         }
@@ -71,7 +71,7 @@ impl AMDArchitecture {
         } else if norm.starts_with("gfx11") {
             Ok(AMDArchitecture::GFX11)
         } else if norm.starts_with("gfx10") {
-            Ok(AMDArchitecture::GFX10)
+            Ok(AMDArchitecture::GFX103)
         } else if norm == "gfx908" {
             Ok(AMDArchitecture::GFX908)
         } else if norm == "gfx90a" {


### PR DESCRIPTION
Two backends advertise tensor-core support on dies that have none. The capability lands in `properties.features.matmul.cmma`, the gate everything downstream reads, so the result is not a refusal but a number that looks like any other.

## CUDA

`supported_cmma_combinations_*` gate on compute capability alone, and TU116/TU117 report 7.5 exactly like every Turing that has tensor cores. The kernel still compiles and runs: `mma.sync` is part of sm_75's ISA and falls back to the ordinary FP16 pipeline. Measured through `examples/throughput` on one machine holding both cards:

| card | compute-cmma |
|---|---|
| RTX 2060 | 60.67 TOPS/s |
| GTX 1660 SUPER | 1.17 TOPS/s |

`CudaArchitecture` now carries `tensor_cores`, decided by the device name because CUDA exposes no attribute for it. No GTX-branded Turing has tensor cores, and every Turing that does shipped under another brand, so the two coincide exactly at 7.5. Two limits: the professional TU117 parts (T400 through T1000) also lack them and are not caught, and a driver that will not name the device keeps the old behaviour rather than silently disabling CMMA on hardware that has it.

## AMD

`AMDArchitecture::parse` matched the `gfx10` prefix, folding gfx101x (RDNA1) into the RDNA2 variant. Both are wave32, which is why nothing keying on `plane_dim` noticed, but RDNA1 has no WMMA instructions at all: they arrive with RDNA3, and rocWMMA does not target gfx101x. The new `GFX101` variant reports wave32 and no WMMA. Folding into `Other` instead would have made the cards unusable, because the runtime refuses a device whose wave width it does not know.

The CUDA half is measured on hardware, the numbers above. The AMD half is unit-tested only: gfx1010 is outside ROCm's support matrix and I have no RDNA1 machine, so nothing here has executed on one.

Draft while the cross-repo validation below is outstanding.

---

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
