### PR TITLE
fix(throughput): key the cache on the device part, and version the probes

### DIFF
--- a/crates/cubecl-environment/src/persistence/storage.rs
+++ b/crates/cubecl-environment/src/persistence/storage.rs
@@ -344,9 +344,8 @@ pub struct NamespaceSummary {
 
 /// Every namespace the active environment holds.
 ///
-/// Empty where the backend cannot enumerate itself, which is every backend
-/// but the database: a caller sweeping what it no longer reads has nothing to
-/// sweep when the store did not outlive the process that wrote it.
+/// Empty on every backend but the database, which are the ones that do not
+/// outlive the process that wrote them.
 pub fn namespaces() -> Vec<String> {
     cfg_if::cfg_if! {
         if #[cfg(native_cache)] {

--- a/crates/cubecl-environment/src/persistence/storage.rs
+++ b/crates/cubecl-environment/src/persistence/storage.rs
@@ -342,6 +342,23 @@ pub struct NamespaceSummary {
     pub bytes: u64,
 }
 
+/// Every namespace the active environment holds.
+///
+/// Empty where the backend cannot enumerate itself, which is every backend
+/// but the database: a caller sweeping what it no longer reads has nothing to
+/// sweep when the store did not outlive the process that wrote it.
+pub fn namespaces() -> Vec<String> {
+    cfg_if::cfg_if! {
+        if #[cfg(native_cache)] {
+            super::Database::open_active()
+                .map(|database| database.namespaces())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        }
+    }
+}
+
 /// The storage serving `namespace` in the active environment.
 ///
 /// The location is not a parameter: an environment is the store, so a cache

--- a/crates/cubecl-ir/src/properties.rs
+++ b/crates/cubecl-ir/src/properties.rs
@@ -90,8 +90,8 @@ pub struct MemoryDeviceProperties {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct DeviceIdentity {
     /// The device as it names itself — `AMD Radeon 8060S Graphics`,
-    /// `NVIDIA H100 PCIe`. Display only: distinct parts may share a name, so
-    /// nothing may gate on it.
+    /// `NVIDIA H100 PCIe`. Distinct parts may share a name, so no capability
+    /// and no compiled artifact may be keyed to it.
     pub name: String,
     /// What this runtime compiles *for* — `hip-kernel_gfx1151`, `ptx_sm90`.
     /// Verbatim the `compilation_store` fingerprint, so a namespace read back

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -1545,7 +1545,7 @@ impl<R: Runtime> ComputeClient<R> {
 
     /// Calculates the maximum throughput of the device given the given config (like tensor core with certain sizes and dtypes, or just arithmetic by dtype)
     ///
-    /// `probe` runs only when this device has no cached value for `key`.
+    /// `probe` runs only when the cache has no value for `key`.
     pub fn measure_throughput(
         &self,
         key: ThroughputKey,

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -16,9 +16,7 @@ use crate::{
         ServerUtilities,
     },
     storage::{ComputeStorage, ManagedResource},
-    throughput::{
-        KernelConfig, ThroughputBenchmarker, ThroughputCache, ThroughputKey, ThroughputValue,
-    },
+    throughput::{ThroughputBenchmarker, ThroughputCache, ThroughputKey, ThroughputValue},
 };
 use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
 
@@ -1546,13 +1544,15 @@ impl<R: Runtime> ComputeClient<R> {
     }
 
     /// Calculates the maximum throughput of the device given the given config (like tensor core with certain sizes and dtypes, or just arithmetic by dtype)
+    ///
+    /// `probe` runs only when this device has no cached value for `key`.
     pub fn measure_throughput(
         &self,
         key: ThroughputKey,
-        kernel_config: KernelConfig,
+        probe: impl FnOnce() -> ThroughputValue,
     ) -> ThroughputValue {
         let cache = ThroughputCache::get_for_device(&self.device_key());
         let mut throughputs = ThroughputBenchmarker::new(cache);
-        throughputs.measure(key, kernel_config)
+        throughputs.measure(key, probe)
     }
 }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -20,7 +20,7 @@ use crate::{
         ThroughputBenchmarker, ThroughputCache, ThroughputError, ThroughputKey, ThroughputValue,
     },
 };
-use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
+use alloc::{format, sync::Arc, vec, vec::Vec};
 
 #[cfg(not(target_family = "wasm"))]
 mod lazy;
@@ -1540,11 +1540,6 @@ impl<R: Runtime> ComputeClient<R> {
         (0..num_candidates).map(|i| 2usize.pow(i)).rev()
     }
 
-    /// Stable per-device identity, used to key device-level measurement caches.
-    fn device_key(&self) -> String {
-        format!("{}_dev{}", R::name(self), self.device.device_id().index_id)
-    }
-
     /// Calculates the maximum throughput of the device given the given config (like tensor core with certain sizes and dtypes, or just arithmetic by dtype)
     ///
     /// # Errors
@@ -1555,7 +1550,7 @@ impl<R: Runtime> ComputeClient<R> {
         key: ThroughputKey,
         probe: impl FnOnce() -> Result<ThroughputValue, ThroughputError>,
     ) -> Result<ThroughputValue, ThroughputError> {
-        let cache = ThroughputCache::get_for_device(&self.device_key());
+        let cache = ThroughputCache::get_for_device(R::name(self), &self.properties().identity);
         let mut throughputs = ThroughputBenchmarker::new(cache);
         throughputs.measure(key, probe)
     }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -16,7 +16,9 @@ use crate::{
         ServerUtilities,
     },
     storage::{ComputeStorage, ManagedResource},
-    throughput::{ThroughputBenchmarker, ThroughputCache, ThroughputKey, ThroughputValue},
+    throughput::{
+        ThroughputBenchmarker, ThroughputCache, ThroughputError, ThroughputKey, ThroughputValue,
+    },
 };
 use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
 
@@ -1545,12 +1547,14 @@ impl<R: Runtime> ComputeClient<R> {
 
     /// Calculates the maximum throughput of the device given the given config (like tensor core with certain sizes and dtypes, or just arithmetic by dtype)
     ///
-    /// `probe` runs only when the cache has no value for `key`.
+    /// # Errors
+    ///
+    /// Whatever `probe` reports.
     pub fn measure_throughput(
         &self,
         key: ThroughputKey,
-        probe: impl FnOnce() -> ThroughputValue,
-    ) -> ThroughputValue {
+        probe: impl FnOnce() -> Result<ThroughputValue, ThroughputError>,
+    ) -> Result<ThroughputValue, ThroughputError> {
         let cache = ThroughputCache::get_for_device(&self.device_key());
         let mut throughputs = ThroughputBenchmarker::new(cache);
         throughputs.measure(key, probe)

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -4,9 +4,8 @@ use core::time::Duration;
 use cubecl_ir::{ElemType, FloatKind};
 use thiserror::Error;
 
-/// What the probes measure, as opposed to which crate release ran them. Bump it
-/// whenever a probe changes what it reports, so numbers taken under the old
-/// behaviour stop being served.
+/// What the probes measure, as opposed to which release ran them. Bump it when
+/// a probe changes what it reports.
 pub const PROBE_VERSION: u32 = 1;
 
 /// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -2,6 +2,7 @@ use crate::throughput::{CmmaDims, ComputeCmmaConfig};
 use alloc::{format, string::String};
 use core::time::Duration;
 use cubecl_ir::{ElemType, FloatKind};
+use thiserror::Error;
 
 /// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default
 /// working set. Clamped to the device's maximum allocation when the probe runs.
@@ -125,6 +126,24 @@ impl ThroughputKey {
             ThroughputMode::Memory(_) | ThroughputMode::Launch => ElemType::Float(FloatKind::F32),
         }
     }
+}
+
+/// Why a device has no peak to report for a probe.
+///
+/// These are answers, not failures to get one: a card without tensor hardware
+/// is not slow at cooperative matrices, and a backend whose timer reports no
+/// elapsed time has not measured a fast kernel. Collapsing them into a number
+/// leaves a consumer dividing by a peak that was never measured.
+#[derive(Error, Eq, PartialEq, Clone, Copy, Debug)]
+pub enum ThroughputError {
+    /// The device implements no such operation: a cooperative matrix shape it
+    /// does not have, a type it cannot compute in.
+    #[error("unsupported")]
+    Unsupported,
+    /// Every shape of the probe launched, and the device's timer reported no
+    /// elapsed time for any of them.
+    #[error("no timing")]
+    NoTiming,
 }
 
 /// Represents the throughput of a computation, including the number of operations and the duration.

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -4,6 +4,11 @@ use core::time::Duration;
 use cubecl_ir::{ElemType, FloatKind};
 use thiserror::Error;
 
+/// What the probes measure, as opposed to which crate release ran them. Bump it
+/// whenever a probe changes what it reports, so numbers taken under the old
+/// behaviour stop being served.
+pub const PROBE_VERSION: u32 = 1;
+
 /// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default
 /// working set. Clamped to the device's maximum allocation when the probe runs.
 pub const DEFAULT_BUFFER_BYTES: u64 = 512 * 1024 * 1024;

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -129,19 +129,12 @@ impl ThroughputKey {
 }
 
 /// Why a device has no peak to report for a probe.
-///
-/// These are answers, not failures to get one: a card without tensor hardware
-/// is not slow at cooperative matrices, and a backend whose timer reports no
-/// elapsed time has not measured a fast kernel. Collapsing them into a number
-/// leaves a consumer dividing by a peak that was never measured.
 #[derive(Error, Eq, PartialEq, Clone, Copy, Debug)]
 pub enum ThroughputError {
-    /// The device implements no such operation: a cooperative matrix shape it
-    /// does not have, a type it cannot compute in.
+    /// The device implements no such operation.
     #[error("unsupported")]
     Unsupported,
-    /// Every shape of the probe launched, and the device's timer reported no
-    /// elapsed time for any of them.
+    /// The device's timer reported no elapsed time for any shape of the probe.
     #[error("no timing")]
     NoTiming,
 }

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::CubeClRuntimeConfig,
-    throughput::{ThroughputCache, ThroughputKey, ThroughputValue},
+    throughput::{ThroughputCache, ThroughputError, ThroughputKey, ThroughputValue},
 };
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -43,24 +43,28 @@ impl ThroughputBenchmarker {
     }
 
     /// The value for `key`, measured by `probe` unless the cache holds one.
+    ///
+    /// # Errors
+    ///
+    /// Whatever `probe` reports. Only a measurement is cached.
     pub fn measure(
         &mut self,
         key: ThroughputKey,
-        probe: impl FnOnce() -> ThroughputValue,
-    ) -> ThroughputValue {
+        probe: impl FnOnce() -> Result<ThroughputValue, ThroughputError>,
+    ) -> Result<ThroughputValue, ThroughputError> {
         if self.cache_enabled
             && let Some(cached_value) = self.cache.lock().get(&key)
         {
-            return *cached_value;
+            return Ok(*cached_value);
         }
 
-        let value = probe();
+        let value = probe()?;
 
         if self.cache_enabled {
             self.cache.lock().insert(key, value);
         }
 
-        value
+        Ok(value)
     }
 
     /// Warm one shape of a kernel up to its plateau, then keep its fastest sample.

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -42,31 +42,44 @@ impl ThroughputBenchmarker {
         }
     }
 
