### PR TITLE
fix(throughput): measure the peaks the hardware can carry, and say why a device has none

### DIFF
--- a/crates/cubecl-environment/src/persistence/storage.rs
+++ b/crates/cubecl-environment/src/persistence/storage.rs
@@ -344,9 +344,8 @@ pub struct NamespaceSummary {
 
 /// Every namespace the active environment holds.
 ///
-/// Empty where the backend cannot enumerate itself, which is every backend
-/// but the database: a caller sweeping what it no longer reads has nothing to
-/// sweep when the store did not outlive the process that wrote it.
+/// Empty on every backend but the database, which are the ones that do not
+/// outlive the process that wrote them.
 pub fn namespaces() -> Vec<String> {
     cfg_if::cfg_if! {
         if #[cfg(native_cache)] {

--- a/crates/cubecl-environment/src/persistence/storage.rs
+++ b/crates/cubecl-environment/src/persistence/storage.rs
@@ -342,6 +342,23 @@ pub struct NamespaceSummary {
     pub bytes: u64,
 }
 
+/// Every namespace the active environment holds.
+///
+/// Empty where the backend cannot enumerate itself, which is every backend
+/// but the database: a caller sweeping what it no longer reads has nothing to
+/// sweep when the store did not outlive the process that wrote it.
+pub fn namespaces() -> Vec<String> {
+    cfg_if::cfg_if! {
+        if #[cfg(native_cache)] {
+            super::Database::open_active()
+                .map(|database| database.namespaces())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        }
+    }
+}
+
 /// The storage serving `namespace` in the active environment.
 ///
 /// The location is not a parameter: an environment is the store, so a cache

--- a/crates/cubecl-ir/src/properties.rs
+++ b/crates/cubecl-ir/src/properties.rs
@@ -90,8 +90,8 @@ pub struct MemoryDeviceProperties {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct DeviceIdentity {
     /// The device as it names itself — `AMD Radeon 8060S Graphics`,
-    /// `NVIDIA H100 PCIe`. Display only: distinct parts may share a name, so
-    /// nothing may gate on it.
+    /// `NVIDIA H100 PCIe`. Distinct parts may share a name, so no capability
+    /// and no compiled artifact may be keyed to it.
     pub name: String,
     /// What this runtime compiles *for* — `hip-kernel_gfx1151`, `ptx_sm90`.
     /// Verbatim the `compilation_store` fingerprint, so a namespace read back

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -1545,7 +1545,7 @@ impl<R: Runtime> ComputeClient<R> {
 
     /// Calculates the maximum throughput of the device given the given config (like tensor core with certain sizes and dtypes, or just arithmetic by dtype)
     ///
-    /// `probe` runs only when this device has no cached value for `key`.
+    /// `probe` runs only when the cache has no value for `key`.
     pub fn measure_throughput(
         &self,
         key: ThroughputKey,

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -16,9 +16,7 @@ use crate::{
         ServerUtilities,
     },
     storage::{ComputeStorage, ManagedResource},
-    throughput::{
-        KernelConfig, ThroughputBenchmarker, ThroughputCache, ThroughputKey, ThroughputValue,
-    },
+    throughput::{ThroughputBenchmarker, ThroughputCache, ThroughputKey, ThroughputValue},
 };
 use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
 
@@ -1546,13 +1544,15 @@ impl<R: Runtime> ComputeClient<R> {
     }
 
     /// Calculates the maximum throughput of the device given the given config (like tensor core with certain sizes and dtypes, or just arithmetic by dtype)
+    ///
+    /// `probe` runs only when this device has no cached value for `key`.
     pub fn measure_throughput(
         &self,
         key: ThroughputKey,
-        kernel_config: KernelConfig,
+        probe: impl FnOnce() -> ThroughputValue,
     ) -> ThroughputValue {
         let cache = ThroughputCache::get_for_device(&self.device_key());
         let mut throughputs = ThroughputBenchmarker::new(cache);
-        throughputs.measure(key, kernel_config)
+        throughputs.measure(key, probe)
     }
 }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -20,7 +20,7 @@ use crate::{
         ThroughputBenchmarker, ThroughputCache, ThroughputError, ThroughputKey, ThroughputValue,
     },
 };
-use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
+use alloc::{format, sync::Arc, vec, vec::Vec};
 
 #[cfg(not(target_family = "wasm"))]
 mod lazy;
@@ -1540,11 +1540,6 @@ impl<R: Runtime> ComputeClient<R> {
         (0..num_candidates).map(|i| 2usize.pow(i)).rev()
     }
 
-    /// Stable per-device identity, used to key device-level measurement caches.
-    fn device_key(&self) -> String {
-        format!("{}_dev{}", R::name(self), self.device.device_id().index_id)
-    }
-
     /// Calculates the maximum throughput of the device given the given config (like tensor core with certain sizes and dtypes, or just arithmetic by dtype)
     ///
     /// # Errors
@@ -1555,7 +1550,7 @@ impl<R: Runtime> ComputeClient<R> {
         key: ThroughputKey,
         probe: impl FnOnce() -> Result<ThroughputValue, ThroughputError>,
     ) -> Result<ThroughputValue, ThroughputError> {
-        let cache = ThroughputCache::get_for_device(&self.device_key());
+        let cache = ThroughputCache::get_for_device(R::name(self), &self.properties().identity);
         let mut throughputs = ThroughputBenchmarker::new(cache);
         throughputs.measure(key, probe)
     }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -16,7 +16,9 @@ use crate::{
         ServerUtilities,
     },
     storage::{ComputeStorage, ManagedResource},
-    throughput::{ThroughputBenchmarker, ThroughputCache, ThroughputKey, ThroughputValue},
+    throughput::{
+        ThroughputBenchmarker, ThroughputCache, ThroughputError, ThroughputKey, ThroughputValue,
+    },
 };
 use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
 
@@ -1545,12 +1547,14 @@ impl<R: Runtime> ComputeClient<R> {
 
     /// Calculates the maximum throughput of the device given the given config (like tensor core with certain sizes and dtypes, or just arithmetic by dtype)
     ///
-    /// `probe` runs only when the cache has no value for `key`.
+    /// # Errors
+    ///
+    /// Whatever `probe` reports.
     pub fn measure_throughput(
         &self,
         key: ThroughputKey,
-        probe: impl FnOnce() -> ThroughputValue,
-    ) -> ThroughputValue {
+        probe: impl FnOnce() -> Result<ThroughputValue, ThroughputError>,
+    ) -> Result<ThroughputValue, ThroughputError> {
         let cache = ThroughputCache::get_for_device(&self.device_key());
         let mut throughputs = ThroughputBenchmarker::new(cache);
         throughputs.measure(key, probe)

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -4,9 +4,8 @@ use core::time::Duration;
 use cubecl_ir::{ElemType, FloatKind};
 use thiserror::Error;
 
-/// What the probes measure, as opposed to which crate release ran them. Bump it
-/// whenever a probe changes what it reports, so numbers taken under the old
-/// behaviour stop being served.
+/// What the probes measure, as opposed to which release ran them. Bump it when
+/// a probe changes what it reports.
 pub const PROBE_VERSION: u32 = 1;
 
 /// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -2,6 +2,7 @@ use crate::throughput::{CmmaDims, ComputeCmmaConfig};
 use alloc::{format, string::String};
 use core::time::Duration;
 use cubecl_ir::{ElemType, FloatKind};
+use thiserror::Error;
 
 /// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default
 /// working set. Clamped to the device's maximum allocation when the probe runs.
@@ -125,6 +126,24 @@ impl ThroughputKey {
             ThroughputMode::Memory(_) | ThroughputMode::Launch => ElemType::Float(FloatKind::F32),
         }
     }
+}
+
+/// Why a device has no peak to report for a probe.
+///
+/// These are answers, not failures to get one: a card without tensor hardware
+/// is not slow at cooperative matrices, and a backend whose timer reports no
+/// elapsed time has not measured a fast kernel. Collapsing them into a number
+/// leaves a consumer dividing by a peak that was never measured.
+#[derive(Error, Eq, PartialEq, Clone, Copy, Debug)]
+pub enum ThroughputError {
+    /// The device implements no such operation: a cooperative matrix shape it
+    /// does not have, a type it cannot compute in.
+    #[error("unsupported")]
+    Unsupported,
+    /// Every shape of the probe launched, and the device's timer reported no
+    /// elapsed time for any of them.
+    #[error("no timing")]
+    NoTiming,
 }
 
 /// Represents the throughput of a computation, including the number of operations and the duration.

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -4,6 +4,11 @@ use core::time::Duration;
 use cubecl_ir::{ElemType, FloatKind};
 use thiserror::Error;
 
+/// What the probes measure, as opposed to which crate release ran them. Bump it
+/// whenever a probe changes what it reports, so numbers taken under the old
+/// behaviour stop being served.
+pub const PROBE_VERSION: u32 = 1;
+
 /// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default
 /// working set. Clamped to the device's maximum allocation when the probe runs.
 pub const DEFAULT_BUFFER_BYTES: u64 = 512 * 1024 * 1024;

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -8,9 +8,10 @@ use thiserror::Error;
 /// a probe changes what it reports.
 pub const PROBE_VERSION: u32 = 1;
 
-/// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default
-/// working set. Clamped to the device's maximum allocation when the probe runs.
-pub const DEFAULT_BUFFER_BYTES: u64 = 512 * 1024 * 1024;
+/// Bytes one buffer of a [`ThroughputMode::Memory`] probe moves per pass at its
+/// default working set. The probe's buffer is a multiple of this, and both are
+/// clamped to the device's maximum allocation when the probe runs.
+pub const DEFAULT_WORKING_SET_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Which directions of traffic a memory probe issues.
 #[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
@@ -44,9 +45,9 @@ impl MemoryAccess {
     }
 
     /// The working set of the single-size probe for this access, in bytes moved
-    /// per pass: [`DEFAULT_BUFFER_BYTES`] per buffer touched.
+    /// per pass: [`DEFAULT_WORKING_SET_BYTES`] per buffer touched.
     pub const fn default_working_set(&self) -> u64 {
-        DEFAULT_BUFFER_BYTES * self.buffers()
+        DEFAULT_WORKING_SET_BYTES * self.buffers()
     }
 }
 

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -129,19 +129,12 @@ impl ThroughputKey {
 }
 
 /// Why a device has no peak to report for a probe.
-///
-/// These are answers, not failures to get one: a card without tensor hardware
-/// is not slow at cooperative matrices, and a backend whose timer reports no
-/// elapsed time has not measured a fast kernel. Collapsing them into a number
-/// leaves a consumer dividing by a peak that was never measured.
 #[derive(Error, Eq, PartialEq, Clone, Copy, Debug)]
 pub enum ThroughputError {
-    /// The device implements no such operation: a cooperative matrix shape it
-    /// does not have, a type it cannot compute in.
+    /// The device implements no such operation.
     #[error("unsupported")]
     Unsupported,
-    /// Every shape of the probe launched, and the device's timer reported no
-    /// elapsed time for any of them.
+    /// The device's timer reported no elapsed time for any shape of the probe.
     #[error("no timing")]
     NoTiming,
 }

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -15,6 +15,10 @@ type Cache = Arc<Mutex<ThroughputCache>>;
 /// a probe whose timer is too coarse to ever reach the target.
 const WARMUP_BUDGET: Duration = Duration::from_secs(2);
 
+/// Wall clock a plateau must hold across before it is accepted, sized against a
+/// clock transition, which takes hundreds of milliseconds.
+const PLATEAU_FLOOR: Duration = Duration::from_millis(250);
+
 /// Configuration and payload for a benchmarkable compute kernel.
 pub struct KernelConfig {
     /// A closure that executes the kernel for the given number of iterations and returns the duration.
@@ -67,52 +71,17 @@ impl ThroughputBenchmarker {
         Ok(value)
     }
 
-    /// The peak of one kernel shape, over measurements taken until two agree.
+    /// Warm one shape of a kernel up to its plateau, then keep its fastest sample.
     pub fn sample(kernel_config: KernelConfig) -> ThroughputValue {
-        let duration =
-            Self::corroborated_peak_duration(kernel_config.min_iterations, kernel_config.sample);
+        let sample = kernel_config.sample;
+
+        let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
+        let duration = Self::sample_peak_duration(iterations, &sample);
 
         ThroughputValue {
             ops_count: kernel_config.ops_count,
             duration,
         }
-    }
-
-    /// The fastest of several whole measurements, taken until two agree.
-    ///
-    /// A device held at a low clock stays there for a whole measurement, its
-    /// warmup and its draws alike, so the warmup plateaus there and every draw
-    /// confirms it. Only a later measurement disagrees with it.
-    fn corroborated_peak_duration(
-        min_iterations: usize,
-        sample: impl Fn(usize) -> Duration,
-    ) -> Duration {
-        const MAX_MEASUREMENTS: usize = 4;
-        // Wider than the plateau tolerance, which compares passes microseconds
-        // apart rather than measurements half a second apart.
-        const AGREEMENT_TOL: f64 = 0.05;
-
-        let mut best = Self::warmed_peak_seconds(min_iterations, &sample);
-
-        for _ in 1..MAX_MEASUREMENTS {
-            let seconds = Self::warmed_peak_seconds(min_iterations, &sample);
-            let agrees = (seconds - best).abs() <= best * AGREEMENT_TOL;
-            best = best.min(seconds);
-
-            if agrees {
-                break;
-            }
-        }
-
-        Duration::from_secs_f64(best)
-    }
-
-    /// One whole measurement: a warmup from scratch, then the fastest draw at
-    /// the iteration count it settles on.
-    fn warmed_peak_seconds(min_iterations: usize, sample: impl Fn(usize) -> Duration) -> f64 {
-        let iterations = Self::warmup(min_iterations, WARMUP_BUDGET, &sample);
-
-        Self::sample_peak_duration(iterations, &sample).as_secs_f64()
     }
 
     /// Warms up the device by running the kernel multiple times
@@ -143,6 +112,7 @@ impl ThroughputBenchmarker {
         let mut stable = 0;
         let mut iterations = min_iterations.max(1);
         let start = Instant::now();
+        let mut plateau_start = start;
 
         for _ in 0..MAX_WARMUP {
             let duration = sample(iterations).as_secs_f64() * 1000.0;
@@ -171,10 +141,12 @@ impl ThroughputBenchmarker {
             if duration_per_iter < best * (1.0 - PLATEAU_TOL) {
                 best = duration_per_iter;
                 stable = 0;
+                // Growth clears `best`, so the window restarts at the settled count.
+                plateau_start = Instant::now();
             } else {
                 best = best.min(duration_per_iter);
                 stable += 1;
-                if stable >= PATIENCE {
+                if stable >= PATIENCE && plateau_start.elapsed() >= PLATEAU_FLOOR {
                     break;
                 }
             }
@@ -232,6 +204,21 @@ mod tests {
     use super::*;
     use core::cell::Cell;
 
+    fn spin(duration: Duration) {
+        let start = Instant::now();
+        while start.elapsed() < duration {}
+    }
+
+    /// A device that takes as long as it reports, at whatever rate it is asked for.
+    fn timed_device(per_iter_nanos: impl Fn() -> u64) -> impl Fn(usize) -> Duration {
+        move |iterations| {
+            let duration = Duration::from_nanos(per_iter_nanos() * iterations as u64);
+            spin(duration);
+
+            duration
+        }
+    }
+
     /// One iteration of the launch probe is a real launch, so a device whose
     /// timer reads zero must not be answered by doubling toward the ceiling the
     /// duration target drives.
@@ -258,8 +245,7 @@ mod tests {
     #[test]
     fn a_timer_that_never_reaches_the_target_stops_growing_on_the_budget() {
         let iterations = ThroughputBenchmarker::warmup(1, Duration::from_millis(12), |_| {
-            let start = Instant::now();
-            while start.elapsed() < Duration::from_millis(5) {}
+            spin(Duration::from_millis(5));
 
             Duration::from_millis(1)
         });
@@ -278,61 +264,60 @@ mod tests {
         assert!(calls.get() < 200, "ran {} samples", calls.get());
     }
 
-    /// Every draw of a measurement taken at a low clock confirms that clock, so
-    /// the low rate is only visible from outside the measurement.
+    /// Passes at one iteration count sit microseconds apart, so a plateau of
+    /// them is evidence about a moment rather than about the device.
     #[test]
-    fn a_measurement_taken_at_a_low_clock_is_outvoted_by_a_later_one() {
-        let measurements = Cell::new(0);
-        let low_clock_first = |iterations: usize| {
-            if iterations == 1 {
-                measurements.set(measurements.get() + 1);
-            }
-            let per_iter_ns = if measurements.get() == 1 { 3000 } else { 1000 };
+    fn a_clock_that_lifts_inside_the_floor_does_not_release_the_warmup() {
+        let lift = Duration::from_millis(100);
+        let clock = Instant::now();
+        let lifts_once = timed_device(move || if clock.elapsed() < lift { 3000 } else { 1000 });
 
-            Duration::from_nanos(iterations as u64 * per_iter_ns)
-        };
+        let start = Instant::now();
+        ThroughputBenchmarker::warmup(1, WARMUP_BUDGET, lifts_once);
 
-        let duration = ThroughputBenchmarker::corroborated_peak_duration(1, low_clock_first);
-
-        assert!(duration < Duration::from_nanos(1100), "kept {duration:?}");
+        assert!(
+            start.elapsed() >= lift + PLATEAU_FLOOR,
+            "released after {:?}",
+            start.elapsed()
+        );
     }
 
-    /// A device that answers the same twice is the case every probe of every
-    /// key pays for, so it must not pay for a third.
+    /// A probe runs on first use of every key, so the quiet device is the cost
+    /// every one of them pays.
     #[test]
-    fn two_agreeing_measurements_are_the_whole_cost() {
-        let measurements = Cell::new(0);
-        let steady = |iterations: usize| {
-            if iterations == 1 {
-                measurements.set(measurements.get() + 1);
-            }
+    fn a_steady_device_pays_the_floor_and_nothing_more() {
+        let passes = Cell::new(0);
+        let steady = timed_device(|| {
+            passes.set(passes.get() + 1);
+            1000
+        });
 
-            Duration::from_nanos(iterations as u64 * 1000)
-        };
+        let start = Instant::now();
+        ThroughputBenchmarker::warmup(1, WARMUP_BUDGET, steady);
 
-        ThroughputBenchmarker::corroborated_peak_duration(1, steady);
-
-        assert_eq!(measurements.get(), 2);
+        assert!(
+            start.elapsed() >= PLATEAU_FLOOR,
+            "left after {:?}",
+            start.elapsed()
+        );
+        assert!(passes.get() <= 20, "ran {} passes", passes.get());
     }
 
-    /// A probe runs on first use of every key, so what it costs where nothing
-    /// ever agrees is the cost that has to be bounded.
+    /// Contention that outlasts the whole warmup is measured, not rejected: a
+    /// device that is genuinely slow answers the same however long it is held.
     #[test]
-    fn a_device_that_never_agrees_with_itself_stops_at_the_cap() {
-        let measurements = Cell::new(0);
-        let never_agrees = |iterations: usize| {
-            if iterations == 1 {
-                measurements.set(measurements.get() + 1);
-            }
-            let per_iter_ns = [1000, 3000, 500, 2000][(measurements.get() - 1) % 4];
+    fn a_device_slow_for_the_whole_measurement_reports_its_slow_rate() {
+        let value = ThroughputBenchmarker::sample(KernelConfig {
+            sample: Box::new(timed_device(|| 3000)),
+            ops_count: 1,
+            min_iterations: 1,
+        });
 
-            Duration::from_nanos(iterations as u64 * per_iter_ns)
-        };
-
-        let duration = ThroughputBenchmarker::corroborated_peak_duration(1, never_agrees);
-
-        assert_eq!(measurements.get(), 4);
-        assert!(duration < Duration::from_nanos(550), "kept {duration:?}");
+        assert!(
+            (Duration::from_nanos(2900)..Duration::from_nanos(3100)).contains(&value.duration),
+            "kept {:?}",
+            value.duration
+        );
     }
 
     /// A working timer still drives the count to the duration target.

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::CubeClRuntimeConfig,
-    throughput::{ThroughputCache, ThroughputKey, ThroughputValue},
+    throughput::{ThroughputCache, ThroughputError, ThroughputKey, ThroughputValue},
 };
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -43,24 +43,28 @@ impl ThroughputBenchmarker {
     }
 
     /// The value for `key`, measured by `probe` unless the cache holds one.
+    ///
+    /// # Errors
+    ///
+    /// Whatever `probe` reports. Only a measurement is cached.
     pub fn measure(
         &mut self,
         key: ThroughputKey,
-        probe: impl FnOnce() -> ThroughputValue,
-    ) -> ThroughputValue {
+        probe: impl FnOnce() -> Result<ThroughputValue, ThroughputError>,
+    ) -> Result<ThroughputValue, ThroughputError> {
         if self.cache_enabled
             && let Some(cached_value) = self.cache.lock().get(&key)
         {
-            return *cached_value;
+            return Ok(*cached_value);
         }
 
-        let value = probe();
+        let value = probe()?;
 
         if self.cache_enabled {
             self.cache.lock().insert(key, value);
         }
 
-        value
+        Ok(value)
     }
 
     /// Warm one shape of a kernel up to its plateau, then keep its fastest sample.

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -42,31 +42,44 @@ impl ThroughputBenchmarker {
         }
     }
 
-    /// Measure the maximum compute throughput of the given kernel.
-    /// Warms up the kernel until it plateaus,
-    /// then measures the throughput over multiple iterations taking the minimum time per iteration (peak attained).
-    pub fn measure(&mut self, key: ThroughputKey, kernel_config: KernelConfig) -> ThroughputValue {
+    /// The value for `key`, measured by `probe` unless the cache already holds
+    /// one, and kept when it is measured.
+    ///
+    /// What a peak is measured *from* is the caller's: a probe may have several
+    /// shapes to try, and which of them the device answers fastest is knowledge
+    /// about that probe rather than about timing it.
+    pub fn measure(
+        &mut self,
+        key: ThroughputKey,
+        probe: impl FnOnce() -> ThroughputValue,
+    ) -> ThroughputValue {
         if self.cache_enabled
             && let Some(cached_value) = self.cache.lock().get(&key)
         {
             return *cached_value;
         }
 
-        let sample = kernel_config.sample;
-
-        let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
-        let duration = Self::sample_peak_duration(iterations, &sample);
-
-        let value = ThroughputValue {
-            ops_count: kernel_config.ops_count,
-            duration,
-        };
+        let value = probe();
 
         if self.cache_enabled {
             self.cache.lock().insert(key, value);
         }
 
         value
+    }
+
+    /// Time one shape of a kernel: warm it up until it plateaus, then sample it
+    /// over several launches keeping the minimum time per iteration.
+    pub fn sample(kernel_config: KernelConfig) -> ThroughputValue {
+        let sample = kernel_config.sample;
+
+        let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
+        let duration = Self::sample_peak_duration(iterations, &sample);
+
+        ThroughputValue {
+            ops_count: kernel_config.ops_count,
+            duration,
+        }
     }
 
     /// Warms up the device by running the kernel multiple times

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -42,12 +42,7 @@ impl ThroughputBenchmarker {
         }
     }
 
-    /// The value for `key`, measured by `probe` unless the cache already holds
-    /// one, and kept when it is measured.
-    ///
-    /// What a peak is measured *from* is the caller's: a probe may have several
-    /// shapes to try, and which of them the device answers fastest is knowledge
-    /// about that probe rather than about timing it.
+    /// The value for `key`, measured by `probe` unless the cache holds one.
     pub fn measure(
         &mut self,
         key: ThroughputKey,
@@ -68,8 +63,7 @@ impl ThroughputBenchmarker {
         value
     }
 
-    /// Time one shape of a kernel: warm it up until it plateaus, then sample it
-    /// over several launches keeping the minimum time per iteration.
+    /// Warm one shape of a kernel up to its plateau, then keep its fastest sample.
     pub fn sample(kernel_config: KernelConfig) -> ThroughputValue {
         let sample = kernel_config.sample;
 

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -67,17 +67,52 @@ impl ThroughputBenchmarker {
         Ok(value)
     }
 
-    /// Warm one shape of a kernel up to its plateau, then keep its fastest sample.
+    /// The peak of one kernel shape, over measurements taken until two agree.
     pub fn sample(kernel_config: KernelConfig) -> ThroughputValue {
-        let sample = kernel_config.sample;
-
-        let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
-        let duration = Self::sample_peak_duration(iterations, &sample);
+        let duration =
+            Self::corroborated_peak_duration(kernel_config.min_iterations, kernel_config.sample);
 
         ThroughputValue {
             ops_count: kernel_config.ops_count,
             duration,
         }
+    }
+
+    /// The fastest of several whole measurements, taken until two agree.
+    ///
+    /// A device held at a low clock stays there for a whole measurement, its
+    /// warmup and its draws alike, so the warmup plateaus there and every draw
+    /// confirms it. Only a later measurement disagrees with it.
+    fn corroborated_peak_duration(
+        min_iterations: usize,
+        sample: impl Fn(usize) -> Duration,
+    ) -> Duration {
+        const MAX_MEASUREMENTS: usize = 4;
+        // Wider than the plateau tolerance, which compares passes microseconds
+        // apart rather than measurements half a second apart.
+        const AGREEMENT_TOL: f64 = 0.05;
+
+        let mut best = Self::warmed_peak_seconds(min_iterations, &sample);
+
+        for _ in 1..MAX_MEASUREMENTS {
+            let seconds = Self::warmed_peak_seconds(min_iterations, &sample);
+            let agrees = (seconds - best).abs() <= best * AGREEMENT_TOL;
+            best = best.min(seconds);
+
+            if agrees {
+                break;
+            }
+        }
+
+        Duration::from_secs_f64(best)
+    }
+
+    /// One whole measurement: a warmup from scratch, then the fastest draw at
+    /// the iteration count it settles on.
+    fn warmed_peak_seconds(min_iterations: usize, sample: impl Fn(usize) -> Duration) -> f64 {
+        let iterations = Self::warmup(min_iterations, WARMUP_BUDGET, &sample);
+
+        Self::sample_peak_duration(iterations, &sample).as_secs_f64()
     }
 
     /// Warms up the device by running the kernel multiple times
@@ -241,6 +276,63 @@ mod tests {
         });
 
         assert!(calls.get() < 200, "ran {} samples", calls.get());
+    }
+
+    /// Every draw of a measurement taken at a low clock confirms that clock, so
+    /// the low rate is only visible from outside the measurement.
+    #[test]
+    fn a_measurement_taken_at_a_low_clock_is_outvoted_by_a_later_one() {
+        let measurements = Cell::new(0);
+        let low_clock_first = |iterations: usize| {
+            if iterations == 1 {
+                measurements.set(measurements.get() + 1);
+            }
+            let per_iter_ns = if measurements.get() == 1 { 3000 } else { 1000 };
+
+            Duration::from_nanos(iterations as u64 * per_iter_ns)
+        };
+
+        let duration = ThroughputBenchmarker::corroborated_peak_duration(1, low_clock_first);
+
+        assert!(duration < Duration::from_nanos(1100), "kept {duration:?}");
+    }
+
+    /// A device that answers the same twice is the case every probe of every
+    /// key pays for, so it must not pay for a third.
+    #[test]
+    fn two_agreeing_measurements_are_the_whole_cost() {
+        let measurements = Cell::new(0);
+        let steady = |iterations: usize| {
+            if iterations == 1 {
+                measurements.set(measurements.get() + 1);
+            }
+
+            Duration::from_nanos(iterations as u64 * 1000)
+        };
+
+        ThroughputBenchmarker::corroborated_peak_duration(1, steady);
+
+        assert_eq!(measurements.get(), 2);
+    }
+
+    /// A probe runs on first use of every key, so what it costs where nothing
+    /// ever agrees is the cost that has to be bounded.
+    #[test]
+    fn a_device_that_never_agrees_with_itself_stops_at_the_cap() {
+        let measurements = Cell::new(0);
+        let never_agrees = |iterations: usize| {
+            if iterations == 1 {
+                measurements.set(measurements.get() + 1);
+            }
+            let per_iter_ns = [1000, 3000, 500, 2000][(measurements.get() - 1) % 4];
+
+            Duration::from_nanos(iterations as u64 * per_iter_ns)
+        };
+
+        let duration = ThroughputBenchmarker::corroborated_peak_duration(1, never_agrees);
+
+        assert_eq!(measurements.get(), 4);
+        assert!(duration < Duration::from_nanos(550), "kept {duration:?}");
     }
 
     /// A working timer still drives the count to the duration target.

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -9,6 +9,10 @@ use cubecl_environment::collections::HashMap;
 use cubecl_environment::sync::Mutex;
 use cubecl_ir::DeviceIdentity;
 
+/// The namespace segment naming which generation of probes wrote a value.
+#[cfg(std_io)]
+const GENERATION: &str = "probe-v";
+
 static GLOBAL_CACHE: Mutex<Option<HashMap<String, Arc<Mutex<ThroughputCache>>>>> = Mutex::new(None);
 
 /// Caches the [`ThroughputValue`] for a given [`ThroughputKey`].
@@ -23,8 +27,7 @@ pub struct ThroughputCache {
 }
 
 impl ThroughputCache {
-    /// Gets or creates the global `ThroughputCache` holding what `runtime`
-    /// measured on the device it reports as `identity`.
+    /// Gets or creates the global `ThroughputCache` for one device.
     pub fn get_for_device(runtime: &str, identity: &DeviceIdentity) -> Arc<Mutex<Self>> {
         let name = device_key(runtime, identity);
         let mut cache_map = GLOBAL_CACHE.lock();
@@ -77,13 +80,12 @@ impl ThroughputCache {
     }
 }
 
-/// What separates one device's measurements from another's: the part, never the
-/// device index, which `CUDA_VISIBLE_DEVICES` makes 0 for whichever card was
-/// pinned. Two cards this cannot tell apart are the same part, and share a peak.
+/// The part, never the device index, which `CUDA_VISIBLE_DEVICES` makes 0 for
+/// whichever card was pinned. Two cards this cannot separate are one part, and
+/// share a peak.
 fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     let DeviceIdentity { name, fingerprint } = identity;
-    // A namespace is a `/`-separated path, and a runtime names itself
-    // `wgpu<spirv>`.
+    // A namespace is a path, and a runtime names itself `wgpu<spirv>`.
     let segment = |text: &str| text.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
 
     format!(
@@ -94,14 +96,24 @@ fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     )
 }
 
-/// Namespaces this build wrote under an earlier [`PROBE_VERSION`], which hold
-/// numbers taken by a probe that no longer measures the same thing.
+/// Namespaces this build wrote under an earlier [`PROBE_VERSION`].
 ///
-/// Scoped to this crate version: another one may belong to a cubecl still in
-/// use, and its measurements are not this build's to discard.
+/// Only this crate version's, and only earlier: another version may belong to a
+/// cubecl still in use, and a later generation to a build running right now. A
+/// namespace with no generation at all predates them.
 #[cfg(std_io)]
-fn is_earlier_generation(candidate: &str, scope: &str, current: &str) -> bool {
-    candidate.starts_with(scope) && !candidate.starts_with(current)
+fn is_earlier_generation(candidate: &str, scope: &str, current: u32) -> bool {
+    let Some(device) = candidate.strip_prefix(scope) else {
+        return false;
+    };
+
+    let generation = device
+        .strip_prefix(GENERATION)
+        .and_then(|device| device.split('/').next())
+        .and_then(|generation| generation.parse::<u32>().ok())
+        .unwrap_or(0);
+
+    generation < current
 }
 
 #[cfg(std_io)]
@@ -115,10 +127,10 @@ fn drop_earlier_generations() {
     }
 
     let scope = String::from(Namespace::scoped("throughput", "").as_str());
-    let current = format!("{scope}probe-v{}/", crate::throughput::PROBE_VERSION);
+    let current = crate::throughput::PROBE_VERSION;
 
     for candidate in cubecl_environment::persistence::namespaces() {
-        if is_earlier_generation(&candidate, &scope, &current) {
+        if is_earlier_generation(&candidate, &scope, current) {
             cubecl_environment::persistence::open(&candidate).purge();
         }
     }
@@ -128,7 +140,10 @@ fn drop_earlier_generations() {
 fn namespace(device_key: &str) -> Namespace {
     Namespace::scoped(
         "throughput",
-        format!("probe-v{}/{device_key}", crate::throughput::PROBE_VERSION),
+        format!(
+            "{GENERATION}{}/{device_key}",
+            crate::throughput::PROBE_VERSION
+        ),
     )
 }
 
@@ -138,7 +153,7 @@ mod tests {
     use alloc::string::ToString;
 
     /// Two cards in one machine were served each other's peaks: pinning either
-    /// one makes it index 0, and the index was all that told them apart.
+    /// makes it index 0, and the index was all that told them apart.
     #[test]
     fn two_parts_of_one_architecture_do_not_share_an_entry() {
         let turing = |name: &str| DeviceIdentity {
@@ -152,9 +167,8 @@ mod tests {
         );
     }
 
-    /// A namespace is a path, so a device key is one segment of one: a runtime
-    /// that names itself `wgpu<spirv>` must not put brackets or a separator in
-    /// it.
+    /// A device key is one segment of a path, so a runtime that names itself
+    /// `wgpu<spirv>` must not put brackets or a separator in it.
     #[test]
     fn a_device_key_is_one_path_segment() {
         let key = device_key(
@@ -172,20 +186,19 @@ mod tests {
         );
     }
 
-    /// A build may drop what its own earlier probes wrote and nothing else: a
-    /// namespace under another crate version can belong to a cubecl still in
-    /// use, and a later probe version to a build running right now.
+    /// A build drops what its own earlier probes wrote and nothing else:
+    /// another crate version may be in use, and a later probe version is
+    /// running right now.
     #[cfg(std_io)]
     #[test]
     fn only_this_crate_version_s_earlier_probes_are_dropped() {
-        let scope = "throughput/0.11.0/";
-        let current = "throughput/0.11.0/probe-v2/";
-        let stale = |ns: &str| is_earlier_generation(ns, scope, current);
+        let stale = |ns: &str| is_earlier_generation(ns, "throughput/0.11.0/", 2);
 
         assert!(stale("throughput/0.11.0/probe-v1/cuda_ptx_sm75_part"));
         assert!(stale("throughput/0.11.0/cuda_dev0"));
 
         assert!(!stale("throughput/0.11.0/probe-v2/cuda_ptx_sm75_part"));
+        assert!(!stale("throughput/0.11.0/probe-v3/cuda_ptx_sm75_part"));
         assert!(!stale("throughput/0.10.0/probe-v1/cuda_ptx_sm75_part"));
         assert!(!stale("autotune/0.11.0/device-0-0-cpu/matmul"));
     }
@@ -195,8 +208,12 @@ mod tests {
     #[cfg(std_io)]
     #[test]
     fn the_namespace_carries_the_probe_version() {
-        let expected = format!("/probe-v{}/", crate::throughput::PROBE_VERSION);
+        let generation = namespace("").as_str().to_string();
 
-        assert!(namespace("cuda_ptx_sm75_part").as_str().contains(&expected));
+        assert!(
+            namespace("cuda_ptx_sm75_part")
+                .as_str()
+                .starts_with(&format!("{generation}/"))
+        );
     }
 }

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -79,9 +79,16 @@ impl ThroughputCache {
 /// pinned. Two cards this cannot tell apart are the same part, and share a peak.
 fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     let DeviceIdentity { name, fingerprint } = identity;
-    let part = name.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
+    // A namespace is a `/`-separated path, and a runtime names itself
+    // `wgpu<spirv>`.
+    let segment = |text: &str| text.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
 
-    format!("{runtime}_{fingerprint}_{part}")
+    format!(
+        "{}_{}_{}",
+        segment(runtime),
+        segment(fingerprint),
+        segment(name)
+    )
 }
 
 #[cfg(std_io)]
@@ -109,6 +116,26 @@ mod tests {
         assert_ne!(
             device_key("cuda", &turing("NVIDIA GeForce RTX 2060")),
             device_key("cuda", &turing("NVIDIA GeForce GTX 1660 SUPER")),
+        );
+    }
+
+    /// A namespace is a path, so a device key is one segment of one: a runtime
+    /// that names itself `wgpu<spirv>` must not put brackets or a separator in
+    /// it.
+    #[test]
+    fn a_device_key_is_one_path_segment() {
+        let key = device_key(
+            "wgpu<spirv>",
+            &DeviceIdentity {
+                name: "Intel(R) Arc(tm) B390 (PTL)".to_string(),
+                fingerprint: "spirv_32902_45184".to_string(),
+            },
+        );
+
+        assert!(
+            key.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "{key}"
         );
     }
 

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -30,6 +30,9 @@ impl ThroughputCache {
         let mut cache_map = GLOBAL_CACHE.lock();
         let cache_map = cache_map.get_or_insert_with(HashMap::new);
 
+        #[cfg(std_io)]
+        drop_earlier_generations();
+
         cache_map
             .entry(name.clone())
             .or_insert_with(|| Arc::new(Mutex::new(Self::new(&name))))
@@ -91,6 +94,36 @@ fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     )
 }
 
+/// Namespaces this build wrote under an earlier [`PROBE_VERSION`], which hold
+/// numbers taken by a probe that no longer measures the same thing.
+///
+/// Scoped to this crate version: another one may belong to a cubecl still in
+/// use, and its measurements are not this build's to discard.
+#[cfg(std_io)]
+fn is_earlier_generation(candidate: &str, scope: &str, current: &str) -> bool {
+    candidate.starts_with(scope) && !candidate.starts_with(current)
+}
+
+#[cfg(std_io)]
+fn drop_earlier_generations() {
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    static DROPPED: AtomicBool = AtomicBool::new(false);
+
+    if DROPPED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    let scope = String::from(Namespace::scoped("throughput", "").as_str());
+    let current = format!("{scope}probe-v{}/", crate::throughput::PROBE_VERSION);
+
+    for candidate in cubecl_environment::persistence::namespaces() {
+        if is_earlier_generation(&candidate, &scope, &current) {
+            cubecl_environment::persistence::open(&candidate).purge();
+        }
+    }
+}
+
 #[cfg(std_io)]
 fn namespace(device_key: &str) -> Namespace {
     Namespace::scoped(
@@ -137,6 +170,24 @@ mod tests {
                 .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
             "{key}"
         );
+    }
+
+    /// A build may drop what its own earlier probes wrote and nothing else: a
+    /// namespace under another crate version can belong to a cubecl still in
+    /// use, and a later probe version to a build running right now.
+    #[cfg(std_io)]
+    #[test]
+    fn only_this_crate_version_s_earlier_probes_are_dropped() {
+        let scope = "throughput/0.11.0/";
+        let current = "throughput/0.11.0/probe-v2/";
+        let stale = |ns: &str| is_earlier_generation(ns, scope, current);
+
+        assert!(stale("throughput/0.11.0/probe-v1/cuda_ptx_sm75_part"));
+        assert!(stale("throughput/0.11.0/cuda_dev0"));
+
+        assert!(!stale("throughput/0.11.0/probe-v2/cuda_ptx_sm75_part"));
+        assert!(!stale("throughput/0.10.0/probe-v1/cuda_ptx_sm75_part"));
+        assert!(!stale("autotune/0.11.0/device-0-0-cpu/matmul"));
     }
 
     /// The crate version in the namespace does not move when a probe changes

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -47,10 +47,8 @@ impl ThroughputCache {
 
         #[cfg(std_io)]
         {
-            let namespace = Namespace::scoped("throughput", name);
-
             Self {
-                cache: Store::new(StoreOptions::new().storage(namespace)),
+                cache: Store::new(StoreOptions::new().storage(namespace(name))),
             }
         }
     }
@@ -86,6 +84,14 @@ fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
     format!("{runtime}_{fingerprint}_{part}")
 }
 
+#[cfg(std_io)]
+fn namespace(device_key: &str) -> Namespace {
+    Namespace::scoped(
+        "throughput",
+        format!("probe-v{}/{device_key}", crate::throughput::PROBE_VERSION),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,5 +110,15 @@ mod tests {
             device_key("cuda", &turing("NVIDIA GeForce RTX 2060")),
             device_key("cuda", &turing("NVIDIA GeForce GTX 1660 SUPER")),
         );
+    }
+
+    /// The crate version in the namespace does not move when a probe changes
+    /// what it measures inside a release, so the probes carry their own.
+    #[cfg(std_io)]
+    #[test]
+    fn the_namespace_carries_the_probe_version() {
+        let expected = format!("/probe-v{}/", crate::throughput::PROBE_VERSION);
+
+        assert!(namespace("cuda_ptx_sm75_part").as_str().contains(&expected));
     }
 }

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -2,10 +2,12 @@
 use cubecl_environment::persistence::{Namespace, Store, StoreOptions};
 
 use crate::throughput::{ThroughputKey, ThroughputValue};
-use alloc::string::{String, ToString};
+use alloc::format;
+use alloc::string::String;
 use alloc::sync::Arc;
 use cubecl_environment::collections::HashMap;
 use cubecl_environment::sync::Mutex;
+use cubecl_ir::DeviceIdentity;
 
 static GLOBAL_CACHE: Mutex<Option<HashMap<String, Arc<Mutex<ThroughputCache>>>>> = Mutex::new(None);
 
@@ -21,14 +23,16 @@ pub struct ThroughputCache {
 }
 
 impl ThroughputCache {
-    /// Gets or creates a global `ThroughputCache` for the given device name.
-    pub fn get_for_device(name: &str) -> Arc<Mutex<Self>> {
+    /// Gets or creates the global `ThroughputCache` holding what `runtime`
+    /// measured on the device it reports as `identity`.
+    pub fn get_for_device(runtime: &str, identity: &DeviceIdentity) -> Arc<Mutex<Self>> {
+        let name = device_key(runtime, identity);
         let mut cache_map = GLOBAL_CACHE.lock();
         let cache_map = cache_map.get_or_insert_with(HashMap::new);
 
         cache_map
-            .entry(name.to_string())
-            .or_insert_with(|| Arc::new(Mutex::new(Self::new(name))))
+            .entry(name.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(Self::new(&name))))
             .clone()
     }
 
@@ -69,5 +73,36 @@ impl ThroughputCache {
     /// Returns the [`ThroughputValue`] for the given [`ThroughputKey`], if it exists in the cache.
     pub fn get(&self, key: &ThroughputKey) -> Option<&ThroughputValue> {
         self.cache.get(key)
+    }
+}
+
+/// What separates one device's measurements from another's: the part, never the
+/// device index, which `CUDA_VISIBLE_DEVICES` makes 0 for whichever card was
+/// pinned. Two cards this cannot tell apart are the same part, and share a peak.
+fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
+    let DeviceIdentity { name, fingerprint } = identity;
+    let part = name.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
+
+    format!("{runtime}_{fingerprint}_{part}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    /// Two cards in one machine were served each other's peaks: pinning either
+    /// one makes it index 0, and the index was all that told them apart.
+    #[test]
+    fn two_parts_of_one_architecture_do_not_share_an_entry() {
+        let turing = |name: &str| DeviceIdentity {
+            name: name.to_string(),
+            fingerprint: "ptx_sm75".to_string(),
+        };
+
+        assert_ne!(
+            device_key("cuda", &turing("NVIDIA GeForce RTX 2060")),
+            device_key("cuda", &turing("NVIDIA GeForce GTX 1660 SUPER")),
+        );
     }
 }

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -5,8 +5,8 @@ use cubecl_runtime::{
     server::CubeDim,
     throughput::{
         ComputeCmmaConfig, DEFAULT_BUFFER_BYTES, KernelConfig, MemoryAccess, MemoryCurve,
-        MemoryPoint, MemorySpec, ThroughputBenchmarker, ThroughputKey, ThroughputMode,
-        ThroughputValue, sweep_size, working_set_sweep,
+        MemoryPoint, MemorySpec, ThroughputBenchmarker, ThroughputError, ThroughputKey,
+        ThroughputMode, ThroughputValue, sweep_size, working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
@@ -28,7 +28,7 @@ const CPU_CHAIN_DEPTH: usize = 64;
 pub fn device_throughput<R: Runtime>(
     device: &R::Device,
     keys: &[ThroughputKey],
-) -> alloc::vec::Vec<ThroughputValue> {
+) -> alloc::vec::Vec<Result<ThroughputValue, ThroughputError>> {
     let client = R::client(device);
     keys.iter()
         .map(|key| measure_peak_throughput::<R>(&client, *key))
@@ -65,9 +65,13 @@ fn sweep<R: Runtime>(
 ) -> alloc::vec::Vec<MemoryPoint> {
     working_set_sweep(working_set_cap(client, access))
         .into_iter()
-        .map(|bytes| MemoryPoint {
-            bytes,
-            value: measure_peak_throughput::<R>(client, ThroughputKey { mode: mode(bytes) }),
+        .filter_map(|bytes| {
+            let key = ThroughputKey { mode: mode(bytes) };
+
+            Some(MemoryPoint {
+                bytes,
+                value: measure_peak_throughput::<R>(client, key).ok()?,
+            })
         })
         .collect()
 }
@@ -83,10 +87,16 @@ fn working_set_cap<R: Runtime>(client: &ComputeClient<R>, access: MemoryAccess) 
 /// Computes the peak throughput for a given runtime and key.
 ///
 /// Native only, panics on WASM
+///
+/// # Errors
+///
+/// [`Unsupported`](ThroughputError::Unsupported) where the device implements
+/// no such operation, [`NoTiming`](ThroughputError::NoTiming) where it does
+/// and reported no elapsed time.
 pub fn measure_peak_throughput<R: Runtime>(
     client: &ComputeClient<R>,
     key: ThroughputKey,
-) -> ThroughputValue {
+) -> Result<ThroughputValue, ThroughputError> {
     // A throughput probe is a measurement: inside a dry run its launches must
     // still execute, or they would be timed anyway and cache a garbage peak in
     // the device-level throughput store. The guard is read where the launch is
@@ -96,22 +106,29 @@ pub fn measure_peak_throughput<R: Runtime>(
     let launch_config = launch_config(client, key.dtype());
 
     let candidates = match key.mode {
-        ThroughputMode::ComputeDirect { .. } => arithmetic_widths(client, key.dtype())
-            .into_iter()
-            .map(|vector_size| {
-                let config = LaunchConfig {
-                    vector_size,
-                    ..launch_config
-                };
-                compute_direct::build_kernel(client, key, config)
-            })
-            .collect(),
+        ThroughputMode::ComputeDirect { dtype } => {
+            // A type the backend cannot lower panics rather than answering.
+            if !client.properties().features.supports_type(dtype) {
+                return Err(ThroughputError::Unsupported);
+            }
+
+            arithmetic_widths(client, dtype)
+                .into_iter()
+                .map(|vector_size| {
+                    let config = LaunchConfig {
+                        vector_size,
+                        ..launch_config
+                    };
+                    compute_direct::build_kernel(client, key, config)
+                })
+                .collect()
+        }
         ThroughputMode::ComputeCmma {
             dtype,
             config: cmma_config,
         } => {
             if !implements_cmma(client, dtype, cmma_config) {
-                return ThroughputValue::ZERO;
+                return Err(ThroughputError::Unsupported);
             }
             alloc::vec![compute_cmma::build_kernel(
                 client,
@@ -157,28 +174,35 @@ pub fn roofline_bounds<R: Runtime>(
         mode: ThroughputMode::Launch,
     };
 
+    // No ceiling to bound against, which `time_at_peak` already declines.
+    let no_ceiling = ThroughputValue::ZERO;
+
     Bounds {
         bounds: calculate_bounds(
             work,
             thresholds,
-            &measure_peak_throughput(client, compute_key),
-            &measure_peak_throughput(client, memory_key),
+            &measure_peak_throughput(client, compute_key).unwrap_or(no_ceiling),
+            &measure_peak_throughput(client, memory_key).unwrap_or(no_ceiling),
             &memory_key,
         ),
-        launch_overhead: measure_peak_throughput(client, launch_key).duration_per_op(),
+        launch_overhead: measure_peak_throughput(client, launch_key)
+            .map(|value| value.duration_per_op())
+            .unwrap_or_default(),
     }
 }
 
 /// What the device answers fastest, of the shapes a probe can be launched in.
 ///
 /// A rate that is not finite is a shape that did not run, not a slow one.
-fn fastest_shape(candidates: alloc::vec::Vec<KernelConfig>) -> ThroughputValue {
+fn fastest_shape(
+    candidates: alloc::vec::Vec<KernelConfig>,
+) -> Result<ThroughputValue, ThroughputError> {
     candidates
         .into_iter()
         .map(ThroughputBenchmarker::sample)
         .filter(|value| value.ops_per_s().is_finite())
         .max_by(|a, b| a.ops_per_s().total_cmp(&b.ops_per_s()))
-        .unwrap_or(ThroughputValue::ZERO)
+        .ok_or(ThroughputError::NoTiming)
 }
 
 /// The vector widths an arithmetic probe is measured at.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -4,9 +4,9 @@ use cubecl_runtime::{
     runtime::Runtime,
     server::CubeDim,
     throughput::{
-        DEFAULT_BUFFER_BYTES, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec,
-        ThroughputBenchmarker, ThroughputKey, ThroughputMode, ThroughputValue, sweep_size,
-        working_set_sweep,
+        ComputeCmmaConfig, DEFAULT_BUFFER_BYTES, KernelConfig, MemoryAccess, MemoryCurve,
+        MemoryPoint, MemorySpec, ThroughputBenchmarker, ThroughputKey, ThroughputMode,
+        ThroughputValue, sweep_size, working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
@@ -95,28 +95,42 @@ pub fn measure_peak_throughput<R: Runtime>(
 
     let launch_config = launch_config(client, key.dtype());
 
-    let kernel_config = match key.mode {
-        ThroughputMode::ComputeDirect { .. } => {
-            compute_direct::build_kernel(client, key, launch_config)
-        }
+    let candidates = match key.mode {
+        ThroughputMode::ComputeDirect { .. } => arithmetic_widths(client, key.dtype())
+            .into_iter()
+            .map(|vector_size| {
+                let config = LaunchConfig {
+                    vector_size,
+                    ..launch_config
+                };
+                compute_direct::build_kernel(client, key, config)
+            })
+            .collect(),
         ThroughputMode::ComputeCmma {
+            dtype,
             config: cmma_config,
-            ..
         } => {
-            if client.properties().features.matmul.cmma.is_empty() {
+            if !implements_cmma(client, dtype, cmma_config) {
                 return ThroughputValue::ZERO;
             }
-            compute_cmma::build_kernel(client, key, cmma_config, launch_config)
+            alloc::vec![compute_cmma::build_kernel(
+                client,
+                key,
+                cmma_config,
+                launch_config
+            )]
         }
-        ThroughputMode::Memory(spec) => match spec.access {
+        ThroughputMode::Memory(spec) => alloc::vec![match spec.access {
             MemoryAccess::Copy => memory_direct::build_kernel(client, key, launch_config, spec),
             MemoryAccess::Read => memory_read::build_kernel(client, key, launch_config, spec),
             MemoryAccess::Write => memory_write::build_kernel(client, key, launch_config, spec),
-        },
-        ThroughputMode::Launch => launch_overhead::build_kernel(client, key, launch_config),
+        }],
+        ThroughputMode::Launch => {
+            alloc::vec![launch_overhead::build_kernel(client, key, launch_config)]
+        }
     };
 
-    let value = client.measure_throughput(key, || ThroughputBenchmarker::sample(kernel_config));
+    let value = client.measure_throughput(key, || fastest_shape(candidates));
 
     client.memory_cleanup();
 
@@ -153,6 +167,62 @@ pub fn roofline_bounds<R: Runtime>(
         ),
         launch_overhead: measure_peak_throughput(client, launch_key).duration_per_op(),
     }
+}
+
+/// What the device answers fastest, of the shapes a probe can be launched in.
+///
+/// A rate that is not finite is a shape that did not run rather than a slow
+/// one, so it does not stand as an answer; where none of them ran there is no
+/// peak to report.
+fn fastest_shape(candidates: alloc::vec::Vec<KernelConfig>) -> ThroughputValue {
+    candidates
+        .into_iter()
+        .map(ThroughputBenchmarker::sample)
+        .filter(|value| value.ops_per_s().is_finite())
+        .max_by(|a, b| a.ops_per_s().total_cmp(&b.ops_per_s()))
+        .unwrap_or(ThroughputValue::ZERO)
+}
+
+/// The vector widths an arithmetic probe is measured at.
+///
+/// [`io_optimized_vector_sizes`](ComputeClient::io_optimized_vector_sizes)
+/// orders widest first because it describes load and store instructions, and
+/// an arithmetic probe issues none. Which width retires the most is a property
+/// of the device — a SIMD CPU needs the widest, while on a scalar-lane GPU the
+/// lane layout a wide vector imposes costs more shuffling than its packing
+/// saves — so the probe measures every width the device offers.
+fn arithmetic_widths<R: Runtime>(
+    client: &ComputeClient<R>,
+    dtype: ElemType,
+) -> alloc::vec::Vec<usize> {
+    let widths: alloc::vec::Vec<usize> = client.io_optimized_vector_sizes(dtype.size()).collect();
+
+    if widths.is_empty() {
+        alloc::vec![1]
+    } else {
+        widths
+    }
+}
+
+/// Whether the device implements the cooperative matrix the probe launches.
+///
+/// A non-empty capability list says the device has tensor hardware, not that it
+/// has this shape on it, and launching a shape it lacks measures nothing while
+/// looking like any other number. The manual `mma` list is deliberately not
+/// consulted: the probe issues `cmma::execute`.
+fn implements_cmma<R: Runtime>(
+    client: &ComputeClient<R>,
+    dtype: ElemType,
+    config: ComputeCmmaConfig,
+) -> bool {
+    client.properties().features.matmul.cmma.iter().any(|it| {
+        it.a_type == dtype
+            && it.b_type == dtype
+            && it.cd_type == config.accumulator_type
+            && it.m as usize == config.cmma_dims.m
+            && it.n as usize == config.cmma_dims.n
+            && it.k as usize == config.cmma_dims.k
+    })
 }
 
 /// Hardware execution parameters for launching a compute kernel.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -4,15 +4,16 @@ use cubecl_runtime::{
     runtime::Runtime,
     server::CubeDim,
     throughput::{
-        ComputeCmmaConfig, DEFAULT_BUFFER_BYTES, KernelConfig, MemoryAccess, MemoryCurve,
-        MemoryPoint, MemorySpec, ThroughputBenchmarker, ThroughputError, ThroughputKey,
-        ThroughputMode, ThroughputValue, sweep_size, working_set_sweep,
+        ComputeCmmaConfig, KernelConfig, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec,
+        ThroughputBenchmarker, ThroughputError, ThroughputKey, ThroughputMode, ThroughputValue,
+        sweep_size, working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
 
 use crate::throughput::{
-    compute_cmma, compute_direct, launch_overhead, memory_direct, memory_read, memory_write,
+    compute_cmma, compute_direct, launch_overhead, memory_direct, memory_probe, memory_read,
+    memory_write,
 };
 
 /// Independent cube positions each CPU worker interleaves, so a compute
@@ -80,12 +81,12 @@ fn sweep<R: Runtime>(
         .collect()
 }
 
-/// The largest working set `access` can be probed at: as much as one buffer can
-/// hold, times the buffers the access touches.
+/// The largest working set `access` can be probed at: the largest window one
+/// buffer holds, times the buffers the access touches.
 fn working_set_cap<R: Runtime>(client: &ComputeClient<R>, access: MemoryAccess) -> u64 {
     let max_alloc = client.properties().memory.max_page_size;
 
-    DEFAULT_BUFFER_BYTES.min(max_alloc) * access.buffers()
+    memory_probe::window_cap(max_alloc) * access.buffers()
 }
 
 /// Computes the peak throughput for a given runtime and key.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -24,9 +24,8 @@ use crate::throughput::{
 /// [`MemoryProbe::new`](crate::throughput::memory_probe::MemoryProbe::new)).
 const CPU_CHAIN_DEPTH: usize = 64;
 
-/// Units a GPU probe asks for. Every larger ask resolves here anyway, since
-/// [`CubeDim::new`] caps a cube at eight planes; cubes built wider than that
-/// measure no faster, and make the memory probes report impossible rates.
+/// Units a GPU probe asks for. A wider cube measures no faster, and makes the
+/// memory probes report several times the bus rate.
 const PROBE_UNITS_PER_CUBE: u32 = 256;
 
 /// Measure peak throughput on `device` for each of the given `keys`.
@@ -249,8 +248,8 @@ fn implements_cmma<R: Runtime>(
 /// Hardware execution parameters for launching a compute kernel.
 #[derive(Clone, Copy)]
 pub struct LaunchConfig {
-    /// The cube the probe launches, resolved once so every runner counts the
-    /// operations the launch it issues actually performs.
+    /// The cube the probe launches, resolved once so `ops_count` cannot
+    /// describe a launch that did not happen.
     pub cube_dim: CubeDim,
     /// The total number of cubes to dispatch.
     pub cube_count: usize,

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -244,8 +244,9 @@ fn implements_cmma<R: Runtime>(
 /// Hardware execution parameters for launching a compute kernel.
 #[derive(Clone, Copy)]
 pub struct LaunchConfig {
-    /// The number of threads per cube.
-    pub cube_dim: usize,
+    /// The cube the probe launches, resolved once so every runner counts the
+    /// operations the launch it issues actually performs.
+    pub cube_dim: CubeDim,
     /// The total number of cubes to dispatch.
     pub cube_count: usize,
     /// The vectorization factor (e.g., 4 for `vec4` operations).
@@ -267,26 +268,21 @@ fn launch_config<R: Runtime>(client: &ComputeClient<R>, dtype: ElemType) -> Laun
     // a cube's units are its real dispatched workers here, while its cube
     // count is only a loop inside each of them. `num_cpu_cores` units, one
     // per core, is the real worker count.
-    if let Some(cores) = hardware.num_cpu_cores {
-        return LaunchConfig {
-            cube_dim: cores as usize,
-            cube_count: CPU_CHAIN_DEPTH,
-            vector_size,
-            plane_size: plane_size as usize,
-        };
-    }
-
-    let requested = (hardware.max_units_per_cube / plane_size * plane_size)
-        .max(plane_size)
-        .min(hardware.max_cube_dim.0);
-
-    let cube_dim = CubeDim::new(client, requested as usize).num_elems();
-
-    let sms = hardware.num_streaming_multiprocessors.unwrap_or(64);
-    let cube_count = (sms * 32).min(hardware.max_cube_count.0);
+    let (units, cube_count) = match hardware.num_cpu_cores {
+        Some(cores) => (cores, CPU_CHAIN_DEPTH as u32),
+        None => {
+            let sms = hardware.num_streaming_multiprocessors.unwrap_or(64);
+            (
+                (hardware.max_units_per_cube / plane_size * plane_size)
+                    .max(plane_size)
+                    .min(hardware.max_cube_dim.0),
+                (sms * 32).min(hardware.max_cube_count.0),
+            )
+        }
+    };
 
     LaunchConfig {
-        cube_dim: cube_dim as usize,
+        cube_dim: CubeDim::new(client, units as usize),
         cube_count: cube_count as usize,
         vector_size,
         plane_size: plane_size as usize,

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -4,8 +4,9 @@ use cubecl_runtime::{
     runtime::Runtime,
     server::CubeDim,
     throughput::{
-        DEFAULT_BUFFER_BYTES, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec, ThroughputKey,
-        ThroughputMode, ThroughputValue, sweep_size, working_set_sweep,
+        DEFAULT_BUFFER_BYTES, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec,
+        ThroughputBenchmarker, ThroughputKey, ThroughputMode, ThroughputValue, sweep_size,
+        working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
@@ -115,7 +116,7 @@ pub fn measure_peak_throughput<R: Runtime>(
         ThroughputMode::Launch => launch_overhead::build_kernel(client, key, launch_config),
     };
 
-    let value = client.measure_throughput(key, kernel_config);
+    let value = client.measure_throughput(key, || ThroughputBenchmarker::sample(kernel_config));
 
     client.memory_cleanup();
 

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -171,9 +171,7 @@ pub fn roofline_bounds<R: Runtime>(
 
 /// What the device answers fastest, of the shapes a probe can be launched in.
 ///
-/// A rate that is not finite is a shape that did not run rather than a slow
-/// one, so it does not stand as an answer; where none of them ran there is no
-/// peak to report.
+/// A rate that is not finite is a shape that did not run, not a slow one.
 fn fastest_shape(candidates: alloc::vec::Vec<KernelConfig>) -> ThroughputValue {
     candidates
         .into_iter()
@@ -185,12 +183,8 @@ fn fastest_shape(candidates: alloc::vec::Vec<KernelConfig>) -> ThroughputValue {
 
 /// The vector widths an arithmetic probe is measured at.
 ///
-/// [`io_optimized_vector_sizes`](ComputeClient::io_optimized_vector_sizes)
-/// orders widest first because it describes load and store instructions, and
-/// an arithmetic probe issues none. Which width retires the most is a property
-/// of the device — a SIMD CPU needs the widest, while on a scalar-lane GPU the
-/// lane layout a wide vector imposes costs more shuffling than its packing
-/// saves — so the probe measures every width the device offers.
+/// `io_optimized_vector_sizes` is ordered for the loads and stores this probe
+/// issues none of, and its widest is not the fastest on every device.
 fn arithmetic_widths<R: Runtime>(
     client: &ComputeClient<R>,
     dtype: ElemType,
@@ -206,10 +200,8 @@ fn arithmetic_widths<R: Runtime>(
 
 /// Whether the device implements the cooperative matrix the probe launches.
 ///
-/// A non-empty capability list says the device has tensor hardware, not that it
-/// has this shape on it, and launching a shape it lacks measures nothing while
-/// looking like any other number. The manual `mma` list is deliberately not
-/// consulted: the probe issues `cmma::execute`.
+/// A non-empty capability list says the device has tensor hardware, not this
+/// shape of it. `mma` is not consulted: the probe issues `cmma::execute`.
 fn implements_cmma<R: Runtime>(
     client: &ComputeClient<R>,
     dtype: ElemType,

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -24,6 +24,11 @@ use crate::throughput::{
 /// [`MemoryProbe::new`](crate::throughput::memory_probe::MemoryProbe::new)).
 const CPU_CHAIN_DEPTH: usize = 64;
 
+/// Units a GPU probe asks for. Every larger ask resolves here anyway, since
+/// [`CubeDim::new`] caps a cube at eight planes; cubes built wider than that
+/// measure no faster, and make the memory probes report impossible rates.
+const PROBE_UNITS_PER_CUBE: u32 = 256;
+
 /// Measure peak throughput on `device` for each of the given `keys`.
 pub fn device_throughput<R: Runtime>(
     device: &R::Device,
@@ -273,9 +278,7 @@ fn launch_config<R: Runtime>(client: &ComputeClient<R>, dtype: ElemType) -> Laun
         None => {
             let sms = hardware.num_streaming_multiprocessors.unwrap_or(64);
             (
-                (hardware.max_units_per_cube / plane_size * plane_size)
-                    .max(plane_size)
-                    .min(hardware.max_cube_dim.0),
+                PROBE_UNITS_PER_CUBE,
                 (sms * 32).min(hardware.max_cube_count.0),
             )
         }

--- a/crates/cubecl-std/src/throughput/runners/compute_cmma.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_cmma.rs
@@ -25,7 +25,7 @@ pub fn build_kernel<R: Runtime>(
             compute_cmma_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(config.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(out, 1),
                 iterations,
@@ -38,7 +38,7 @@ pub fn build_kernel<R: Runtime>(
         start.elapsed()
     });
 
-    let planes_per_cube = config.cube_dim / config.plane_size;
+    let planes_per_cube = config.cube_dim.num_elems() as usize / config.plane_size;
     let ops_count = config.cube_count * planes_per_cube * ops_per_cmma;
 
     KernelConfig {

--- a/crates/cubecl-std/src/throughput/runners/compute_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_direct.rs
@@ -22,7 +22,7 @@ pub fn build_kernel<R: Runtime>(
             compute_direct_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(config.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(out, 1),
                 iterations,
@@ -36,8 +36,11 @@ pub fn build_kernel<R: Runtime>(
 
     // `CHAINS` independent accumulators per lane, each retiring one fma (two flops) or one mul.
     let ops_per_chain = if use_fma { 2 } else { 1 };
-    let ops_count =
-        ops_per_chain * CHAINS * config.cube_count * config.cube_dim * config.vector_size;
+    let ops_count = ops_per_chain
+        * CHAINS
+        * config.cube_count
+        * config.cube_dim.num_elems() as usize
+        * config.vector_size;
 
     KernelConfig {
         sample,

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -31,7 +31,7 @@ pub fn build_kernel<R: Runtime>(
             memory_direct_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(probe.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(in_handle.clone(), probe.pool_lines),
                 BufferArg::from_raw_parts(out_handle.clone(), probe.pool_lines),

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -106,9 +106,6 @@ pub fn memory_direct_throughput<I: Numeric, N: Size>(
             }
         }
 
-        // Step to the next window, modulo the pool — see
-        // [`MemoryProbe`](super::memory_probe::MemoryProbe) on why it is
-        // modulo and not a wrap counter.
         start += window;
         if start >= len {
             start -= len;

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -2,10 +2,22 @@ use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, ir::ElemType};
 use cubecl_runtime::{
     server::Handle,
-    throughput::{DEFAULT_BUFFER_BYTES, MemorySpec},
+    throughput::{DEFAULT_WORKING_SET_BYTES, MemorySpec},
 };
 
 use crate::throughput::LaunchConfig;
+
+/// Windows the pool holds. What decides whether a rewritten line is still
+/// resident is the pool's size against the last level cache, not the positions
+/// the window walks, so two is a floor a probe that cannot read that cache size
+/// can justify rather than a ratio known to be enough.
+const POOL_WINDOWS: usize = 2;
+
+/// The largest window one buffer is probed at: the default working set, or as
+/// much of the device's allocation as leaves room for the pool around it.
+pub(crate) fn window_cap(max_alloc: u64) -> u64 {
+    (DEFAULT_WORKING_SET_BYTES.min(max_alloc / POOL_WINDOWS as u64)).max(1)
+}
 
 /// The buffer geometry and launch shape a memory probe uses to move a working
 /// set of a given size in one pass.
@@ -22,42 +34,20 @@ use crate::throughput::LaunchConfig;
 /// the data cold — by the time the window comes back around, a whole buffer of
 /// traffic has evicted it — so what varies across the sweep is how much a pass
 /// moves, which is the thing being measured.
-/// # The window steps modulo the pool
 ///
-/// Between passes a kernel advances `start` by one window and subtracts the
-/// pool where that runs past the end. It used to land instead on a counter
-/// incremented once per cycle, so that a window which does not divide the pool
-/// would eventually cover every line rather than always stopping at the same
-/// boundary. Stepping modularly covers them anyway, and the counter had a
-/// degenerate case that cost real bandwidth.
+/// # The pool is sized against the cache, not against the window
 ///
-/// When the window *is* the pool — the top of every sweep, and the single-size
-/// probe every peak is read from — `start += window` reaches `len` on the very
-/// first pass, so the counter sent it to 1, then 2, then 3. Every pass after
-/// the first read the whole buffer offset by a line or two, unaligned against
-/// every cache line and page boundary it crossed, and gained nothing for it: a
-/// window that is the pool has nowhere to rotate to.
-///
-/// Measured on a Radeon 8060S reading a 512 MiB window, best of nine, varying
-/// only the passes folded into one launch:
-///
-/// | passes | counter | modulo |
-/// |---|---|---|
-/// | 1 | 218-224 GB/s | 213-226 |
-/// | 4 | 203-209 | 228 |
-/// | 16 | 191 | 232-234 |
-///
-/// The counter fell the longer the launch ran; modulo rises to the sustained
-/// rate. The warmup targets 20 ms a sample, about eight passes at this size.
+/// A store into a line a recent pass left in the last level cache never reaches
+/// memory, so a pool the cache holds a large share of reports write traffic the
+/// bus never carried: 747 GB/s across a 672 GB/s bus on an RTX 4070 Ti SUPER,
+/// at every working set from 32 MiB up. More positions did not fix that — the
+/// 32 MiB window already walked sixteen of them — and doubling the pool did.
 #[derive(Clone, Copy, Debug)]
 pub struct MemoryProbe {
-    /// Lines of each buffer the probe walks: what the window is cold against,
-    /// and the whole buffer until the window spans several last level caches
-    /// and is cold on its own.
+    /// Lines of each buffer the probe walks: what the window is cold against.
     pub pool_lines: usize,
-    /// Lines one pass moves through, per buffer. Never more than
-    /// [`pool_lines`](Self::pool_lines); equal to it at the top of the sweep,
-    /// where the window is its own pool.
+    /// Lines one pass moves through, per buffer. Always a fraction of
+    /// [`pool_lines`](Self::pool_lines), the top of the sweep included.
     pub window_lines: usize,
     /// Bytes in each buffer, which is exactly the pool. The probe kernels take
     /// their wrap-around from `len()`, so a buffer longer than the pool would
@@ -121,11 +111,6 @@ impl MemoryProbe {
     /// The geometry itself, with the device reduced to its allocation limit and
     /// launch shape so the sizing can be exercised without one.
     ///
-    /// The pool is always the whole buffer, so every window has somewhere cold
-    /// to come back to. A window pinned to its own bytes revisits them one line
-    /// further along each pass, which is a stationary probe: on both a 32 MiB
-    /// and an 18 MiB last level cache that reads 10% and writes 20% high.
-    ///
     /// The launch shrinks with the window instead of the window growing to fill
     /// the launch. A small window measured with the full dispatch would either
     /// hand many threads the same line or be padded back up to a large one, and
@@ -136,10 +121,10 @@ impl MemoryProbe {
         let buffers = spec.access.buffers() as usize;
         let window_bytes = (spec.bytes.min(usize::MAX as u64) as usize) / buffers;
 
-        let cold_lines = (shape.max_alloc.min(DEFAULT_BUFFER_BYTES as usize) / line_bytes).max(1);
-        let window_lines = (window_bytes / line_bytes).max(1).min(cold_lines);
+        let cap_lines = (window_cap(shape.max_alloc as u64) as usize / line_bytes).max(1);
+        let window_lines = (window_bytes / line_bytes).clamp(1, cap_lines);
 
-        let pool_lines = cold_lines;
+        let pool_lines = cap_lines * POOL_WINDOWS;
 
         let cube_count = (window_lines / shape.cube_dim).clamp(1, shape.cube_count);
 
@@ -208,10 +193,10 @@ mod tests {
     const KB: usize = 1024;
     const MB: usize = 1024 * 1024;
 
-    /// Half a gigabyte of allocation, 256-thread cubes, and a full dispatch of
+    /// A gigabyte of allocation, 256-thread cubes, and a full dispatch of
     /// 2048 cubes.
     const DEVICE: DeviceShape = DeviceShape {
-        max_alloc: 512 * MB,
+        max_alloc: 1024 * MB,
         cube_dim: 256,
         cube_count: 2048,
     };
@@ -224,47 +209,47 @@ mod tests {
 
     #[test]
     fn the_pool_stays_large_however_small_the_window() {
-        // 256 KiB of traffic, but still half a gigabyte to be cold against.
+        // 256 KiB of traffic, but still a gigabyte to be cold against.
         let small = probe(256 * KB, MemoryAccess::Read);
-        assert_eq!(small.pool_lines, 512 * MB / 16);
+        assert_eq!(small.pool_lines, 1024 * MB / 16);
         assert_eq!(small.window_lines, 256 * KB / 16);
 
         // A copy splits its working set across two buffers, so the same traffic
         // is half the window per buffer.
         let copy = probe(256 * KB, MemoryAccess::Copy);
-        assert_eq!(copy.pool_lines, 512 * MB / 16);
+        assert_eq!(copy.pool_lines, 1024 * MB / 16);
         assert_eq!(copy.window_lines, 128 * KB / 16);
     }
 
-    /// A window pinned to its own bytes would revisit them one line further
-    /// along each pass, which is a stationary probe reading its own cache.
-    /// Nothing below the top of the sweep may stop walking.
+    /// Every window is a fraction of the pool, the top of the sweep included,
+    /// so no point of the sweep measures a window rewriting its own bytes pass
+    /// after pass.
     #[test]
-    fn no_window_short_of_the_pool_stops_walking() {
-        for bytes in [256 * KB, 64 * MB, 128 * MB, 256 * MB] {
+    fn no_window_stops_walking() {
+        for bytes in [256 * KB, 64 * MB, 256 * MB, 512 * MB, 8 * 1024 * MB] {
             let probe = probe(bytes, MemoryAccess::Read);
-            assert_eq!(probe.pool_lines, 512 * MB / 16, "at {bytes} bytes");
+            assert_eq!(probe.pool_lines, 1024 * MB / 16, "at {bytes} bytes");
             assert!(probe.window_lines < probe.pool_lines, "at {bytes} bytes");
-            assert_eq!(probe.buffer_bytes, 512 * MB, "at {bytes} bytes");
+            assert_eq!(probe.buffer_bytes, 1024 * MB, "at {bytes} bytes");
         }
     }
 
     #[test]
     fn a_small_window_carries_the_passes_that_walk_the_pool() {
-        // 8 KiB of a half-gigabyte pool: 65536 passes to come back round.
+        // 8 KiB of a gigabyte pool: 131072 passes to come back round.
         let small = probe(8 * KB, MemoryAccess::Read);
-        assert_eq!(small.min_iterations(), 512 * MB / (8 * KB));
+        assert_eq!(small.min_iterations(), 1024 * MB / (8 * KB));
 
-        // Only the top of the sweep, where the window is the pool, needs one.
+        // The top of the sweep still carries the passes its own walk needs.
         let whole = probe(512 * MB, MemoryAccess::Read);
-        assert_eq!(whole.min_iterations(), 1);
+        assert_eq!(whole.min_iterations(), 2);
     }
 
     #[test]
     fn walking_the_pool_costs_the_pool_whatever_the_window() {
         // Every pass moves one window, so the traffic a launch must carry is
         // the pool, and a small window buys passes rather than time.
-        for bytes in [8 * KB, 256 * KB, 4 * MB] {
+        for bytes in [8 * KB, 256 * KB, 4 * MB, 512 * MB] {
             let probe = probe(bytes, MemoryAccess::Read);
             let walked = probe.min_iterations() * probe.window_lines;
             assert_eq!(walked, probe.pool_lines, "at {bytes} bytes");
@@ -272,15 +257,15 @@ mod tests {
     }
 
     #[test]
-    fn the_window_fills_the_pool_at_the_top_of_the_sweep() {
-        // The default working set is the whole buffer, where the window has
-        // nowhere to move and the probe is the single-size one.
+    fn the_window_stops_at_the_default_working_set() {
+        // The single-size probe every peak is read from asks for the default
+        // working set, and gets it whole.
         let read = probe(512 * MB, MemoryAccess::Read);
-        assert_eq!(read.window_lines, read.pool_lines);
+        assert_eq!(read.window_lines, 512 * MB / 16);
 
-        // And a window can never exceed the pool, whatever it is asked for.
+        // Asking for more buys nothing: the pool has to stay larger.
         let huge = probe(8 * 1024 * MB, MemoryAccess::Read);
-        assert_eq!(huge.window_lines, huge.pool_lines);
+        assert_eq!(huge.window_lines, read.window_lines);
     }
 
     #[test]
@@ -298,8 +283,8 @@ mod tests {
     }
 
     #[test]
-    fn a_device_that_allocates_little_shrinks_the_pool_with_it() {
-        // The pool is the allocation limit, and the window follows it down
+    fn a_device_that_allocates_little_shrinks_the_window_with_it() {
+        // The pool is the allocation limit, and the window drops below it
         // rather than asking for memory the device does not have.
         let shape = DeviceShape {
             max_alloc: 4 * MB,
@@ -309,6 +294,6 @@ mod tests {
         let probe = MemoryProbe::sized(shape, 16, spec, false);
 
         assert_eq!(probe.buffer_bytes, 4 * MB);
-        assert_eq!(probe.window_lines, probe.pool_lines);
+        assert_eq!(probe.window_lines, 2 * MB / 16);
     }
 }

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -111,7 +111,7 @@ impl MemoryProbe {
         let blocked = config.plane_size == 1;
         let shape = DeviceShape {
             max_alloc: client.properties().memory.max_page_size as usize,
-            cube_dim: config.cube_dim,
+            cube_dim: config.cube_dim.num_elems() as usize,
             cube_count: if blocked { 1 } else { config.cube_count },
         };
 
@@ -173,7 +173,7 @@ pub fn prime<R: Runtime>(
         prime_buffer::launch_unchecked(
             client,
             CubeCount::Static(config.cube_count as u32, 1, 1),
-            CubeDim::new(client, config.cube_dim),
+            config.cube_dim,
             config.vector_size,
             BufferArg::from_raw_parts(handle.clone(), pool_lines),
             pool_lines,

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -45,7 +45,7 @@ pub fn build_kernel<R: Runtime>(
             memory_read_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(probe.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(in_handle.clone(), probe.pool_lines),
                 BufferArg::from_raw_parts(out_handle.clone(), 1),

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -136,9 +136,6 @@ pub fn memory_read_throughput<I: Numeric, N: Size>(
             }
         }
 
-        // Step to the next window, modulo the pool — see
-        // [`MemoryProbe`](super::memory_probe::MemoryProbe) on why it is
-        // modulo and not a wrap counter.
         start += window;
         if start >= len {
             start -= len;

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -36,7 +36,7 @@ pub fn build_kernel<R: Runtime>(
             memory_write_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(probe.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(out_handle.clone(), probe.pool_lines),
                 probe.window_lines,

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -122,9 +122,6 @@ pub fn memory_write_throughput<I: Numeric, N: Size>(
             }
         }
 
-        // Step to the next window, modulo the pool — see
-        // [`MemoryProbe`](super::memory_probe::MemoryProbe) on why it is
-        // modulo and not a wrap counter.
         start += window;
         if start >= len {
             start -= len;

--- a/examples/throughput/README.md
+++ b/examples/throughput/README.md
@@ -2,13 +2,16 @@
 
 Small benchmarks that measure a device's **peak throughput** for a few workloads:
 
-| example           | measures                                          |
-| ----------------- | ------------------------------------------------- |
-| `compute_direct`  | peak arithmetic throughput (non-CMMA, f32)        |
-| `compute_cmma`    | peak tensor-core (CMMA) throughput (f16 → f32)    |
-| `memory`          | peak memory (copy) bandwidth                      |
-| `launch_overhead` | peak launch throughput (dispatch rate)          |
-| `all`             | runs all of the above and prints them as a table  |
+| example           | measures                                                     |
+| ----------------- | ------------------------------------------------------------ |
+| `compute_direct`  | peak arithmetic throughput, per float type the device supports |
+| `compute_cmma`    | peak cooperative-matrix throughput, per accumulator width      |
+| `memory`          | peak memory (copy) bandwidth                                   |
+| `memory_read`     | peak read-only streaming bandwidth                             |
+| `memory_write`    | peak write-only streaming bandwidth                            |
+| `memory_curve`    | bandwidth against working set size, for each access pattern    |
+| `launch_overhead` | the fixed cost of a single kernel launch                       |
+| `all`             | every single-size probe above, as one table                    |
 
 ## Running
 
@@ -26,15 +29,35 @@ Always use `--release`; a debug build measures the wrong thing.
 Example output:
 
 ```
-Peak throughput — wgpu<wgsl>
-  compute-direct f32                          6.4877 TOPS/s
-  compute-cmma   f16→f16 16×16×16               unsupported
-  memory                                  131.5563 Gbytes/s
-  launch                                       32.4µs/launch
+Peak throughput — cuda / NVIDIA GeForce RTX 4070 Ti SUPER
+  compute-direct f32                         46.0146 TOPS/s
+  compute-direct f16                         48.5997 TOPS/s
+  compute-direct bf16                        48.5997 TOPS/s
+  compute-cmma   f16→f16 32×8×16            192.7744 TOPS/s
+  compute-cmma   f16→f32 32×8×16             96.3201 TOPS/s
+  memory         copy    1 GiB            601.4902 Gbytes/s
+  memory         read    512 MiB          660.2920 Gbytes/s
+  memory         write   512 MiB          748.0780 Gbytes/s
+  launch                                     3.502µs/launch
 ```
 
-CMMA needs a tensor-core backend. On backends without it (e.g. WGSL) it prints
-`unsupported` and is skipped.
+A row reads `unsupported` where the device implements no such thing: a
+cooperative matrix on a card without tensor hardware, a type it cannot compute
+in. A row that measured nothing reads `N/A` instead — the two are different
+answers.
+
+## Reading the numbers
+
+The two accumulator rows are separate because consumer parts halve their tensor
+rate for f32 accumulation, and that is the rate a matmul runs on.
+
+Memory counts the bytes a kernel asks for, not the traffic that reaches DRAM: an
+ordinary store also pays read-for-ownership where the hardware does, so on a CPU
+the write and copy figures land near half the bus while read lands near all of
+it. Comparing any of them against a vendor bus figure needs that in mind.
+
+`memory` reports one working set. `memory_curve` reports the whole sweep, and a
+kernel moving far less than the top of it cannot reach the top of it.
 
 ## Backends
 
@@ -65,4 +88,3 @@ CUBECL_THROUGHPUT_CACHE=off cargo run --release -p throughput --example all --fe
 
 Accepted values: `on` / `1` / `true` to enable (the default), `off` / `0` /
 `false` to disable.
-

--- a/examples/throughput/README.md
+++ b/examples/throughput/README.md
@@ -43,8 +43,10 @@ Peak throughput — cuda / NVIDIA GeForce RTX 4070 Ti SUPER
 
 A row reads `unsupported` where the device implements no such thing: a
 cooperative matrix on a card without tensor hardware, a type it cannot compute
-in. A row that measured nothing reads `N/A` instead — the two are different
-answers.
+in. It reads `no timing` where the device does implement it and reported no
+elapsed time for any shape of the probe — which is every wgpu backend's launch
+row, since that is the one probe timed on the device rather than on the host.
+The two are different answers, and neither is a slow one.
 
 ## Reading the numbers
 

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -3,7 +3,8 @@ use cubecl::{
     prelude::*,
     std::throughput::{measure_memory_curve, measure_peak_throughput},
     throughput::{
-        CmmaDims, ComputeCmmaConfig, MemoryAccess, MemoryCurve, ThroughputKey, ThroughputMode,
+        CmmaDims, ComputeCmmaConfig, MemoryAccess, MemoryCurve, ThroughputError, ThroughputKey,
+        ThroughputMode,
     },
 };
 
@@ -133,8 +134,13 @@ fn report<R: Runtime>(device: &R::Device, rows: impl FnOnce(&ComputeClient<R>) -
 
     for row in rows(&client) {
         let value = match row.key {
-            Some(key) => measure_peak_throughput(&client, key).format(&key),
-            None => String::from("unsupported"),
+            Some(key) => match measure_peak_throughput(&client, key) {
+                Ok(value) => value.format(&key),
+                Err(unavailable) => unavailable.to_string(),
+            },
+            // A row the device could not even be asked for: no tile to name, no
+            // type to compute in.
+            None => ThroughputError::Unsupported.to_string(),
         };
 
         println!("  {:<15}{:<24}{:>18}", row.mode, row.operands, value);

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -115,8 +115,7 @@ pub fn all<R: Runtime>(device: &R::Device) {
     });
 }
 
-/// One line of the report: what it measures, on which operands, and the probe
-/// behind it — or `None` where the device implements no such thing.
+/// One line of the report, or `None` where the device implements no such thing.
 struct Row {
     mode: &'static str,
     operands: String,
@@ -162,8 +161,8 @@ fn compute_direct_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
 
 /// A row per accumulator width, at f16 inputs.
 ///
-/// The accumulator earns a row of its own because consumer parts halve their
-/// tensor rate for f32 accumulation, which is the one a matmul runs on.
+/// Consumer parts halve their tensor rate for f32 accumulation, which is the
+/// one a matmul runs on.
 fn compute_cmma_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
     let dtype = ElemType::Float(FloatKind::F16);
 
@@ -200,9 +199,8 @@ fn compute_cmma_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
 
 /// The largest cooperative matrix the device implements for these operands.
 ///
-/// Read from the `cmma` capability rather than through `select_cmma_tile`,
-/// which answers from the manual `mma` list as well: the probe issues
-/// `cmma::execute`, and a shape only the other instruction has does not run.
+/// Read from `cmma` rather than through `select_cmma_tile`, which answers from
+/// `mma` as well: a shape only that instruction has does not run here.
 fn largest_cmma<R: Runtime>(
     client: &ComputeClient<R>,
     dtype: ElemType,

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -138,8 +138,6 @@ fn report<R: Runtime>(device: &R::Device, rows: impl FnOnce(&ComputeClient<R>) -
                 Ok(value) => value.format(&key),
                 Err(unavailable) => unavailable.to_string(),
             },
-            // A row the device could not even be asked for: no tile to name, no
-            // type to compute in.
             None => ThroughputError::Unsupported.to_string(),
         };
 

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -44,31 +44,31 @@ macro_rules! dispatch {
     }};
 }
 
-/// Peak direct (non-CMMA) compute throughput.
+/// Peak arithmetic throughput, per float type the device supports.
 pub fn compute_direct<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[compute_direct_key()]);
+    report::<R>(device, compute_direct_rows);
 }
 
-/// Peak CMMA (tensor-core) compute throughput.
+/// Peak cooperative-matrix throughput, per accumulator width.
 pub fn compute_cmma<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[compute_cmma_key()]);
+    report::<R>(device, compute_cmma_rows);
 }
 
 /// Peak memory (copy) throughput, reads and writes both counted.
 pub fn memory<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[memory_key()]);
+    report::<R>(device, |_| vec![memory_row(MemoryAccess::Copy)]);
 }
 
 /// Peak read-only streaming throughput. Expect this to exceed
 /// [`memory`], which pays for a store the read-only case never issues.
 pub fn memory_read<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[memory_read_key()]);
+    report::<R>(device, |_| vec![memory_row(MemoryAccess::Read)]);
 }
 
 /// Peak write-only streaming throughput. Expect this to exceed
 /// [`memory`], which pays for a read the write-only case never issues.
 pub fn memory_write<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[memory_write_key()]);
+    report::<R>(device, |_| vec![memory_row(MemoryAccess::Write)]);
 }
 
 /// Peak memory throughput as a function of working set size, for both access
@@ -99,8 +99,156 @@ fn print_curve(access: MemoryAccess, curve: &MemoryCurve) {
     }
 }
 
+/// Measures the fixed cost of a single kernel launch.
+pub fn launch_overhead<R: Runtime>(device: &R::Device) {
+    report::<R>(device, |_| vec![launch_row()]);
+}
+
+/// Runs every throughput benchmark and prints them as a table.
+pub fn all<R: Runtime>(device: &R::Device) {
+    report::<R>(device, |client| {
+        let mut rows = compute_direct_rows(client);
+        rows.extend(compute_cmma_rows(client));
+        rows.extend([MemoryAccess::Copy, MemoryAccess::Read, MemoryAccess::Write].map(memory_row));
+        rows.push(launch_row());
+        rows
+    });
+}
+
+/// One line of the report: what it measures, on which operands, and the probe
+/// behind it — or `None` where the device implements no such thing.
+struct Row {
+    mode: &'static str,
+    operands: String,
+    key: Option<ThroughputKey>,
+}
+
+fn report<R: Runtime>(device: &R::Device, rows: impl FnOnce(&ComputeClient<R>) -> Vec<Row>) {
+    let client = R::client(device);
+
+    println!(
+        "Peak throughput — {} / {}",
+        R::name(&client),
+        client.properties().identity.name
+    );
+
+    for row in rows(&client) {
+        let value = match row.key {
+            Some(key) => measure_peak_throughput(&client, key).format(&key),
+            None => String::from("unsupported"),
+        };
+
+        println!("  {:<15}{:<24}{:>18}", row.mode, row.operands, value);
+    }
+}
+
+fn compute_direct_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
+    [FloatKind::F32, FloatKind::F16, FloatKind::BF16]
+        .into_iter()
+        .map(|kind| {
+            let dtype = ElemType::Float(kind);
+            let supported = client.properties().features.supports_type(dtype);
+
+            Row {
+                mode: "compute-direct",
+                operands: dtype.to_string(),
+                key: supported.then_some(ThroughputKey {
+                    mode: ThroughputMode::ComputeDirect { dtype },
+                }),
+            }
+        })
+        .collect()
+}
+
+/// A row per accumulator width, at f16 inputs.
+///
+/// The accumulator earns a row of its own because consumer parts halve their
+/// tensor rate for f32 accumulation, which is the one a matmul runs on.
+fn compute_cmma_rows<R: Runtime>(client: &ComputeClient<R>) -> Vec<Row> {
+    let dtype = ElemType::Float(FloatKind::F16);
+
+    [FloatKind::F16, FloatKind::F32]
+        .into_iter()
+        .map(|kind| {
+            let accumulator_type = ElemType::Float(kind);
+            let dims = largest_cmma(client, dtype, accumulator_type);
+
+            Row {
+                mode: "compute-cmma",
+                operands: match dims {
+                    Some(dims) => {
+                        format!(
+                            "{dtype}→{accumulator_type} {}×{}×{}",
+                            dims.m, dims.n, dims.k
+                        )
+                    }
+                    None => format!("{dtype}→{accumulator_type}"),
+                },
+                key: dims.map(|cmma_dims| ThroughputKey {
+                    mode: ThroughputMode::ComputeCmma {
+                        dtype,
+                        config: ComputeCmmaConfig {
+                            cmma_dims,
+                            accumulator_type,
+                        },
+                    },
+                }),
+            }
+        })
+        .collect()
+}
+
+/// The largest cooperative matrix the device implements for these operands.
+///
+/// Read from the `cmma` capability rather than through `select_cmma_tile`,
+/// which answers from the manual `mma` list as well: the probe issues
+/// `cmma::execute`, and a shape only the other instruction has does not run.
+fn largest_cmma<R: Runtime>(
+    client: &ComputeClient<R>,
+    dtype: ElemType,
+    accumulator_type: ElemType,
+) -> Option<CmmaDims> {
+    client
+        .properties()
+        .features
+        .matmul
+        .cmma
+        .iter()
+        .filter(|it| it.a_type == dtype && it.b_type == dtype && it.cd_type == accumulator_type)
+        .max_by_key(|it| it.m as u64 * it.n as u64 * it.k as u64)
+        .map(|it| CmmaDims {
+            m: it.m as usize,
+            n: it.n as usize,
+            k: it.k as usize,
+        })
+}
+
+fn memory_row(access: MemoryAccess) -> Row {
+    Row {
+        mode: "memory",
+        operands: format!(
+            "{:<8}{}",
+            format!("{access:?}").to_lowercase(),
+            bytes_label(access.default_working_set())
+        ),
+        key: Some(ThroughputKey {
+            mode: ThroughputMode::memory(access),
+        }),
+    }
+}
+
+fn launch_row() -> Row {
+    Row {
+        mode: "launch",
+        operands: String::new(),
+        key: Some(ThroughputKey {
+            mode: ThroughputMode::Launch,
+        }),
+    }
+}
+
 fn bytes_label(bytes: u64) -> String {
-    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
 
     let mut value = bytes as f64;
     let mut unit = 0;
@@ -111,117 +259,4 @@ fn bytes_label(bytes: u64) -> String {
     }
 
     format!("{value:.0} {}", UNITS[unit])
-}
-
-/// Measures the fixed cost of a single kernel launch.
-pub fn launch_overhead<R: Runtime>(device: &R::Device) {
-    run::<R>(device, &[launch_overhead_key()]);
-}
-
-/// Runs every throughput benchmark and prints them as a table.
-pub fn all<R: Runtime>(device: &R::Device) {
-    run::<R>(
-        device,
-        &[
-            compute_direct_key(),
-            compute_cmma_key(),
-            memory_key(),
-            memory_read_key(),
-            memory_write_key(),
-            launch_overhead_key(),
-        ],
-    );
-}
-
-fn run<R: Runtime>(device: &R::Device, keys: &[ThroughputKey]) {
-    let client = R::client(device);
-
-    println!("Peak throughput — {}", R::name(&client));
-    for &key in keys {
-        let value = measure_peak_throughput(&client, key).format(&key);
-
-        println!(
-            "  {:<15}{:<24}{:>18}",
-            mode_label(&key.mode),
-            describe(&key),
-            value,
-        );
-    }
-}
-
-/// Describes the operands of a benchmark: input dtype, plus CMMA shape and accumulator.
-fn describe(key: &ThroughputKey) -> String {
-    match key.mode {
-        ThroughputMode::ComputeCmma {
-            dtype: input_dtype,
-            config: cfg,
-        } => format!(
-            "{}→{} {}×{}×{}",
-            input_dtype, cfg.accumulator_type, cfg.cmma_dims.m, cfg.cmma_dims.n, cfg.cmma_dims.k,
-        ),
-        ThroughputMode::ComputeDirect { .. } => key.dtype().to_string(),
-        ThroughputMode::Memory(spec) => bytes_label(spec.bytes),
-        ThroughputMode::Launch => String::new(),
-    }
-}
-
-fn mode_label(mode: &ThroughputMode) -> &'static str {
-    match mode {
-        ThroughputMode::ComputeDirect { .. } => "compute-direct",
-        ThroughputMode::ComputeCmma { .. } => "compute-cmma",
-        ThroughputMode::Memory(spec) => match spec.access {
-            MemoryAccess::Copy => "memory",
-            MemoryAccess::Read => "memory-read",
-            MemoryAccess::Write => "memory-write",
-        },
-        ThroughputMode::Launch => "launch",
-    }
-}
-
-fn compute_direct_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::ComputeDirect {
-            dtype: ElemType::Float(FloatKind::F16),
-        },
-    }
-}
-
-fn compute_cmma_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::ComputeCmma {
-            dtype: ElemType::Float(FloatKind::F16),
-            config: ComputeCmmaConfig {
-                cmma_dims: CmmaDims {
-                    m: 16,
-                    n: 16,
-                    k: 16,
-                },
-                accumulator_type: ElemType::Float(FloatKind::F16),
-            },
-        },
-    }
-}
-
-fn memory_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::memory(MemoryAccess::Copy),
-    }
-}
-
-fn memory_read_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::memory(MemoryAccess::Read),
-    }
-}
-
-fn memory_write_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::memory(MemoryAccess::Write),
-    }
-}
-
-fn launch_overhead_key() -> ThroughputKey {
-    ThroughputKey {
-        mode: ThroughputMode::Launch,
-    }
 }


### PR DESCRIPTION
The throughput probes reported writes the bus cannot carry, measured arithmetic at two thirds of the machine, served one card's numbers to another, and answered zero for two different kinds of "no". Six fixes, in the order they build on each other. Every number downstream that is a percent of peak divides by these.

One API change: `measure_peak_throughput` and `device_throughput` return `Result<ThroughputValue, ThroughputError>`. Downstream: tracel-ai/cubek#604 and tracel-ai/burn#5561, both pinned to this head.

## 1. The arithmetic peak is measured at the width that reaches it

`launch_config` took the widest `io_optimized_vector_sizes` entry, a list ordered for loads and stores the arithmetic probe never issues. On sm_89 an f16 vec8 hot loop spent a quarter of its instructions shuffling lanes. Which width wins is a property of the device (a SIMD CPU wants the widest, Arc 4, NVIDIA 1), so every width the device offers is measured and the best kept.

| compute-direct | before | after | |
|---|---|---|---|
| RTX 4070 Ti SUPER f32 | 31.80 | 46.01 TOPS/s | 95% of the 48.7 its clock and lanes allow |
| RTX 4070 Ti SUPER f16 | 34.60 | 48.60 | |
| RTX 2060 f16 | 11.12 | 15.12 | twice its f32, the documented rate |
| Arc B390, Ryzen 5700X, Xeon E5-2620 v4 | unmoved | | their widest was already their best |

`implements_cmma` refuses a tile shape the device lacks instead of launching it and reporting nothing under a number's clothing.

## 2. A device with no peak says why

`ThroughputValue::ZERO` stood for both a device that implements no such operation and one whose timer reported nothing, so both rendered `N/A` and consumers re-derived the difference from the arithmetic. The two are now `ThroughputError` variants, and only a measurement is cached. A dtype the backend cannot lower is checked before building, where asking a WGSL device for bf16 used to panic a compiler worker.

The example prints what the device says it can do: one row per supported float type and one per accumulator width at the largest tile it reports, `unsupported` distinct from `N/A`. The f32 accumulator earns its row because consumer parts halve their tensor rate for it, and that is the rate a matmul runs on:

| RTX 4070 Ti SUPER cmma 32x8x16 | |
|---|---|
| f16 to f16 | 192.77 TOPS/s |
| f16 to f32 | 96.32 |

## 3. The cache is keyed on the device part, and versioned

The namespace was `throughput/<crate version>/<runtime>_dev<index>`, and the index is the one thing a user changes: pinning a card with `CUDA_VISIBLE_DEVICES` makes it index 0. On a box holding an RTX 2060 and a GTX 1660 SUPER, the second card was handed the first card's whole row:

| GTX 1660 SUPER | before | after |
|---|---|---|
| compute-direct f16 | 11.19 TOPS/s, the 2060's | 10.84, its own |
| memory read | 304.2 GB/s, the 2060's | 317.3 |
| memory write | 257.3, the 2060's | 282.0 |

The key is now the device's name and fingerprint. A `PROBE_VERSION` segment sits beside the throughput keys so a probe that changes what it reports stops serving its predecessor, and opening the cache purges this build's earlier generations once per process. Every value cached under the old namespace is invalidated, which is intended.

## 4. The probe cube is resolved once

`LaunchConfig::cube_dim` was a `usize` every runner pushed back through `CubeDim::new` while `ops_count` counted the raw value, so the operations reported could describe a launch that did not happen. It now carries the resolved `CubeDim`. The maximal-cube arithmetic, which `CubeDim::new` capped to 256 anyway, is replaced by asking for 256: arithmetic is flat within 1% from 128 to 1024 units on the 4070, and above 256 the memory probes claim five times the bus, a defect at a geometry nothing reaches, left alone.

## 5. The memory pool is larger than the cache

The pool was a fixed 512 MiB and the largest window was the same 512 MiB, so on a card with 48 MiB of L2 enough of it stayed resident that stores never reached memory. The pool is now twice the largest window.

| RTX 4070 Ti SUPER, 672 GB/s bus | before | after | |
|---|---|---|---|
| write 512 MiB | 747.8 to 751.0 | 581.0 to 583.8 GB/s | 111% of the bus to 87% |
| read 512 MiB | 658.7 to 661.6 | 638.3 to 638.4 | |
| copy 1 GiB | 600.4 to 602.1 | 591.5 to 591.7 | |

An nvcc fill of a 512 MiB buffer with the same grid moves 606 to 619 GB/s, which is what the probe now reports. Read and copy give back a few percent for the larger footprint. An RX 5600 XT that never reported above its bus does not move. Each buffer doubles, so a copy probe reserves 2 GiB.

## 6. The warmup plateau holds across a wall-clock floor

A device sitting at a low clock for the whole measurement window was invisible from inside it: the plateau check compares passes taken microseconds apart, so warmup found a genuine 3%-stable plateau at the low rate and every draw confirmed it. On an Intel Arc B390 a poisoned arithmetic probe read 7.0 us an iteration where a clean one read 2.4, at the same iteration count.

A plateau is now accepted only once it has held for 250 ms of wall clock at the settled iteration count, sized against the transition it has to see. The window restarts whenever the count grows or the rate improves past the tolerance, so a device climbing out of a low clock waits for its new rate to hold. Sampling then runs once, as before.

| RTX 4070 Ti SUPER, one full `all` run, cache off | |
|---|---|
| before | 9.4 s |
| after | 13.6 to 14.2 s |

Paid once per key per crate version. Sustained contention answers the same however long it is held, and is not what this fixes.

## At the tip, three runs each

| | RTX 4070 Ti SUPER | RTX 2060 | GTX 1660 SUPER | Ryzen 7 5700X |
|---|---|---|---|---|
| compute-direct f32 | 46.01 x3 | 7.53 to 7.65 | 5.44 x3 | 1.07 TOPS/s |
| compute-direct f16 | 48.06 to 48.60 | 15.01 to 15.12 | 10.84 x3 | 116 GOPS/s, emulated |
| memory read | 638.7 to 638.9 | 303.6 to 304.3 | 317.1 to 317.5 | 44.0 to 44.6 GB/s |
| memory write | 581.9 to 582.8 | 248.6 to 250.1 | 281.7 to 282.3 | 19.8 to 20.0 |
| memory copy | 591.7 to 594.1 | 252.0 to 253.2 | 275.6 to 275.8 | 26.4 to 26.5 |

## Not fixed here

An unmeasurable launch is still charged as free in `roofline_bounds`. A launch that fails still presents as one of the other two errors. Two pool windows is a floor, not a ratio known to suffice; sizing the pool from the device's last level cache is still open. The 2060's CUDA memory rows sit ten points under its Vulkan rows for a reason outside this PR, fixed in #1595.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
