### PR TITLE
fix: don't compile AMDGPU for MacOS

### DIFF
--- a/crates/cubecl-hip/Cargo.toml
+++ b/crates/cubecl-hip/Cargo.toml
@@ -42,7 +42,6 @@ tracing = [
     "cubecl-core/tracing",
 ]
 
-
 [dependencies]
 # Runtime Deps
 log = { workspace = true }
@@ -62,6 +61,7 @@ cubecl-cpp = { path = "../cubecl-cpp", version = "=0.11.0-pre.3", default-featur
 cubecl-hip-sys = { version = "7.1.5280200" }
 cubecl-llvm = { path = "../cubecl-llvm", version = "=0.11.0-pre.3", default-features = false, features = [
     "std",
+    "amdgpu",
 ] }
 cubecl-runtime = { path = "../cubecl-runtime", version = "=0.11.0-pre.3", default-features = false, features = [
     "channel-mutex",

--- a/crates/cubecl-llvm/Cargo.toml
+++ b/crates/cubecl-llvm/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 
 [features]
-default = ["std", "cubecl-core/default", "cubecl-runtime/default"]
+default = ["std", "cubecl-core/default", "cubecl-runtime/default", "amdgpu"]
 
 pliron-dump = []
 std = ["cubecl-core/std", "cubecl-runtime/std"]

--- a/crates/cubecl-llvm/Cargo.toml
+++ b/crates/cubecl-llvm/Cargo.toml
@@ -22,6 +22,7 @@ pliron-dump = []
 std = ["cubecl-core/std", "cubecl-runtime/std"]
 
 tracing = ["cubecl-core/tracing", "cubecl-runtime/tracing", "cubecl-opt/tracing"]
+amdgpu = []
 
 
 [dependencies]

--- a/crates/cubecl-llvm/build.rs
+++ b/crates/cubecl-llvm/build.rs
@@ -6,28 +6,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rustc-cfg=feature=\"pliron-dump\"");
     }
 
-    println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/lld.cpp");
-    println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/device_libs.cpp");
-    println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/printf.cpp");
-    let prefix = tracel_llvm_bundler::config::llvm_path()?.into_os_string();
-    let mut shim = cc::Build::new();
-    shim.cpp(true)
-        .file("src/amdgpu/cpp_shims/lld.cpp")
-        .file("src/amdgpu/cpp_shims/device_libs.cpp")
-        .file("src/amdgpu/cpp_shims/printf.cpp");
+    #[cfg(not(target_os = "macos"))]
+    {
+        println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/lld.cpp");
+        println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/device_libs.cpp");
+        println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/printf.cpp");
+        let prefix = tracel_llvm_bundler::config::llvm_path()?.into_os_string();
+        let mut shim = cc::Build::new();
+        shim.cpp(true)
+            .file("src/amdgpu/cpp_shims/lld.cpp")
+            .file("src/amdgpu/cpp_shims/device_libs.cpp")
+            .file("src/amdgpu/cpp_shims/printf.cpp");
 
-    shim.flags(tracel_llvm_bundler::config::get_cxxflags_args(Some(
-        &prefix,
-    ))?);
+        shim.flags(tracel_llvm_bundler::config::get_cxxflags_args(Some(
+            &prefix,
+        ))?);
 
-    // The LLVM headers have multiple warning under `cc`'s default `-Wall -Wextra`
-    shim.warnings(false);
-    shim.opt_level(3);
+        // The LLVM headers have multiple warning under `cc`'s default `-Wall -Wextra`
+        shim.warnings(false);
+        shim.opt_level(3);
+        shim.compile("cubecl_llvm_shim");
 
-    shim.compile("cubecl_llvm_shim");
-
-    println!("cargo:rustc-link-lib=static=lldELF");
-    println!("cargo:rustc-link-lib=static=lldCommon");
+        println!("cargo:rustc-link-lib=static=lldELF");
+        println!("cargo:rustc-link-lib=static=lldCommon");
+    }
 
     tracel_llvm_bundler::llvm_sys::link()?;
 

--- a/crates/cubecl-llvm/build.rs
+++ b/crates/cubecl-llvm/build.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rustc-cfg=feature=\"pliron-dump\"");
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(feature = "amdgpu")]
     {
         println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/lld.cpp");
         println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/device_libs.cpp");

--- a/crates/cubecl-llvm/src/lib.rs
+++ b/crates/cubecl-llvm/src/lib.rs
@@ -3,6 +3,7 @@ extern crate derive_new;
 
 extern crate alloc;
 
+#[cfg(feature = "amdgpu")]
 pub mod amdgpu;
 pub mod cpu;
 pub mod shared;
@@ -11,5 +12,7 @@ pub mod target;
 pub use cpu::jit::data::{PlironData, SharedData};
 pub use cpu::jit::engine::{KernelRequirements, PlironEngine};
 pub use cpu::shared_memory::SharedMemories;
-pub use shared::{AmdGpuModule, PlironArtifact, PlironCompiler, PlironOptions};
+#[cfg(feature = "amdgpu")]
+pub use shared::AmdGpuModule;
+pub use shared::{PlironArtifact, PlironCompiler, PlironOptions};
 pub use target::LlvmTarget;

--- a/crates/cubecl-llvm/src/shared/base.rs
+++ b/crates/cubecl-llvm/src/shared/base.rs
@@ -3,6 +3,7 @@ use cubecl_runtime::kernel::BufferIOAttr;
 use std::rc::Rc;
 
 use cubecl_environment::backtrace::BackTrace;
+#[cfg(feature = "amdgpu")]
 use cubecl_environment::bytes::Bytes;
 use pliron_llvm::builtin_to_llvm::builtin_to_llvm_pass;
 #[cfg(feature = "pliron-dump")]
@@ -35,10 +36,10 @@ use pliron::{
     printable::Printable,
 };
 
-use crate::amdgpu::abi::AmdGpuLowering;
-use crate::amdgpu::matrix::CtxWmma;
-use crate::amdgpu::plane::CtxPlaneDim;
-use crate::amdgpu::shared_memory::CtxSharedMemory;
+#[cfg(feature = "amdgpu")]
+use crate::amdgpu::{
+    abi::AmdGpuLowering, matrix::CtxWmma, plane::CtxPlaneDim, shared_memory::CtxSharedMemory,
+};
 use crate::cpu::{
     abi::CpuLowering,
     jit::engine::{KernelRequirements, PlironEngine},
@@ -63,6 +64,7 @@ pub struct PlironOptions {
     pub arch: Option<GfxArch>,
 }
 
+#[cfg(feature = "amdgpu")]
 /// A finished AMD code object, compiled and linked by this crate.
 #[derive(Clone, Debug)]
 pub struct AmdGpuModule {
@@ -87,6 +89,7 @@ pub struct AmdGpuModule {
 #[derive(Clone)]
 pub enum PlironArtifact {
     Jit(PlironEngine),
+    #[cfg(feature = "amdgpu")]
     AmdGpuCode(AmdGpuModule),
 }
 
@@ -95,6 +98,7 @@ impl PlironArtifact {
     pub fn expect_jit(self) -> PlironEngine {
         match self {
             PlironArtifact::Jit(engine) => engine,
+            #[cfg(feature = "amdgpu")]
             PlironArtifact::AmdGpuCode(_) => {
                 panic!("expected a JIT engine, got an AMDGPU code object")
             }
@@ -106,6 +110,7 @@ impl core::fmt::Display for PlironArtifact {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             PlironArtifact::Jit(engine) => write!(f, "{engine}"),
+            #[cfg(feature = "amdgpu")]
             PlironArtifact::AmdGpuCode(module) => write!(f, "{}", module.ir),
         }
     }
@@ -119,6 +124,7 @@ impl Compiler for PlironCompiler {
     fn buffer_io(repr: &Self::Representation) -> Option<Vec<BufferIOAttr>> {
         match repr {
             PlironArtifact::Jit(engine) => Some(engine.buffer_io().to_vec()),
+            #[cfg(feature = "amdgpu")]
             PlironArtifact::AmdGpuCode(module) => Some(module.io.clone()),
         }
     }
@@ -148,6 +154,7 @@ impl Compiler for PlironCompiler {
     fn extension(&self) -> &'static str {
         match self.target {
             LlvmTarget::Cpu => "plir",
+            #[cfg(feature = "amdgpu")]
             LlvmTarget::AmdGpu => "ll",
         }
     }
@@ -157,12 +164,13 @@ impl PlironCompiler {
     fn compile_ir(
         self,
         kernel: KernelDefinition,
-        options: &PlironOptions,
+        _options: &PlironOptions,
     ) -> Result<PlironArtifact, CompilationError> {
         match self.target {
             LlvmTarget::Cpu => Ok(PlironArtifact::Jit(self.compile_cpu(kernel)?)),
+            #[cfg(feature = "amdgpu")]
             LlvmTarget::AmdGpu => {
-                let arch = options.arch.as_ref().ok_or_else(|| {
+                let arch = _options.arch.as_ref().ok_or_else(|| {
                     generic("the AMDGPU target needs the device it compiles for".to_string())
                 })?;
                 Ok(PlironArtifact::AmdGpuCode(
@@ -197,6 +205,7 @@ impl PlironCompiler {
     }
 
     /// Lowers `kernel` for `arch` and compiles it into a linked AMD code object.
+    #[cfg(feature = "amdgpu")]
     fn compile_amdgpu(
         self,
         kernel: KernelDefinition,

--- a/crates/cubecl-llvm/src/shared/base.rs
+++ b/crates/cubecl-llvm/src/shared/base.rs
@@ -392,26 +392,3 @@ fn pliron_path(name: &str) -> Option<PathBuf> {
         None
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn default_target_is_cpu() {
-        assert!(matches!(PlironCompiler::default().target, LlvmTarget::Cpu));
-    }
-
-    #[test]
-    fn amdgpu_artifact_displays_its_ir() {
-        let artifact = PlironArtifact::AmdGpuCode(AmdGpuModule {
-            code_object: Bytes::from_bytes_vec(vec![0x7f, 0x45, 0x4c, 0x46]),
-            entrypoint: "k".to_string(),
-            ir: "define void @k() { ret void }".to_string(),
-            asm: None,
-            shared_memory_size: 0,
-            io: Vec::new(),
-        });
-        assert!(artifact.to_string().contains("@k"));
-    }
-}

--- a/crates/cubecl-llvm/src/shared/polyfill/synchronization.rs
+++ b/crates/cubecl-llvm/src/shared/polyfill/synchronization.rs
@@ -27,6 +27,7 @@ impl LowerOp for SyncOp {
             SyncScope::Plane => match target {
                 // A plane is one unit on the CPU, so there is nothing to synchronize.
                 LlvmTarget::Cpu => {}
+                #[cfg(feature = "amdgpu")]
                 LlvmTarget::AmdGpu => crate::amdgpu::synchronization::lower_sync_plane(scope),
             },
             // A device wide barrier is a cube barrier on the GPU, as it is in the C++ backends:
@@ -36,6 +37,7 @@ impl LowerOp for SyncOp {
                     panic!("Device wide synchronization is not supported by the CPU runtime")
                 }
                 LlvmTarget::Cpu => crate::cpu::synchronization::lower_sync_cube(scope, op),
+                #[cfg(feature = "amdgpu")]
                 LlvmTarget::AmdGpu => crate::amdgpu::synchronization::lower_sync_cube(scope),
             },
         }

--- a/crates/cubecl-llvm/src/shared/to_llvm/math.rs
+++ b/crates/cubecl-llvm/src/shared/to_llvm/math.rs
@@ -344,6 +344,7 @@ impl ToLLVMDialect for BoolNotOp {
 /// the kernel wrote.
 fn fma_contraction(ctx: &Context) -> FastmathFlagsAttr {
     match ctx.target() {
+        #[cfg(feature = "amdgpu")]
         LlvmTarget::AmdGpu => FastmathFlagsAttr(FastmathFlags::CONTRACT),
         LlvmTarget::Cpu => FastmathFlagsAttr::default(),
     }

--- a/crates/cubecl-llvm/src/target.rs
+++ b/crates/cubecl-llvm/src/target.rs
@@ -11,6 +11,7 @@ use pliron::context::Context;
 pub enum LlvmTarget {
     #[default]
     Cpu,
+    #[cfg(feature = "amdgpu")]
     AmdGpu,
 }
 

--- a/crates/cubecl-llvm/src/target.rs
+++ b/crates/cubecl-llvm/src/target.rs
@@ -26,21 +26,3 @@ pub trait CtxTarget: ContextExt {
         self.set_aux_ty(value);
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Both pipelines put the target on the context before their first pass runs, which is the
-    /// whole of how a shared pass finds out what it is lowering for.
-    #[test]
-    fn the_context_carries_the_target() {
-        let mut ctx = Context::default();
-
-        ctx.set_target(LlvmTarget::AmdGpu);
-        assert_eq!(ctx.target(), LlvmTarget::AmdGpu);
-
-        ctx.set_target(LlvmTarget::Cpu);
-        assert_eq!(ctx.target(), LlvmTarget::Cpu);
-    }
-}


### PR DESCRIPTION
This PR gate AMDGPU so it's only compiled when cubecl-hip is selected

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
