### PR TITLE
fix(topology): a cube's units are contiguous in ABSOLUTE_POS

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/topology.rs
+++ b/crates/cubecl-core/src/runtime_tests/topology.rs
@@ -12,6 +12,15 @@ pub fn kernel_absolute_pos(output1: &mut [u32]) {
     output1[ABSOLUTE_POS] = ABSOLUTE_POS as u32;
 }
 
+#[cube(launch, address_type = "dynamic")]
+pub fn kernel_absolute_pos_cube(output1: &mut [u32]) {
+    if ABSOLUTE_POS >= output1.len() {
+        terminate!();
+    }
+
+    output1[ABSOLUTE_POS] = CUBE_POS as u32;
+}
+
 pub fn test_kernel_topology_absolute_pos<R: Runtime>(
     client: ComputeClient<R>,
     addr_type: AddressType,
@@ -43,6 +52,43 @@ pub fn test_kernel_topology_absolute_pos<R: Runtime>(
     assert_eq!(actual, &expect);
 }
 
+/// `ABSOLUTE_POS` is cube major: one cube's units occupy one contiguous run.
+///
+/// The bijectivity the test above checks holds under any ordering, so it cannot
+/// see a cube whose units are scattered across the grid.
+pub fn test_kernel_topology_absolute_pos_is_cube_major<R: Runtime>(
+    client: ComputeClient<R>,
+    addr_type: AddressType,
+) {
+    if !client.properties().supports_address(addr_type) {
+        return;
+    }
+
+    let cube_count = (3, 5, 7);
+    let cube_dim = (2, 2, 1);
+
+    let units_per_cube = cube_dim.0 * cube_dim.1 * cube_dim.2;
+    let cubes = cube_count.0 * cube_count.1 * cube_count.2;
+    let length = cubes * units_per_cube;
+    let handle = client.empty(length as usize * core::mem::size_of::<u32>());
+
+    unsafe {
+        kernel_absolute_pos_cube::launch(
+            &client,
+            CubeCount::Static(cube_count.0, cube_count.1, cube_count.2),
+            cube_dim.into(),
+            addr_type,
+            BufferArg::from_raw_parts(handle.clone(), length as usize),
+        )
+    };
+
+    let actual = client.read_one_unchecked(handle);
+    let actual = u32::from_bytes(&actual);
+    let expect: Vec<u32> = (0..cubes).flat_map(|cube| core::iter::repeat_n(cube, units_per_cube as usize)).collect();
+
+    assert_eq!(actual, &expect);
+}
+
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! testgen_topology {
@@ -60,6 +106,16 @@ macro_rules! testgen_topology {
                 client,
                 AddressType::U64,
             );
+        }
+        #[$crate::runtime_tests::test_log::test]
+        fn test_topology_absolute_pos_is_cube_major() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::topology::test_kernel_topology_absolute_pos_is_cube_major::<
+                TestRuntime,
+            >(client.clone(), AddressType::U32);
+            cubecl_core::runtime_tests::topology::test_kernel_topology_absolute_pos_is_cube_major::<
+                TestRuntime,
+            >(client, AddressType::U64);
         }
     };
 }

--- a/crates/cubecl-core/src/runtime_tests/topology.rs
+++ b/crates/cubecl-core/src/runtime_tests/topology.rs
@@ -84,7 +84,9 @@ pub fn test_kernel_topology_absolute_pos_is_cube_major<R: Runtime>(
 
     let actual = client.read_one_unchecked(handle);
     let actual = u32::from_bytes(&actual);
-    let expect: Vec<u32> = (0..cubes).flat_map(|cube| core::iter::repeat_n(cube, units_per_cube as usize)).collect();
+    let expect: Vec<u32> = (0..cubes)
+        .flat_map(|cube| core::iter::repeat_n(cube, units_per_cube as usize))
+        .collect();
 
     assert_eq!(actual, &expect);
 }