-    /// Measure the maximum compute throughput of the given kernel.
-    /// Warms up the kernel until it plateaus,
-    /// then measures the throughput over multiple iterations taking the minimum time per iteration (peak attained).
-    pub fn measure(&mut self, key: ThroughputKey, kernel_config: KernelConfig) -> ThroughputValue {
+    /// The value for `key`, measured by `probe` unless the cache already holds
+    /// one, and kept when it is measured.
+    ///
+    /// What a peak is measured *from* is the caller's: a probe may have several
+    /// shapes to try, and which of them the device answers fastest is knowledge
+    /// about that probe rather than about timing it.
+    pub fn measure(
+        &mut self,
+        key: ThroughputKey,
+        probe: impl FnOnce() -> ThroughputValue,
+    ) -> ThroughputValue {
         if self.cache_enabled
             && let Some(cached_value) = self.cache.lock().get(&key)
         {
             return *cached_value;
         }
 
-        let sample = kernel_config.sample;
-
-        let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
-        let duration = Self::sample_peak_duration(iterations, &sample);
-
-        let value = ThroughputValue {
-            ops_count: kernel_config.ops_count,
-            duration,
-        };
+        let value = probe();
 
         if self.cache_enabled {
             self.cache.lock().insert(key, value);
         }
 
         value
+    }
+
+    /// Time one shape of a kernel: warm it up until it plateaus, then sample it
+    /// over several launches keeping the minimum time per iteration.
+    pub fn sample(kernel_config: KernelConfig) -> ThroughputValue {
+        let sample = kernel_config.sample;
+
+        let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
+        let duration = Self::sample_peak_duration(iterations, &sample);
+
+        ThroughputValue {
+            ops_count: kernel_config.ops_count,
+            duration,
+        }
     }
 
     /// Warms up the device by running the kernel multiple times

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -42,12 +42,7 @@ impl ThroughputBenchmarker {
         }
     }
 
