### PR TITLE
fix(throughput): size the memory probe's pool past the cache, not equal to its window

### DIFF
--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -8,9 +8,10 @@ use thiserror::Error;
 /// a probe changes what it reports.
 pub const PROBE_VERSION: u32 = 1;
 
-/// Bytes per buffer of a [`ThroughputMode::Memory`] probe left at its default
-/// working set. Clamped to the device's maximum allocation when the probe runs.
-pub const DEFAULT_BUFFER_BYTES: u64 = 512 * 1024 * 1024;
+/// Bytes one buffer of a [`ThroughputMode::Memory`] probe moves per pass at its
+/// default working set. The probe's buffer is a multiple of this, and both are
+/// clamped to the device's maximum allocation when the probe runs.
+pub const DEFAULT_WORKING_SET_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Which directions of traffic a memory probe issues.
 #[derive(Eq, PartialEq, Clone, Hash, Debug, Copy)]
@@ -44,9 +45,9 @@ impl MemoryAccess {
     }
 
     /// The working set of the single-size probe for this access, in bytes moved
-    /// per pass: [`DEFAULT_BUFFER_BYTES`] per buffer touched.
+    /// per pass: [`DEFAULT_WORKING_SET_BYTES`] per buffer touched.
     pub const fn default_working_set(&self) -> u64 {
-        DEFAULT_BUFFER_BYTES * self.buffers()
+        DEFAULT_WORKING_SET_BYTES * self.buffers()
     }
 }
 

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -4,15 +4,16 @@ use cubecl_runtime::{
     runtime::Runtime,
     server::CubeDim,
     throughput::{
-        ComputeCmmaConfig, DEFAULT_BUFFER_BYTES, KernelConfig, MemoryAccess, MemoryCurve,
-        MemoryPoint, MemorySpec, ThroughputBenchmarker, ThroughputError, ThroughputKey,
-        ThroughputMode, ThroughputValue, sweep_size, working_set_sweep,
+        ComputeCmmaConfig, KernelConfig, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec,
+        ThroughputBenchmarker, ThroughputError, ThroughputKey, ThroughputMode, ThroughputValue,
+        sweep_size, working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
 
 use crate::throughput::{
-    compute_cmma, compute_direct, launch_overhead, memory_direct, memory_read, memory_write,
+    compute_cmma, compute_direct, launch_overhead, memory_direct, memory_probe, memory_read,
+    memory_write,
 };
 
 /// Independent cube positions each CPU worker interleaves, so a compute
@@ -80,12 +81,12 @@ fn sweep<R: Runtime>(
         .collect()
 }
 
-/// The largest working set `access` can be probed at: as much as one buffer can
-/// hold, times the buffers the access touches.
+/// The largest working set `access` can be probed at: the largest window one
+/// buffer holds, times the buffers the access touches.
 fn working_set_cap<R: Runtime>(client: &ComputeClient<R>, access: MemoryAccess) -> u64 {
     let max_alloc = client.properties().memory.max_page_size;
 
-    DEFAULT_BUFFER_BYTES.min(max_alloc) * access.buffers()
+    memory_probe::window_cap(max_alloc) * access.buffers()
 }
 
 /// Computes the peak throughput for a given runtime and key.

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -106,9 +106,6 @@ pub fn memory_direct_throughput<I: Numeric, N: Size>(
             }
         }
 
-        // Step to the next window, modulo the pool — see
-        // [`MemoryProbe`](super::memory_probe::MemoryProbe) on why it is
-        // modulo and not a wrap counter.
         start += window;
         if start >= len {
             start -= len;

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -2,10 +2,22 @@ use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, ir::ElemType};
 use cubecl_runtime::{
     server::Handle,
-    throughput::{DEFAULT_BUFFER_BYTES, MemorySpec},
+    throughput::{DEFAULT_WORKING_SET_BYTES, MemorySpec},
 };
 
 use crate::throughput::LaunchConfig;
+
+/// Windows the pool holds. What decides whether a rewritten line is still
+/// resident is the pool's size against the last level cache, not the positions
+/// the window walks, so two is a floor a probe that cannot read that cache size
+/// can justify rather than a ratio known to be enough.
+const POOL_WINDOWS: usize = 2;
+
+/// The largest window one buffer is probed at: the default working set, or as
+/// much of the device's allocation as leaves room for the pool around it.
+pub(crate) fn window_cap(max_alloc: u64) -> u64 {
+    (DEFAULT_WORKING_SET_BYTES.min(max_alloc / POOL_WINDOWS as u64)).max(1)
+}
 
 /// The buffer geometry and launch shape a memory probe uses to move a working
 /// set of a given size in one pass.
@@ -22,42 +34,20 @@ use crate::throughput::LaunchConfig;
 /// the data cold — by the time the window comes back around, a whole buffer of
 /// traffic has evicted it — so what varies across the sweep is how much a pass
 /// moves, which is the thing being measured.
-/// # The window steps modulo the pool
 ///
-/// Between passes a kernel advances `start` by one window and subtracts the
-/// pool where that runs past the end. It used to land instead on a counter
-/// incremented once per cycle, so that a window which does not divide the pool
-/// would eventually cover every line rather than always stopping at the same
-/// boundary. Stepping modularly covers them anyway, and the counter had a
-/// degenerate case that cost real bandwidth.
+/// # The pool is sized against the cache, not against the window
 ///
-/// When the window *is* the pool — the top of every sweep, and the single-size
-/// probe every peak is read from — `start += window` reaches `len` on the very
-/// first pass, so the counter sent it to 1, then 2, then 3. Every pass after
-/// the first read the whole buffer offset by a line or two, unaligned against
-/// every cache line and page boundary it crossed, and gained nothing for it: a
-/// window that is the pool has nowhere to rotate to.
-///
-/// Measured on a Radeon 8060S reading a 512 MiB window, best of nine, varying
-/// only the passes folded into one launch:
-///
-/// | passes | counter | modulo |
-/// |---|---|---|
-/// | 1 | 218-224 GB/s | 213-226 |
-/// | 4 | 203-209 | 228 |
-/// | 16 | 191 | 232-234 |
-///
-/// The counter fell the longer the launch ran; modulo rises to the sustained
-/// rate. The warmup targets 20 ms a sample, about eight passes at this size.
+/// A store into a line a recent pass left in the last level cache never reaches
+/// memory, so a pool the cache holds a large share of reports write traffic the
+/// bus never carried: 747 GB/s across a 672 GB/s bus on an RTX 4070 Ti SUPER,
+/// at every working set from 32 MiB up. More positions did not fix that — the
+/// 32 MiB window already walked sixteen of them — and doubling the pool did.
 #[derive(Clone, Copy, Debug)]
 pub struct MemoryProbe {
-    /// Lines of each buffer the probe walks: what the window is cold against,
-    /// and the whole buffer until the window spans several last level caches
-    /// and is cold on its own.
+    /// Lines of each buffer the probe walks: what the window is cold against.
     pub pool_lines: usize,
-    /// Lines one pass moves through, per buffer. Never more than
-    /// [`pool_lines`](Self::pool_lines); equal to it at the top of the sweep,
-    /// where the window is its own pool.
+    /// Lines one pass moves through, per buffer. Always a fraction of
+    /// [`pool_lines`](Self::pool_lines), the top of the sweep included.
     pub window_lines: usize,
     /// Bytes in each buffer, which is exactly the pool. The probe kernels take
     /// their wrap-around from `len()`, so a buffer longer than the pool would
@@ -121,11 +111,6 @@ impl MemoryProbe {
     /// The geometry itself, with the device reduced to its allocation limit and
     /// launch shape so the sizing can be exercised without one.
     ///
-    /// The pool is always the whole buffer, so every window has somewhere cold
-    /// to come back to. A window pinned to its own bytes revisits them one line
-    /// further along each pass, which is a stationary probe: on both a 32 MiB
-    /// and an 18 MiB last level cache that reads 10% and writes 20% high.
-    ///
     /// The launch shrinks with the window instead of the window growing to fill
     /// the launch. A small window measured with the full dispatch would either
     /// hand many threads the same line or be padded back up to a large one, and
@@ -136,10 +121,10 @@ impl MemoryProbe {
         let buffers = spec.access.buffers() as usize;
         let window_bytes = (spec.bytes.min(usize::MAX as u64) as usize) / buffers;
 
-        let cold_lines = (shape.max_alloc.min(DEFAULT_BUFFER_BYTES as usize) / line_bytes).max(1);
-        let window_lines = (window_bytes / line_bytes).max(1).min(cold_lines);
+        let cap_lines = (window_cap(shape.max_alloc as u64) as usize / line_bytes).max(1);
+        let window_lines = (window_bytes / line_bytes).clamp(1, cap_lines);
 
-        let pool_lines = cold_lines;
+        let pool_lines = cap_lines * POOL_WINDOWS;
 
         let cube_count = (window_lines / shape.cube_dim).clamp(1, shape.cube_count);
 
@@ -208,10 +193,10 @@ mod tests {
     const KB: usize = 1024;
     const MB: usize = 1024 * 1024;
 
-    /// Half a gigabyte of allocation, 256-thread cubes, and a full dispatch of
+    /// A gigabyte of allocation, 256-thread cubes, and a full dispatch of
     /// 2048 cubes.
     const DEVICE: DeviceShape = DeviceShape {
-        max_alloc: 512 * MB,
+        max_alloc: 1024 * MB,
         cube_dim: 256,
         cube_count: 2048,
     };
@@ -224,47 +209,47 @@ mod tests {
 
     #[test]
     fn the_pool_stays_large_however_small_the_window() {
-        // 256 KiB of traffic, but still half a gigabyte to be cold against.
+        // 256 KiB of traffic, but still a gigabyte to be cold against.
         let small = probe(256 * KB, MemoryAccess::Read);
-        assert_eq!(small.pool_lines, 512 * MB / 16);
+        assert_eq!(small.pool_lines, 1024 * MB / 16);
         assert_eq!(small.window_lines, 256 * KB / 16);
 
         // A copy splits its working set across two buffers, so the same traffic
         // is half the window per buffer.
         let copy = probe(256 * KB, MemoryAccess::Copy);
-        assert_eq!(copy.pool_lines, 512 * MB / 16);
+        assert_eq!(copy.pool_lines, 1024 * MB / 16);
         assert_eq!(copy.window_lines, 128 * KB / 16);
     }
 
-    /// A window pinned to its own bytes would revisit them one line further
-    /// along each pass, which is a stationary probe reading its own cache.
-    /// Nothing below the top of the sweep may stop walking.
+    /// Every window is a fraction of the pool, the top of the sweep included,
+    /// so no point of the sweep measures a window rewriting its own bytes pass
+    /// after pass.
     #[test]
-    fn no_window_short_of_the_pool_stops_walking() {
-        for bytes in [256 * KB, 64 * MB, 128 * MB, 256 * MB] {
+    fn no_window_stops_walking() {
+        for bytes in [256 * KB, 64 * MB, 256 * MB, 512 * MB, 8 * 1024 * MB] {
             let probe = probe(bytes, MemoryAccess::Read);
-            assert_eq!(probe.pool_lines, 512 * MB / 16, "at {bytes} bytes");
+            assert_eq!(probe.pool_lines, 1024 * MB / 16, "at {bytes} bytes");
             assert!(probe.window_lines < probe.pool_lines, "at {bytes} bytes");
-            assert_eq!(probe.buffer_bytes, 512 * MB, "at {bytes} bytes");
+            assert_eq!(probe.buffer_bytes, 1024 * MB, "at {bytes} bytes");
         }
     }
 
     #[test]
     fn a_small_window_carries_the_passes_that_walk_the_pool() {
-        // 8 KiB of a half-gigabyte pool: 65536 passes to come back round.
+        // 8 KiB of a gigabyte pool: 131072 passes to come back round.
         let small = probe(8 * KB, MemoryAccess::Read);
-        assert_eq!(small.min_iterations(), 512 * MB / (8 * KB));
+        assert_eq!(small.min_iterations(), 1024 * MB / (8 * KB));
 
-        // Only the top of the sweep, where the window is the pool, needs one.
+        // The top of the sweep still carries the passes its own walk needs.
         let whole = probe(512 * MB, MemoryAccess::Read);
-        assert_eq!(whole.min_iterations(), 1);
+        assert_eq!(whole.min_iterations(), 2);
     }
 
     #[test]
     fn walking_the_pool_costs_the_pool_whatever_the_window() {
         // Every pass moves one window, so the traffic a launch must carry is
         // the pool, and a small window buys passes rather than time.
-        for bytes in [8 * KB, 256 * KB, 4 * MB] {
+        for bytes in [8 * KB, 256 * KB, 4 * MB, 512 * MB] {
             let probe = probe(bytes, MemoryAccess::Read);
             let walked = probe.min_iterations() * probe.window_lines;
             assert_eq!(walked, probe.pool_lines, "at {bytes} bytes");
@@ -272,15 +257,15 @@ mod tests {
     }
 
     #[test]
-    fn the_window_fills_the_pool_at_the_top_of_the_sweep() {
-        // The default working set is the whole buffer, where the window has
-        // nowhere to move and the probe is the single-size one.
+    fn the_window_stops_at_the_default_working_set() {
+        // The single-size probe every peak is read from asks for the default
+        // working set, and gets it whole.
         let read = probe(512 * MB, MemoryAccess::Read);
-        assert_eq!(read.window_lines, read.pool_lines);
+        assert_eq!(read.window_lines, 512 * MB / 16);
 
-        // And a window can never exceed the pool, whatever it is asked for.
+        // Asking for more buys nothing: the pool has to stay larger.
         let huge = probe(8 * 1024 * MB, MemoryAccess::Read);
-        assert_eq!(huge.window_lines, huge.pool_lines);
+        assert_eq!(huge.window_lines, read.window_lines);
     }
 
     #[test]
@@ -298,8 +283,8 @@ mod tests {
     }
 
     #[test]
-    fn a_device_that_allocates_little_shrinks_the_pool_with_it() {
-        // The pool is the allocation limit, and the window follows it down
+    fn a_device_that_allocates_little_shrinks_the_window_with_it() {
+        // The pool is the allocation limit, and the window drops below it
         // rather than asking for memory the device does not have.
         let shape = DeviceShape {
             max_alloc: 4 * MB,
@@ -309,6 +294,6 @@ mod tests {
         let probe = MemoryProbe::sized(shape, 16, spec, false);
 
         assert_eq!(probe.buffer_bytes, 4 * MB);
-        assert_eq!(probe.window_lines, probe.pool_lines);
+        assert_eq!(probe.window_lines, 2 * MB / 16);
     }
 }

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -136,9 +136,6 @@ pub fn memory_read_throughput<I: Numeric, N: Size>(
             }
         }
 
-        // Step to the next window, modulo the pool — see
-        // [`MemoryProbe`](super::memory_probe::MemoryProbe) on why it is
-        // modulo and not a wrap counter.
         start += window;
         if start >= len {
             start -= len;

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -122,9 +122,6 @@ pub fn memory_write_throughput<I: Numeric, N: Size>(
             }
         }
 
-        // Step to the next window, modulo the pool — see
-        // [`MemoryProbe`](super::memory_probe::MemoryProbe) on why it is
-        // modulo and not a wrap counter.
         start += window;
         if start >= len {
             start -= len;


### PR DESCRIPTION
Stacked on #1599.

The pool was a fixed 512 MiB and the largest window was the same 512 MiB, so the pool the sweep walked was never larger than a working set. On a card with 48 MiB of L2 enough of it stayed resident that stores never reached memory, and the write probe reported traffic the bus never carried: 747 to 751 GB/s across a 672 GB/s bus on an RTX 4070 Ti SUPER, at every working set from 32 MiB up.

The pool is now twice the largest window. Two windows is a floor a probe that cannot read the device's last level cache size can justify, not a ratio known to be enough; sizing it from that cache is still open.

Single-size probes on that card, three runs each, cache off:

| | before | after | |
|---|---|---|---|
| write | 747.8 to 751.0 | 581.0 to 583.8 GB/s | 111% of the bus to 87% |
| read | 658.7 to 661.6 | 638.3 to 638.4 | |
| copy | 600.4 to 602.1 | 591.5 to 591.7 | |

A plain CUDA fill of a 512 MiB buffer with the same grid, compiled by nvcc and timed with events, moves 606 to 619 GB/s, which is what the sweep now reports. The write curve loses the step it had at 32 MiB where it jumped from 593 to 754 and held past the bus to the end of the sweep. On an RX 5600 XT under Vulkan, which never reported above its bus, nothing moves.

Costs: each buffer doubles, so a copy probe reserves 2 GiB where it reserved 1, and a device that will not hand out a gigabyte in one allocation now measures its headline peak at half that allocation.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
