### PR TITLE
fix(cuda): brace the ldmatrix destination when the vector is 1 wide

### DIFF
--- a/crates/cubecl-cpp/src/cuda/ptx/mma.rs
+++ b/crates/cubecl-cpp/src/cuda/ptx/mma.rs
@@ -97,12 +97,14 @@ fn ldmatrix(
     row: *const u32,
     #[comptime] num: usize,
     #[comptime] transpose: &str,
+    #[comptime] open: &str,
+    #[comptime] close: &str,
 ) -> Vector<u32, NCD> {
     let row_addr = generic_to_shared::<u32>(row);
 
     let out: Vector<u32, NCD>;
     gpu_asm!(
-        "ldmatrix.sync.aligned.m8n8.x{num}{transpose}.shared::cta.b16 {out}, [{addr}];",
+        "ldmatrix.sync.aligned.m8n8.x{num}{transpose}.shared::cta.b16 {open}{out}{close}, [{addr}];",
         out = out(_) out, addr = mem_in(_) row_addr, options(explicit_mem),
     );
     out
@@ -198,10 +200,11 @@ impl LowerOp<Cuda> for LdMatrixOp {
         let out_arr = self.out_arr(ctx);
         let factor = self.factor(ctx).0;
         let trans = if self.transpose(ctx).0 { ".trans" } else { "" };
+        let (open, close) = if factor == 1 { ("{", "}") } else { ("", "") };
 
         scope.register_size::<NCD>(factor);
 
-        let frag_out = ldmatrix::expand(scope, &row_ptr, factor, trans);
+        let frag_out = ldmatrix::expand(scope, &row_ptr, factor, trans, open, close);
         let frag_out =
             reinterpret_value(scope, frag_out.read_value(scope), out_arr.unwrap_ptr(ctx));
         assign::expand_element(scope, frag_out.into(), out_arr.into());


### PR DESCRIPTION
## Issue

PTX writes `ldmatrix`'s destination as a **vector operand at every width, `.x1` included**. The operand is `Vector<u32, NCD>`, and a width-1 `Vector` lowers to its scalar type (`frontend/container/vector/base.rs`, `__expand_as_type`: `if vectorization > 1`), so the placeholder substitution takes the scalar branch and emits a bare `%0` where ptxas demands `{%0}`.

```
ptxas application ptx input, line 300; error   : Vector of size 1 is expected for argument 0 of instruction 'ldmatrix'
ptxas fatal   : Ptx assembly aborted due to errors
```

Both forms in one generated kernel — `.x2` is correct, `.x1` is not:

```cuda
ldmatrix.sync.aligned.m8n8.x2.shared::cta.b16 {%0, %1}, [%2];   // fine
ldmatrix.sync.aligned.m8n8.x1.trans.shared::cta.b16 %0, [%1];   // needs {%0}
```

## Reproducer

Any f16 `mma` matmul on `sm_75` with the `m16n8k8` tile — the B fragment is 8x8, one register, so it takes `.x1`.

Surface the compile error rather than letting it be swallowed (`CUBECL_DEBUG_OPTION=debug`).