-    /// The value for `key`, measured by `probe` unless the cache already holds
-    /// one, and kept when it is measured.
-    ///
-    /// What a peak is measured *from* is the caller's: a probe may have several
-    /// shapes to try, and which of them the device answers fastest is knowledge
-    /// about that probe rather than about timing it.
+    /// The value for `key`, measured by `probe` unless the cache holds one.
     pub fn measure(
         &mut self,
         key: ThroughputKey,
@@ -68,8 +63,7 @@ impl ThroughputBenchmarker {
         value
     }
 
-    /// Time one shape of a kernel: warm it up until it plateaus, then sample it
-    /// over several launches keeping the minimum time per iteration.
+    /// Warm one shape of a kernel up to its plateau, then keep its fastest sample.
     pub fn sample(kernel_config: KernelConfig) -> ThroughputValue {
         let sample = kernel_config.sample;
 

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -9,6 +9,10 @@ use cubecl_environment::collections::HashMap;
 use cubecl_environment::sync::Mutex;
 use cubecl_ir::DeviceIdentity;
 
+/// The namespace segment naming which generation of probes wrote a value.
+#[cfg(std_io)]
+const GENERATION: &str = "probe-v";
+
 static GLOBAL_CACHE: Mutex<Option<HashMap<String, Arc<Mutex<ThroughputCache>>>>> = Mutex::new(None);
 
 /// Caches the [`ThroughputValue`] for a given [`ThroughputKey`].
@@ -23,8 +27,7 @@ pub struct ThroughputCache {
 }
 
 impl ThroughputCache {
-    /// Gets or creates the global `ThroughputCache` holding what `runtime`
-    /// measured on the device it reports as `identity`.
+    /// Gets or creates the global `ThroughputCache` for one device.
     pub fn get_for_device(runtime: &str, identity: &DeviceIdentity) -> Arc<Mutex<Self>> {
         let name = device_key(runtime, identity);
         let mut cache_map = GLOBAL_CACHE.lock();
@@ -77,13 +80,12 @@ impl ThroughputCache {
     }
 }
 
-/// What separates one device's measurements from another's: the part, never the
-/// device index, which `CUDA_VISIBLE_DEVICES` makes 0 for whichever card was
-/// pinned. Two cards this cannot tell apart are the same part, and share a peak.
+/// The part, never the device index, which `CUDA_VISIBLE_DEVICES` makes 0 for
+/// whichever card was pinned. Two cards this cannot separate are one part, and
+/// share a peak.
 fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     let DeviceIdentity { name, fingerprint } = identity;
-    // A namespace is a `/`-separated path, and a runtime names itself
-    // `wgpu<spirv>`.
+    // A namespace is a path, and a runtime names itself `wgpu<spirv>`.
     let segment = |text: &str| text.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
 
     format!(
@@ -94,14 +96,24 @@ fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     )
 }
 
-/// Namespaces this build wrote under an earlier [`PROBE_VERSION`], which hold
-/// numbers taken by a probe that no longer measures the same thing.
+/// Namespaces this build wrote under an earlier [`PROBE_VERSION`].
 ///
-/// Scoped to this crate version: another one may belong to a cubecl still in
-/// use, and its measurements are not this build's to discard.
+/// Only this crate version's, and only earlier: another version may belong to a
+/// cubecl still in use, and a later generation to a build running right now. A
+/// namespace with no generation at all predates them.
 #[cfg(std_io)]
-fn is_earlier_generation(candidate: &str, scope: &str, current: &str) -> bool {
-    candidate.starts_with(scope) && !candidate.starts_with(current)
+fn is_earlier_generation(candidate: &str, scope: &str, current: u32) -> bool {
+    let Some(device) = candidate.strip_prefix(scope) else {
+        return false;
+    };
+
+    let generation = device
+        .strip_prefix(GENERATION)
+        .and_then(|device| device.split('/').next())
+        .and_then(|generation| generation.parse::<u32>().ok())
+        .unwrap_or(0);
+
+    generation < current
 }
 
 #[cfg(std_io)]
@@ -115,10 +127,10 @@ fn drop_earlier_generations() {
     }
 
     let scope = String::from(Namespace::scoped("throughput", "").as_str());
-    let current = format!("{scope}probe-v{}/", crate::throughput::PROBE_VERSION);
+    let current = crate::throughput::PROBE_VERSION;
 
     for candidate in cubecl_environment::persistence::namespaces() {
-        if is_earlier_generation(&candidate, &scope, &current) {
+        if is_earlier_generation(&candidate, &scope, current) {
             cubecl_environment::persistence::open(&candidate).purge();
         }
     }
@@ -128,7 +140,10 @@ fn drop_earlier_generations() {
 fn namespace(device_key: &str) -> Namespace {
     Namespace::scoped(
         "throughput",
-        format!("probe-v{}/{device_key}", crate::throughput::PROBE_VERSION),
+        format!(
+            "{GENERATION}{}/{device_key}",
+            crate::throughput::PROBE_VERSION
+        ),
     )
 }
 
@@ -138,7 +153,7 @@ mod tests {
     use alloc::string::ToString;
 
     /// Two cards in one machine were served each other's peaks: pinning either
-    /// one makes it index 0, and the index was all that told them apart.
+    /// makes it index 0, and the index was all that told them apart.
     #[test]
     fn two_parts_of_one_architecture_do_not_share_an_entry() {
         let turing = |name: &str| DeviceIdentity {
@@ -152,9 +167,8 @@ mod tests {
         );
     }
 
-    /// A namespace is a path, so a device key is one segment of one: a runtime
-    /// that names itself `wgpu<spirv>` must not put brackets or a separator in
-    /// it.
+    /// A device key is one segment of a path, so a runtime that names itself
+    /// `wgpu<spirv>` must not put brackets or a separator in it.
     #[test]
     fn a_device_key_is_one_path_segment() {
         let key = device_key(
@@ -172,20 +186,19 @@ mod tests {
         );
     }
 
-    /// A build may drop what its own earlier probes wrote and nothing else: a
-    /// namespace under another crate version can belong to a cubecl still in
-    /// use, and a later probe version to a build running right now.
+    /// A build drops what its own earlier probes wrote and nothing else:
+    /// another crate version may be in use, and a later probe version is
+    /// running right now.
     #[cfg(std_io)]
     #[test]
     fn only_this_crate_version_s_earlier_probes_are_dropped() {
-        let scope = "throughput/0.11.0/";
-        let current = "throughput/0.11.0/probe-v2/";
-        let stale = |ns: &str| is_earlier_generation(ns, scope, current);
+        let stale = |ns: &str| is_earlier_generation(ns, "throughput/0.11.0/", 2);
 
         assert!(stale("throughput/0.11.0/probe-v1/cuda_ptx_sm75_part"));
         assert!(stale("throughput/0.11.0/cuda_dev0"));
 
         assert!(!stale("throughput/0.11.0/probe-v2/cuda_ptx_sm75_part"));
+        assert!(!stale("throughput/0.11.0/probe-v3/cuda_ptx_sm75_part"));
         assert!(!stale("throughput/0.10.0/probe-v1/cuda_ptx_sm75_part"));
         assert!(!stale("autotune/0.11.0/device-0-0-cpu/matmul"));
     }
@@ -195,8 +208,12 @@ mod tests {
     #[cfg(std_io)]
     #[test]
     fn the_namespace_carries_the_probe_version() {
-        let expected = format!("/probe-v{}/", crate::throughput::PROBE_VERSION);
+        let generation = namespace("").as_str().to_string();
 
-        assert!(namespace("cuda_ptx_sm75_part").as_str().contains(&expected));
+        assert!(
+            namespace("cuda_ptx_sm75_part")
+                .as_str()
+                .starts_with(&format!("{generation}/"))
+        );
     }
 }

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -79,9 +79,16 @@ impl ThroughputCache {
 /// pinned. Two cards this cannot tell apart are the same part, and share a peak.
 fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     let DeviceIdentity { name, fingerprint } = identity;
-    let part = name.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
+    // A namespace is a `/`-separated path, and a runtime names itself
+    // `wgpu<spirv>`.
+    let segment = |text: &str| text.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
 
-    format!("{runtime}_{fingerprint}_{part}")
+    format!(
+        "{}_{}_{}",
+        segment(runtime),
+        segment(fingerprint),
+        segment(name)
+    )
 }
 
 #[cfg(std_io)]
@@ -109,6 +116,26 @@ mod tests {
         assert_ne!(
             device_key("cuda", &turing("NVIDIA GeForce RTX 2060")),
             device_key("cuda", &turing("NVIDIA GeForce GTX 1660 SUPER")),
+        );
+    }
+
+    /// A namespace is a path, so a device key is one segment of one: a runtime
+    /// that names itself `wgpu<spirv>` must not put brackets or a separator in
+    /// it.
+    #[test]
+    fn a_device_key_is_one_path_segment() {
+        let key = device_key(
+            "wgpu<spirv>",
+            &DeviceIdentity {
+                name: "Intel(R) Arc(tm) B390 (PTL)".to_string(),
+                fingerprint: "spirv_32902_45184".to_string(),
+            },
+        );
+
+        assert!(
+            key.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "{key}"
         );
     }
 

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -30,6 +30,9 @@ impl ThroughputCache {
         let mut cache_map = GLOBAL_CACHE.lock();
         let cache_map = cache_map.get_or_insert_with(HashMap::new);
 
+        #[cfg(std_io)]
+        drop_earlier_generations();
+
         cache_map
             .entry(name.clone())
             .or_insert_with(|| Arc::new(Mutex::new(Self::new(&name))))
@@ -91,6 +94,36 @@ fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     )
 }
 
+/// Namespaces this build wrote under an earlier [`PROBE_VERSION`], which hold
+/// numbers taken by a probe that no longer measures the same thing.
+///
+/// Scoped to this crate version: another one may belong to a cubecl still in
+/// use, and its measurements are not this build's to discard.
+#[cfg(std_io)]
+fn is_earlier_generation(candidate: &str, scope: &str, current: &str) -> bool {
+    candidate.starts_with(scope) && !candidate.starts_with(current)
+}
+
+#[cfg(std_io)]
+fn drop_earlier_generations() {
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    static DROPPED: AtomicBool = AtomicBool::new(false);
+
+    if DROPPED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    let scope = String::from(Namespace::scoped("throughput", "").as_str());
+    let current = format!("{scope}probe-v{}/", crate::throughput::PROBE_VERSION);
+
+    for candidate in cubecl_environment::persistence::namespaces() {
+        if is_earlier_generation(&candidate, &scope, &current) {
+            cubecl_environment::persistence::open(&candidate).purge();
+        }
+    }
+}
+
 #[cfg(std_io)]
 fn namespace(device_key: &str) -> Namespace {
     Namespace::scoped(
@@ -137,6 +170,24 @@ mod tests {
                 .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
             "{key}"
         );
+    }
+
+    /// A build may drop what its own earlier probes wrote and nothing else: a
+    /// namespace under another crate version can belong to a cubecl still in
+    /// use, and a later probe version to a build running right now.
+    #[cfg(std_io)]
+    #[test]
+    fn only_this_crate_version_s_earlier_probes_are_dropped() {
+        let scope = "throughput/0.11.0/";
+        let current = "throughput/0.11.0/probe-v2/";
+        let stale = |ns: &str| is_earlier_generation(ns, scope, current);
+
+        assert!(stale("throughput/0.11.0/probe-v1/cuda_ptx_sm75_part"));
+        assert!(stale("throughput/0.11.0/cuda_dev0"));
+
+        assert!(!stale("throughput/0.11.0/probe-v2/cuda_ptx_sm75_part"));
+        assert!(!stale("throughput/0.10.0/probe-v1/cuda_ptx_sm75_part"));
+        assert!(!stale("autotune/0.11.0/device-0-0-cpu/matmul"));
     }
 
     /// The crate version in the namespace does not move when a probe changes

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -47,10 +47,8 @@ impl ThroughputCache {
 
         #[cfg(std_io)]
         {
-            let namespace = Namespace::scoped("throughput", name);
-
             Self {
-                cache: Store::new(StoreOptions::new().storage(namespace)),
+                cache: Store::new(StoreOptions::new().storage(namespace(name))),
             }
         }
     }
@@ -86,6 +84,14 @@ fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     format!("{runtime}_{fingerprint}_{part}")
 }
 
+#[cfg(std_io)]
+fn namespace(device_key: &str) -> Namespace {
+    Namespace::scoped(
+        "throughput",
+        format!("probe-v{}/{device_key}", crate::throughput::PROBE_VERSION),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,5 +110,15 @@ mod tests {
             device_key("cuda", &turing("NVIDIA GeForce RTX 2060")),
             device_key("cuda", &turing("NVIDIA GeForce GTX 1660 SUPER")),
         );
+    }
+
+    /// The crate version in the namespace does not move when a probe changes
+    /// what it measures inside a release, so the probes carry their own.
+    #[cfg(std_io)]
+    #[test]
+    fn the_namespace_carries_the_probe_version() {
+        let expected = format!("/probe-v{}/", crate::throughput::PROBE_VERSION);
+
+        assert!(namespace("cuda_ptx_sm75_part").as_str().contains(&expected));
     }
 }

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -2,10 +2,12 @@
 use cubecl_environment::persistence::{Namespace, Store, StoreOptions};
 
 use crate::throughput::{ThroughputKey, ThroughputValue};
-use alloc::string::{String, ToString};
+use alloc::format;
+use alloc::string::String;
 use alloc::sync::Arc;
 use cubecl_environment::collections::HashMap;
 use cubecl_environment::sync::Mutex;
+use cubecl_ir::DeviceIdentity;
 
 static GLOBAL_CACHE: Mutex<Option<HashMap<String, Arc<Mutex<ThroughputCache>>>>> = Mutex::new(None);
 
@@ -21,14 +23,16 @@ pub struct ThroughputCache {
 }
 
 impl ThroughputCache {
-    /// Gets or creates a global `ThroughputCache` for the given device name.
-    pub fn get_for_device(name: &str) -> Arc<Mutex<Self>> {
+    /// Gets or creates the global `ThroughputCache` holding what `runtime`
+    /// measured on the device it reports as `identity`.
+    pub fn get_for_device(runtime: &str, identity: &DeviceIdentity) -> Arc<Mutex<Self>> {
+        let name = device_key(runtime, identity);
         let mut cache_map = GLOBAL_CACHE.lock();
         let cache_map = cache_map.get_or_insert_with(HashMap::new);
 
         cache_map
-            .entry(name.to_string())
-            .or_insert_with(|| Arc::new(Mutex::new(Self::new(name))))
+            .entry(name.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(Self::new(&name))))
             .clone()
     }
 
@@ -69,5 +73,36 @@ impl ThroughputCache {
     /// Returns the [`ThroughputValue`] for the given [`ThroughputKey`], if it exists in the cache.
     pub fn get(&self, key: &ThroughputKey) -> Option<&ThroughputValue> {
         self.cache.get(key)
+    }
+}
+
+/// What separates one device's measurements from another's: the part, never the
+/// device index, which `CUDA_VISIBLE_DEVICES` makes 0 for whichever card was
+/// pinned. Two cards this cannot tell apart are the same part, and share a peak.
+fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
+    let DeviceIdentity { name, fingerprint } = identity;
+    let part = name.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
+
+    format!("{runtime}_{fingerprint}_{part}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    /// Two cards in one machine were served each other's peaks: pinning either
+    /// one makes it index 0, and the index was all that told them apart.
+    #[test]
+    fn two_parts_of_one_architecture_do_not_share_an_entry() {
+        let turing = |name: &str| DeviceIdentity {
+            name: name.to_string(),
+            fingerprint: "ptx_sm75".to_string(),
+        };
+
+        assert_ne!(
+            device_key("cuda", &turing("NVIDIA GeForce RTX 2060")),
+            device_key("cuda", &turing("NVIDIA GeForce GTX 1660 SUPER")),
+        );
     }
 }

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -5,8 +5,8 @@ use cubecl_runtime::{
     server::CubeDim,
     throughput::{
         ComputeCmmaConfig, DEFAULT_BUFFER_BYTES, KernelConfig, MemoryAccess, MemoryCurve,
-        MemoryPoint, MemorySpec, ThroughputBenchmarker, ThroughputKey, ThroughputMode,
-        ThroughputValue, sweep_size, working_set_sweep,
+        MemoryPoint, MemorySpec, ThroughputBenchmarker, ThroughputError, ThroughputKey,
+        ThroughputMode, ThroughputValue, sweep_size, working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
@@ -28,7 +28,7 @@ const CPU_CHAIN_DEPTH: usize = 64;
 pub fn device_throughput<R: Runtime>(
     device: &R::Device,
     keys: &[ThroughputKey],
-) -> alloc::vec::Vec<ThroughputValue> {
+) -> alloc::vec::Vec<Result<ThroughputValue, ThroughputError>> {
     let client = R::client(device);
     keys.iter()
         .map(|key| measure_peak_throughput::<R>(&client, *key))
@@ -65,9 +65,13 @@ fn sweep<R: Runtime>(
 ) -> alloc::vec::Vec<MemoryPoint> {
     working_set_sweep(working_set_cap(client, access))
         .into_iter()
-        .map(|bytes| MemoryPoint {
-            bytes,
-            value: measure_peak_throughput::<R>(client, ThroughputKey { mode: mode(bytes) }),
+        .filter_map(|bytes| {
+            let key = ThroughputKey { mode: mode(bytes) };
+
+            Some(MemoryPoint {
+                bytes,
+                value: measure_peak_throughput::<R>(client, key).ok()?,
+            })
         })
         .collect()
 }
@@ -83,10 +87,16 @@ fn working_set_cap<R: Runtime>(client: &ComputeClient<R>, access: MemoryAccess) 
 /// Computes the peak throughput for a given runtime and key.
 ///
 /// Native only, panics on WASM
+///
+/// # Errors
+///
+/// [`Unsupported`](ThroughputError::Unsupported) where the device implements
+/// no such operation, [`NoTiming`](ThroughputError::NoTiming) where it does
+/// and reported no elapsed time.
 pub fn measure_peak_throughput<R: Runtime>(
     client: &ComputeClient<R>,
     key: ThroughputKey,
-) -> ThroughputValue {
+) -> Result<ThroughputValue, ThroughputError> {
     // A throughput probe is a measurement: inside a dry run its launches must
     // still execute, or they would be timed anyway and cache a garbage peak in
     // the device-level throughput store. The guard is read where the launch is
@@ -96,22 +106,29 @@ pub fn measure_peak_throughput<R: Runtime>(
     let launch_config = launch_config(client, key.dtype());
 
     let candidates = match key.mode {
-        ThroughputMode::ComputeDirect { .. } => arithmetic_widths(client, key.dtype())
-            .into_iter()
-            .map(|vector_size| {
-                let config = LaunchConfig {
-                    vector_size,
-                    ..launch_config
-                };
-                compute_direct::build_kernel(client, key, config)
-            })
-            .collect(),
+        ThroughputMode::ComputeDirect { dtype } => {
+            // A type the backend cannot lower panics rather than answering.
+            if !client.properties().features.supports_type(dtype) {
+                return Err(ThroughputError::Unsupported);
+            }
+
+            arithmetic_widths(client, dtype)
+                .into_iter()
+                .map(|vector_size| {
+                    let config = LaunchConfig {
+                        vector_size,
+                        ..launch_config
+                    };
+                    compute_direct::build_kernel(client, key, config)
+                })
+                .collect()
+        }
         ThroughputMode::ComputeCmma {
             dtype,
             config: cmma_config,
         } => {
             if !implements_cmma(client, dtype, cmma_config) {
-                return ThroughputValue::ZERO;
+                return Err(ThroughputError::Unsupported);
             }
             alloc::vec![compute_cmma::build_kernel(
                 client,
@@ -157,28 +174,35 @@ pub fn roofline_bounds<R: Runtime>(
         mode: ThroughputMode::Launch,
     };
 
+    // No ceiling to bound against, which `time_at_peak` already declines.
+    let no_ceiling = ThroughputValue::ZERO;
+
     Bounds {
         bounds: calculate_bounds(
             work,
             thresholds,
-            &measure_peak_throughput(client, compute_key),
-            &measure_peak_throughput(client, memory_key),
+            &measure_peak_throughput(client, compute_key).unwrap_or(no_ceiling),
+            &measure_peak_throughput(client, memory_key).unwrap_or(no_ceiling),
             &memory_key,
         ),
-        launch_overhead: measure_peak_throughput(client, launch_key).duration_per_op(),
+        launch_overhead: measure_peak_throughput(client, launch_key)
+            .map(|value| value.duration_per_op())
+            .unwrap_or_default(),
     }
 }
 
 /// What the device answers fastest, of the shapes a probe can be launched in.
 ///
 /// A rate that is not finite is a shape that did not run, not a slow one.
-fn fastest_shape(candidates: alloc::vec::Vec<KernelConfig>) -> ThroughputValue {
+fn fastest_shape(
+    candidates: alloc::vec::Vec<KernelConfig>,
+) -> Result<ThroughputValue, ThroughputError> {
     candidates
         .into_iter()
         .map(ThroughputBenchmarker::sample)
         .filter(|value| value.ops_per_s().is_finite())
         .max_by(|a, b| a.ops_per_s().total_cmp(&b.ops_per_s()))
-        .unwrap_or(ThroughputValue::ZERO)
+        .ok_or(ThroughputError::NoTiming)
 }
 
 /// The vector widths an arithmetic probe is measured at.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -4,9 +4,9 @@ use cubecl_runtime::{
     runtime::Runtime,
     server::CubeDim,
     throughput::{
-        DEFAULT_BUFFER_BYTES, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec,
-        ThroughputBenchmarker, ThroughputKey, ThroughputMode, ThroughputValue, sweep_size,
-        working_set_sweep,
+        ComputeCmmaConfig, DEFAULT_BUFFER_BYTES, KernelConfig, MemoryAccess, MemoryCurve,
+        MemoryPoint, MemorySpec, ThroughputBenchmarker, ThroughputKey, ThroughputMode,
+        ThroughputValue, sweep_size, working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
@@ -95,28 +95,42 @@ pub fn measure_peak_throughput<R: Runtime>(
 
     let launch_config = launch_config(client, key.dtype());
 
-    let kernel_config = match key.mode {
-        ThroughputMode::ComputeDirect { .. } => {
-            compute_direct::build_kernel(client, key, launch_config)
-        }
+    let candidates = match key.mode {
+        ThroughputMode::ComputeDirect { .. } => arithmetic_widths(client, key.dtype())
+            .into_iter()
+            .map(|vector_size| {
+                let config = LaunchConfig {
+                    vector_size,
+                    ..launch_config
+                };
+                compute_direct::build_kernel(client, key, config)
+            })
+            .collect(),
         ThroughputMode::ComputeCmma {
+            dtype,
             config: cmma_config,
-            ..
         } => {
-            if client.properties().features.matmul.cmma.is_empty() {
+            if !implements_cmma(client, dtype, cmma_config) {
                 return ThroughputValue::ZERO;
             }
-            compute_cmma::build_kernel(client, key, cmma_config, launch_config)
+            alloc::vec![compute_cmma::build_kernel(
+                client,
+                key,
+                cmma_config,
+                launch_config
+            )]
         }
-        ThroughputMode::Memory(spec) => match spec.access {
+        ThroughputMode::Memory(spec) => alloc::vec![match spec.access {
             MemoryAccess::Copy => memory_direct::build_kernel(client, key, launch_config, spec),
             MemoryAccess::Read => memory_read::build_kernel(client, key, launch_config, spec),
             MemoryAccess::Write => memory_write::build_kernel(client, key, launch_config, spec),
-        },
-        ThroughputMode::Launch => launch_overhead::build_kernel(client, key, launch_config),
+        }],
+        ThroughputMode::Launch => {
+            alloc::vec![launch_overhead::build_kernel(client, key, launch_config)]
+        }
     };
 
-    let value = client.measure_throughput(key, || ThroughputBenchmarker::sample(kernel_config));
+    let value = client.measure_throughput(key, || fastest_shape(candidates));
 
     client.memory_cleanup();
 
@@ -153,6 +167,62 @@ pub fn roofline_bounds<R: Runtime>(
         ),
         launch_overhead: measure_peak_throughput(client, launch_key).duration_per_op(),
     }
+}
+
+/// What the device answers fastest, of the shapes a probe can be launched in.
+///
+/// A rate that is not finite is a shape that did not run rather than a slow
+/// one, so it does not stand as an answer; where none of them ran there is no
+/// peak to report.
+fn fastest_shape(candidates: alloc::vec::Vec<KernelConfig>) -> ThroughputValue {
+    candidates
+        .into_iter()
+        .map(ThroughputBenchmarker::sample)
+        .filter(|value| value.ops_per_s().is_finite())
+        .max_by(|a, b| a.ops_per_s().total_cmp(&b.ops_per_s()))
+        .unwrap_or(ThroughputValue::ZERO)
+}
+
+/// The vector widths an arithmetic probe is measured at.
+///
+/// [`io_optimized_vector_sizes`](ComputeClient::io_optimized_vector_sizes)
+/// orders widest first because it describes load and store instructions, and
+/// an arithmetic probe issues none. Which width retires the most is a property
+/// of the device — a SIMD CPU needs the widest, while on a scalar-lane GPU the
+/// lane layout a wide vector imposes costs more shuffling than its packing
+/// saves — so the probe measures every width the device offers.
+fn arithmetic_widths<R: Runtime>(
+    client: &ComputeClient<R>,
+    dtype: ElemType,
+) -> alloc::vec::Vec<usize> {
+    let widths: alloc::vec::Vec<usize> = client.io_optimized_vector_sizes(dtype.size()).collect();
+
+    if widths.is_empty() {
+        alloc::vec![1]
+    } else {
+        widths
+    }
+}
+
+/// Whether the device implements the cooperative matrix the probe launches.
+///
+/// A non-empty capability list says the device has tensor hardware, not that it
+/// has this shape on it, and launching a shape it lacks measures nothing while
+/// looking like any other number. The manual `mma` list is deliberately not
+/// consulted: the probe issues `cmma::execute`.
+fn implements_cmma<R: Runtime>(
+    client: &ComputeClient<R>,
+    dtype: ElemType,
+    config: ComputeCmmaConfig,
+) -> bool {
+    client.properties().features.matmul.cmma.iter().any(|it| {
+        it.a_type == dtype
+            && it.b_type == dtype
+            && it.cd_type == config.accumulator_type
+            && it.m as usize == config.cmma_dims.m
+            && it.n as usize == config.cmma_dims.n
+            && it.k as usize == config.cmma_dims.k
+    })
 }
 
 /// Hardware execution parameters for launching a compute kernel.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -4,8 +4,9 @@ use cubecl_runtime::{
     runtime::Runtime,
     server::CubeDim,
     throughput::{
-        DEFAULT_BUFFER_BYTES, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec, ThroughputKey,
-        ThroughputMode, ThroughputValue, sweep_size, working_set_sweep,
+        DEFAULT_BUFFER_BYTES, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec,
+        ThroughputBenchmarker, ThroughputKey, ThroughputMode, ThroughputValue, sweep_size,
+        working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
@@ -115,7 +116,7 @@ pub fn measure_peak_throughput<R: Runtime>(
         ThroughputMode::Launch => launch_overhead::build_kernel(client, key, launch_config),
     };
 
-    let value = client.measure_throughput(key, kernel_config);
+    let value = client.measure_throughput(key, || ThroughputBenchmarker::sample(kernel_config));
 
     client.memory_cleanup();
 

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -171,9 +171,7 @@ pub fn roofline_bounds<R: Runtime>(
 
 /// What the device answers fastest, of the shapes a probe can be launched in.
 ///
-/// A rate that is not finite is a shape that did not run rather than a slow
-/// one, so it does not stand as an answer; where none of them ran there is no
-/// peak to report.
+/// A rate that is not finite is a shape that did not run, not a slow one.
 fn fastest_shape(candidates: alloc::vec::Vec<KernelConfig>) -> ThroughputValue {
     candidates
         .into_iter()
@@ -185,12 +183,8 @@ fn fastest_shape(candidates: alloc::vec::Vec<KernelConfig>) -> ThroughputValue {
 
 /// The vector widths an arithmetic probe is measured at.
 ///
-/// [`io_optimized_vector_sizes`](ComputeClient::io_optimized_vector_sizes)
-/// orders widest first because it describes load and store instructions, and
-/// an arithmetic probe issues none. Which width retires the most is a property
-/// of the device — a SIMD CPU needs the widest, while on a scalar-lane GPU the
-/// lane layout a wide vector imposes costs more shuffling than its packing
-/// saves — so the probe measures every width the device offers.
+/// `io_optimized_vector_sizes` is ordered for the loads and stores this probe
+/// issues none of, and its widest is not the fastest on every device.
 fn arithmetic_widths<R: Runtime>(
     client: &ComputeClient<R>,
     dtype: ElemType,
@@ -206,10 +200,8 @@ fn arithmetic_widths<R: Runtime>(
 
 /// Whether the device implements the cooperative matrix the probe launches.
 ///
-/// A non-empty capability list says the device has tensor hardware, not that it
-/// has this shape on it, and launching a shape it lacks measures nothing while
-/// looking like any other number. The manual `mma` list is deliberately not
-/// consulted: the probe issues `cmma::execute`.
+/// A non-empty capability list says the device has tensor hardware, not this
+/// shape of it. `mma` is not consulted: the probe issues `cmma::execute`.
 fn implements_cmma<R: Runtime>(
     client: &ComputeClient<R>,
     dtype: ElemType,

--- a/examples/throughput/README.md
+++ b/examples/throughput/README.md
@@ -2,13 +2,16 @@
 
 Small benchmarks that measure a device's **peak throughput** for a few workloads:
 
-| example           | measures                                          |
-| ----------------- | ------------------------------------------------- |
-| `compute_direct`  | peak arithmetic throughput (non-CMMA, f32)        |
-| `compute_cmma`    | peak tensor-core (CMMA) throughput (f16 → f32)    |
-| `memory`          | peak memory (copy) bandwidth                      |
-| `launch_overhead` | peak launch throughput (dispatch rate)          |
-| `all`             | runs all of the above and prints them as a table  |
+| example           | measures                                                     |
+| ----------------- | ------------------------------------------------------------ |
+| `compute_direct`  | peak arithmetic throughput, per float type the device supports |
+| `compute_cmma`    | peak cooperative-matrix throughput, per accumulator width      |
+| `memory`          | peak memory (copy) bandwidth                                   |
+| `memory_read`     | peak read-only streaming bandwidth                             |
+| `memory_write`    | peak write-only streaming bandwidth                            |
+| `memory_curve`    | bandwidth against working set size, for each access pattern    |
+| `launch_overhead` | the fixed cost of a single kernel launch                       |
+| `all`             | every single-size probe above, as one table                    |
 
 ## Running
 
@@ -26,15 +29,35 @@ Always use `--release`; a debug build measures the wrong thing.
 Example output:
 
 ```
-Peak throughput — wgpu<wgsl>
-  compute-direct f32                          6.4877 TOPS/s
-  compute-cmma   f16→f16 16×16×16               unsupported
-  memory                                  131.5563 Gbytes/s
-  launch                                       32.4µs/launch
+Peak throughput — cuda / NVIDIA GeForce RTX 4070 Ti SUPER
+  compute-direct f32                         46.0146 TOPS/s
+  compute-direct f16                         48.5997 TOPS/s
+  compute-direct bf16                        48.5997 TOPS/s
+  compute-cmma   f16→f16 32×8×16            192.7744 TOPS/s
+  compute-cmma   f16→f32 32×8×16             96.3201 TOPS/s
+  memory         copy    1 GiB            601.4902 Gbytes/s
+  memory         read    512 MiB          660.2920 Gbytes/s
+  memory         write   512 MiB          748.0780 Gbytes/s
+  launch                                     3.502µs/launch
 ```
 
-CMMA needs a tensor-core backend. On backends without it (e.g. WGSL) it prints
-`unsupported` and is skipped.
+A row reads `unsupported` where the device implements no such thing: a
+cooperative matrix on a card without tensor hardware, a type it cannot compute
+in. A row that measured nothing reads `N/A` instead — the two are different
+answers.
+
+## Reading the numbers
+
+The two accumulator rows are separate because consumer parts halve their tensor
+rate for f32 accumulation, and that is the rate a matmul runs on.
+
+Memory counts the bytes a kernel asks for, not the traffic that reaches DRAM: an
+ordinary store also pays read-for-ownership where the hardware does, so on a CPU
+the write and copy figures land near half the bus while read lands near all of
+it. Comparing any of them against a vendor bus figure needs that in mind.
+
+`memory` reports one working set. `memory_curve` reports the whole sweep, and a
+kernel moving far less than the top of it cannot reach the top of it.
 
 ## Backends
 
@@ -65,4 +88,3 @@ CUBECL_THROUGHPUT_CACHE=off cargo run --release -p throughput --example all --fe
 
 Accepted values: `on` / `1` / `true` to enable (the default), `off` / `0` /
 `false` to disable.
-

--- a/examples/throughput/README.md
+++ b/examples/throughput/README.md
@@ -43,8 +43,10 @@ Peak throughput — cuda / NVIDIA GeForce RTX 4070 Ti SUPER
 
 A row reads `unsupported` where the device implements no such thing: a
 cooperative matrix on a card without tensor hardware, a type it cannot compute
-in. A row that measured nothing reads `N/A` instead — the two are different
-answers.
+in. It reads `no timing` where the device does implement it and reported no
+elapsed time for any shape of the probe — which is every wgpu backend's launch
+row, since that is the one probe timed on the device rather than on the host.
+The two are different answers, and neither is a slow one.
 
 ## Reading the numbers
 

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -3,7 +3,8 @@ use cubecl::{
     prelude::*,
     std::throughput::{measure_memory_curve, measure_peak_throughput},
     throughput::{
-        CmmaDims, ComputeCmmaConfig, MemoryAccess, MemoryCurve, ThroughputKey, ThroughputMode,
+        CmmaDims, ComputeCmmaConfig, MemoryAccess, MemoryCurve, ThroughputError, ThroughputKey,
+        ThroughputMode,
     },
 };
 
@@ -133,8 +134,13 @@ fn report<R: Runtime>(device: &R::Device, rows: impl FnOnce(&ComputeClient<R>) -
 
     for row in rows(&client) {
         let value = match row.key {
-            Some(key) => measure_peak_throughput(&client, key).format(&key),
-            None => String::from("unsupported"),
+            Some(key) => match measure_peak_throughput(&client, key) {
+                Ok(value) => value.format(&key),
+                Err(unavailable) => unavailable.to_string(),
+            },
+            // A row the device could not even be asked for: no tile to name, no
+            // type to compute in.
+            None => ThroughputError::Unsupported.to_string(),
         };
 
         println!("  {:<15}{:<24}{:>18}", row.mode, row.operands, value);

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -115,8 +115,7 @@ pub fn all<R: Runtime>(device: &R::Device) {
     });
 }
 
-/// One line of the report: what it measures, on which operands, and the probe
-/// behind it — or `None` where the device implements no such thing.
+/// One line of the report, or `None` where the device implements no such thing.
 struct Row {
     mode: &'static str,
     operands: String,
@@ -162,8 +161,8 @@ fn compute_direct_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
 
 /// A row per accumulator width, at f16 inputs.
 ///
-/// The accumulator earns a row of its own because consumer parts halve their
-/// tensor rate for f32 accumulation, which is the one a matmul runs on.
+/// Consumer parts halve their tensor rate for f32 accumulation, which is the
+/// one a matmul runs on.
 fn compute_cmma_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
     let dtype = ElemType::Float(FloatKind::F16);
 
@@ -200,9 +199,8 @@ fn compute_cmma_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
 
 /// The largest cooperative matrix the device implements for these operands.
 ///
-/// Read from the `cmma` capability rather than through `select_cmma_tile`,
-/// which answers from the manual `mma` list as well: the probe issues
-/// `cmma::execute`, and a shape only the other instruction has does not run.
+/// Read from `cmma` rather than through `select_cmma_tile`, which answers from
+/// `mma` as well: a shape only that instruction has does not run here.
 fn largest_cmma<R: Runtime>(
     client: &ComputeClient<R>,
     dtype: ElemType,

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -138,8 +138,6 @@ fn report<R: Runtime>(device: &R::Device, rows: impl FnOnce(&ComputeClient<R>) -
                 Ok(value) => value.format(&key),
                 Err(unavailable) => unavailable.to_string(),
             },
-            // A row the device could not even be asked for: no tile to name, no
-            // type to compute in.
             None => ThroughputError::Unsupported.to_string(),
         };
 

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -44,31 +44,31 @@ macro_rules! dispatch {
     }};
 }
 
-/// Peak direct (non-CMMA) compute throughput.
+/// Peak arithmetic throughput, per float type the device supports.
 pub fn compute_direct<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[compute_direct_key()]);
+    report::<R>(device, compute_direct_rows);
 }
 
-/// Peak CMMA (tensor-core) compute throughput.
+/// Peak cooperative-matrix throughput, per accumulator width.
 pub fn compute_cmma<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[compute_cmma_key()]);
+    report::<R>(device, compute_cmma_rows);
 }
 
 /// Peak memory (copy) throughput, reads and writes both counted.
 pub fn memory<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[memory_key()]);
+    report::<R>(device, |_| vec![memory_row(MemoryAccess::Copy)]);
 }
 
 /// Peak read-only streaming throughput. Expect this to exceed
 /// [`memory`], which pays for a store the read-only case never issues.
 pub fn memory_read<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[memory_read_key()]);
+    report::<R>(device, |_| vec![memory_row(MemoryAccess::Read)]);
 }
 
 /// Peak write-only streaming throughput. Expect this to exceed
 /// [`memory`], which pays for a read the write-only case never issues.
 pub fn memory_write<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[memory_write_key()]);
+    report::<R>(device, |_| vec![memory_row(MemoryAccess::Write)]);
 }
 
 /// Peak memory throughput as a function of working set size, for both access
@@ -99,8 +99,156 @@ fn print_curve(access: MemoryAccess, curve: &MemoryCurve) {
     }
 }
 
+/// Measures the fixed cost of a single kernel launch.
+pub fn launch_overhead<R: Runtime>(device: &R::Device) {
+    report::<R>(device, |_| vec![launch_row()]);
+}
+
+/// Runs every throughput benchmark and prints them as a table.
+pub fn all<R: Runtime>(device: &R::Device) {
+    report::<R>(device, |client| {
+        let mut rows = compute_direct_rows(client);
+        rows.extend(compute_cmma_rows(client));
+        rows.extend([MemoryAccess::Copy, MemoryAccess::Read, MemoryAccess::Write].map(memory_row));
+        rows.push(launch_row());
+        rows
+    });
+}
+
+/// One line of the report: what it measures, on which operands, and the probe
+/// behind it — or `None` where the device implements no such thing.
+struct Row {
+    mode: &'static str,
+    operands: String,
+    key: Option<ThroughputKey>,
+}
+
+fn report<R: Runtime>(device: &R::Device, rows: impl FnOnce(&ComputeClient<R>) -> Vec<Row>) {
+    let client = R::client(device);
+
+    println!(
+        "Peak throughput — {} / {}",
+        R::name(&client),
+        client.properties().identity.name
+    );
+
+    for row in rows(&client) {
+        let value = match row.key {
+            Some(key) => measure_peak_throughput(&client, key).format(&key),
+            None => String::from("unsupported"),
+        };
+
+        println!("  {:<15}{:<24}{:>18}", row.mode, row.operands, value);
+    }
+}
+
+fn compute_direct_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
+    [FloatKind::F32, FloatKind::F16, FloatKind::BF16]
+        .into_iter()
+        .map(|kind| {
+            let dtype = ElemType::Float(kind);
+            let supported = client.properties().features.supports_type(dtype);
+
+            Row {
+                mode: "compute-direct",
+                operands: dtype.to_string(),
+                key: supported.then_some(ThroughputKey {
+                    mode: ThroughputMode::ComputeDirect { dtype },
+                }),
+            }
+        })
+        .collect()
+}
+
+/// A row per accumulator width, at f16 inputs.
+///
+/// The accumulator earns a row of its own because consumer parts halve their
+/// tensor rate for f32 accumulation, which is the one a matmul runs on.
+fn compute_cmma_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
+    let dtype = ElemType::Float(FloatKind::F16);
+
+    [FloatKind::F16, FloatKind::F32]
+        .into_iter()
+        .map(|kind| {
+            let accumulator_type = ElemType::Float(kind);
+            let dims = largest_cmma(client, dtype, accumulator_type);
+
+            Row {
+                mode: "compute-cmma",
+                operands: match dims {
+                    Some(dims) => {
+                        format!(
+                            "{dtype}→{accumulator_type} {}×{}×{}",
+                            dims.m, dims.n, dims.k
+                        )
+                    }
+                    None => format!("{dtype}→{accumulator_type}"),
+                },
+                key: dims.map(|cmma_dims| ThroughputKey {
+                    mode: ThroughputMode::ComputeCmma {
+                        dtype,
+                        config: ComputeCmmaConfig {
+                            cmma_dims,
+                            accumulator_type,
+                        },
+                    },
+                }),
+            }
+        })
+        .collect()
+}
+
+/// The largest cooperative matrix the device implements for these operands.
+///
+/// Read from the `cmma` capability rather than through `select_cmma_tile`,
+/// which answers from the manual `mma` list as well: the probe issues
+/// `cmma::execute`, and a shape only the other instruction has does not run.
+fn largest_cmma<R: Runtime>(
+    client: &ComputeClient<R>,
+    dtype: ElemType,
+    accumulator_type: ElemType,
+) -> Option<CmmaDims> {
+    client
+        .properties()
+        .features
+        .matmul
+        .cmma
+        .iter()
+        .filter(|it| it.a_type == dtype && it.b_type == dtype && it.cd_type == accumulator_type)
+        .max_by_key(|it| it.m as u64 * it.n as u64 * it.k as u64)
+        .map(|it| CmmaDims {
+            m: it.m as usize,
+            n: it.n as usize,
+            k: it.k as usize,
+        })
+}
+
+fn memory_row(access: MemoryAccess) -> Row {
+    Row {
+        mode: "memory",
+        operands: format!(
+            "{:<8}{}",
+            format!("{access:?}").to_lowercase(),
+            bytes_label(access.default_working_set())
+        ),
+        key: Some(ThroughputKey {
+            mode: ThroughputMode::memory(access),
+        }),
+    }
+}
+
+fn launch_row() -> Row {
+    Row {
+        mode: "launch",
+        operands: String::new(),
+        key: Some(ThroughputKey {
+            mode: ThroughputMode::Launch,
+        }),
+    }
+}
+
 fn bytes_label(bytes: u64) -> String {
-    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
 
     let mut value = bytes as f64;
     let mut unit = 0;
@@ -111,117 +259,4 @@ fn bytes_label(bytes: u64) -> String {
     }
 
     format!("{value:.0} {}", UNITS[unit])
-}
-
-/// Measures the fixed cost of a single kernel launch.
-pub fn launch_overhead<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[launch_overhead_key()]);
-}
-
-/// Runs every throughput benchmark and prints them as a table.
-pub fn all<R: Runtime>(device: &R::Device) {
-    run::<R>(
-        device,
-        &[
-            compute_direct_key(),
-            compute_cmma_key(),
-            memory_key(),
-            memory_read_key(),
-            memory_write_key(),
-            launch_overhead_key(),
-        ],
-    );
-}
-
-fn run<R: Runtime>(device: &R::Device, keys: &[ThroughputKey]) {
-    let client = R::client(device);
-
-    println!("Peak throughput — {}", R::name(&client));
-    for &key in keys {
-        let value = measure_peak_throughput(&client, key).format(&key);
-
-        println!(
-            "  {:<15}{:<24}{:>18}",
-            mode_label(&key.mode),
-            describe(&key),
-            value,
-        );
-    }
-}
-
-/// Describes the operands of a benchmark: input dtype, plus CMMA shape and accumulator.
-fn describe(key: &ThroughputKey) -> String {
-    match key.mode {
-        ThroughputMode::ComputeCmma {
-            dtype: input_dtype,
-            config: cfg,
-        } => format!(
-            "{}→{} {}×{}×{}",
-            input_dtype, cfg.accumulator_type, cfg.cmma_dims.m, cfg.cmma_dims.n, cfg.cmma_dims.k,
-        ),
-        ThroughputMode::ComputeDirect { .. } => key.dtype().to_string(),
-        ThroughputMode::Memory(spec) => bytes_label(spec.bytes),
-        ThroughputMode::Launch => String::new(),
-    }
-}
-
-fn mode_label(mode: &ThroughputMode) -> &'static str {
-    match mode {
-        ThroughputMode::ComputeDirect { .. } => "compute-direct",
-        ThroughputMode::ComputeCmma { .. } => "compute-cmma",
-        ThroughputMode::Memory(spec) => match spec.access {
-            MemoryAccess::Copy => "memory",
-            MemoryAccess::Read => "memory-read",
-            MemoryAccess::Write => "memory-write",
-        },
-        ThroughputMode::Launch => "launch",
-    }
-}
-
-fn compute_direct_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::ComputeDirect {
-            dtype: ElemType::Float(FloatKind::F16),
-        },
-    }
-}
-
-fn compute_cmma_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::ComputeCmma {
-            dtype: ElemType::Float(FloatKind::F16),
-            config: ComputeCmmaConfig {
-                cmma_dims: CmmaDims {
-                    m: 16,
-                    n: 16,
-                    k: 16,
-                },
-                accumulator_type: ElemType::Float(FloatKind::F16),
-            },
-        },
-    }
-}
-
-fn memory_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::memory(MemoryAccess::Copy),
-    }
-}
-
-fn memory_read_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::memory(MemoryAccess::Read),
-    }
-}
-
-fn memory_write_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::memory(MemoryAccess::Write),
-    }
-}
-
-fn launch_overhead_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::Launch,
-    }
 }


