### PR TITLE
refactor(throughput): resolve the probe cube once, and ask for 256 units outright

### DIFF
--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -24,9 +24,8 @@ use crate::throughput::{
 /// [`MemoryProbe::new`](crate::throughput::memory_probe::MemoryProbe::new)).
 const CPU_CHAIN_DEPTH: usize = 64;
 
-/// Units a GPU probe asks for. Every larger ask resolves here anyway, since
-/// [`CubeDim::new`] caps a cube at eight planes; cubes built wider than that
-/// measure no faster, and make the memory probes report impossible rates.
+/// Units a GPU probe asks for. A wider cube measures no faster, and makes the
+/// memory probes report several times the bus rate.
 const PROBE_UNITS_PER_CUBE: u32 = 256;
 
 /// Measure peak throughput on `device` for each of the given `keys`.
@@ -249,8 +248,8 @@ fn implements_cmma<R: Runtime>(
 /// Hardware execution parameters for launching a compute kernel.
 #[derive(Clone, Copy)]
 pub struct LaunchConfig {
-    /// The cube the probe launches, resolved once so every runner counts the
-    /// operations the launch it issues actually performs.
+    /// The cube the probe launches, resolved once so `ops_count` cannot
+    /// describe a launch that did not happen.
     pub cube_dim: CubeDim,
     /// The total number of cubes to dispatch.
     pub cube_count: usize,

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -244,8 +244,9 @@ fn implements_cmma<R: Runtime>(
 /// Hardware execution parameters for launching a compute kernel.
 #[derive(Clone, Copy)]
 pub struct LaunchConfig {
-    /// The number of threads per cube.
-    pub cube_dim: usize,
+    /// The cube the probe launches, resolved once so every runner counts the
+    /// operations the launch it issues actually performs.
+    pub cube_dim: CubeDim,
     /// The total number of cubes to dispatch.
     pub cube_count: usize,
     /// The vectorization factor (e.g., 4 for `vec4` operations).
@@ -267,26 +268,21 @@ fn launch_config<R: Runtime>(client: &ComputeClient<R>, dtype: ElemType) -> Laun
     // a cube's units are its real dispatched workers here, while its cube
     // count is only a loop inside each of them. `num_cpu_cores` units, one
     // per core, is the real worker count.
-    if let Some(cores) = hardware.num_cpu_cores {
-        return LaunchConfig {
-            cube_dim: cores as usize,
-            cube_count: CPU_CHAIN_DEPTH,
-            vector_size,
-            plane_size: plane_size as usize,
-        };
-    }
-
-    let requested = (hardware.max_units_per_cube / plane_size * plane_size)
-        .max(plane_size)
-        .min(hardware.max_cube_dim.0);
-
-    let cube_dim = CubeDim::new(client, requested as usize).num_elems();
-
-    let sms = hardware.num_streaming_multiprocessors.unwrap_or(64);
-    let cube_count = (sms * 32).min(hardware.max_cube_count.0);
+    let (units, cube_count) = match hardware.num_cpu_cores {
+        Some(cores) => (cores, CPU_CHAIN_DEPTH as u32),
+        None => {
+            let sms = hardware.num_streaming_multiprocessors.unwrap_or(64);
+            (
+                (hardware.max_units_per_cube / plane_size * plane_size)
+                    .max(plane_size)
+                    .min(hardware.max_cube_dim.0),
+                (sms * 32).min(hardware.max_cube_count.0),
+            )
+        }
+    };
 
     LaunchConfig {
-        cube_dim: cube_dim as usize,
+        cube_dim: CubeDim::new(client, units as usize),
         cube_count: cube_count as usize,
         vector_size,
         plane_size: plane_size as usize,

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -24,6 +24,11 @@ use crate::throughput::{
 /// [`MemoryProbe::new`](crate::throughput::memory_probe::MemoryProbe::new)).
 const CPU_CHAIN_DEPTH: usize = 64;
 
+/// Units a GPU probe asks for. Every larger ask resolves here anyway, since
+/// [`CubeDim::new`] caps a cube at eight planes; cubes built wider than that
+/// measure no faster, and make the memory probes report impossible rates.
+const PROBE_UNITS_PER_CUBE: u32 = 256;
+
 /// Measure peak throughput on `device` for each of the given `keys`.
 pub fn device_throughput<R: Runtime>(
     device: &R::Device,
@@ -273,9 +278,7 @@ fn launch_config<R: Runtime>(client: &ComputeClient<R>, dtype: ElemType) -> Laun
         None => {
             let sms = hardware.num_streaming_multiprocessors.unwrap_or(64);
             (
-                (hardware.max_units_per_cube / plane_size * plane_size)
-                    .max(plane_size)
-                    .min(hardware.max_cube_dim.0),
+                PROBE_UNITS_PER_CUBE,
                 (sms * 32).min(hardware.max_cube_count.0),
             )
         }

--- a/crates/cubecl-std/src/throughput/runners/compute_cmma.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_cmma.rs
@@ -25,7 +25,7 @@ pub fn build_kernel<R: Runtime>(
             compute_cmma_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(config.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(out, 1),
                 iterations,
@@ -38,7 +38,7 @@ pub fn build_kernel<R: Runtime>(
         start.elapsed()
     });
 
-    let planes_per_cube = config.cube_dim / config.plane_size;
+    let planes_per_cube = config.cube_dim.num_elems() as usize / config.plane_size;
     let ops_count = config.cube_count * planes_per_cube * ops_per_cmma;
 
     KernelConfig {

--- a/crates/cubecl-std/src/throughput/runners/compute_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_direct.rs
@@ -22,7 +22,7 @@ pub fn build_kernel<R: Runtime>(
             compute_direct_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(config.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(out, 1),
                 iterations,
@@ -36,8 +36,11 @@ pub fn build_kernel<R: Runtime>(
 
     // `CHAINS` independent accumulators per lane, each retiring one fma (two flops) or one mul.
     let ops_per_chain = if use_fma { 2 } else { 1 };
-    let ops_count =
-        ops_per_chain * CHAINS * config.cube_count * config.cube_dim * config.vector_size;
+    let ops_count = ops_per_chain
+        * CHAINS
+        * config.cube_count
+        * config.cube_dim.num_elems() as usize
+        * config.vector_size;
 
     KernelConfig {
         sample,

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -31,7 +31,7 @@ pub fn build_kernel<R: Runtime>(
             memory_direct_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(probe.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(in_handle.clone(), probe.pool_lines),
                 BufferArg::from_raw_parts(out_handle.clone(), probe.pool_lines),

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -111,7 +111,7 @@ impl MemoryProbe {
         let blocked = config.plane_size == 1;
         let shape = DeviceShape {
             max_alloc: client.properties().memory.max_page_size as usize,
-            cube_dim: config.cube_dim,
+            cube_dim: config.cube_dim.num_elems() as usize,
             cube_count: if blocked { 1 } else { config.cube_count },
         };
 
@@ -173,7 +173,7 @@ pub fn prime<R: Runtime>(
         prime_buffer::launch_unchecked(
             client,
             CubeCount::Static(config.cube_count as u32, 1, 1),
-            CubeDim::new(client, config.cube_dim),
+            config.cube_dim,
             config.vector_size,
             BufferArg::from_raw_parts(handle.clone(), pool_lines),
             pool_lines,

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -45,7 +45,7 @@ pub fn build_kernel<R: Runtime>(
             memory_read_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(probe.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(in_handle.clone(), probe.pool_lines),
                 BufferArg::from_raw_parts(out_handle.clone(), 1),

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -36,7 +36,7 @@ pub fn build_kernel<R: Runtime>(
             memory_write_throughput::launch_unchecked(
                 &client,
                 CubeCount::Static(probe.cube_count as u32, 1, 1),
-                CubeDim::new(&client, config.cube_dim),
+                config.cube_dim,
                 config.vector_size,
                 BufferArg::from_raw_parts(out_handle.clone(), probe.pool_lines),
                 probe.window_lines,


### PR DESCRIPTION
Stacked on #1594.

`LaunchConfig::cube_dim` was a `usize` that every runner pushed back through `CubeDim::new` inside its sample closure while `ops_count` counted the raw value: two derivations of one quantity, agreeing only because the constructor is idempotent on its own output. `LaunchConfig` now carries the resolved `CubeDim`, and the runners launch with it and count from it.

`launch_config` also computed the largest legal cube, 1024 units on NVIDIA, and handed it to `CubeDim::new`, which caps a cube at eight planes and answered 256. The computation read as though it chose the geometry and chose nothing. It now asks for 256 outright, which `CubeDim::new` already clamps on every device.

Wider cubes were measured before choosing, built directly to bypass the cap. RTX 4070 Ti SUPER, best of two rounds:

| units | compute-direct f32 | f16 | memory read |
|---|---|---|---|
| 128 | 46.01 TOPS/s | 48.06 | 648 GB/s |
| 256 | 46.01 | 48.06 | 663 |
| 512 | 45.77 | 48.33 | 2963 |
| 1024 | 45.41 | 48.46 | 3421 |

Arithmetic is flat across the range, so the maximal cube buys nothing. The memory rows above 256 are not a result: 663 GB/s is the bus, and a wider cube claiming five times it is a launch whose traffic is not happening. That defect sits at a geometry nothing reaches and is left alone here.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