--- a/crates/cubecl-cpp/src/shared/builtin.rs
+++ b/crates/cubecl-cpp/src/shared/builtin.rs
@@ -18,13 +18,7 @@ shared_op_with_out!(ReadBuiltinOp, |op, ctx| {
 
 #[cube]
 pub fn absolute_pos() -> usize {
-    let cubes_x = CUBE_COUNT_X as usize;
-    let cubes_y = CUBE_COUNT_Y as usize;
-    let cube_dim_x = CUBE_DIM_X as usize;
-    let cube_dim_y = CUBE_DIM_Y as usize;
-    let z = ABSOLUTE_POS_Z as usize * cubes_x * cube_dim_x * cubes_y * cube_dim_y;
-    let y = ABSOLUTE_POS_Y as usize * cubes_x * cube_dim_x;
-    z + y + ABSOLUTE_POS_X as usize
+    cube_pos() * CUBE_DIM as usize + UNIT_POS as usize
 }
 
 #[cube]

--- a/crates/cubecl-llvm/src/amdgpu/builtins.rs
+++ b/crates/cubecl-llvm/src/amdgpu/builtins.rs
@@ -202,19 +202,6 @@ fn derive_positions(scope: &Scope, builtins: &mut BuiltinValues, cube_dim: Dim3)
     builtins.set(Builtin::AbsolutePosY, abs_y);
     builtins.set(Builtin::AbsolutePosZ, abs_z);
 
-    let absolute_pos = absolute_pos::expand(
-        scope,
-        abs_x.into(),
-        abs_y.into(),
-        abs_z.into(),
-        cube_count_x.into(),
-        cube_count_y.into(),
-        cube_dim.x,
-        cube_dim.y,
-    )
-    .value(scope);
-    builtins.set(Builtin::AbsolutePos, absolute_pos);
-
     let cube_pos = cube_pos::expand(
         scope,
         cube_pos_x.into(),
@@ -225,6 +212,15 @@ fn derive_positions(scope: &Scope, builtins: &mut BuiltinValues, cube_dim: Dim3)
     )
     .value(scope);
     builtins.set(Builtin::CubePos, cube_pos);
+
+    let absolute_pos = absolute_pos::expand(
+        scope,
+        cube_pos.into(),
+        unit_pos.into(),
+        cube_dim.num_elems(),
+    )
+    .value(scope);
+    builtins.set(Builtin::AbsolutePos, absolute_pos);
 }
 
 /// The lane's index within its wavefront.

--- a/crates/cubecl-llvm/src/cpu/entrypoint.rs
+++ b/crates/cubecl-llvm/src/cpu/entrypoint.rs
@@ -86,20 +86,8 @@ pub(crate) fn absolute_pos_z(cube_pos_z: u32, unit_pos_z: u32, #[comptime] cube_
 }
 
 #[cube]
-pub(crate) fn absolute_pos(
-    absolute_pos_x: u32,
-    absolute_pos_y: u32,
-    absolute_pos_z: u32,
-    cube_count_x: u32,
-    cube_count_y: u32,
-    #[comptime] cube_dim_x: u32,
-    #[comptime] cube_dim_y: u32,
-) -> usize {
-    let units_x = cube_count_x as usize * cube_dim_x as usize;
-    let units_y = cube_count_y as usize * cube_dim_y as usize;
-    absolute_pos_z as usize * units_x * units_y
-        + absolute_pos_y as usize * units_x
-        + absolute_pos_x as usize
+pub(crate) fn absolute_pos(cube_pos: usize, unit_pos: u32, #[comptime] cube_dim: u32) -> usize {
+    cube_pos * cube_dim as usize + unit_pos as usize
 }
 
 #[cube]
@@ -347,19 +335,6 @@ fn insert_skeleton(
                 .value(&scope_x);
         builtins.set(Builtin::AbsolutePosX, absolute_pos_x);
 
-        let absolute_pos = absolute_pos::expand(
-            &scope_x,
-            absolute_pos_x.into(),
-            builtins.expect(Builtin::AbsolutePosY).into(),
-            builtins.expect(Builtin::AbsolutePosZ).into(),
-            cube_count_x.into(),
-            cube_count_y.into(),
-            cube_dim.x,
-            cube_dim.y,
-        )
-        .value(&scope_x);
-        builtins.set(Builtin::AbsolutePos, absolute_pos);
-
         let cube_pos = cube_pos::expand(
             &scope_x,
             cube_pos_x.into(),
@@ -370,6 +345,15 @@ fn insert_skeleton(
         )
         .value(&scope_x);
         builtins.set(Builtin::CubePos, cube_pos);
+
+        let absolute_pos = absolute_pos::expand(
+            &scope_x,
+            cube_pos.into(),
+            builtins.expect(Builtin::UnitPos).into(),
+            cube_dim.num_elems(),
+        )
+        .value(&scope_x);
+        builtins.set(Builtin::AbsolutePos, absolute_pos);
     }
 
     scope_y.register(&loop_x);

--- a/crates/cubecl-spirv/src/ops/builtin.rs
+++ b/crates/cubecl-spirv/src/ops/builtin.rs
@@ -168,13 +168,7 @@ impl MatchRewrite for RewriteBuiltins<'_> {
 
 #[cube]
 fn absolute_pos() -> usize {
-    let cubes_x = CUBE_COUNT_X as usize;
-    let cubes_y = CUBE_COUNT_Y as usize;
-    let cube_dim_x = CUBE_DIM_X as usize;
-    let cube_dim_y = CUBE_DIM_Y as usize;
-    let z = ABSOLUTE_POS_Z as usize * cubes_x * cube_dim_x * cubes_y * cube_dim_y;
-    let y = ABSOLUTE_POS_Y as usize * cubes_x * cube_dim_x;
-    z + y + ABSOLUTE_POS_X as usize
+    cube_pos() * CUBE_DIM as usize + UNIT_POS as usize
 }
 
 #[cube]

--- a/crates/cubecl-wgpu/src/compiler/wgsl/builtin.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/builtin.rs
@@ -148,13 +148,7 @@ impl MatchRewrite for RewriteBuiltins {
 
 #[cube]
 fn absolute_pos() -> usize {
-    let cubes_x = CUBE_COUNT_X as usize;
-    let cubes_y = CUBE_COUNT_Y as usize;
-    let cube_dim_x = CUBE_DIM_X as usize;
-    let cube_dim_y = CUBE_DIM_Y as usize;
-    let z = ABSOLUTE_POS_Z as usize * cubes_x * cube_dim_x * cubes_y * cube_dim_y;
-    let y = ABSOLUTE_POS_Y as usize * cubes_x * cube_dim_x;
-    z + y + ABSOLUTE_POS_X as usize
+    cube_pos() * CUBE_DIM as usize + UNIT_POS as usize
 }
 
 #[cube]


### PR DESCRIPTION
`CubeDim::new` always returns a 2D cube, and `ABSOLUTE_POS` is linearized grid-major, so its y term strides the whole grid. For a cube of (32, 8, 1) on a grid of (2112, 1, 1) it comes out as `ty*(gridDim.x*32) + bx*32 + tx`, and the eight planes of one cube land on eight streams 1.03 MiB apart instead of one contiguous run.

Each warp is still fully coalesced, so the generated code is unchanged. What changes is how many concurrent streams reach DRAM, and stores are far more sensitive to that than loads.

This linearizes it as `cube_pos() * CUBE_DIM + UNIT_POS` in all four backends.

## Measured

RTX 4070 Ti SUPER, the `throughput` example, three runs each:

| | before | after | |
| --- | --- | --- | --- |
| memory write 512 MiB | 581.4 GB/s | 596.4 | +2.6% |
| memory copy 1 GiB | 592.1 GB/s | 597.3 | +0.9% |
| memory read 512 MiB | 638.9 GB/s | 638.4 | unchanged |

RTX 2060, same example, three runs each, main against this branch on the same day. This card has a 3 MiB L2 against the 4070's 48 MiB, and pays far more for scattered streams:

| | before | after | |
| --- | --- | --- | --- |
| memory write 512 MiB | 255.7 to 256.9 GB/s | 284.9 to 285.9 | +11%, 76% of bus to 85% |
| memory copy 1 GiB | 251.3 to 252.3 GB/s | 269.2 to 269.7 | +7% |
| memory read 512 MiB | 305.3 to 307.8 GB/s | 319.3 | +4% |

The after column is within two points of what the same card reports under Vulkan, which was the only backend on it that reached those rates before.

Copy is the `out[i] = f(in[i])` shape most elementwise kernels have, so about 1% is the realistic figure for those. Read is unchanged, which is expected: only the store side is stream sensitive.

## cubek kernels

cubek main pinned at this branch's base against this branch, RTX 4070 Ti SUPER, same day. Rows are one strategy on one shape; a negative change is faster.

| bench | rows | median | range | runs per side |
| --- | --- | --- | --- | --- |
| reduce | 132 | 0.0% | -0.7% to +2.6% | 1 |
| gemm, tensor-core strategies on 4096³ f16/f32 and a skinny shape | 12 | +0.0% | -0.1% to +0.4% | 2 |
| gemv | 22 | +0.2% | -13.4% to +3.1% | 1 |
| conv2d | 2 | -0.7% | -8.1% to -0.7% | 1 |
| unary | 3 | +1.4% | -5.3% to +1.8% | 3 |

The two large moves are gains: the autotuned gemm entry on the vector-matrix shapes, -13%, and the AlexNet-shaped conv2d, -8%. Unary at vec4 is 1.5% slower in all three rounds, the one row pointing the other way; at vec8 it is 5% faster in two of three.

## Compatibility

`ABSOLUTE_POS` no longer linearizes `(ABSOLUTE_POS_X, Y, Z)`. Both forms are bijections onto the same range, so a kernel computing `f(ABSOLUTE_POS)` covers identical indices and only which unit gets which index changes. The axes themselves are unchanged, and nothing outside their definition sites pairs them with `ABSOLUTE_POS`.

## Tests

The existing topology test writes value `i` to index `i` and compares against `0..n`, which holds under any bijection, so it cannot see this. Added one that writes `CUBE_POS` to each unit's `ABSOLUTE_POS` slot and asserts contiguous runs per cube. It fails on main and passes here, on CUDA and on Vulkan.

| suite | result |
| --- | --- |
| cubecl-cuda runtime tests, RTX 4070 Ti SUPER | 933 pass, 17 fail: the same 17 as the base commit (16 complex math, `test_cmma_manual` on sm_89) |
| cubecl-cpu runtime tests | 766 pass |
| cubecl-wgpu runtime tests, Vulkan | 743 pass |
| burn main against this branch | builds |
| cubek main against this branch | builds; kernels benchmarked above |
