### PR TITLE
fix(throughput): outvote a measurement taken at a low clock

### DIFF
--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -67,17 +67,52 @@ impl ThroughputBenchmarker {
         Ok(value)
     }
 
-    /// Warm one shape of a kernel up to its plateau, then keep its fastest sample.
+    /// The peak of one kernel shape, over measurements taken until two agree.
     pub fn sample(kernel_config: KernelConfig) -> ThroughputValue {
-        let sample = kernel_config.sample;
-
-        let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
-        let duration = Self::sample_peak_duration(iterations, &sample);
+        let duration =
+            Self::corroborated_peak_duration(kernel_config.min_iterations, kernel_config.sample);
 
         ThroughputValue {
             ops_count: kernel_config.ops_count,
             duration,
         }
+    }
+
+    /// The fastest of several whole measurements, taken until two agree.
+    ///
+    /// A device held at a low clock stays there for a whole measurement, its
+    /// warmup and its draws alike, so the warmup plateaus there and every draw
+    /// confirms it. Only a later measurement disagrees with it.
+    fn corroborated_peak_duration(
+        min_iterations: usize,
+        sample: impl Fn(usize) -> Duration,
+    ) -> Duration {
+        const MAX_MEASUREMENTS: usize = 4;
+        // Wider than the plateau tolerance, which compares passes microseconds
+        // apart rather than measurements half a second apart.
+        const AGREEMENT_TOL: f64 = 0.05;
+
+        let mut best = Self::warmed_peak_seconds(min_iterations, &sample);
+
+        for _ in 1..MAX_MEASUREMENTS {
+            let seconds = Self::warmed_peak_seconds(min_iterations, &sample);
+            let agrees = (seconds - best).abs() <= best * AGREEMENT_TOL;
+            best = best.min(seconds);
+
+            if agrees {
+                break;
+            }
+        }
+
+        Duration::from_secs_f64(best)
+    }
+
+    /// One whole measurement: a warmup from scratch, then the fastest draw at
+    /// the iteration count it settles on.
+    fn warmed_peak_seconds(min_iterations: usize, sample: impl Fn(usize) -> Duration) -> f64 {
+        let iterations = Self::warmup(min_iterations, WARMUP_BUDGET, &sample);
+
+        Self::sample_peak_duration(iterations, &sample).as_secs_f64()
     }
 
     /// Warms up the device by running the kernel multiple times
@@ -241,6 +276,63 @@ mod tests {
         });
 
         assert!(calls.get() < 200, "ran {} samples", calls.get());
+    }
+
+    /// Every draw of a measurement taken at a low clock confirms that clock, so
+    /// the low rate is only visible from outside the measurement.
+    #[test]
+    fn a_measurement_taken_at_a_low_clock_is_outvoted_by_a_later_one() {
+        let measurements = Cell::new(0);
+        let low_clock_first = |iterations: usize| {
+            if iterations == 1 {
+                measurements.set(measurements.get() + 1);
+            }
+            let per_iter_ns = if measurements.get() == 1 { 3000 } else { 1000 };
+
+            Duration::from_nanos(iterations as u64 * per_iter_ns)
+        };
+
+        let duration = ThroughputBenchmarker::corroborated_peak_duration(1, low_clock_first);
+
+        assert!(duration < Duration::from_nanos(1100), "kept {duration:?}");
+    }
+
+    /// A device that answers the same twice is the case every probe of every
+    /// key pays for, so it must not pay for a third.
+    #[test]
+    fn two_agreeing_measurements_are_the_whole_cost() {
+        let measurements = Cell::new(0);
+        let steady = |iterations: usize| {
+            if iterations == 1 {
+                measurements.set(measurements.get() + 1);
+            }
+
+            Duration::from_nanos(iterations as u64 * 1000)
+        };
+
+        ThroughputBenchmarker::corroborated_peak_duration(1, steady);
+
+        assert_eq!(measurements.get(), 2);
+    }
+
+    /// A probe runs on first use of every key, so what it costs where nothing
+    /// ever agrees is the cost that has to be bounded.
+    #[test]
+    fn a_device_that_never_agrees_with_itself_stops_at_the_cap() {
+        let measurements = Cell::new(0);
+        let never_agrees = |iterations: usize| {
+            if iterations == 1 {
+                measurements.set(measurements.get() + 1);
+            }
+            let per_iter_ns = [1000, 3000, 500, 2000][(measurements.get() - 1) % 4];
+
+            Duration::from_nanos(iterations as u64 * per_iter_ns)
+        };
+
+        let duration = ThroughputBenchmarker::corroborated_peak_duration(1, never_agrees);
+
+        assert_eq!(measurements.get(), 4);
+        assert!(duration < Duration::from_nanos(550), "kept {duration:?}");
     }
 
     /// A working timer still drives the count to the duration target.


### PR DESCRIPTION
Stacked on #1600.

**Cost first: the full `all` table takes 17.5 s where it took 9.4 s, 1.86x**, paid once per key per crate version. The gain is repeatability: on a quiet RTX 4070 Ti SUPER ten interleaved runs of compute-direct f32 read 46.015 every time where they spread 45.53 to 46.51 before.

A probe warms one kernel shape to a plateau and keeps the fastest of the draws it takes at that iteration count, all inside one window of about four hundred milliseconds. A device sitting at a low clock for that whole window is invisible from inside it: the warmup plateaus at the low rate and every draw confirms it. The minimum rejects one slow draw; it cannot reject a slow window. On an Intel Arc B390 a poisoned arithmetic probe reads 7.0 us an iteration through its warmup and all ten draws where a clean one reads 2.4 us, at the same iteration count.

`sample` now takes the whole measurement again from a cold warmup until two agree within 5%, to a cap of four, and keeps the fastest. Two agreeing measurements is the common case and the only one a quiet device pays for. Three deterministic unit tests cover it.

Not fixed here: sustained contention, which answers the same however often it is asked; and the minimum is still taken over however many draws fit the 200 ms budget, three to thirteen in practice.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