### PR DESCRIPTION
Now stacked on the probes PR (`dev/throughput-probes`), which is the API-breaking one and goes first; this PR's own five commits are unchanged, rebased with one conflict in `client.rs` where both branches changed the cache lookup.

The throughput cache namespace was `throughput/<crate version>/<runtime>_dev<index>`, and the index is the one thing about a device that a user changes. Pinning a card with `CUDA_VISIBLE_DEVICES`, which is how anyone selects one, makes whichever card was pinned index 0 — so two different cards measured one after the other on one machine key to one entry.

On a machine holding an RTX 2060 and a GTX 1660 SUPER, cache on, same build, one run after the other:

| | 2060, main | 1660S, main | 2060, branch | 1660S, branch |
| --- | --- | --- | --- | --- |
| compute-direct f16 | 11.1868 | **11.1868** | 11.0921 | **7.9767** |
| memory 1 GiB | 252.6 | **252.6** | 252.5 | **273.5** |
| memory-read | 304.2 | **304.2** | 305.6 | **316.1** |
| memory-write | 257.3 | **257.3** | 254.9 | **282.2** |
| launch | 8.156 µs | **8.156 µs** | 9.085 µs | **8.138 µs** |

The 1660 SUPER's whole row is the 2060's, digit for digit. Its own f16 peak is 7.98, so a denominator every percent-of-peak figure divides by was 40 % wrong with nothing in the output saying so.

