### PR TITLE
fix(cuda): stop advertising MMA and tensor cores on dies that have none

### DIFF
--- a/crates/cubecl-cpp/src/cuda/arch.rs
+++ b/crates/cubecl-cpp/src/cuda/arch.rs
@@ -25,6 +25,30 @@ impl CudaArchitecture {
     }
 }
 
+impl Display for CudaArchitecture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.version)
+    }
+}
+
+impl Architecture for CudaArchitecture {
+    fn warp_size(&self) -> u32 {
+        32
+    }
+
+    fn is_wmma_capable(&self) -> bool {
+        self.tensor_cores
+    }
+
+    fn is_mfma_capable(&self) -> bool {
+        false
+    }
+
+    fn get_version(&self) -> u32 {
+        self.version
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::CudaArchitecture;
@@ -71,29 +95,5 @@ mod tests {
             75,
             "unknown CUDA device"
         ));
-    }
-}
-
-impl Display for CudaArchitecture {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.version)
-    }
-}
-
-impl Architecture for CudaArchitecture {
-    fn warp_size(&self) -> u32 {
-        32
-    }
-
-    fn is_wmma_capable(&self) -> bool {
-        self.tensor_cores
-    }
-
-    fn is_mfma_capable(&self) -> bool {
-        false
-    }
-
-    fn get_version(&self) -> u32 {
-        self.version
     }
 }

--- a/crates/cubecl-cpp/src/cuda/mma/manual.rs
+++ b/crates/cubecl-cpp/src/cuda/mma/manual.rs
@@ -101,6 +101,9 @@ fn col_index(
 }
 
 pub fn supported_mma_combinations(arch: &CudaArchitecture) -> SupportedMmaCombinations {
+    if !arch.tensor_cores {
+        return vec![];
+    }
     let mut result: SupportedMmaCombinations = vec![];
     // Higher than WMMA because we only support the newest shapes. Other shapes would make things
     // very complicated.
@@ -201,6 +204,9 @@ pub fn supported_mma_combinations(arch: &CudaArchitecture) -> SupportedMmaCombin
 pub fn supported_scaled_mma_combinations(
     arch: &CudaArchitecture,
 ) -> SupportedScaledMmaCombinations {
+    if !arch.tensor_cores {
+        return vec![];
+    }
     let mut result: SupportedScaledMmaCombinations = vec![];
     // sm_120f
     if arch.get_version() >= 120 && arch.get_version() < 130 {
@@ -262,5 +268,24 @@ pub fn contiguous_elements_cuda(
     match ident {
         MatrixIdent::A | MatrixIdent::B => 32 / elem.size_bits(ctx),
         MatrixIdent::Accumulator => 2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::supported_mma_combinations;
+    use crate::cuda::arch::CudaArchitecture;
+
+    /// A die with no tensor cores offers no MMA at all, so nothing downstream can pick a tile
+    /// and measure the FP16 pipeline in units that claim tensor hardware.
+    #[test]
+    fn a_turing_die_without_tensor_cores_offers_no_mma() {
+        let turing = |name: &str| CudaArchitecture {
+            version: 75,
+            tensor_cores: CudaArchitecture::has_tensor_cores(75, name),
+        };
+
+        assert!(supported_mma_combinations(&turing("NVIDIA GeForce GTX 1660 SUPER")).is_empty());
+        assert!(!supported_mma_combinations(&turing("NVIDIA GeForce RTX 2060")).is_empty());
     }
 }

--- a/crates/cubecl-cuda/src/runtime.rs
+++ b/crates/cubecl-cuda/src/runtime.rs
@@ -152,7 +152,7 @@ impl DeviceService for CudaServer {
             let num_streaming_multiprocessors = Some(
                 get_attribute(device_ptr, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT).unwrap() as u32,
             );
-            let num_tensor_cores = tensor_cores_per_sm(arch_version);
+            let num_tensor_cores = tensor_cores_per_sm(&arch);
 
             comp_opts.warp_size = warp_size as usize;
 
@@ -369,8 +369,11 @@ impl DeviceService for CudaServer {
 pub type CudaCompiler = CppCompiler<Cuda>;
 pub type CudaComputeKernel = ComputeKernel;
 
-fn tensor_cores_per_sm(version: u32) -> Option<u32> {
-    match version {
+fn tensor_cores_per_sm(arch: &CudaArchitecture) -> Option<u32> {
+    if !arch.tensor_cores {
+        return None;
+    }
+    match arch.version {
         70 | 75 => Some(8),                           // Volta, Turing
         80 | 86 | 89 | 90 | 91 | 92 | 100 => Some(4), // Ampere, Hopper, Blackwell
         _ => None,                                    // Unknown or unsupported architecture


### PR DESCRIPTION
Follow up to #1588 

`CudaArchitecture::tensor_cores` gated the CMMA lists, but two other capability reports still keyed on compute capability alone. Measured on a GTX 1660 SUPER through the CUDA backend:

    hardware.num_tensor_cores    Some(8)
    features.matmul.mma          16x8x8 f16->f32
    features.matmul.cmma         empty

`select_cmma_tile` finds that MMA entry, a caller builds a probe around it, and the probe then measures the ordinary FP16 pipeline under a flag that says tensor hardware. The same card through the Vulkan backend reports no tensor cores and no tile for either accumulator, so the two backends disagreed about one die.

`tensor_cores_per_sm` now takes the architecture rather than the bare version, so the flag decides the count as it already decides the lists. `min_tensor_cores_dim` needed nothing: it keys on the CMMA list, which is empty on these dies.

Scaled MMA is gated on the same flag. Block-scaled `mma.sync` is a tensor-core instruction like the plain form, and gating it makes "no tensor hardware, no MMA" hold structurally instead of resting on the coincidence that the scaled list also requires sm_120, where every die has them.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
