### PR TITLE
fix(wgpu): close a device profile on its last compute pass

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/profiling.rs
+++ b/crates/cubecl-core/src/runtime_tests/profiling.rs
@@ -30,6 +30,34 @@ fn busy_kernel(output: &mut [f32]) {
     }
 }
 
+/// Launch counts sixteen times apart, both long enough to fill several command
+/// passes on a backend that batches launches into them.
+const FEW_LAUNCHES: usize = 32;
+const MANY_LAUNCHES: usize = 512;
+
+/// A quarter of the sixteen those counts differ by, leaving room for timer noise
+/// and the fixed cost of a window, and still far above the ratio of one that a
+/// window pinned to its first pass reports.
+const MIN_GROWTH: u32 = 4;
+
+#[cube(launch_unchecked)]
+fn touch_kernel(output: &mut [f32]) {
+    if ABSOLUTE_POS == 0 {
+        output[0] += 1.0;
+    }
+}
+
+fn touch<R: Runtime>(client: &ComputeClient<R>, output: &Handle) {
+    unsafe {
+        touch_kernel::launch_unchecked::<R>(
+            client,
+            CubeCount::new_single(),
+            CubeDim::new_single(),
+            BufferArg::from_raw_parts(output.clone(), 1),
+        );
+    }
+}
+
 fn launch<R: Runtime>(client: &ComputeClient<R>, output: &Handle) {
     unsafe {
         busy_kernel::launch_unchecked::<R>(
@@ -79,6 +107,43 @@ pub fn test_kernel_window_reports_positive_device_time<R: Runtime>(client: Compu
     assert!(
         duration < Duration::from_secs(5),
         "implausibly large: {duration:?}"
+    );
+}
+
+/// A window measures every command pass it spans, not just the first.
+///
+/// A backend batches launches into passes of a fixed size, so a loop long
+/// enough to fill several is the ordinary case rather than an edge one. Marking
+/// only the pass that opened the window reports the same figure however long
+/// the loop runs, which reads as launches getting cheaper the more of them
+/// there are, and autotune prices a candidate's launches off it.
+pub fn test_window_spans_every_pass_in_it<R: Runtime>(client: ComputeClient<R>) {
+    let output = client.empty(core::mem::size_of::<f32>());
+
+    // Compiling the kernel would otherwise land inside the first window.
+    touch::<R>(&client, &output);
+    cubecl_environment::future::block_on(client.sync()).unwrap();
+
+    let window = |launches: usize| {
+        let (_, profile) = client
+            .profile(
+                || {
+                    for _ in 0..launches {
+                        touch::<R>(&client, &output);
+                    }
+                },
+                "touch",
+            )
+            .unwrap();
+        resolve(profile)
+    };
+
+    let few = window(FEW_LAUNCHES);
+    let many = window(MANY_LAUNCHES);
+
+    assert!(
+        many > few * MIN_GROWTH,
+        "{MANY_LAUNCHES} launches measured {many:?} against {few:?} for {FEW_LAUNCHES}"
     );
 }
 
@@ -154,6 +219,14 @@ macro_rules! testgen_profiling {
         fn test_kernel_window_reports_positive_device_time() {
             let client = TestRuntime::client(&Default::default());
             cubecl_core::runtime_tests::profiling::test_kernel_window_reports_positive_device_time::<
+                TestRuntime,
+            >(client);
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_window_spans_every_pass_in_it() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::profiling::test_window_spans_every_pass_in_it::<
                 TestRuntime,
             >(client);
         }

--- a/crates/cubecl-wgpu/src/compute/stream.rs
+++ b/crates/cubecl-wgpu/src/compute/stream.rs
@@ -776,16 +776,9 @@ impl WgpuStream {
         device: &wgpu::Device,
     ) -> &'a mut wgpu::ComputePass<'static> {
         compute_pass.get_or_insert_with(|| {
-            let writes = if let Timings::Device(query_time) = timings {
-                query_time.register_profile_device(device).map(|query_set| {
-                    wgpu::ComputePassTimestampWrites {
-                        query_set,
-                        beginning_of_pass_write_index: Some(0),
-                        end_of_pass_write_index: Some(1),
-                    }
-                })
-            } else {
-                None
+            let writes = match timings {
+                Timings::Device(query_time) => query_time.register_profile_device(device),
+                Timings::System(_) => None,
             };
             encoder
                 .begin_compute_pass(&wgpu::ComputePassDescriptor {

--- a/crates/cubecl-wgpu/src/compute/timings.rs
+++ b/crates/cubecl-wgpu/src/compute/timings.rs
@@ -11,6 +11,11 @@ use wgpu::{QUERY_SIZE, QuerySet, QuerySetDescriptor, QueryType};
 
 type QuerySetId = u64;
 
+/// Slot a profile's start timestamp is written to, once, by the pass that opens it.
+const PROFILE_START_INDEX: u32 = 0;
+/// Slot every pass of a live profile rewrites, so the last one to run marks the end.
+const PROFILE_END_INDEX: u32 = 1;
+
 /// Metal caps live `MTLCounterSampleBuffer`s at 32 per device; leave a little headroom.
 const DEFAULT_MAX_METAL_TIMING_QUERY_SETS: u32 = 28;
 
@@ -82,8 +87,9 @@ impl TimestampQuerySetBudget {
 /// exhausted it reuses its own sets round-robin instead of allocating past the hardware limit.
 /// Reuse is safe because all of a device's streams submit to a single ordered queue, so a
 /// set's timestamp-write and resolve always execute atomically and in submission order — the
-/// only cost is that a profile spanning more compute passes than this allocator has sets may
-/// under-measure, which autotune tolerates. Releases every slot it holds on drop.
+/// only cost is that once the budget is exhausted a profile opens in a set an older one may
+/// still have started in, rewriting that start, which autotune tolerates. Releases every slot
+/// it holds on drop.
 #[derive(Debug)]
 struct QuerySetAllocator {
     /// Shared device budget of live timestamp query sets.
@@ -369,8 +375,10 @@ impl QueryProfiler {
         let query_set_end = self.query_sets.get(end).ok_or_else(query_set_error)?;
 
         let size = QUERY_SIZE as u64;
-        encoder.resolve_query_set(&query_set_start.query_set, 0..1, &resolve_start, 0);
-        encoder.resolve_query_set(&query_set_end.query_set, 1..2, &resolve_end, 0);
+        let start_slot = PROFILE_START_INDEX..PROFILE_START_INDEX + 1;
+        let end_slot = PROFILE_END_INDEX..PROFILE_END_INDEX + 1;
+        encoder.resolve_query_set(&query_set_start.query_set, start_slot, &resolve_start, 0);
+        encoder.resolve_query_set(&query_set_end.query_set, end_slot, &resolve_end, 0);
         encoder.copy_buffer_to_buffer(&resolve_start, 0, &map_buffer, 0, size);
         encoder.copy_buffer_to_buffer(&resolve_end, 0, &map_buffer, size, size);
         Ok(Some(map_buffer))
@@ -432,21 +440,37 @@ impl QueryProfiler {
         }
     }
 
-    /// Returns the query set to be used by the [`wgpu::ComputePass`].
+    /// Returns the timestamp writes a [`wgpu::ComputePass`] about to be opened should carry.
+    ///
+    /// A pass that opens one or more profiles writes both ends of a fresh query set. Every
+    /// later pass of a live profile rewrites only the end slot of that same set, so the window
+    /// closes on the last pass of the region instead of the first; a pass outside any profile
+    /// writes nothing.
     ///
     /// Also performs cleanup of old [query set](QuerySet).
-    pub fn register_profile_device(&mut self, device: &wgpu::Device) -> Option<&QuerySet> {
-        self.init_query_set().map(|info| {
-            let item = self.new_query_set(info, device);
-            &item.query_set
+    pub fn register_profile_device(
+        &mut self,
+        device: &wgpu::Device,
+    ) -> Option<wgpu::ComputePassTimestampWrites<'_>> {
+        let (query_set_id, beginning_of_pass_write_index) = match self.init_query_set() {
+            Some(info) => {
+                self.new_query_set(info, device);
+                (info.0, Some(PROFILE_START_INDEX))
+            }
+            None if self.timestamps.is_empty() => return None,
+            None => (self.current?, None),
+        };
+
+        let item = self.query_sets.get(&query_set_id)?;
+
+        Some(wgpu::ComputePassTimestampWrites {
+            query_set: &item.query_set,
+            beginning_of_pass_write_index,
+            end_of_pass_write_index: Some(PROFILE_END_INDEX),
         })
     }
 
-    fn new_query_set(
-        &mut self,
-        query_set_info: (u64, u32),
-        device: &wgpu::Device,
-    ) -> &mut QuerySetItem {
+    fn new_query_set(&mut self, query_set_info: (u64, u32), device: &wgpu::Device) {
         let (query_set_id, num_ref) = query_set_info;
         let query_set = match self.query_set_pool.pop() {
             // Recycle a set we already own and are done with.
@@ -457,7 +481,6 @@ impl QueryProfiler {
 
         let slot = QuerySetItem { query_set, num_ref };
         self.query_sets.insert(query_set_id, slot);
-        self.query_sets.get_mut(&query_set_id).unwrap()
     }
 
     fn init_query_set(&mut self) -> Option<(QuerySetId, u32)> {
@@ -495,9 +518,7 @@ impl QueryProfiler {
     /// all gone, because it is still the *end* marker:
     /// [`stop_profile_setup`](Self::stop_profile_setup) writes `end = self.current` and then
     /// resolves it, so recycling it here leaves a profile that started earlier unable to read its
-    /// own end timestamp. The end it reads can be stale, since a new set is only allocated when
-    /// tokens are waiting for one, but a short measurement beats none at all: autotune reads a
-    /// profiling error as the tunable failing.
+    /// own end timestamp.
     fn cleanup_query_sets(&mut self) {
         let mut cleanups = core::mem::take(&mut self.cleanups);
 

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -36,6 +36,7 @@ mod tests {
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([flex32, f32, u32]);
     cubecl_std::testgen_quantized_view!(f32);
+    cubecl_core::testgen_profiling!();
 
     /// WGSL packs fp8 four lanes to a `u32` and has no type for anything narrower. Rejecting
     /// that has to reach the caller: a panic on the device thread is caught there, logged as a
@@ -127,6 +128,7 @@ mod tests_spirv {
     cubecl_std::testgen!();
     cubecl_std::testgen_tensor_identity!([f16, flex32, f32, u32]);
     cubecl_std::testgen_quantized_view!(f16);
+    cubecl_core::testgen_profiling!();
 }
 
 #[cfg(all(test, feature = "msl"))]


### PR DESCRIPTION
Closes #1421.

A profiled region gets timestamp writes only on the pass that drains its token, so `stop_profile_setup` resolves the end from the set the start came from and the window is the first compute pass alone. `WgpuStream` closes a pass every 32 dispatches, so any longer region reports a constant.

That constant becomes zero in `launch_overhead`, which derives its loop length from the measurement: a window that never grows drives warmup to ~670k iterations, and 23.9 µs over that count underflows `Duration` to zero. It prints `N/A`, and `roofline_bounds` has been costing a launch at zero on every wgpu backend.

**The fix.** A profile keeps one query set for its whole span. The pass that opens it writes both slots; every later pass while it is live rewrites only the end slot, so the last pass marks the end. No extra query sets, and the allocator is untouched.

Not the per-pass sets #1421 suggests: that is ~233k `create_query_set` calls per sample at these counts, and under Metal's 28-set budget the round-robin hands back the set a live profile started in and clobbers that start, giving zero again.

**Measured**, RTX 4070 Ti SUPER, profiling N launches:

| launches | main | per launch | this branch | per launch |
| --- | --- | --- | --- | --- |
| 8 | 7.424 µs | 928 ns | 7.68 µs | 960 ns |
| 64 | 27.136 µs | 424 ns | 162.8 µs | 2.544 µs |
| 512 | 27.648 µs | 54 ns | 1.917 ms | 3.745 µs |
| 4096 | 27.392 µs | 6 ns | 14.366 ms | 3.507 µs |

Pinned within 2 % while the work grows 64×. One and eight launches are unchanged; the single-pass regime was already right. 3.5 µs per launch matches what CUDA measures on the same card. WGSL is the same shape.

`cubecl-wgpu` was not instantiating `testgen_profiling!`, which is why this survived; it is wired in here, and `test_window_spans_every_pass_in_it` reports a growth ratio of 0.76 on the unfixed code while both pre-existing profiling tests pass.

Green on `cubecl-wgpu --features spirv` (746 + 17), on lavapipe as a CI stand-in, and on CUDA against `origin/main` (same 17 pre-existing failures both sides, one-test delta is the new test).

## Known, not fixed here

- A cached zero outlives this fix: the throughput store has no probe-behaviour version, so a machine that recorded one keeps serving it until the cache is keyed properly.
- `roofline_bounds` still charges an unmeasurable launch as free; that wants `Bounds::launch_overhead` to become optional.
- Once Metal's 28-set budget is exhausted a new profile can open in a set an older live one started in. The `QuerySetAllocator` doc is corrected to say so; fixing it needs the allocator to know which sets are live.
- HIP and Metal not run. Both pick up the new test; neither is touched by this change.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