## What changed

**Key on the part.** `DeviceProperties::identity` already carries what names it: the device's own name and the fingerprint the runtime compiles for. The fingerprint alone does not separate these two cards, which both report `ptx_sm75`; the name does. Two identical cards now share an entry, taken deliberately — identical parts have the same peak, whereas the index was not buying separation, it was assigning the wrong number.

Keying a measurement cache on `identity.name` is not the gating its doc forbade. That rule protects correctness: a name collision must never decide a capability or address a compiled artifact, because two parts sharing a name would then run each other's code. The doc is reworded to say what it protects rather than to forbid every use.

**Version the probes.** The crate version answers "which release wrote this", not "what did the probe measure", and those come apart inside a release: within `0.11.0-pre.3` one commit moved CUDA memory write +39 % and copy +14 %, and another moves compute-direct f32 +45 %. `PROBE_VERSION` sits beside the throughput keys so it lands in the diff of anyone changing what a probe reports, and is its own namespace segment. It is a bare counter, disposable once the probes stop moving.

**Reclaim what it strands.** A version bump alone leaves the old namespace in the store for good, since nothing reads it again and nothing deletes it. Opening the throughput cache now purges the namespaces this build wrote under an earlier probe version, once per process — scoped to this crate version, because another may belong to a cubecl still in use, and a *later* probe version to a build running right now. Planting namespaces around a run:

```
throughput/<this version>/probe-v0/...   dropped
throughput/<this version>/cuda_dev0      dropped   (predates the version)
throughput/<this version>/probe-v2/...   kept      (a build running right now)
throughput/<other version>/probe-v1/...  kept      (a cubecl still in use)
autotune/<this version>/...              kept
```

`persistence::namespaces` is the enumeration this needs, beside `open` and abstracting the backend the same way; it answers empty where the backend cannot enumerate itself.

Namespaces now read `throughput/0.11.0-pre.3/probe-v1/cuda_ptx_sm75_NVIDIA-GeForce-RTX-2060`. Every component is reduced to characters that can sit in one path segment, since a runtime names itself `wgpu<spirv>`.

**This invalidates every value cached under the old namespace, which is intended:** those entries cannot be told apart from the ones this fixes.

## Not fixed here

A bad measurement is still frozen: the cache returns the first value written and never re-measures, so an outlier from an unstable host persists for the life of the namespace. Every fix for that is a tunable heuristic, and on stable hardware the estimator holds to 0.15 % across runs, so it is left alone deliberately rather than overlooked.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
