### PR TITLE
refactor: `ComputeClient` and `ComputeServer` are `Client` and `Server`

### DIFF
--- a/crates/cubecl-core/src/compute/launcher.rs
+++ b/crates/cubecl-core/src/compute/launcher.rs
@@ -7,7 +7,7 @@ use core::cell::RefCell;
 use cubecl_ir::{AddressType, ElemType, Scope, settings::KernelSettings};
 use cubecl_runtime::kernel::BufferIOAttr;
 use cubecl_runtime::server::{BufferBinding, CubeCount, KernelResource, TensorMapBinding};
-use cubecl_runtime::{client::ComputeClient, kernel::CubeKernel, server::KernelArguments};
+use cubecl_runtime::{client::Client, kernel::CubeKernel, server::KernelArguments};
 
 #[cfg(feature = "std")]
 std::thread_local! {
@@ -65,7 +65,7 @@ impl KernelLauncher {
 
     /// Launch the kernel.
     #[track_caller]
-    pub fn launch<K: CubeKernel>(self, cube_count: CubeCount, kernel: K, client: &ComputeClient) {
+    pub fn launch<K: CubeKernel>(self, cube_count: CubeCount, kernel: K, client: &Client) {
         let bindings = self.into_bindings();
         let kernel = Box::new(kernel);
 

--- a/crates/cubecl-core/src/frontend/element/complex.rs
+++ b/crates/cubecl-core/src/frontend/element/complex.rs
@@ -17,7 +17,7 @@ use cubecl_ir::{
         scalar::{Complex32Type, Complex64Type},
     },
 };
-use cubecl_runtime::client::ComputeClient;
+use cubecl_runtime::client::Client;
 
 use crate::{
     frontend::{
@@ -74,7 +74,7 @@ pub trait ComplexCore:
         unexpanded!()
     }
 
-    fn supported_complex_uses(client: &ComputeClient) -> cubecl_ir::EnumSet<ComplexUsage> {
+    fn supported_complex_uses(client: &Client) -> cubecl_ir::EnumSet<ComplexUsage> {
         client.properties().complex_usage(Self::elem_type_native())
     }
 }

--- a/crates/cubecl-core/src/frontend/element/cube_elem.rs
+++ b/crates/cubecl-core/src/frontend/element/cube_elem.rs
@@ -9,7 +9,7 @@ use crate::{
 use cubecl_ir::EnumSet;
 use cubecl_ir::{ConstantValue, ElemType, ExpandValue, features::TypeUsage, interfaces::TypedExt};
 use cubecl_macros::{comptime_type, cube, intrinsic};
-use cubecl_runtime::client::ComputeClient;
+use cubecl_runtime::client::Client;
 use pliron::r#type::TypeHandle;
 
 use crate::frontend::CubeType;
@@ -114,7 +114,7 @@ pub trait Scalar:
         unexpanded!()
     }
 
-    fn supported_uses(client: &ComputeClient) -> EnumSet<TypeUsage> {
+    fn supported_uses(client: &Client) -> EnumSet<TypeUsage> {
         let ty = Self::elem_type_native();
         client.features().type_usage(ty)
     }

--- a/crates/cubecl-core/src/id.rs
+++ b/crates/cubecl-core/src/id.rs
@@ -1,5 +1,5 @@
 use cubecl_common::device::{Device, DeviceId};
-use cubecl_runtime::client::ComputeClient;
+use cubecl_runtime::client::Client;
 
 /// ID used to identify a Just-in-Time environment.
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
@@ -10,7 +10,7 @@ pub struct CubeTuneId {
 
 impl CubeTuneId {
     /// Create a new ID.
-    pub fn new(client: &ComputeClient, device: &impl Device) -> Self {
+    pub fn new(client: &Client, device: &impl Device) -> Self {
         Self {
             device: device.to_id(),
             name: client.name(),

--- a/crates/cubecl-core/src/lib.rs
+++ b/crates/cubecl-core/src/lib.rs
@@ -24,7 +24,7 @@ pub use cubecl_environment as environment;
 pub use cubecl_environment::future;
 
 use cubecl_ir::VectorSize;
-use cubecl_runtime::client::ComputeClient;
+use cubecl_runtime::client::Client;
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
 use cubecl_runtime::server::CubeCountSelection;
 pub use frontend::cmma;
@@ -80,7 +80,7 @@ pub use prelude::{Assign, IntoRuntime};
 /// Calculate the number of cubes required to execute an operation where one cube unit is
 /// assigned to one element.
 pub fn calculate_cube_count_elemwise(
-    client: &ComputeClient,
+    client: &Client,
     num_elems: usize,
     cube_dim: CubeDim,
 ) -> CubeCount {

--- a/crates/cubecl-core/src/prelude.rs
+++ b/crates/cubecl-core/src/prelude.rs
@@ -14,7 +14,7 @@ pub use cubecl_ir::{
     settings::{ExecutionMode, KernelSettings},
 };
 pub use cubecl_runtime::{
-    client::ComputeClient,
+    client::Client,
     id::KernelId,
     kernel::*,
     server::{CubeCount, CubeDim, LaunchError},

--- a/crates/cubecl-core/src/runtime_tests/assign.rs
+++ b/crates/cubecl-core/src/runtime_tests/assign.rs
@@ -69,7 +69,7 @@ fn assign_mut_expression(output: &mut [u32]) {
     }
 }
 
-pub fn test_kernel_assign_scalar<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_kernel_assign_scalar<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(F::as_bytes(&[F::new(0.0), F::new(1.0)]));
 
     kernel_assign::launch::<F>(
@@ -85,7 +85,7 @@ pub fn test_kernel_assign_scalar<R: Runtime, F: Float + CubeElement>(client: Com
     assert_eq!(actual[0], F::new(5.0));
 }
 
-pub fn test_kernel_assign_one_tuple<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_kernel_assign_one_tuple<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(F::as_bytes(&[F::new(0.0)]));
 
     kernel_assign_one_tuple::launch::<F>(
@@ -101,7 +101,7 @@ pub fn test_kernel_assign_one_tuple<R: Runtime, F: Float + CubeElement>(client: 
     assert_eq!(actual[0], F::new(5.0));
 }
 
-pub fn test_kernel_add_assign_array<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_kernel_add_assign_array<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(F::as_bytes(&[F::new(0.0), F::new(1.0)]));
 
     let vectorization = 2;
@@ -120,7 +120,7 @@ pub fn test_kernel_add_assign_array<R: Runtime, F: Float + CubeElement>(client: 
     assert_eq!(actual[0], F::new(6.0));
 }
 
-pub fn test_kernel_add_assign_vector<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_kernel_add_assign_vector<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(F::as_bytes(&[F::new(0.0), F::new(1.0)]));
 
     let vectorization = 2;
@@ -140,7 +140,7 @@ pub fn test_kernel_add_assign_vector<R: Runtime, F: Float + CubeElement>(client:
     assert_eq!(actual[1], F::new(2.0));
 }
 
-pub fn test_kernel_assign_ref<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_kernel_assign_ref<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(F::as_bytes(&[F::new(0.0), F::new(1.0)]));
 
     kernel_assign_ref::launch::<F>(
@@ -156,7 +156,7 @@ pub fn test_kernel_assign_ref<R: Runtime, F: Float + CubeElement>(client: Comput
     assert_eq!(actual[0], F::new(5.0));
 }
 
-pub fn test_assign_mut_expr<R: Runtime>(client: ComputeClient) {
+pub fn test_assign_mut_expr<R: Runtime>(client: Client) {
     let output = client.empty(128 * size_of::<u32>());
 
     unsafe {

--- a/crates/cubecl-core/src/runtime_tests/atomic.rs
+++ b/crates/cubecl-core/src/runtime_tests/atomic.rs
@@ -25,17 +25,13 @@ pub enum IntAtomicOp {
     CompareExchange,
 }
 
-fn supports_feature<F: Numeric>(
-    client: &ComputeClient,
-    feat: AtomicUsage,
-    vector_size: usize,
-) -> bool {
+fn supports_feature<F: Numeric>(client: &Client, feat: AtomicUsage, vector_size: usize) -> bool {
     let ty = Type::atomic(F::elem_type_native().with_vector_size(vector_size));
     client.properties().atomic_type_usage(ty).contains(feat)
 }
 
 fn require_feature<F: Numeric>(
-    client: &ComputeClient,
+    client: &Client,
     feat: AtomicUsage,
     vector_size: usize,
     operation: &str,
@@ -154,7 +150,7 @@ pub fn kernel_atomic_numeric<I: Numeric, N: Size>(
 }
 
 pub fn test_kernel_atomic_numeric<R: Runtime, F: Numeric + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     vector_size: usize,
     op: NumericAtomicOp,
 ) {
@@ -192,7 +188,7 @@ pub fn test_kernel_atomic_numeric<R: Runtime, F: Numeric + CubeElement>(
 }
 
 pub fn test_kernel_atomic_numeric_all_sizes<R: Runtime, F: Numeric + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     op: NumericAtomicOp,
 ) {
     for vector_size in [1, 2, 4] {
@@ -224,10 +220,7 @@ pub fn kernel_atomic_int<I: Int>(
     }
 }
 
-pub fn test_kernel_atomic_int<R: Runtime, I: Int + CubeElement>(
-    client: ComputeClient,
-    op: IntAtomicOp,
-) {
+pub fn test_kernel_atomic_int<R: Runtime, I: Int + CubeElement>(client: Client, op: IntAtomicOp) {
     if !require_feature::<I>(&client, int_op_feature(op), 1, int_op_name(op)) {
         return;
     }
@@ -263,9 +256,7 @@ pub fn kernel_atomic_max_contention<I: Numeric>(atomics: &[Atomic<I>]) {
 }
 
 /// Many threads race `fetch_max` into one cell. The result must be the largest contribution.
-pub fn test_kernel_atomic_max_contention<R: Runtime, I: Numeric + CubeElement>(
-    client: ComputeClient,
-) {
+pub fn test_kernel_atomic_max_contention<R: Runtime, I: Numeric + CubeElement>(client: Client) {
     if !require_feature::<I>(&client, AtomicUsage::MinMax, 1, "Max contention") {
         return;
     }

--- a/crates/cubecl-core/src/runtime_tests/barrier.rs
+++ b/crates/cubecl-core/src/runtime_tests/barrier.rs
@@ -20,7 +20,7 @@ pub fn async_memcpy_test<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut
     output[0] = smem[0];
 }
 
-pub fn test_async_memcpy<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_async_memcpy<R: Runtime, F: Float + CubeElement>(client: Client) {
     if !client.properties().supports_type(OpaqueType::Barrier) {
         // We can't execute the test, skip.
         return;
@@ -65,7 +65,7 @@ pub fn async_copy_test<F: Float, N: Size>(input: &[Vector<F, N>], output: &mut [
     }
 }
 
-pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_async_copy<R: Runtime, F: Float + CubeElement>(client: Client) {
     if !client.properties().features.copy_async {
         // We can't execute the test, skip.
         return;
@@ -177,7 +177,7 @@ fn two_independent_loads<F: Float, N: Size>(
     output[UNIT_POS_X as usize] = dot;
 }
 
-pub fn test_memcpy_one_load<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_memcpy_one_load<R: Runtime, F: Float + CubeElement>(client: Client) {
     if !client.properties().supports_type(OpaqueType::Barrier) {
         // We can't execute the test, skip.
         return;
@@ -206,7 +206,7 @@ pub fn test_memcpy_one_load<R: Runtime, F: Float + CubeElement>(client: ComputeC
 
 pub fn test_memcpy_two_loads<R: Runtime, F: Float + CubeElement>(
     independent: bool,
-    client: ComputeClient,
+    client: Client,
 ) {
     if !client.properties().supports_type(OpaqueType::Barrier) {
         // We can't execute the test, skip.

--- a/crates/cubecl-core/src/runtime_tests/binary.rs
+++ b/crates/cubecl-core/src/runtime_tests/binary.rs
@@ -15,7 +15,7 @@ const ULPS_ALLOWED: f32 = 32.0;
 
 #[track_caller]
 pub(crate) fn assert_equals_approx<F: num_traits::Float + CubeElement + Display>(
-    client: &ComputeClient,
+    client: &Client,
     output: Handle,
     expected: &[F],
     epsilon: f32,
@@ -69,7 +69,7 @@ macro_rules! test_binary_impl {
             rhs: $rhs:expr,
             expected: $expected:expr
         }),*]) => {
-        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: Client) {
             #[cube(launch_unchecked, fast_math = *FAST_MATH)]
             fn test_function<$float_type: Float, In: Size, Out: Size>(
                 lhs: &[Vector<$float_type, In>],
@@ -276,7 +276,7 @@ macro_rules! test_powi_impl {
             rhs: $rhs:expr,
             expected: $expected:expr
         }),*]) => {
-        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: Client) {
             $(
             {
                 let lhs = $lhs;
@@ -374,7 +374,7 @@ fn test_minus_product_kernel<F: Float, N: Size>(
 /// `c - a * b` negates a factor rather than the product, which is the same number only
 /// because flipping one factor flips the product exactly.
 pub fn test_fma_from_sub<R: Runtime, F: Float + num_traits::Float + CubeElement + Display>(
-    client: ComputeClient,
+    client: Client,
 ) {
     let a = as_type![F: 1., -3.1, -2.4, 15.1];
     let b = as_type![F: -1., 23.1, -1.4, 5.1];
@@ -422,7 +422,7 @@ macro_rules! test_fma_impl {
             c: $c:expr,
             expected: $expected:expr
         }),*]) => {
-        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: Client) {
             $(
             {
                 let a = $a;
@@ -522,7 +522,7 @@ macro_rules! test_mulhi_impl {
             rhs: $rhs:expr,
             expected: $expected:expr
         }),*]) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             $(
             {
                 let lhs = $lhs;
@@ -594,7 +594,7 @@ fn reference_dp4a(a: i32, b: i32, c: i32) -> i32 {
         })
 }
 
-pub fn test_dp4a<R: Runtime>(client: ComputeClient) {
+pub fn test_dp4a<R: Runtime>(client: Client) {
     let a = [
         i32::from_le_bytes([1, 2, 3, 4]),
         i32::from_le_bytes([255, 254, 253, 252]),
@@ -668,7 +668,7 @@ fn kernel_self_div(output: &mut [u32]) {
     }
 }
 
-pub fn test_self_div<R: Runtime>(client: ComputeClient) {
+pub fn test_self_div<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(u32::as_bytes(&[7u32, 1, 255, 42]));
 
     kernel_self_div::launch(

--- a/crates/cubecl-core/src/runtime_tests/branch.rs
+++ b/crates/cubecl-core/src/runtime_tests/branch.rs
@@ -17,7 +17,7 @@ macro_rules! lit_value_form {
             }
         }
 
-        fn $check(client: &ComputeClient) {
+        fn $check(client: &Client) {
             let run = |cond: u32| -> Vec<u8> {
                 let handle = client.empty(core::mem::size_of::<$ty>());
                 $kernel::launch(
@@ -50,7 +50,7 @@ lit_value_form!(kernel_lit_u64, check_u64, u64, 30u64, 50u64);
 lit_value_form!(kernel_lit_f32, check_f32, f32, 30.0f32, 50.0f32);
 lit_value_form!(kernel_lit_f64, check_f64, f64, 30.0f64, 50.0f64);
 
-pub fn test_value_form_literals<R: Runtime>(client: ComputeClient) {
+pub fn test_value_form_literals<R: Runtime>(client: Client) {
     check_i8(&client);
     check_i16(&client);
     check_i32(&client);
@@ -64,7 +64,7 @@ pub fn test_value_form_literals<R: Runtime>(client: ComputeClient) {
 }
 
 // Subset using only types every backend supports (wgpu rejects i8/i16/u8/u16/f64).
-pub fn test_value_form_literals_portable<R: Runtime>(client: ComputeClient) {
+pub fn test_value_form_literals_portable<R: Runtime>(client: Client) {
     check_f32(&client);
     check_i32(&client);
     check_u32(&client);
@@ -87,7 +87,7 @@ macro_rules! lit_match_value {
             }
         }
 
-        fn $check(client: &ComputeClient) {
+        fn $check(client: &Client) {
             let run = |sel: u32| -> Vec<u8> {
                 let handle = client.empty(core::mem::size_of::<$ty>());
                 $kernel::launch(
@@ -141,7 +141,7 @@ lit_match_value!(
     30.0f64
 );
 
-pub fn test_match_value_literals<R: Runtime>(client: ComputeClient) {
+pub fn test_match_value_literals<R: Runtime>(client: Client) {
     match_check_i8(&client);
     match_check_i16(&client);
     match_check_i32(&client);
@@ -155,7 +155,7 @@ pub fn test_match_value_literals<R: Runtime>(client: ComputeClient) {
 }
 
 // Subset using only types every backend supports (wgpu rejects i8/i16/u8/u16/f64).
-pub fn test_match_value_literals_portable<R: Runtime>(client: ComputeClient) {
+pub fn test_match_value_literals_portable<R: Runtime>(client: Client) {
     match_check_f32(&client);
     match_check_i32(&client);
     match_check_u32(&client);
@@ -245,7 +245,7 @@ pub fn kernel_for_loop_with_return<F: Float>(output: &mut [F]) {
     output[0] = F::new(5f32);
 }
 
-pub fn test_switch_const<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_switch_const<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes![F: 0.0, 1.0]);
 
     kernel_switch_const::launch::<F>(
@@ -262,7 +262,7 @@ pub fn test_switch_const<R: Runtime, F: Float + CubeElement>(client: ComputeClie
     assert_eq!(actual[0], F::new(3.0));
 }
 
-pub fn test_switch_statement<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_switch_statement<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes![F: 0.0, 1.0]);
 
     unsafe {
@@ -281,7 +281,7 @@ pub fn test_switch_statement<R: Runtime, F: Float + CubeElement>(client: Compute
     assert_eq!(actual[0], F::new(1.0));
 }
 
-pub fn test_switch_used_as_value<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_switch_used_as_value<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes![F: 0.0, 1.0]);
 
     kernel_switch_value_expr::launch::<F>(
@@ -298,7 +298,7 @@ pub fn test_switch_used_as_value<R: Runtime, F: Float + CubeElement>(client: Com
     assert_eq!(actual[0], F::new(3.0));
 }
 
-pub fn test_switch_default<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_switch_default<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes![F: 0.0, 1.0]);
 
     kernel_switch_value_expr::launch::<F>(
@@ -315,7 +315,7 @@ pub fn test_switch_default<R: Runtime, F: Float + CubeElement>(client: ComputeCl
     assert_eq!(actual[0], F::new(5.0));
 }
 
-pub fn test_switch_or_branch<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_switch_or_branch<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes![F: 0.0, 1.0]);
 
     kernel_switch_or_arm::launch::<F>(
@@ -332,7 +332,7 @@ pub fn test_switch_or_branch<R: Runtime, F: Float + CubeElement>(client: Compute
     assert_eq!(actual[0], F::new(3.0));
 }
 
-pub fn test_select<R: Runtime, F: Float + CubeElement>(client: ComputeClient, cond: bool) {
+pub fn test_select<R: Runtime, F: Float + CubeElement>(client: Client, cond: bool) {
     let handle = client.create_from_slice(as_bytes![F: 0.0]);
 
     let cond_u32 = if cond { 1 } else { 0 };
@@ -355,7 +355,7 @@ pub fn test_select<R: Runtime, F: Float + CubeElement>(client: ComputeClient, co
     }
 }
 
-pub fn test_for_loop_with_break<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_for_loop_with_break<R: Runtime, F: Float + CubeElement>(client: Client) {
     let zeros = vec![F::new(0.0); 20];
     let handle = client.create_from_slice(F::as_bytes(&zeros));
 
@@ -375,7 +375,7 @@ pub fn test_for_loop_with_break<R: Runtime, F: Float + CubeElement>(client: Comp
     assert_eq!(actual, expected.as_slice());
 }
 
-pub fn test_for_loop_with_return<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_for_loop_with_return<R: Runtime, F: Float + CubeElement>(client: Client) {
     let zeros = vec![F::new(0.0); 20];
     let handle = client.create_from_slice(F::as_bytes(&zeros));
 

--- a/crates/cubecl-core/src/runtime_tests/cluster.rs
+++ b/crates/cubecl-core/src/runtime_tests/cluster.rs
@@ -23,7 +23,7 @@ fn cluster_meta_kernel(out: &mut [u32]) {
     }
 }
 
-pub fn test_cluster_meta<R: Runtime>(client: ComputeClient) {
+pub fn test_cluster_meta<R: Runtime>(client: Client) {
     if !client.features().cube_cluster {
         return;
     }

--- a/crates/cubecl-core/src/runtime_tests/cmma.rs
+++ b/crates/cubecl-core/src/runtime_tests/cmma.rs
@@ -384,7 +384,7 @@ pub fn cast_matrix_bf16(input: &[f32], out: &mut [bf16]) {
     cmma::store(out, &output, 16, cmma::MatrixLayout::RowMajor);
 }
 
-pub fn test_simple_1_vectorized<R: Runtime>(client: ComputeClient, cube_dimensions: CubeDim) {
+pub fn test_simple_1_vectorized<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     if !client.features().matmul.cmma.contains(&MmaConfig {
         a_type: ElemType::Float(FloatKind::F16),
         b_type: ElemType::Float(FloatKind::F16),
@@ -422,10 +422,7 @@ pub fn test_simple_1_vectorized<R: Runtime>(client: ComputeClient, cube_dimensio
     assert_eq!(test_simple_1_expected(), actual);
 }
 
-pub fn test_simple_1_vectorized_offset<R: Runtime>(
-    client: ComputeClient,
-    cube_dimensions: CubeDim,
-) {
+pub fn test_simple_1_vectorized_offset<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     if !client.features().matmul.cmma.contains(&MmaConfig {
         a_type: ElemType::Float(FloatKind::F16),
         b_type: ElemType::Float(FloatKind::F16),
@@ -519,7 +516,7 @@ pub fn kernel_accumulator_row_major(lhs: &[f16], rhs: &[f16], out: &mut [f32]) {
     cmma::store(out, &c, 16, cmma::MatrixLayout::RowMajor);
 }
 
-pub fn test_accumulator_row_major<R: Runtime>(client: ComputeClient, cube_dimensions: CubeDim) {
+pub fn test_accumulator_row_major<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     if !client.features().matmul.cmma.contains(&MmaConfig {
         a_type: ElemType::Float(FloatKind::F16),
         b_type: ElemType::Float(FloatKind::F16),
@@ -556,7 +553,7 @@ pub fn test_accumulator_row_major<R: Runtime>(client: ComputeClient, cube_dimens
     assert_eq!(test_simple_1_expected(), actual);
 }
 
-pub fn test_simple_1<R: Runtime>(client: ComputeClient, cube_dimensions: CubeDim) {
+pub fn test_simple_1<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     if !client.features().matmul.cmma.contains(&MmaConfig {
         a_type: ElemType::Float(FloatKind::F16),
         b_type: ElemType::Float(FloatKind::F16),
@@ -606,7 +603,7 @@ pub fn kernel_unsupported_fragment(out: &mut [f32]) {
     cmma::store(out, &acc, 5, cmma::MatrixLayout::RowMajor);
 }
 
-pub fn test_unsupported_fragment<R: Runtime>(client: ComputeClient, cube_dimensions: CubeDim) {
+pub fn test_unsupported_fragment<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     let out = client.empty(core::mem::size_of::<f32>() * 16);
 
     kernel_unsupported_fragment::launch(
@@ -655,7 +652,7 @@ pub fn test_simple_1_expected() -> Vec<f32> {
     ]
 }
 
-pub fn test_simple_cube<R: Runtime>(client: ComputeClient, cube_dimensions: u32) {
+pub fn test_simple_cube<R: Runtime>(client: Client, cube_dimensions: u32) {
     let ab_ty = ElemType::Float(FloatKind::F16);
     let cd_ty = ElemType::Float(FloatKind::F32);
     let config = client.features().matmul.cube_mma.iter().find(|cfg| {
@@ -711,7 +708,7 @@ pub fn test_simple_cube<R: Runtime>(client: ComputeClient, cube_dimensions: u32)
     assert_eq!(test_simple_cube_expected(m, n, k), actual);
 }
 
-pub fn test_simple_cube_tensor<R: Runtime>(client: ComputeClient, cube_dimensions: u32) {
+pub fn test_simple_cube_tensor<R: Runtime>(client: Client, cube_dimensions: u32) {
     let ab_ty = ElemType::Float(FloatKind::F16);
     let cd_ty = ElemType::Float(FloatKind::F32);
     let config = client.features().matmul.cube_mma.iter().find(|cfg| {
@@ -802,7 +799,7 @@ pub fn test_simple_cube_expected(m: usize, n: usize, k: usize) -> Vec<f32> {
 }
 
 // pub fn test_simple_2<R: Runtime>(
-//     client: ComputeClient,
+//     client: Client,
 //     cube_dimensions: CubeDim,
 // ) {
 //     if !client.features().matmul.cmma.contains(&MmaConfig {
@@ -843,7 +840,7 @@ pub fn test_simple_cube_expected(m: usize, n: usize, k: usize) -> Vec<f32> {
 //     assert_eq!(expected, actual);
 // }
 
-pub fn test_cmma_cast_f16<R: Runtime>(client: ComputeClient, cube_dimensions: CubeDim) {
+pub fn test_cmma_cast_f16<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     if !client.features().matmul.cmma.contains(&MmaConfig {
         a_type: ElemType::Float(FloatKind::F16),
         b_type: ElemType::Float(FloatKind::F16),
@@ -877,7 +874,7 @@ pub fn test_cmma_cast_f16<R: Runtime>(client: ComputeClient, cube_dimensions: Cu
     assert_eq!(actual, expected);
 }
 
-pub fn test_cmma_cast_bf16<R: Runtime>(client: ComputeClient, cube_dimensions: CubeDim) {
+pub fn test_cmma_cast_bf16<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     if !client.features().matmul.cmma.contains(&MmaConfig {
         a_type: ElemType::Float(FloatKind::BF16),
         b_type: ElemType::Float(FloatKind::BF16),
@@ -911,7 +908,7 @@ pub fn test_cmma_cast_bf16<R: Runtime>(client: ComputeClient, cube_dimensions: C
     assert_eq!(actual, expected);
 }
 
-pub fn test_simple_tf32<R: Runtime>(client: ComputeClient, cube_dimensions: CubeDim) {
+pub fn test_simple_tf32<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     if !client.features().matmul.cmma.contains(&MmaConfig {
         a_type: ElemType::Float(FloatKind::TF32),
         b_type: ElemType::Float(FloatKind::TF32),
@@ -1009,7 +1006,7 @@ pub fn kernel_strided(
     cmma::store(out, &c, 16, cmma::MatrixLayout::RowMajor);
 }
 
-pub fn test_cmma_strided<R: Runtime>(client: ComputeClient, cube_dimensions: CubeDim) {
+pub fn test_cmma_strided<R: Runtime>(client: Client, cube_dimensions: CubeDim) {
     // Lhs (row major) will have strided tiles
     let (m, n, k) = (16, 16, 32);
     let (t_m, t_n, t_k) = (16, 16, 16);
@@ -1182,7 +1179,7 @@ pub fn test_cmma_manual<
     B: CubeElement + Scalar + NumCast,
     CD: CubeElement + Numeric,
 >(
-    client: ComputeClient,
+    client: Client,
     cube_dimensions: CubeDim,
     (m, n, k): (usize, usize, usize),
 ) {
@@ -1359,7 +1356,7 @@ pub fn test_cmma_manual_ldmatrix<
     AB: CubeElement + Numeric,
     CD: CubeElement + Numeric,
 >(
-    client: ComputeClient,
+    client: Client,
     cube_dimensions: CubeDim,
     (m, n, k): (usize, usize, usize),
 ) {
@@ -1558,7 +1555,7 @@ pub fn test_cmma_scaled<
     A: CubeElement + Scalar + NumCast,
     B: CubeElement + Scalar + NumCast,
 >(
-    client: ComputeClient,
+    client: Client,
     cube_dimensions: CubeDim,
     (m, n, k): (usize, usize, usize),
     scales_factor: usize,
@@ -1673,7 +1670,7 @@ pub fn test_cmma_scaled<
 }
 
 pub fn test_cmma_scaled_fp4<R: Runtime>(
-    client: ComputeClient,
+    client: Client,
     cube_dimensions: CubeDim,
     (m, n, k): (usize, usize, usize),
     scales_factor: usize,
@@ -2027,7 +2024,7 @@ macro_rules! testgen_cmma {
             test(16, 8, 64, 2);
         }
 
-        fn cube_dim<R: Runtime>(client: &ComputeClient) -> CubeDim {
+        fn cube_dim<R: Runtime>(client: &Client) -> CubeDim {
             let plane_dim = client.properties().hardware.plane_size_max;
             CubeDim::new_1d(plane_dim)
         }

--- a/crates/cubecl-core/src/runtime_tests/cmma2.rs
+++ b/crates/cubecl-core/src/runtime_tests/cmma2.rs
@@ -33,7 +33,7 @@ pub fn kernel_simple_f16_workgroup_gmem(
     cmma::store(out, &matrix, n as u32, cmma::MatrixLayout::RowMajor);
 }
 
-pub fn test_elemwise_cube<R: Runtime>(client: ComputeClient, cube_dimensions: u32) {
+pub fn test_elemwise_cube<R: Runtime>(client: Client, cube_dimensions: u32) {
     let cd_ty = ElemType::Float(FloatKind::F32);
     let config = client.features().matmul.cube_mma.iter().find(|cfg| {
         cfg.cd_type == cd_ty

--- a/crates/cubecl-core/src/runtime_tests/comparison.rs
+++ b/crates/cubecl-core/src/runtime_tests/comparison.rs
@@ -12,7 +12,7 @@ macro_rules! test_binary_impl {
             lhs: $lhs:expr,
             rhs: $rhs:expr,
         }),*]) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             #[cube(launch_unchecked, fast_math = FastMath::all())]
             fn test_function<N: Size>(
                 lhs: &[Vector<$primitive_type, N>],
@@ -140,7 +140,7 @@ test_binary_impl!(
 );
 
 /// NaN comparison semantics: `<`, `<=`, `>`, `>=` and `==` are *ordered* (false whenever an
-pub fn test_nan_ordering<R: Runtime>(client: ComputeClient) {
+pub fn test_nan_ordering<R: Runtime>(client: Client) {
     #[cube(launch_unchecked)]
     fn test_function(lhs: &[f32], rhs: &[f32], output: &mut [u32]) {
         if ABSOLUTE_POS < lhs.len() {
@@ -221,7 +221,7 @@ fn kernel_folded(output: &mut [Vector<u32, Const<4>>]) {
 }
 
 /// A vector comparison that constant folds still answers per lane.
-pub fn test_folded_vector<R: Runtime>(client: ComputeClient) {
+pub fn test_folded_vector<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(u32::as_bytes(&[7u32, 0, 3, 0]));
 
     unsafe {

--- a/crates/cubecl-core/src/runtime_tests/complex.rs
+++ b/crates/cubecl-core/src/runtime_tests/complex.rs
@@ -6,7 +6,7 @@ use cubecl_runtime::runtime::Runtime;
 use cubecl_runtime::server::ServerError;
 
 fn assert_exact_eq<E: CubeElement + Debug + PartialEq>(
-    client: &ComputeClient,
+    client: &Client,
     output: cubecl_runtime::server::Handle,
     expected: &[E],
 ) {
@@ -17,7 +17,7 @@ fn assert_exact_eq<E: CubeElement + Debug + PartialEq>(
 }
 
 fn assert_real_approx_eq<F: num_traits::Float + CubeElement + Display>(
-    client: &ComputeClient,
+    client: &Client,
     output: cubecl_runtime::server::Handle,
     expected: &[F],
     epsilon: F,
@@ -43,7 +43,7 @@ fn assert_real_approx_eq<F: num_traits::Float + CubeElement + Display>(
 }
 
 fn assert_complex_approx_eq<F: num_traits::Float + CubeElement + Display>(
-    client: &ComputeClient,
+    client: &Client,
     output: cubecl_runtime::server::Handle,
     expected: &[num_complex::Complex<F>],
     epsilon: F,
@@ -225,7 +225,7 @@ macro_rules! test_complex_binary_eq_op {
         rhs: [$($rhs:expr),+ $(,)?],
         expect: |$lhs_var:ident, $rhs_var:ident| $expected:expr
     ) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             type C = $ty;
             let lhs = vec![$($lhs),+];
             let rhs = vec![$($rhs),+];
@@ -264,7 +264,7 @@ macro_rules! test_complex_unary_eq_op {
         input: [$($value:expr),+ $(,)?],
         expect: |$value_var:ident| $expected:expr
     ) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             type C = $ty;
             let input = vec![$($value),+];
             let expected = input
@@ -300,7 +300,7 @@ macro_rules! test_complex_scalar_eq_op {
         scalar: $scalar:expr,
         expect: |$value_var:ident, $scale_var:ident| $expected:expr
     ) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             type C = $ty;
             let input = vec![$($value),+];
             let scale = $scalar;
@@ -339,7 +339,7 @@ macro_rules! test_complex_unary_scalar_eq_op {
         input: [$($value:expr),+ $(,)?],
         expect: |$value_var:ident| $expected:expr
     ) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             type C = $input_ty;
             type O = $output_ty;
             let input = vec![$($value),+];
@@ -376,7 +376,7 @@ macro_rules! test_complex_binary_bool_eq_op {
         rhs: [$($rhs:expr),+ $(,)?],
         expect: |$lhs_var:ident, $rhs_var:ident| $expected:expr
     ) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             type C = $ty;
             let lhs = vec![$($lhs),+];
             let rhs = vec![$($rhs),+];
@@ -745,7 +745,7 @@ pub fn kernel_complex_powf<C: ComplexMath + Powf>(output: &mut [C], lhs: &[C], r
     }
 }
 
-pub fn test_complex_abs_cf32<R: Runtime>(client: ComputeClient) {
+pub fn test_complex_abs_cf32<R: Runtime>(client: Client) {
     type C = num_complex::Complex<f32>;
     let input = vec![C::new(3.0f32, 4.0f32), C::new(5.0f32, -12.0f32)];
     let expected = vec![complex_abs_value(input[0]), complex_abs_value(input[1])];
@@ -766,7 +766,7 @@ pub fn test_complex_abs_cf32<R: Runtime>(client: ComputeClient) {
     assert_real_approx_eq::<f32>(&client, handle_output, &expected, 1.0e-5f32);
 }
 
-pub fn test_complex_norm_cf64<R: Runtime>(client: ComputeClient) {
+pub fn test_complex_norm_cf64<R: Runtime>(client: Client) {
     type C = num_complex::Complex<f64>;
     let input = vec![C::new(3.0f64, 4.0f64), C::new(5.0f64, -12.0f64)];
     let expected = vec![complex_abs_value(input[0]), complex_abs_value(input[1])];
@@ -789,7 +789,7 @@ pub fn test_complex_norm_cf64<R: Runtime>(client: ComputeClient) {
 
 macro_rules! test_complex_unary_op {
     ($test_name:ident, $kernel:ident, $method:ident, $ty:ty, $epsilon:expr, [$($value:expr),+ $(,)?]) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             type C = $ty;
             let input = vec![$($value),+];
             let expected = input.iter().copied().map(|value| value.$method()).collect::<vec::Vec<_>>();
@@ -814,7 +814,7 @@ macro_rules! test_complex_unary_op {
 
 macro_rules! test_complex_powf_op {
     ($test_name:ident, $ty:ty, $epsilon:expr, lhs: [$($lhs:expr),+ $(,)?], rhs: [$($rhs:expr),+ $(,)?]) => {
-        pub fn $test_name<R: Runtime>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime>(client: Client) {
             type C = $ty;
             let lhs = vec![$($lhs),+];
             let rhs = vec![$($rhs),+];
@@ -1098,7 +1098,7 @@ pub fn kernel_complex_validation_math<C: ComplexMath>(output: &mut [C], input: &
     }
 }
 
-pub fn test_complex_validation_core<R: Runtime>(client: ComputeClient) {
+pub fn test_complex_validation_core<R: Runtime>(client: Client) {
     type C = num_complex::Complex<f32>;
     if C::supported_complex_uses(&client).contains(cubecl::ir::features::ComplexUsage::Core) {
         return;
@@ -1120,7 +1120,7 @@ pub fn test_complex_validation_core<R: Runtime>(client: ComputeClient) {
     assert_complex_validation_error(client.read_one(output).map(|_| ()), "Complex operation");
 }
 
-pub fn test_complex_validation_compare<R: Runtime>(client: ComputeClient) {
+pub fn test_complex_validation_compare<R: Runtime>(client: Client) {
     type C = num_complex::Complex<f32>;
     if C::supported_complex_uses(&client).contains(cubecl::ir::features::ComplexUsage::Compare) {
         return;
@@ -1142,7 +1142,7 @@ pub fn test_complex_validation_compare<R: Runtime>(client: ComputeClient) {
     assert_complex_validation_error(client.read_one(output).map(|_| ()), "Complex operation");
 }
 
-pub fn test_complex_validation_math<R: Runtime>(client: ComputeClient) {
+pub fn test_complex_validation_math<R: Runtime>(client: Client) {
     type C = num_complex::Complex<f32>;
     if C::supported_complex_uses(&client).contains(cubecl::ir::features::ComplexUsage::Math) {
         return;

--- a/crates/cubecl-core/src/runtime_tests/const_match.rs
+++ b/crates/cubecl-core/src/runtime_tests/const_match.rs
@@ -28,7 +28,7 @@ pub fn test_kernel_const_match<
     F: Float + CubeElement,
     U: Int + hash::Hash + Eq + Debug,
 >(
-    client: ComputeClient,
+    client: Client,
 ) {
     // Workaround for Naga bug, remove in future wgpu version to test again
     if U::BITS == 64 {

--- a/crates/cubecl-core/src/runtime_tests/debug.rs
+++ b/crates/cubecl-core/src/runtime_tests/debug.rs
@@ -14,7 +14,7 @@ fn simple_call_kernel<F: Float>(out: &mut [F]) {
     }
 }
 
-pub fn test_simple_call<R: Runtime>(client: ComputeClient) {
+pub fn test_simple_call<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(f32::as_bytes(&[10.0, 1.0]));
 
     simple_call_kernel::launch::<f32>(
@@ -42,7 +42,7 @@ fn nested_call_kernel<F: Float>(out: &mut [F]) {
     }
 }
 
-pub fn test_nested_call<R: Runtime>(client: ComputeClient) {
+pub fn test_nested_call<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(f32::as_bytes(&[10.0, 1.0]));
 
     nested_call_kernel::launch::<f32>(
@@ -68,7 +68,7 @@ fn debug_print_kernel<F: Float>(out: &mut [F]) {
 }
 
 #[cfg(not(all(target_os = "macos")))]
-pub fn test_debug_print<R: Runtime>(client: ComputeClient) {
+pub fn test_debug_print<R: Runtime>(client: Client) {
     //let logger = MemoryLogger::setup(log::Level::Info);
     let handle = client.create_from_slice(f32::as_bytes(&[10.0, 1.0]));
 

--- a/crates/cubecl-core/src/runtime_tests/different_rank.rs
+++ b/crates/cubecl-core/src/runtime_tests/different_rank.rs
@@ -14,7 +14,7 @@ pub fn kernel_different_rank<F: Float, N: Size>(
 }
 
 pub fn test_kernel_different_rank_first_biggest<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient,
+    client: Client,
 ) {
     let shape_lhs = vec![2, 2, 2];
     let shape_rhs = vec![8];
@@ -31,9 +31,7 @@ pub fn test_kernel_different_rank_first_biggest<R: Runtime, F: Float + CubeEleme
     );
 }
 
-pub fn test_kernel_different_rank_last_biggest<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient,
-) {
+pub fn test_kernel_different_rank_last_biggest<R: Runtime, F: Float + CubeElement>(client: Client) {
     let shape_lhs = vec![2, 4];
     let shape_rhs = vec![8];
     let shape_out = vec![2, 2, 2];
@@ -50,7 +48,7 @@ pub fn test_kernel_different_rank_last_biggest<R: Runtime, F: Float + CubeElemen
 }
 
 fn test_kernel_different_rank<F: Float + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     (shape_lhs, shape_rhs, shape_out): (Vec<usize>, Vec<usize>, Vec<usize>),
     (strides_lhs, strides_rhs, strides_out): (Vec<usize>, Vec<usize>, Vec<usize>),
 ) {

--- a/crates/cubecl-core/src/runtime_tests/enums.rs
+++ b/crates/cubecl-core/src/runtime_tests/enums.rs
@@ -150,7 +150,7 @@ pub fn kernel_runtime_variants_value(test: RuntimeEnumSingleValue, output: &mut 
     output[0] = value as f32;
 }
 
-pub fn test_scalar_enum<R: Runtime>(client: ComputeClient) {
+pub fn test_scalar_enum<R: Runtime>(client: Client) {
     let array = client.empty(core::mem::size_of::<f32>());
 
     kernel_scalar_enum::launch(
@@ -166,7 +166,7 @@ pub fn test_scalar_enum<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[0], 10.0);
 }
 
-pub fn test_runtime_variants_empty<R: Runtime>(client: ComputeClient) {
+pub fn test_runtime_variants_empty<R: Runtime>(client: Client) {
     let array = client.empty(core::mem::size_of::<f32>());
 
     unsafe {
@@ -184,7 +184,7 @@ pub fn test_runtime_variants_empty<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[0], 20.0);
 }
 
-pub fn test_runtime_variants_value<R: Runtime>(client: ComputeClient) {
+pub fn test_runtime_variants_value<R: Runtime>(client: Client) {
     let array = client.empty(core::mem::size_of::<f32>());
 
     unsafe {
@@ -204,7 +204,7 @@ pub fn test_runtime_variants_value<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[0], 5.0);
 }
 
-pub fn test_runtime_variants_empty_wildcard<R: Runtime>(client: ComputeClient) {
+pub fn test_runtime_variants_empty_wildcard<R: Runtime>(client: Client) {
     let array = client.empty(core::mem::size_of::<f32>());
 
     unsafe {
@@ -238,10 +238,7 @@ fn kernel_array_float_int(array: &mut ArrayFloatInt) {
     }
 }
 
-pub fn test_array_float_int<R: Runtime, T: Scalar + CubeElement>(
-    client: &ComputeClient,
-    expected: T,
-) {
+pub fn test_array_float_int<R: Runtime, T: Scalar + CubeElement>(client: &Client, expected: T) {
     let array = client.empty(core::mem::size_of::<T>());
 
     kernel_array_float_int::launch(
@@ -277,7 +274,7 @@ fn kernel_tuple_enum(first: SimpleEnum<&mut [u32]>, second: SimpleEnum<&[u32]>) 
     }
 }
 
-pub fn test_tuple_enum<R: Runtime>(client: &ComputeClient) {
+pub fn test_tuple_enum<R: Runtime>(client: &Client) {
     let first = client.create_from_slice(as_bytes![u32: 20]);
     let second = client.create_from_slice(as_bytes![u32: 5]);
 
@@ -309,7 +306,7 @@ pub fn kernel_comptime_option_scalar(opt: ComptimeOption<f32>, output: &mut [f32
     output[0] = value;
 }
 
-pub fn test_comptime_option_scalar<R: Runtime>(client: &ComputeClient) {
+pub fn test_comptime_option_scalar<R: Runtime>(client: &Client) {
     let read = |args: ComptimeOptionArgs<f32>| {
         let array = client.empty(core::mem::size_of::<f32>());
         kernel_comptime_option_scalar::launch(

--- a/crates/cubecl-core/src/runtime_tests/file.rs
+++ b/crates/cubecl-core/src/runtime_tests/file.rs
@@ -6,7 +6,7 @@ use cubecl_runtime::runtime::Runtime;
 use std::io::Write;
 
 const MB: usize = 1024 * 1024;
-pub fn test_file_memory<R: Runtime>(client: ComputeClient) {
+pub fn test_file_memory<R: Runtime>(client: Client) {
     let dir = tempfile::tempdir().unwrap();
     let file_name = dir.path().join("test");
     let data_init = (0i32..MB as i32).collect::<Vec<i32>>();

--- a/crates/cubecl-core/src/runtime_tests/index.rs
+++ b/crates/cubecl-core/src/runtime_tests/index.rs
@@ -46,7 +46,7 @@ fn destructurable_kernel(orders: &mut [u32]) {
 }
 
 // Regression test for invalid `CopyTransform`
-pub fn test_kernel_shuffle<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_shuffle<R: Runtime>(client: Client) {
     let handle = client.empty(4 * size_of::<u32>());
 
     shuffle_kernel::launch(
@@ -63,7 +63,7 @@ pub fn test_kernel_shuffle<R: Runtime>(client: ComputeClient) {
 }
 
 // Test to ensure destructuring arrays doesn't break anything
-pub fn test_kernel_destructurable<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_destructurable<R: Runtime>(client: Client) {
     let data = vec![1, 2, 3, 4, 10, 10, 10, 10];
     let handle = client.create_from_slice(u32::as_bytes(&data));
 

--- a/crates/cubecl-core/src/runtime_tests/launch.rs
+++ b/crates/cubecl-core/src/runtime_tests/launch.rs
@@ -82,7 +82,7 @@ pub fn kernel_resource_errors(output: &mut [u32], #[comptime] shared_size: usize
     output[0] = shared[0];
 }
 
-pub fn test_kernel_with_comptime_tag<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_with_comptime_tag<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(f32::as_bytes(&[5.0]));
     let array_arg = unsafe { BufferArg::from_raw_parts(handle.clone(), 1) };
 
@@ -114,7 +114,7 @@ pub fn test_kernel_with_comptime_tag<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[0], f32::new(1.0));
 }
 
-pub fn test_kernel_with_generics<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_kernel_with_generics<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes![F: 0.0, 1.0]);
 
     kernel_with_generics::launch::<F>(
@@ -130,7 +130,7 @@ pub fn test_kernel_with_generics<R: Runtime, F: Float + CubeElement>(client: Com
     assert_eq!(actual[0], F::new(5.0));
 }
 
-pub fn test_kernel_without_generics<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_without_generics<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(f32::as_bytes(&[0.0, 1.0]));
 
     kernel_without_generics::launch(
@@ -146,7 +146,7 @@ pub fn test_kernel_without_generics<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[0], 5.0);
 }
 
-pub fn test_kernel_inplace<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_inplace<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(f32::as_bytes(&[0.0, 1.0]));
 
     kernel_inplace::launch(
@@ -163,7 +163,7 @@ pub fn test_kernel_inplace<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[0], 5.0);
 }
 
-pub fn test_kernel_zero_cube_count<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_zero_cube_count<R: Runtime>(client: Client) {
     // A zero-element fill resolves to `Static(0, 0, 0)`. Launching it is a no-op.
     let handle = client.create_from_slice(f32::as_bytes(&[7.0, 8.0]));
 
@@ -180,7 +180,7 @@ pub fn test_kernel_zero_cube_count<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual, &[7.0, 8.0]);
 }
 
-pub fn test_kernel_dynamic_zero_cube_count<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_dynamic_zero_cube_count<R: Runtime>(client: Client) {
     // The (0, 0, 0) count lives in a buffer, so the client guard can't see it.
     // Scoped to CUDA/HIP because wgpu can't bind a storage buffer for indirect
     // dispatch.
@@ -200,7 +200,7 @@ pub fn test_kernel_dynamic_zero_cube_count<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual, &[7.0, 8.0]);
 }
 
-pub fn test_kernel_max_shared<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_max_shared<R: Runtime>(client: Client) {
     let total_shared_size = client.properties().hardware.max_shared_memory_size;
 
     let handle = client.create_from_slice(u32::as_bytes(&[0, 1, 2, 3, 4, 5, 6, 7]));
@@ -231,7 +231,7 @@ pub fn test_kernel_max_shared<R: Runtime>(client: ComputeClient) {
 /// unwritten, and the claim on those bytes is what carries the reason. So the
 /// read is the assertion: it must fail, and it must fail on the limit that
 /// stopped the launch rather than on anything the runtime invented.
-fn resource_error(client: &ComputeClient, out: Handle) -> ResourceLimitError {
+fn resource_error(client: &Client, out: Handle) -> ResourceLimitError {
     let err = client
         .read_one(out)
         .expect_err("a refused launch never wrote the buffer, so the read must fail");
@@ -248,7 +248,7 @@ fn resource_error(client: &ComputeClient, out: Handle) -> ResourceLimitError {
     }
 }
 
-pub fn test_shared_memory_error<R: Runtime>(client: ComputeClient) {
+pub fn test_shared_memory_error<R: Runtime>(client: Client) {
     // A CPU runtime emulates the cube model rather than dispatching it, so it
     // enforces none of these limits and refuses nothing.
     if client.properties().hardware.num_cpu_cores.is_some() {
@@ -284,7 +284,7 @@ pub fn test_shared_memory_error<R: Runtime>(client: ComputeClient) {
     }
 }
 
-pub fn test_cube_dim_error<R: Runtime>(client: ComputeClient) {
+pub fn test_cube_dim_error<R: Runtime>(client: Client) {
     // A CPU runtime emulates the cube model rather than dispatching it, so it
     // enforces none of these limits and refuses nothing. Same reason the
     // shared-memory case skips it.
@@ -322,7 +322,7 @@ pub fn test_cube_dim_error<R: Runtime>(client: ComputeClient) {
     }
 }
 
-pub fn test_max_units_error<R: Runtime>(client: ComputeClient) {
+pub fn test_max_units_error<R: Runtime>(client: Client) {
     // A CPU runtime emulates the cube model rather than dispatching it, so it
     // enforces none of these limits and refuses nothing. Same reason the
     // shared-memory case skips it.
@@ -358,10 +358,7 @@ pub fn test_max_units_error<R: Runtime>(client: ComputeClient) {
     }
 }
 
-pub fn test_kernel_dynamic_addressing<R: Runtime>(
-    client: ComputeClient,
-    address_type: AddressType,
-) {
+pub fn test_kernel_dynamic_addressing<R: Runtime>(client: Client, address_type: AddressType) {
     let handle = client.create_from_slice(f32::as_bytes(&[0.0, 1.0]));
 
     if !client.properties().supports_address(address_type) {

--- a/crates/cubecl-core/src/runtime_tests/metadata.rs
+++ b/crates/cubecl-core/src/runtime_tests/metadata.rs
@@ -82,7 +82,7 @@ pub fn kernel_buffer_len<N: Size>(out: &mut Tensor<Vector<u32, N>>) {
     out[0] = Vector::new(out.buffer_len() as u32);
 }
 
-pub fn test_shape_dim_4<R: Runtime>(client: ComputeClient, addr_type: AddressType) {
+pub fn test_shape_dim_4<R: Runtime>(client: Client, addr_type: AddressType) {
     if !client.properties().supports_address(addr_type) {
         return;
     }
@@ -114,7 +114,7 @@ pub fn test_shape_dim_4<R: Runtime>(client: ComputeClient, addr_type: AddressTyp
     assert_eq!(actual, &expect);
 }
 
-pub fn test_shape_different_ranks<R: Runtime>(client: ComputeClient, addr_type: AddressType) {
+pub fn test_shape_different_ranks<R: Runtime>(client: Client, addr_type: AddressType) {
     if !client.properties().supports_address(addr_type) {
         return;
     }
@@ -142,7 +142,7 @@ pub fn test_shape_different_ranks<R: Runtime>(client: ComputeClient, addr_type: 
     assert_eq!(actual, &expect);
 }
 
-pub fn test_stride_different_ranks<R: Runtime>(client: ComputeClient, addr_type: AddressType) {
+pub fn test_stride_different_ranks<R: Runtime>(client: Client, addr_type: AddressType) {
     if !client.properties().supports_address(addr_type) {
         return;
     }
@@ -170,7 +170,7 @@ pub fn test_stride_different_ranks<R: Runtime>(client: ComputeClient, addr_type:
     assert_eq!(actual, &expect);
 }
 
-pub fn test_len_different_ranks<R: Runtime>(client: ComputeClient, addr_type: AddressType) {
+pub fn test_len_different_ranks<R: Runtime>(client: Client, addr_type: AddressType) {
     if !client.properties().supports_address(addr_type) {
         return;
     }
@@ -198,7 +198,7 @@ pub fn test_len_different_ranks<R: Runtime>(client: ComputeClient, addr_type: Ad
     assert_eq!(actual, &expect);
 }
 
-pub fn test_buffer_len_discontiguous<R: Runtime>(client: ComputeClient, addr_type: AddressType) {
+pub fn test_buffer_len_discontiguous<R: Runtime>(client: Client, addr_type: AddressType) {
     if !client.properties().supports_address(addr_type) {
         return;
     }
@@ -222,7 +222,7 @@ pub fn test_buffer_len_discontiguous<R: Runtime>(client: ComputeClient, addr_typ
     assert_eq!(actual[0], 64);
 }
 
-pub fn test_buffer_len_vectorized<R: Runtime>(client: ComputeClient, addr_type: AddressType) {
+pub fn test_buffer_len_vectorized<R: Runtime>(client: Client, addr_type: AddressType) {
     if !client.properties().supports_address(addr_type) {
         return;
     }
@@ -246,7 +246,7 @@ pub fn test_buffer_len_vectorized<R: Runtime>(client: ComputeClient, addr_type: 
     assert_eq!(actual[0], 8);
 }
 
-pub fn test_buffer_len_offset<R: Runtime>(client: ComputeClient, addr_type: AddressType) {
+pub fn test_buffer_len_offset<R: Runtime>(client: Client, addr_type: AddressType) {
     if !client.properties().supports_address(addr_type) {
         return;
     }

--- a/crates/cubecl-core/src/runtime_tests/minifloat.rs
+++ b/crates/cubecl-core/src/runtime_tests/minifloat.rs
@@ -54,10 +54,7 @@ pub fn kernel_scale<N: Size>(input: &mut [Vector<f32, N>], out: &mut [Vector<ue8
 }
 
 #[allow(clippy::unusual_byte_groupings, reason = "Split by float components")]
-pub fn test_fp8<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient,
-    vector_size: VectorSize,
-) {
+pub fn test_fp8<R: Runtime, F: Float + CubeElement>(client: Client, vector_size: VectorSize) {
     let byte_buffers = u8::supported_uses(&client).contains(TypeUsage::Buffer);
     if !e4m3::supported_uses(&client).contains(TypeUsage::Conversion) || !byte_buffers {
         println!("Unsupported, skipping");
@@ -101,10 +98,7 @@ pub fn test_fp8<R: Runtime, F: Float + CubeElement>(
 }
 
 #[allow(clippy::unusual_byte_groupings, reason = "Split by float components")]
-pub fn test_fp6<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient,
-    vector_size: VectorSize,
-) {
+pub fn test_fp6<R: Runtime, F: Float + CubeElement>(client: Client, vector_size: VectorSize) {
     if !e2m3::supported_uses(&client).contains(TypeUsage::Conversion) {
         println!("Unsupported, skipping");
         return;
@@ -147,10 +141,7 @@ pub fn test_fp6<R: Runtime, F: Float + CubeElement>(
 }
 
 #[allow(clippy::unusual_byte_groupings, reason = "Split by float components")]
-pub fn test_fp4<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient,
-    vector_size: VectorSize,
-) {
+pub fn test_fp4<R: Runtime, F: Float + CubeElement>(client: Client, vector_size: VectorSize) {
     if !e2m1x2::supported_uses(&client).contains(TypeUsage::Conversion) {
         println!("Unsupported, skipping");
         return;
@@ -190,7 +181,7 @@ pub fn test_fp4<R: Runtime, F: Float + CubeElement>(
     assert_eq!(&actual_2[..num_out], &expected_data[..num_out]);
 }
 
-fn fp8_supported(client: &ComputeClient) -> bool {
+fn fp8_supported(client: &Client) -> bool {
     let usable = |uses: EnumSet<TypeUsage>| uses.contains(TypeUsage::Conversion);
     usable(e4m3::supported_uses(client)) && usable(e5m2::supported_uses(client))
 }
@@ -314,7 +305,7 @@ macro_rules! fp8_format_tests {
                 }
             }
 
-            pub fn equality<R: Runtime>(client: ComputeClient) {
+            pub fn equality<R: Runtime>(client: Client) {
                 if !fp8_supported(&client) {
                     println!("Unsupported, skipping");
                     return;
@@ -371,7 +362,7 @@ macro_rules! fp8_format_tests {
                 }
             }
 
-            pub fn bool_casts<R: Runtime>(client: ComputeClient) {
+            pub fn bool_casts<R: Runtime>(client: Client) {
                 if !fp8_supported(&client) {
                     println!("Unsupported, skipping");
                     return;
@@ -439,7 +430,7 @@ macro_rules! fp8_format_tests {
                 }
             }
 
-            pub fn decode_exhaustive<R: Runtime>(client: ComputeClient, lanes: VectorSize) {
+            pub fn decode_exhaustive<R: Runtime>(client: Client, lanes: VectorSize) {
                 if !fp8_supported(&client) {
                     println!("Unsupported, skipping");
                     return;
@@ -480,7 +471,7 @@ macro_rules! fp8_format_tests {
                 }
             }
 
-            pub fn encode_exhaustive<R: Runtime>(client: ComputeClient, lanes: VectorSize) {
+            pub fn encode_exhaustive<R: Runtime>(client: Client, lanes: VectorSize) {
                 if !fp8_supported(&client) {
                     println!("Unsupported, skipping");
                     return;
@@ -519,7 +510,7 @@ macro_rules! fp8_format_tests {
             /// Every `f32` bit pattern, in chunks, against the host codec. Slow by
             /// construction, so it is `#[ignore]`d rather than gated: an ignored test still
             /// compiles, so it cannot rot unnoticed.
-            pub fn encode_sweep<R: Runtime>(client: ComputeClient) {
+            pub fn encode_sweep<R: Runtime>(client: Client) {
                 if !fp8_supported(&client) {
                     println!("Unsupported, skipping");
                     return;
@@ -644,7 +635,7 @@ fn assert_same_float(actual: f32, expected: f32, format: &str, bits: u32) {
     }
 }
 
-pub fn test_scale<R: Runtime>(client: ComputeClient, vector_size: VectorSize) {
+pub fn test_scale<R: Runtime>(client: Client, vector_size: VectorSize) {
     // The same pair of questions [`test_fp8`] asks, and for the same reason: this kernel writes a
     // buffer of the fp8 type itself, at vector sizes below a word. A backend that converts fp8 but
     // packs it four lanes to a `u32` — WGSL — can do the conversion and has no such binding, so
@@ -713,7 +704,7 @@ pub mod fp8_ue8m0 {
         }
     }
 
-    fn supported(client: &ComputeClient) -> bool {
+    fn supported(client: &Client) -> bool {
         ue8m0::supported_uses(client).contains(TypeUsage::Conversion)
     }
 
@@ -723,7 +714,7 @@ pub mod fp8_ue8m0 {
     /// `bf16` a backend may convert through, so they are pinned exactly. So is 255, the format's
     /// NaN. Code 0 is 2^-127, which is subnormal in both, so it is only asked not to land on a
     /// *different* exponent — the failure a wrong shift or a missing special case produces.
-    pub fn decode_exhaustive<R: Runtime>(client: ComputeClient, lanes: VectorSize) {
+    pub fn decode_exhaustive<R: Runtime>(client: Client, lanes: VectorSize) {
         if !supported(&client) {
             println!("Unsupported, skipping");
             return;
@@ -778,7 +769,7 @@ pub mod fp8_ue8m0 {
     /// Not swept here: infinity and NaN. `__NV_NOSAT` and the software path disagree on what
     /// infinity encodes to, and pinning either answer would assert a divergence rather than a
     /// rule. The saturating end is reached through 2^127 itself.
-    pub fn encode_exhaustive<R: Runtime>(client: ComputeClient, lanes: VectorSize) {
+    pub fn encode_exhaustive<R: Runtime>(client: Client, lanes: VectorSize) {
         if !supported(&client) {
             println!("Unsupported, skipping");
             return;

--- a/crates/cubecl-core/src/runtime_tests/numeric.rs
+++ b/crates/cubecl-core/src/runtime_tests/numeric.rs
@@ -17,7 +17,7 @@ pub fn kernel_define_many<N: Numeric, N2: Numeric>(
     array[UNIT_POS as usize] += N::cast_from(second[UNIT_POS as usize]);
 }
 
-pub fn test_kernel_define<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_define<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(f32::as_bytes(&[f32::new(0.0), f32::new(1.0)]));
 
     let elem = ElemType::Float(FloatKind::F32);
@@ -37,7 +37,7 @@ pub fn test_kernel_define<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[1], f32::new(6.0));
 }
 
-pub fn test_kernel_define_many<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_define_many<R: Runtime>(client: Client) {
     let first = client.create_from_slice(f32::as_bytes(&[f32::new(0.0), f32::new(1.0)]));
     let second = client.create_from_slice(u32::as_bytes(&[u32::new(5), u32::new(6)]));
 

--- a/crates/cubecl-core/src/runtime_tests/plane.rs
+++ b/crates/cubecl-core/src/runtime_tests/plane.rs
@@ -160,7 +160,7 @@ pub fn test_plane_sum<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -192,7 +192,7 @@ pub fn test_plane_inclusive_sum<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -229,7 +229,7 @@ pub fn test_plane_exclusive_sum<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -266,7 +266,7 @@ pub fn test_plane_prod<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -303,7 +303,7 @@ pub fn test_plane_inclusive_prod<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -344,7 +344,7 @@ pub fn test_plane_exclusive_prod<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -385,7 +385,7 @@ pub fn test_plane_max<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -419,7 +419,7 @@ pub fn test_plane_min<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -455,7 +455,7 @@ pub fn test_plane_min_partial<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
 ) {
     let vectorization = 1;
     // Below the minimum plane width of any supported backend.
@@ -488,7 +488,7 @@ pub fn test_plane_all<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
 ) {
     let vectorization = 1; // Vectorization can't work for all/any
     let plane_size = 32;
@@ -518,7 +518,7 @@ pub fn test_plane_any<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
 ) {
     let vectorization = 1; // Vectorization can't work for all/any
     let plane_size = 32;
@@ -544,7 +544,7 @@ pub fn test_plane_any<
     });
 }
 
-pub fn test_plane_ballot<TestRuntime: Runtime>(client: ComputeClient) {
+pub fn test_plane_ballot<TestRuntime: Runtime>(client: Client) {
     if !client.features().plane.contains(Plane::Ops) {
         // Can't execute the test.
         return;
@@ -572,7 +572,7 @@ pub fn test_plane_elect<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
 ) {
     let plane_size = 32;
     let input = vec![0.0; plane_size as usize];
@@ -592,7 +592,7 @@ pub fn test_plane_broadcast<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -622,7 +622,7 @@ pub fn test_plane_shuffle<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = client.properties().hardware.plane_size_max;
@@ -652,7 +652,7 @@ pub fn test_plane_shuffle_xor<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = 32;
@@ -688,7 +688,7 @@ pub fn test_plane_shuffle_up<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = client.properties().hardware.plane_size_max;
@@ -722,7 +722,7 @@ pub fn test_plane_shuffle_down<
     TestRuntime: Runtime,
     F: Float + num_traits::Float + CubeElement + Display,
 >(
-    client: ComputeClient,
+    client: Client,
     vectorization: VectorSize,
 ) {
     let plane_size = client.properties().hardware.plane_size_max;
@@ -755,7 +755,7 @@ pub fn test_plane_shuffle_down<
 fn test_plane_operation<F: Float + num_traits::Float + CubeElement + Display, Launch>(
     input: &[F],
     expected: &[F],
-    client: ComputeClient,
+    client: Client,
     launch: Launch,
 ) where
     Launch: Fn(CubeCount, TensorArg),

--- a/crates/cubecl-core/src/runtime_tests/profiling.rs
+++ b/crates/cubecl-core/src/runtime_tests/profiling.rs
@@ -48,7 +48,7 @@ fn touch_kernel(output: &mut [f32]) {
     }
 }
 
-fn touch(client: &ComputeClient, output: &Handle) {
+fn touch(client: &Client, output: &Handle) {
     unsafe {
         touch_kernel::launch_unchecked(
             client,
@@ -59,7 +59,7 @@ fn touch(client: &ComputeClient, output: &Handle) {
     }
 }
 
-fn launch(client: &ComputeClient, output: &Handle) {
+fn launch(client: &Client, output: &Handle) {
     unsafe {
         busy_kernel::launch_unchecked(
             client,
@@ -81,7 +81,7 @@ fn resolve(profile: ProfileDuration) -> Duration {
 /// times the wall clock around a drained stream reports the drain here, which
 /// is milliseconds of launch latency rather than the microseconds two events
 /// recorded back to back on an idle stream are apart.
-pub fn test_empty_window_reports_no_device_time<R: Runtime>(client: ComputeClient) {
+pub fn test_empty_window_reports_no_device_time<R: Runtime>(client: Client) {
     let (_, profile) = client.profile(|| {}, "empty").unwrap();
     let duration = resolve(profile);
 
@@ -96,7 +96,7 @@ pub fn test_empty_window_reports_no_device_time<R: Runtime>(client: ComputeClien
 /// The upper bound is the one that catches a broken clock conversion: a
 /// backend reading its device's ticks as the wrong unit passes "> 0" and fails
 /// here.
-pub fn test_kernel_window_reports_positive_device_time<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_window_reports_positive_device_time<R: Runtime>(client: Client) {
     let output = client.empty(LEN * core::mem::size_of::<f32>());
 
     let (_, profile) = client.profile(|| launch(&client, &output), "busy").unwrap();
@@ -116,7 +116,7 @@ pub fn test_kernel_window_reports_positive_device_time<R: Runtime>(client: Compu
 /// only the pass that opened the window reports the same figure however long
 /// the loop runs, which reads as launches getting cheaper the more of them
 /// there are, and autotune prices a candidate's launches off it.
-pub fn test_window_spans_every_pass_in_it<R: Runtime>(client: ComputeClient) {
+pub fn test_window_spans_every_pass_in_it<R: Runtime>(client: Client) {
     let output = client.empty(core::mem::size_of::<f32>());
 
     // Compiling the kernel would otherwise land inside the first window.
@@ -159,7 +159,7 @@ pub fn test_window_spans_every_pass_in_it<R: Runtime>(client: ComputeClient) {
 /// profiling logger reads them: resolving one inside the outer window would
 /// stall the stream and put the stall in the outer measurement — real GPU idle
 /// time, correctly reported, but not what this is testing.
-pub fn test_nested_windows_are_contained_by_the_outer_one<R: Runtime>(client: ComputeClient) {
+pub fn test_nested_windows_are_contained_by_the_outer_one<R: Runtime>(client: Client) {
     let output = client.empty(LEN * core::mem::size_of::<f32>());
 
     let (inner, outer) = client

--- a/crates/cubecl-core/src/runtime_tests/properties.rs
+++ b/crates/cubecl-core/src/runtime_tests/properties.rs
@@ -12,7 +12,7 @@ pub fn kernel_properties(output: &mut [u32]) {
     }
 }
 
-pub fn test_kernel_properties<R: Runtime>(client: ComputeClient) {
+pub fn test_kernel_properties<R: Runtime>(client: Client) {
     let handle = client.create_from_slice(u32::as_bytes(as_type![u32: 0, 0]));
 
     kernel_properties::launch(

--- a/crates/cubecl-core/src/runtime_tests/read_lazy.rs
+++ b/crates/cubecl-core/src/runtime_tests/read_lazy.rs
@@ -8,7 +8,7 @@ use cubecl_zspace::shape;
 
 /// A device resource read lazily must defer the device-to-host copy until first access, then
 /// return the same data as an eager read.
-pub fn test_read_lazy<R: Runtime>(client: ComputeClient) {
+pub fn test_read_lazy<R: Runtime>(client: Client) {
     let data = (0i32..1024).collect::<Vec<i32>>();
     let bytes_expected = i32::as_bytes(&data);
     let elem_size = size_of::<i32>();

--- a/crates/cubecl-core/src/runtime_tests/saturating.rs
+++ b/crates/cubecl-core/src/runtime_tests/saturating.rs
@@ -33,7 +33,7 @@ pub fn kernel_saturating_sub<I: Int, N: Size>(
 
 #[allow(clippy::needless_range_loop)]
 pub fn test_saturating_add_unsigned<R: Runtime, I: Int + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     vector_size: VectorSize,
 ) {
     if I::cube_type() == u64::cube_type() {
@@ -82,7 +82,7 @@ pub fn test_saturating_add_unsigned<R: Runtime, I: Int + CubeElement>(
 
 #[allow(clippy::needless_range_loop)]
 pub fn test_saturating_sub_unsigned<R: Runtime, I: Int + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     vector_size: VectorSize,
 ) {
     if I::cube_type() == u64::cube_type() {
@@ -127,7 +127,7 @@ pub fn test_saturating_sub_unsigned<R: Runtime, I: Int + CubeElement>(
 // Signed has a lot more possible cases due to overflow/underflow
 #[allow(clippy::needless_range_loop)]
 pub fn test_saturating_add_signed<R: Runtime, I: Int + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     vector_size: VectorSize,
 ) {
     let lhs = vec![
@@ -212,7 +212,7 @@ pub fn test_saturating_add_signed<R: Runtime, I: Int + CubeElement>(
 // Signed has a lot more possible cases due to overflow/underflow
 #[allow(clippy::needless_range_loop)]
 pub fn test_saturating_sub_signed<R: Runtime, I: Int + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     vector_size: VectorSize,
 ) {
     let lhs = vec![

--- a/crates/cubecl-core/src/runtime_tests/sequence.rs
+++ b/crates/cubecl-core/src/runtime_tests/sequence.rs
@@ -31,7 +31,7 @@ pub fn sequence_index<F: Float>(output: &mut [F]) {
     output[0] += *Sequence::<F>::index(&sequence, 1usize);
 }
 
-pub fn test_sequence_for_loop<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_sequence_for_loop<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes![F: 0.0]);
 
     sequence_for_loop::launch::<F>(
@@ -47,7 +47,7 @@ pub fn test_sequence_for_loop<R: Runtime, F: Float + CubeElement>(client: Comput
     assert_eq!(actual[0], F::new(5.0));
 }
 
-pub fn test_sequence_index<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_sequence_index<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes![F: 0.0]);
 
     sequence_index::launch::<F>(

--- a/crates/cubecl-core/src/runtime_tests/short_circuit.rs
+++ b/crates/cubecl-core/src/runtime_tests/short_circuit.rs
@@ -66,7 +66,7 @@ pub fn kernel_pure_and(output: &mut [u32], a: u32, b: u32) {
     }
 }
 
-pub fn test_short_circuit_or<R: Runtime>(client: ComputeClient) {
+pub fn test_short_circuit_or<R: Runtime>(client: Client) {
     let handle = client.empty(core::mem::size_of::<u32>());
     kernel_short_circuit_or::launch(
         &client,
@@ -80,7 +80,7 @@ pub fn test_short_circuit_or<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[0], 0, "`||` did not short-circuit");
 }
 
-pub fn test_short_circuit_and<R: Runtime>(client: ComputeClient) {
+pub fn test_short_circuit_and<R: Runtime>(client: Client) {
     let handle = client.empty(core::mem::size_of::<u32>());
     kernel_short_circuit_and::launch(
         &client,
@@ -94,20 +94,15 @@ pub fn test_short_circuit_and<R: Runtime>(client: ComputeClient) {
     assert_eq!(actual[0], 0, "`&&` did not short-circuit");
 }
 
-fn run_pure(
-    client: &ComputeClient,
-    launch: impl Fn(&ComputeClient, Handle, u32, u32),
-    a: u32,
-    b: u32,
-) -> u32 {
+fn run_pure(client: &Client, launch: impl Fn(&Client, Handle, u32, u32), a: u32, b: u32) -> u32 {
     let handle = client.empty(core::mem::size_of::<u32>());
     launch(client, handle.clone(), a, b);
     let actual = client.read_one_unchecked(handle);
     u32::from_bytes(&actual)[0]
 }
 
-pub fn test_pure_or<R: Runtime>(client: ComputeClient) {
-    let launch = |client: &ComputeClient, handle: Handle, a, b| {
+pub fn test_pure_or<R: Runtime>(client: Client) {
+    let launch = |client: &Client, handle: Handle, a, b| {
         kernel_pure_or::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -123,8 +118,8 @@ pub fn test_pure_or<R: Runtime>(client: ComputeClient) {
     assert_eq!(run_pure(&client, launch, 5, 7), 1, "5 || 7");
 }
 
-pub fn test_pure_and<R: Runtime>(client: ComputeClient) {
-    let launch = |client: &ComputeClient, handle: Handle, a, b| {
+pub fn test_pure_and<R: Runtime>(client: Client) {
+    let launch = |client: &Client, handle: Handle, a, b| {
         kernel_pure_and::launch(
             client,
             CubeCount::Static(1, 1, 1),

--- a/crates/cubecl-core/src/runtime_tests/slice.rs
+++ b/crates/cubecl-core/src/runtime_tests/slice.rs
@@ -47,7 +47,7 @@ pub fn slice_mut_len(output: &mut [u32]) {
     }
 }
 
-pub fn test_slice_select<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_slice_select<R: Runtime, F: Float + CubeElement>(client: Client) {
     let input = client.create_from_slice(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
     let output = client.empty(core::mem::size_of::<F>());
 
@@ -67,7 +67,7 @@ pub fn test_slice_select<R: Runtime, F: Float + CubeElement>(client: ComputeClie
     assert_eq!(actual[0], F::new(2.0));
 }
 
-pub fn test_slice_len<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_slice_len<R: Runtime, F: Float + CubeElement>(client: Client) {
     let input = client.create_from_slice(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
     let output = client.empty(core::mem::size_of::<u32>());
 
@@ -87,7 +87,7 @@ pub fn test_slice_len<R: Runtime, F: Float + CubeElement>(client: ComputeClient)
     assert_eq!(actual, &[2]);
 }
 
-pub fn test_slice_for<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_slice_for<R: Runtime, F: Float + CubeElement>(client: Client) {
     let input = client.create_from_slice(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
     let output = client.create_from_slice(as_bytes![F: 0.0]);
 
@@ -107,7 +107,7 @@ pub fn test_slice_for<R: Runtime, F: Float + CubeElement>(client: ComputeClient)
     assert_eq!(actual[0], F::new(5.0));
 }
 
-pub fn test_slice_mut_assign<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_slice_mut_assign<R: Runtime, F: Float + CubeElement>(client: Client) {
     let input = client.create_from_slice(as_bytes![F: 15.0]);
     let output = client.create_from_slice(as_bytes![F: 0.0, 1.0, 2.0, 3.0, 4.0]);
 
@@ -127,7 +127,7 @@ pub fn test_slice_mut_assign<R: Runtime, F: Float + CubeElement>(client: Compute
     assert_eq!(&actual[0..5], as_type![F: 0.0, 1.0, 15.0, 3.0, 4.0]);
 }
 
-pub fn test_slice_mut_len<R: Runtime>(client: ComputeClient) {
+pub fn test_slice_mut_len<R: Runtime>(client: Client) {
     let output = client.empty(core::mem::size_of::<u32>() * 4);
 
     unsafe {

--- a/crates/cubecl-core/src/runtime_tests/stream.rs
+++ b/crates/cubecl-core/src/runtime_tests/stream.rs
@@ -16,7 +16,7 @@ pub fn big_task<F: Float>(input: &[u32], output: &mut [F], num_loop: usize) {
     }
 }
 
-pub fn test_stream<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_stream<R: Runtime, F: Float + CubeElement>(client: Client) {
     let client_1 = unsafe {
         let mut c = client.clone();
         c.set_stream(StreamId { value: 10000 });

--- a/crates/cubecl-core/src/runtime_tests/stream_errors.rs
+++ b/crates/cubecl-core/src/runtime_tests/stream_errors.rs
@@ -76,7 +76,7 @@ fn sharing_one_pooled_stream(seed: u64) -> (StreamId, StreamId) {
     )
 }
 
-fn launch_rejected_into(client: &ComputeClient, out: Handle, reason: &str) {
+fn launch_rejected_into(client: &Client, out: Handle, reason: &str) {
     unsafe {
         rejected::launch_unchecked(
             &client.clone(),
@@ -88,13 +88,13 @@ fn launch_rejected_into(client: &ComputeClient, out: Handle, reason: &str) {
     };
 }
 
-fn launch_rejected(client: &ComputeClient, reason: &str) -> Handle {
+fn launch_rejected(client: &Client, reason: &str) -> Handle {
     let out = client.empty(core::mem::size_of::<u32>());
     launch_rejected_into(client, out.clone(), reason);
     out
 }
 
-fn assert_rejected(client: &ComputeClient, out: Handle, reason: &str) {
+fn assert_rejected(client: &Client, out: Handle, reason: &str) {
     let err = client
         .read_one(out)
         .expect_err("the kernel pushed a validation error, the launch must fail")
@@ -118,9 +118,7 @@ fn assert_rejected(client: &ComputeClient, out: Handle, reason: &str) {
 /// can be issued on one stream without one failing case poisoning the others.
 /// Anything scoped to a stream rather than to memory — a per-stream error
 /// queue, a per-stream device fault — breaks it.
-pub fn test_two_workflows_on_one_stream_do_not_contaminate_each_other<R: Runtime>(
-    client: ComputeClient,
-) {
+pub fn test_two_workflows_on_one_stream_do_not_contaminate_each_other<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_013);
     let size = core::mem::size_of::<u32>();
 
@@ -183,7 +181,7 @@ pub fn test_two_workflows_on_one_stream_do_not_contaminate_each_other<R: Runtime
 /// The rejection belongs to the stream that launched, so the reader's own flush
 /// never sees it — and a read that does not consult the producer hands back the
 /// buffer the failed launch never wrote.
-pub fn test_a_read_surfaces_the_producers_rejection<R: Runtime>(client: ComputeClient) {
+pub fn test_a_read_surfaces_the_producers_rejection<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_002);
 
     let out = producer.executes(|| launch_rejected(&client, "producer"));
@@ -208,7 +206,7 @@ pub fn test_a_read_surfaces_the_producers_rejection<R: Runtime>(client: ComputeC
 /// and failed at nothing. Only the buffer itself connects the read to the
 /// launch that never ran.
 pub fn test_a_read_surfaces_a_rejection_on_a_buffer_it_allocated_itself<R: Runtime>(
-    client: ComputeClient,
+    client: Client,
 ) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_003);
 
@@ -224,7 +222,7 @@ pub fn test_a_read_surfaces_a_rejection_on_a_buffer_it_allocated_itself<R: Runti
 /// and it lives until something writes it — under a per-task stream policy,
 /// possibly forever. A read that failed on the mere presence of a failure
 /// somewhere would refuse every unrelated buffer for exactly that long.
-pub fn test_a_buffer_the_failure_never_touched_reads_normally<R: Runtime>(client: ComputeClient) {
+pub fn test_a_buffer_the_failure_never_touched_reads_normally<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_004);
 
     let untouched = reader.executes(|| client.create_from_slice(u32::as_bytes(&[7u32])));
@@ -246,9 +244,7 @@ pub fn test_a_buffer_the_failure_never_touched_reads_normally<R: Runtime>(client
 /// drains first — and a launch that was enqueued *before* the write can land
 /// *after* it, overwriting bytes the caller had every reason to believe were the
 /// last word.
-pub fn test_a_write_lands_after_the_work_queued_on_its_buffers_stream<R: Runtime>(
-    client: ComputeClient,
-) {
+pub fn test_a_write_lands_after_the_work_queued_on_its_buffers_stream<R: Runtime>(client: Client) {
     // Two ids far enough apart to land on different pooled streams for any
     // `max_streams`: one queue has to be aligned against the other for the
     // ordering to mean anything.
@@ -301,9 +297,7 @@ pub fn test_a_write_lands_after_the_work_queued_on_its_buffers_stream<R: Runtime
 /// read-only parameter, and the launcher upgrades the aliased buffer's
 /// declaration at registration —
 /// [`test_a_failed_in_place_launch_names_the_buffer_it_aliased`] pins that.
-pub fn test_a_launch_that_never_compiled_taints_only_its_outputs<R: Runtime>(
-    client: ComputeClient,
-) {
+pub fn test_a_launch_that_never_compiled_taints_only_its_outputs<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_005);
 
     let (input, out) = producer.executes(|| {
@@ -349,9 +343,7 @@ pub fn test_a_launch_that_never_compiled_taints_only_its_outputs<R: Runtime>(
 /// Flushing has nothing to do with the claim, and neither does reading: the
 /// bytes stay stale until something writes them, however many flushes and
 /// failed reads come between.
-pub fn test_a_buffer_stays_unreadable_after_the_failure_was_reported<R: Runtime>(
-    client: ComputeClient,
-) {
+pub fn test_a_buffer_stays_unreadable_after_the_failure_was_reported<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_007);
 
     let out = producer.executes(|| launch_rejected(&client, "reported-once"));
@@ -374,7 +366,7 @@ pub fn test_a_buffer_stays_unreadable_after_the_failure_was_reported<R: Runtime>
 /// already, and it happens before the flush that reports the failure as often
 /// as after — so a claim that only listened for writes from its report onward
 /// would refuse the buffer for good.
-pub fn test_a_host_write_makes_a_stale_buffer_readable_again<R: Runtime>(client: ComputeClient) {
+pub fn test_a_host_write_makes_a_stale_buffer_readable_again<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_008);
 
     let out = producer.executes(|| {
@@ -411,7 +403,7 @@ pub fn test_a_host_write_makes_a_stale_buffer_readable_again<R: Runtime>(client:
 /// A relaunch into the same buffer is the other way out, and it must not be
 /// refused on its way in: a pure output is not read, so the launch that would
 /// repair a buffer is never the one skipped for its being broken.
-pub fn test_a_relaunch_makes_a_stale_buffer_readable_again<R: Runtime>(client: ComputeClient) {
+pub fn test_a_relaunch_makes_a_stale_buffer_readable_again<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_009);
     let len = 4;
 
@@ -444,9 +436,7 @@ pub fn test_a_relaunch_makes_a_stale_buffer_readable_again<R: Runtime>(client: C
 /// outputs on a successful launch without looking at its inputs catches the
 /// direct read of a buffer nothing wrote and misses everything computed
 /// *from* one — in a fused stack, nearly everything that matters.
-pub fn test_a_read_downstream_of_a_failure_fails_on_the_root_cause<R: Runtime>(
-    client: ComputeClient,
-) {
+pub fn test_a_read_downstream_of_a_failure_fails_on_the_root_cause<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_011);
 
     let launch_copy = |input: &Handle, out: &Handle| {
@@ -499,7 +489,7 @@ pub fn test_a_read_downstream_of_a_failure_fails_on_the_root_cause<R: Runtime>(
 /// `check` answers whether the bytes can be trusted without reading them and
 /// without a barrier — one lookup, so a caller can recover per tensor instead
 /// of tearing down a device.
-pub fn test_check_answers_without_a_read<R: Runtime>(client: ComputeClient) {
+pub fn test_check_answers_without_a_read<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_013);
 
     let (stale, clean) = producer.executes(|| {
@@ -534,7 +524,7 @@ pub fn test_check_answers_without_a_read<R: Runtime>(client: ComputeClient) {
 /// read as (x, y, z) dispatches an absurd grid or scatters into memory that
 /// carried no failure at all. The skip never reaches a dispatch, which is
 /// what lets every backend run this test, indirect dispatch support or none.
-pub fn test_a_tainted_dynamic_cube_count_skips_the_launch<R: Runtime>(client: ComputeClient) {
+pub fn test_a_tainted_dynamic_cube_count_skips_the_launch<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_015);
 
     let (count, out) = producer.executes(|| {
@@ -568,9 +558,7 @@ pub fn test_a_tainted_dynamic_cube_count_skips_the_launch<R: Runtime>(client: Co
 /// Host-readback backends only (CUDA, HIP), registered through
 /// `testgen_launch_dynamic_count`: an indirect-dispatch backend never learns
 /// the count on the host.
-pub fn test_a_zero_cube_count_launch_does_not_untaint_its_outputs<R: Runtime>(
-    client: ComputeClient,
-) {
+pub fn test_a_zero_cube_count_launch_does_not_untaint_its_outputs<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_017);
 
     let (out, count) = producer.executes(|| {
@@ -607,9 +595,7 @@ pub fn test_a_zero_cube_count_launch_does_not_untaint_its_outputs<R: Runtime>(
 /// the alias at registration and upgrades the aliased buffer's declaration,
 /// which is what this pins: the kernel below fails to compile, so the
 /// declaration is the only answer there is.
-pub fn test_a_failed_in_place_launch_names_the_buffer_it_aliased<R: Runtime>(
-    client: ComputeClient,
-) {
+pub fn test_a_failed_in_place_launch_names_the_buffer_it_aliased<R: Runtime>(client: Client) {
     let (producer, reader) = sharing_one_pooled_stream(1_000_006);
 
     let inout = producer.executes(|| {

--- a/crates/cubecl-core/src/runtime_tests/synchronization.rs
+++ b/crates/cubecl-core/src/runtime_tests/synchronization.rs
@@ -16,7 +16,7 @@ fn kernel_test_sync_cube(buffer: &mut [u32], out: &mut [u32]) {
     }
 }
 
-pub fn test_sync_cube<R: Runtime>(client: ComputeClient) {
+pub fn test_sync_cube<R: Runtime>(client: Client) {
     // Clamp the cube dim to the device's limit (e.g. the core count on CPU).
     let max_units = client.properties().hardware.max_units_per_cube;
     let dim_x = core::cmp::min(8, (max_units / 2).max(1));
@@ -59,7 +59,7 @@ fn kernel_test_finished_sync_cube(buffer: &mut [u32], out: &mut [u32]) {
     sync_cube();
 }
 
-pub fn test_finished_sync_cube<R: Runtime>(client: ComputeClient) {
+pub fn test_finished_sync_cube<R: Runtime>(client: Client) {
     // Clamp the cube dim to the device's limit (e.g. the core count on CPU).
     let max_units = client.properties().hardware.max_units_per_cube;
     let dim_x = core::cmp::min(8, (max_units / 2).max(1));
@@ -100,7 +100,7 @@ fn kernel_test_sync_plane<F: Float>(out: &mut [F]) {
     out[UNIT_POS as usize] = *shared_memory;
 }
 
-pub fn test_sync_plane<R: Runtime>(client: ComputeClient) {
+pub fn test_sync_plane<R: Runtime>(client: Client) {
     if !client.features().plane.contains(Plane::Sync) {
         // We can't execute the test, skip.
         return;
@@ -139,7 +139,7 @@ fn kernel_test_sync_cube_shared<F: Float>(out: &mut [F]) {
     out[UNIT_POS as usize] = *shared_memory;
 }
 
-pub fn test_sync_cube_shared<R: Runtime>(client: ComputeClient) {
+pub fn test_sync_cube_shared<R: Runtime>(client: Client) {
     let max_cube_count = std::cmp::min(64, client.properties().hardware.max_units_per_cube);
     let handle = client.empty(max_cube_count as usize * core::mem::size_of::<f32>());
 
@@ -172,7 +172,7 @@ fn kernel_test_workgroup_uniform_load(out: &mut [u32]) {
     out[UNIT_POS as usize] = n;
 }
 
-pub fn test_workgroup_uniform_load<R: Runtime>(client: ComputeClient) {
+pub fn test_workgroup_uniform_load<R: Runtime>(client: Client) {
     let max_cube_count = std::cmp::min(64, client.properties().hardware.max_units_per_cube);
     let handle = client.empty(max_cube_count as usize * core::mem::size_of::<u32>());
 
@@ -203,7 +203,7 @@ fn kernel_test_workgroup_uniform_load_atomic(out: &mut [u32]) {
     out[UNIT_POS as usize] = n;
 }
 
-pub fn test_workgroup_uniform_load_atomic<R: Runtime>(client: ComputeClient) {
+pub fn test_workgroup_uniform_load_atomic<R: Runtime>(client: Client) {
     let ty = Type::atomic(u32::elem_type_native());
     if !client
         .properties()
@@ -239,7 +239,7 @@ fn kernel_test_workgroup_uniform_load_vec<N: Size>(out: &mut [Vector<f32, N>]) {
     out[UNIT_POS as usize] = workgroup_uniform_load(&smem[0]);
 }
 
-pub fn test_workgroup_uniform_load_vec<R: Runtime>(client: ComputeClient) {
+pub fn test_workgroup_uniform_load_vec<R: Runtime>(client: Client) {
     let lanes = 4usize;
     let max_cube_count = std::cmp::min(64, client.properties().hardware.max_units_per_cube);
     let output = client.create_from_slice(f32::as_bytes(&vec![
@@ -294,7 +294,7 @@ fn expected_uniform_load_sum() -> u32 {
     (0..capped).sum()
 }
 
-pub fn test_workgroup_uniform_load_synchronizes<R: Runtime>(client: ComputeClient) {
+pub fn test_workgroup_uniform_load_synchronizes<R: Runtime>(client: Client) {
     let units = std::cmp::min(256, client.properties().hardware.max_units_per_cube);
     let handle = client.empty(units as usize * core::mem::size_of::<u32>());
 
@@ -334,7 +334,7 @@ fn kernel_test_workgroup_uniform_load_atomic_synchronizes(out: &mut [u32]) {
     out[UNIT_POS as usize] = sum;
 }
 
-pub fn test_workgroup_uniform_load_atomic_synchronizes<R: Runtime>(client: ComputeClient) {
+pub fn test_workgroup_uniform_load_atomic_synchronizes<R: Runtime>(client: Client) {
     let units = std::cmp::min(256, client.properties().hardware.max_units_per_cube);
     let handle = client.empty(units as usize * core::mem::size_of::<u32>());
 

--- a/crates/cubecl-core/src/runtime_tests/tensor.rs
+++ b/crates/cubecl-core/src/runtime_tests/tensor.rs
@@ -11,7 +11,7 @@ pub fn tensor_coordinate<N: Size>(input: &Tensor<Vector<f32, N>>, output: &mut [
     output[UNIT_POS as usize] = input.coordinate(index, dim) as u32;
 }
 
-pub fn test_tensor_coordinate<R: Runtime>(client: ComputeClient) {
+pub fn test_tensor_coordinate<R: Runtime>(client: Client) {
     let (stride, shape, expected) =
         if let Some(num_core) = client.properties().hardware.num_cpu_cores {
             if num_core < 12 {

--- a/crates/cubecl-core/src/runtime_tests/tensormap.rs
+++ b/crates/cubecl-core/src/runtime_tests/tensormap.rs
@@ -111,7 +111,7 @@ fn tensormap_metadata<F: Float, N: Size>(
     output_2[3] = output_2.shape(0) as u32;
 }
 
-pub fn test_tensormap_load<R: Runtime, F: Float + CubeElement>(client: ComputeClient)
+pub fn test_tensormap_load<R: Runtime, F: Float + CubeElement>(client: Client)
 where
     <<R::Server as ServerStorage>::Storage as ComputeStorage>::Resource: Debug,
 {
@@ -154,7 +154,7 @@ where
     assert_eq!(actual, &expected);
 }
 
-pub fn test_tensormap_store<R: Runtime, F: Float + CubeElement>(client: ComputeClient)
+pub fn test_tensormap_store<R: Runtime, F: Float + CubeElement>(client: Client)
 where
     <<R::Server as ServerStorage>::Storage as ComputeStorage>::Resource: Debug,
 {
@@ -210,7 +210,7 @@ where
     assert_eq!(actual, &expected);
 }
 
-pub fn test_tensormap_load_im2col<R: Runtime, F: Float + CubeElement>(client: ComputeClient)
+pub fn test_tensormap_load_im2col<R: Runtime, F: Float + CubeElement>(client: Client)
 where
     <<R::Server as ServerStorage>::Storage as ComputeStorage>::Resource: Debug,
 {
@@ -300,7 +300,7 @@ where
     assert_eq!(actual, &expected_actual);
 }
 
-pub fn test_tensormap_metadata<R: Runtime, F: Float + CubeElement>(client: ComputeClient)
+pub fn test_tensormap_metadata<R: Runtime, F: Float + CubeElement>(client: Client)
 where
     <<R::Server as ServerStorage>::Storage as ComputeStorage>::Resource: Debug,
 {

--- a/crates/cubecl-core/src/runtime_tests/topology.rs
+++ b/crates/cubecl-core/src/runtime_tests/topology.rs
@@ -13,10 +13,7 @@ pub fn kernel_absolute_pos(output1: &mut [u32]) {
     output1[ABSOLUTE_POS] = ABSOLUTE_POS as u32;
 }
 
-pub fn test_kernel_topology_absolute_pos<R: Runtime>(
-    client: ComputeClient,
-    addr_type: AddressType,
-) {
+pub fn test_kernel_topology_absolute_pos<R: Runtime>(client: Client, addr_type: AddressType) {
     if !client.properties().supports_address(addr_type) {
         return;
     }

--- a/crates/cubecl-core/src/runtime_tests/unary.rs
+++ b/crates/cubecl-core/src/runtime_tests/unary.rs
@@ -12,7 +12,7 @@ use cubecl::prelude::*;
 use cubecl_runtime::server::Handle;
 
 pub(crate) fn assert_equals_approx<F: num_traits::Float + CubeElement + Display>(
-    client: &ComputeClient,
+    client: &Client,
     output: Handle,
     expected: &[F],
     epsilon: F,
@@ -88,7 +88,7 @@ macro_rules! test_unary_impl {
             expected: $expected:expr
         }),*],
         $epsilon:expr) => {
-        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: Client) {
             #[cube(launch_unchecked, fast_math = FastMath::all())]
             fn test_function<$float_type: Float, In: Size, Out: Size>(
                 input: &[Vector<$float_type, In>], output: &mut [Vector<$float_type, Out>]
@@ -134,7 +134,7 @@ macro_rules! test_unary_impl_fixed {
             input: $input:expr,
             expected: $expected:expr
         }),*]) => {
-        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime, $float_type: Float + num_traits::Float + CubeElement + Display>(client: Client) {
             #[cube(launch_unchecked)]
             fn test_function<$float_type: Float, N: Size>(
                 input: &[Vector<$float_type, N>],
@@ -182,7 +182,7 @@ macro_rules! test_unary_impl_int {
             input: $input:expr,
             expected: $expected:expr
         }),*]) => {
-        pub fn $test_name<R: Runtime, $int_type: Int + CubeElement>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime, $int_type: Int + CubeElement>(client: Client) {
             #[cube(launch_unchecked)]
             fn test_function<$int_type: Int, N: Size>(
                 input: &[Vector<$int_type, N>],
@@ -231,7 +231,7 @@ macro_rules! test_unary_impl_int_fixed {
             input: $input:expr,
             expected: $expected:expr
         }),*]) => {
-        pub fn $test_name<R: Runtime, $int_type: Int + CubeElement>(client: ComputeClient) {
+        pub fn $test_name<R: Runtime, $int_type: Int + CubeElement>(client: Client) {
             #[cube(launch_unchecked)]
             fn test_function<$int_type: Int, N: Size>(
                 input: &[Vector<$int_type, N>],
@@ -922,7 +922,7 @@ test_unary_impl_fixed!(
     ]
 );
 
-pub fn test_expm1_f32<R: Runtime>(client: ComputeClient) {
+pub fn test_expm1_f32<R: Runtime>(client: Client) {
     #[cube(launch_unchecked)]
     fn test_function<In: Size, Out: Size>(
         input: &[Vector<f32, In>],
@@ -1145,7 +1145,7 @@ test_unary_impl_int!(test_abs_int, I, Abs::abs, [
     }
 ]);
 
-pub fn test_vector_sum_int<R: Runtime, I: Int + CubeElement>(client: ComputeClient) {
+pub fn test_vector_sum_int<R: Runtime, I: Int + CubeElement>(client: Client) {
     #[cube(launch_unchecked)]
     fn test_function<I: Int, In: Size, Out: Size>(
         input: &[Vector<I, In>],

--- a/crates/cubecl-core/src/runtime_tests/unroll.rs
+++ b/crates/cubecl-core/src/runtime_tests/unroll.rs
@@ -51,7 +51,7 @@ pub fn unroll_reinterpret<F: Float, N: Size>(output: &mut [Vector<F, N>]) {
     output[0] = Vector::cast_from(Vector::<f32, N>::reinterpret(scaled));
 }
 
-pub fn test_unroll_add<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_unroll_add<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.empty(4 * size_of::<F>());
 
     unroll_add::launch::<F>(
@@ -68,7 +68,7 @@ pub fn test_unroll_add<R: Runtime, F: Float + CubeElement>(client: ComputeClient
     assert_eq!(actual[0], F::new(3.0));
 }
 
-pub fn test_unroll_load_store<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_unroll_load_store<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes!(F: 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0));
 
     unroll_load_store::launch::<F>(
@@ -85,7 +85,7 @@ pub fn test_unroll_load_store<R: Runtime, F: Float + CubeElement>(client: Comput
     assert_eq!(actual, as_type!(F: 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
 }
 
-pub fn test_unroll_reinterpret<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_unroll_reinterpret<R: Runtime, F: Float + CubeElement>(client: Client) {
     let handle = client.create_from_slice(as_bytes!(F: 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0));
 
     unroll_reinterpret::launch::<F>(

--- a/crates/cubecl-core/src/runtime_tests/vector.rs
+++ b/crates/cubecl-core/src/runtime_tests/vector.rs
@@ -18,7 +18,7 @@ pub fn kernel_vector_index<F: Float, N: Size>(output: &mut [F]) {
 }
 
 #[allow(clippy::needless_range_loop)]
-pub fn test_vector_index<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_vector_index<R: Runtime, F: Float + CubeElement>(client: Client) {
     for vector_size in client.io_optimized_vector_sizes(size_of::<F>()) {
         if vector_size < 4 {
             continue;
@@ -54,7 +54,7 @@ pub fn kernel_vector_index_assign<F: Float, N: Size>(output: &mut [Vector<F, N>]
     }
 }
 
-pub fn test_vector_index_assign<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_vector_index_assign<R: Runtime, F: Float + CubeElement>(client: Client) {
     for vector_size in client.io_optimized_vector_sizes(size_of::<F>()) {
         let handle = client.create_from_slice(F::as_bytes(&vec![F::new(0.0); vector_size]));
         unsafe {
@@ -89,7 +89,7 @@ pub fn kernel_vector_loop_unroll<F: Float, N: Size>(output: &mut [Vector<F, N>])
     }
 }
 
-pub fn test_vector_loop_unroll<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_vector_loop_unroll<R: Runtime, F: Float + CubeElement>(client: Client) {
     for vector_size in client.io_optimized_vector_sizes(size_of::<F>()) {
         let handle = client.create_from_slice(F::as_bytes(&vec![F::new(0.0); vector_size]));
         unsafe {
@@ -124,7 +124,7 @@ pub fn kernel_vector_conditional<F: Float, N: Size>(
     output[0] = vector;
 }
 
-pub fn test_vector_conditional<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_vector_conditional<R: Runtime, F: Float + CubeElement>(client: Client) {
     let vector_size = 8usize;
     let mut input_data = vec![F::new(1.0); vector_size];
     input_data.extend(vec![F::new(2.0); vector_size]);
@@ -178,7 +178,7 @@ pub fn kernel_vector_extract_dynamic<F: Float, N: Size>(
     }
 }
 
-pub fn test_vector_extract_dynamic<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_vector_extract_dynamic<R: Runtime, F: Float + CubeElement>(client: Client) {
     let vector_size = 8usize;
     let data = (0..vector_size as i64)
         .map(|x| F::from_int(x + 1))
@@ -216,7 +216,7 @@ pub fn kernel_vector_insert_dynamic<F: Float, N: Size>(index: &[u32], output: &m
     }
 }
 
-pub fn test_vector_insert_dynamic<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_vector_insert_dynamic<R: Runtime, F: Float + CubeElement>(client: Client) {
     let vector_size = 8usize;
 
     for lane in 0..vector_size {
@@ -250,7 +250,7 @@ pub fn kernel_shared_memory<F: Float, N: Size>(output: &mut [Vector<F, N>]) {
     output[0] = smem1[0];
 }
 
-pub fn test_shared_memory<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_shared_memory<R: Runtime, F: Float + CubeElement>(client: Client) {
     for vector_size in client.io_optimized_vector_sizes(size_of::<F>()) {
         let output = client.create_from_slice(F::as_bytes(&vec![F::new(0.0); vector_size]));
         unsafe {
@@ -285,7 +285,7 @@ macro_rules! impl_vector_comparison {
             }
 
             pub fn [< test_vector_ $cmp >] <R: Runtime, F: Float + CubeElement>(
-                client: ComputeClient,
+                client: Client,
             ) {
                 let lhs = client.create_from_slice(as_bytes![F: 0.0, 1.0, 2.0, 3.0]);
                 let rhs = client.create_from_slice(as_bytes![F: 0.0, 2.0, 1.0, 3.0]);

--- a/crates/cubecl-cpu/README.md
+++ b/crates/cubecl-cpu/README.md
@@ -18,7 +18,7 @@ cubecl = { version = "*", features = ["cpu"] }
 
 | Module                | What it does                                                        |
 | --------------------- | ------------------------------------------------------------------- |
-| `compute::server`     | The `ComputeServer` impl: allocation, launches and reads            |
+| `compute::server`     | The `Server` impl: allocation, launches and reads            |
 | `compute::threadpool` | Worker threads, and the per-unit dispatch of a launch               |
 | `compute::affinity`   | Core topology and thread pinning, per platform                      |
 | `runtime`             | `CpuRuntime`, device properties and the supported type/atomic table |

--- a/crates/cubecl-cpu/src/compute/server.rs
+++ b/crates/cubecl-cpu/src/compute/server.rs
@@ -13,9 +13,8 @@ use cubecl_core::{
     CompilationError, CubeCount, MemoryConfiguration, MemoryUsage,
     ir::MemoryDeviceProperties,
     server::{
-        BufferBinding, ComputeServer, CopyDescriptor, IoError, KernelArguments, KernelResource,
-        LaunchError, ProfileError, ProfilingToken, ServerCommunication, ServerError,
-        ServerUtilities,
+        BufferBinding, CopyDescriptor, IoError, KernelArguments, KernelResource, LaunchError,
+        ProfileError, ProfilingToken, Server, ServerCommunication, ServerError, ServerUtilities,
     },
     zspace::{Shape, Strides, strides},
 };
@@ -209,7 +208,7 @@ impl CpuServer {
     }
 }
 
-impl ComputeServer for CpuServer {
+impl Server for CpuServer {
     fn logger(&self) -> Arc<ServerLogger> {
         self.scheduler.logger.clone()
     }

--- a/crates/cubecl-cuda/src/compute/server.rs
+++ b/crates/cubecl-cuda/src/compute/server.rs
@@ -31,7 +31,7 @@ use cubecl_runtime::{
         InstallMemoryPoolsError, ManagedMemoryHandle, MemoryAllocationMode, MemoryReport,
         MemoryUsage,
     },
-    server::ComputeServer,
+    server::Server,
     storage::{ComputeStorage, ManagedResource},
     stream::{ExecuteScope, FailureStore, MultiStream, StreamCapture, WriteScoped, failed_writing},
 };
@@ -98,7 +98,7 @@ pub struct CudaServer {
 // it manages are never shared across threads without synchronization.
 unsafe impl Send for CudaServer {}
 
-impl ComputeServer for CudaServer {
+impl Server for CudaServer {
     fn logger(&self) -> Arc<ServerLogger> {
         self.streams.logger.clone()
     }
@@ -657,7 +657,7 @@ impl CudaServer {
     }
 
     /// The reduction itself, so every way it can fail settles the destination
-    /// through one path in [`all_reduce`](ComputeServer::all_reduce).
+    /// through one path in [`all_reduce`](Server::all_reduce).
     ///
     /// # Errors
     ///

--- a/crates/cubecl-cuda/src/compute/stream.rs
+++ b/crates/cubecl-cuda/src/compute/stream.rs
@@ -66,7 +66,7 @@ pub struct CudaStreamBackend {
     logger: Arc<ServerLogger>,
     priority: StreamPriority,
     /// Programmatic main-GPU pool layout (see
-    /// [`ComputeServer::install_memory_pools`](cubecl_runtime::server::ComputeServer::install_memory_pools)):
+    /// [`Server::install_memory_pools`](cubecl_runtime::server::Server::install_memory_pools)):
     /// streams created after it is set build their GPU pools from it instead
     /// of the runtime default. Auxiliary pools are unaffected.
     #[new(default)]

--- a/crates/cubecl-cuda/tests/graph.rs
+++ b/crates/cubecl-cuda/tests/graph.rs
@@ -41,7 +41,7 @@ fn cuda_graph_capture_replay() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -94,7 +94,7 @@ fn cuda_graph_capture_growing_the_pool_is_rejected() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -136,7 +136,7 @@ fn cuda_graph_input_rewrite() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -193,7 +193,7 @@ fn cuda_graph_intermediate_recycling() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(bytes);
 
-    let run = |client: &ComputeClient, tmp: &Handle| {
+    let run = |client: &Client, tmp: &Handle| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -280,7 +280,7 @@ fn cuda_graph_many_launches_dynamic_metadata() {
 
     // One pass: ping-pong `dst = src + 1` between `a` and `b`. The identical
     // sequence is run once as warmup and once recorded.
-    fn run_pass(client: &ComputeClient, a: &Handle, b: &Handle) {
+    fn run_pass(client: &Client, a: &Handle, b: &Handle) {
         for i in 0..PASS_LAUNCHES {
             let (src, dst) = if i % 2 == 0 { (a, b) } else { (b, a) };
             add_one_tensor::launch(

--- a/crates/cubecl-environment/src/bytes/base.rs
+++ b/crates/cubecl-environment/src/bytes/base.rs
@@ -39,7 +39,7 @@ pub enum AllocationProperty {
     /// Pinned memory is used.
     Pinned,
     /// The data still lives on a compute device and is only copied to host memory
-    /// lazily on first access (see [`ComputeClient::read_lazy`](https://docs.rs/cubecl-runtime)).
+    /// lazily on first access (see [`Client::read_lazy`](https://docs.rs/cubecl-runtime)).
     Device,
     /// Another kind of memory is used.
     Other,

--- a/crates/cubecl-hip/src/compute/server.rs
+++ b/crates/cubecl-hip/src/compute/server.rs
@@ -1,7 +1,7 @@
 //! The HIP compute server: the device's streams, its compiled kernels, and
 //! the graphs it has captured.
 //!
-//! Every entry point here is a [`ComputeServer`] method, and the ones that
+//! Every entry point here is a [`Server`] method, and the ones that
 //! write device memory run inside a [write scope](WriteScoped) — the taint
 //! bookkeeping is not spelled out on the failure paths, because a path that
 //! forgot it would be silent.
@@ -35,7 +35,7 @@ use cubecl_runtime::{
         InstallMemoryPoolsError, ManagedMemoryHandle, MemoryAllocationMode, MemoryReport,
         MemoryUsage,
     },
-    server::ComputeServer,
+    server::Server,
     storage::{ComputeStorage, ManagedResource},
     stream::{ExecuteScope, FailureStore, MultiStream, StreamCapture, WriteScoped, failed_writing},
 };
@@ -56,7 +56,7 @@ pub struct HipServer {
 // shared across threads without synchronization.
 unsafe impl Send for HipServer {}
 
-impl ComputeServer for HipServer {
+impl Server for HipServer {
     fn logger(&self) -> Arc<ServerLogger> {
         self.streams.logger.clone()
     }

--- a/crates/cubecl-hip/src/compute/stream.rs
+++ b/crates/cubecl-hip/src/compute/stream.rs
@@ -73,7 +73,7 @@ pub struct HipStreamBackend {
     is_integrated: bool,
     logger: Arc<ServerLogger>,
     /// Programmatic main-GPU pool layout (see
-    /// [`ComputeServer::install_memory_pools`](cubecl_runtime::server::ComputeServer::install_memory_pools)):
+    /// [`Server::install_memory_pools`](cubecl_runtime::server::Server::install_memory_pools)):
     /// streams created after it is set build their GPU pools from it instead
     /// of the runtime default. Auxiliary pools are unaffected.
     #[new(default)]

--- a/crates/cubecl-hip/src/runtime.rs
+++ b/crates/cubecl-hip/src/runtime.rs
@@ -218,7 +218,7 @@ impl DeviceService for HipServer {
     }
 
     fn utilities(&self) -> ServerUtilitiesHandle {
-        cubecl_core::server::ComputeServer::utilities(self) as ServerUtilitiesHandle
+        cubecl_core::server::Server::utilities(self) as ServerUtilitiesHandle
     }
 }
 

--- a/crates/cubecl-hip/tests/graph.rs
+++ b/crates/cubecl-hip/tests/graph.rs
@@ -39,7 +39,7 @@ fn hip_graph_capture_replay() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -91,7 +91,7 @@ fn hip_graph_capture_growing_the_pool_is_rejected() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -133,7 +133,7 @@ fn hip_graph_input_rewrite() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -190,7 +190,7 @@ fn hip_graph_intermediate_recycling() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(bytes);
 
-    let run = |client: &ComputeClient, tmp: &Handle| {
+    let run = |client: &Client, tmp: &Handle| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -277,7 +277,7 @@ fn hip_graph_many_launches_dynamic_metadata() {
 
     // One pass: ping-pong `dst = src + 1` between `a` and `b`. The identical
     // sequence is run once as warmup and once recorded.
-    fn run_pass(client: &ComputeClient, a: &Handle, b: &Handle) {
+    fn run_pass(client: &Client, a: &Handle, b: &Handle) {
         for i in 0..PASS_LAUNCHES {
             let (src, dst) = if i % 2 == 0 { (a, b) } else { (b, a) };
             add_one_tensor::launch(

--- a/crates/cubecl-macros/src/generate/launch.rs
+++ b/crates/cubecl-macros/src/generate/launch.rs
@@ -55,7 +55,7 @@ impl ToTokens for Launch {
 impl Launch {
     fn launch(&self) -> TokenStream {
         if self.args.launch.is_present() {
-            let compute_client = prelude_type("ComputeClient");
+            let compute_client = prelude_type("Client");
             let cube_count = prelude_type("CubeCount");
             let cube_dim = prelude_type("CubeDim");
             let address_type = prelude_type("AddressType");
@@ -94,7 +94,7 @@ impl Launch {
 
     fn launch_unchecked(&self) -> TokenStream {
         if self.args.launch_unchecked.is_present() {
-            let compute_client = prelude_type("ComputeClient");
+            let compute_client = prelude_type("Client");
             let cube_count = prelude_type("CubeCount");
             let cube_dim = prelude_type("CubeDim");
             let address_type = prelude_type("AddressType");

--- a/crates/cubecl-metal/src/compute/server.rs
+++ b/crates/cubecl-metal/src/compute/server.rs
@@ -23,7 +23,7 @@ use cubecl_runtime::{
     kernel::CubeKernel,
     logging::ServerLogger,
     memory_management::{InstallMemoryPoolsError, ManagedMemoryHandle},
-    server::ComputeServer,
+    server::Server,
     storage::{ComputeStorage, ManagedResource},
     stream::{
         EventStreamBackend, ExecuteScope, FailureStore, MultiStream, ResolvedStreams, WriteScoped,
@@ -172,7 +172,7 @@ impl WriteScoped for MetalServer {
     }
 }
 
-impl ComputeServer for MetalServer {
+impl Server for MetalServer {
     fn logger(&self) -> Arc<ServerLogger> {
         self.utilities.logger.clone()
     }

--- a/crates/cubecl-metal/src/compute/stream.rs
+++ b/crates/cubecl-metal/src/compute/stream.rs
@@ -285,7 +285,7 @@ pub struct MetalStreamBackend {
     mem_config: MemoryConfiguration,
     logger: Arc<ServerLogger>,
     /// Programmatic main-GPU pool layout (see
-    /// [`ComputeServer::install_memory_pools`](cubecl_runtime::server::ComputeServer::install_memory_pools)):
+    /// [`Server::install_memory_pools`](cubecl_runtime::server::Server::install_memory_pools)):
     /// streams created after it is set build their GPU pools from it instead
     /// of the runtime default.
     gpu_pools_override: Option<MemoryConfiguration>,

--- a/crates/cubecl-metal/src/tests_multistream.rs
+++ b/crates/cubecl-metal/src/tests_multistream.rs
@@ -1,6 +1,6 @@
 //! Cross-stream correctness tests for the native Metal backend.
 //!
-//! `StreamId` is derived from the OS thread, so a single [`ComputeClient`] drives a
+//! `StreamId` is derived from the OS thread, so a single [`Client`] drives a
 //! different stream per thread, and each stream owns its own `memory_management`. A
 //! buffer therefore lives only in its origin stream's manager. These tests allocate a
 //! binding on one stream and consume it on another to exercise cross-stream resolution
@@ -25,7 +25,7 @@ fn copy_kernel(input: &[u32], output: &mut [u32]) {
     }
 }
 
-fn client() -> ComputeClient {
+fn client() -> Client {
     let device = Default::default();
     R::client(&device)
 }

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -9,10 +9,9 @@ use crate::{
         MemoryUsage,
     },
     server::{
-        BufferBinding, CommunicationId, ComputeServer, CopyDescriptor, CubeCount, Handle,
-        KernelArguments, KernelResource, MemoryLayout, MemoryLayoutDescriptor,
-        MemoryLayoutStrategy, ProfileError, ReduceOperation, ServerError, ServerStorage,
-        ServerUtilities,
+        BufferBinding, CommunicationId, CopyDescriptor, CubeCount, Handle, KernelArguments,
+        KernelResource, MemoryLayout, MemoryLayoutDescriptor, MemoryLayoutStrategy, ProfileError,
+        ReduceOperation, Server, ServerError, ServerStorage, ServerUtilities,
     },
     storage::{ComputeStorage, ManagedResource},
     throughput::{
@@ -39,15 +38,15 @@ use cubecl_zspace::Shape;
 use cubecl_common::profile::TimingMethod;
 use cubecl_environment::stream::StreamId;
 
-/// The `ComputeClient` is the entry point to require tasks from the `ComputeServer`.
+/// The `Client` is the entry point to require tasks from the `Server`.
 /// It should be obtained for a specific device via the Compute struct.
-pub struct ComputeClient {
-    device: DeviceHandle<dyn ComputeServer>,
+pub struct Client {
+    device: DeviceHandle<dyn Server>,
     utilities: Arc<ServerUtilities>,
     stream_id: Option<StreamId>,
 }
 
-/// A captured graph produced by [`ComputeClient::stop_capture`]: a recorded
+/// A captured graph produced by [`Client::stop_capture`]: a recorded
 /// launch sequence that [`replay`](Graph::replay) re-runs against its original
 /// buffers, skipping the launch path it was recorded from. Cheap to clone
 /// (shares one backend graph).
@@ -58,13 +57,13 @@ pub struct ComputeClient {
 /// device buffers used during capture. The caller keeps those input/output
 /// [`Handle`]s alive and, each iteration, writes fresh inputs into the input
 /// handles (same device pointers) and reads the output handles after replaying —
-/// see [`ComputeClient::stop_capture`].
+/// see [`Client::stop_capture`].
 ///
 /// **Stream ordering.** [`replay`](Graph::replay) always dispatches on the
 /// stream the graph was captured on, but input writes and output reads go on the
 /// *writing client's* current stream. They are ordered against the replay only
 /// when they land on that same stream, so keep the client pinned to the capture
-/// stream (via [`set_stream`](ComputeClient::set_stream)) — or issue all writes,
+/// stream (via [`set_stream`](Client::set_stream)) — or issue all writes,
 /// replays, and reads from the same unpinned client — for the whole decode loop.
 /// Refreshing inputs from a client on a different stream races the replay and
 /// silently feeds it stale data.
@@ -86,7 +85,7 @@ impl core::fmt::Debug for Graph {
 /// thread that owns it.
 struct GraphHandle {
     id: GraphId,
-    device: DeviceHandle<dyn ComputeServer>,
+    device: DeviceHandle<dyn Server>,
     stream_id: StreamId,
 }
 
@@ -132,7 +131,7 @@ impl Graph {
     ///   only against work on its capture stream.
     /// - **Same-stream refreshes** — input writes and output reads are issued on
     ///   the capture stream (keep the client pinned to it via
-    ///   [`set_stream`](ComputeClient::set_stream), or do everything from the
+    ///   [`set_stream`](Client::set_stream), or do everything from the
     ///   one client), so they order against the replay instead of racing it.
     pub unsafe fn replay(&self) -> Result<(), ServerError> {
         let id = self.inner.id;
@@ -168,13 +167,13 @@ impl Drop for GraphHandle {
 /// The state a `DeviceHandle` reaches, seen as the server it is. A client
 /// keeps this cast, not the server type, so every operation reads the same
 /// whatever backend is underneath.
-fn as_server<S: ComputeServer>(state: &mut dyn Any) -> &mut dyn ComputeServer {
+fn as_server<S: Server>(state: &mut dyn Any) -> &mut dyn Server {
     state
         .downcast_mut::<S>()
         .expect("State type mismatch in the device registry")
 }
 
-impl Clone for ComputeClient {
+impl Clone for Client {
     fn clone(&self) -> Self {
         Self {
             device: self.device.clone(),
@@ -184,7 +183,7 @@ impl Clone for ComputeClient {
     }
 }
 
-impl ComputeClient {
+impl Client {
     /// The runtime name on this device, as logs and cache keys show it.
     pub fn name(&self) -> &'static str {
         self.utilities.name
@@ -192,7 +191,7 @@ impl ComputeClient {
 
     /// Create a new client with a new server.
     pub fn init<S: ServerStorage>(device_id: DeviceId, server: S) -> Self {
-        let utilities = ComputeServer::utilities(&server);
+        let utilities = Server::utilities(&server);
         let context = DeviceHandle::<S>::insert(device_id, server)
             .expect("Can't create a new client on an already registered server")
             .seen_as(as_server::<S>);
@@ -350,14 +349,14 @@ impl ComputeClient {
     /// the one created by the runtime (i.e. padded on only the last dimension). A way to check
     /// stride compatibility on the runtime will be added in the future.
     ///
-    /// Also see [`ComputeClient::create_tensor`].
+    /// Also see [`Client::create_tensor`].
     pub fn read_tensor(&self, descriptors: Vec<CopyDescriptor>) -> Vec<Bytes> {
         cubecl_environment::future::reader::read_sync(self.read_tensor_async(descriptors))
             .expect("TODO")
     }
 
     /// Given a binding, returns owned resource as bytes.
-    /// See [`ComputeClient::read_tensor`]
+    /// See [`Client::read_tensor`]
     pub fn read_one_tensor_async(
         &self,
         descriptor: CopyDescriptor,
@@ -372,7 +371,7 @@ impl ComputeClient {
     /// # Remarks
     ///
     /// Panics if the read operation fails.
-    /// See [`ComputeClient::read_tensor`]
+    /// See [`Client::read_tensor`]
     pub fn read_one_unchecked_tensor(&self, descriptor: CopyDescriptor) -> Bytes {
         self.read_tensor(vec![descriptor]).remove(0)
     }
@@ -646,7 +645,7 @@ impl ComputeClient {
     /// also take cache lines into account.
     ///
     /// However, the stride must be taken into account when indexing and reading the tensor
-    /// (also see [`ComputeClient::read_tensor`]).
+    /// (also see [`Client::read_tensor`]).
     ///
     /// # Notes
     ///
@@ -680,7 +679,7 @@ impl ComputeClient {
     /// also take cache lines into account.
     ///
     /// However, the stride must be taken into account when indexing and reading the tensor
-    /// (also see [`ComputeClient::read_tensor`]).
+    /// (also see [`Client::read_tensor`]).
     pub fn create_tensor(&self, bytes: Bytes, shape: Shape, elem_size: usize) -> MemoryLayout {
         self.do_create(
             vec![MemoryLayoutDescriptor::new(
@@ -695,7 +694,7 @@ impl ComputeClient {
 
     /// Reserves all `shapes` in a single storage buffer, copies the corresponding `data` into each
     /// handle, and returns the handles for them.
-    /// See [`ComputeClient::create_tensor`]
+    /// See [`Client::create_tensor`]
     ///
     /// # Notes
     ///
@@ -716,7 +715,7 @@ impl ComputeClient {
 
     /// Reserves all `shapes` in a single storage buffer, copies the corresponding `data` into each
     /// handle, and returns the handles for them.
-    /// See [`ComputeClient::create_tensor`]
+    /// See [`Client::create_tensor`]
     pub fn create_tensors(
         &self,
         descriptors: Vec<(MemoryLayoutDescriptor, Bytes)>,
@@ -749,7 +748,7 @@ impl ComputeClient {
     }
 
     /// Reserves `shape` in the storage, and returns a tensor handle for it.
-    /// See [`ComputeClient::create_tensor`]
+    /// See [`Client::create_tensor`]
     pub fn empty_tensor(&self, shape: Shape, elem_size: usize) -> MemoryLayout {
         let descriptor =
             MemoryLayoutDescriptor::new(MemoryLayoutStrategy::Optimized, shape, elem_size);
@@ -757,7 +756,7 @@ impl ComputeClient {
     }
 
     /// Reserves all `shapes` in a single storage buffer, and returns the handles for them.
-    /// See [`ComputeClient::create_tensor`]
+    /// See [`Client::create_tensor`]
     pub fn empty_tensors(&self, descriptors: Vec<MemoryLayoutDescriptor>) -> Vec<MemoryLayout> {
         self.do_empty(descriptors)
     }
@@ -865,7 +864,7 @@ impl ComputeClient {
     /// Wait on the communication stream.
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip(self)))]
     pub fn sync_collective(&self) {
-        if DeviceHandle::<dyn ComputeServer>::is_blocking() {
+        if DeviceHandle::<dyn Server>::is_blocking() {
             panic!("Can't use `sync_collective` with a blocking device handle");
         }
         let stream_id = self.stream_id();
@@ -897,7 +896,7 @@ impl ComputeClient {
         device_ids: Vec<DeviceId>,
         op: ReduceOperation,
     ) {
-        if DeviceHandle::<dyn ComputeServer>::is_blocking() {
+        if DeviceHandle::<dyn Server>::is_blocking() {
             panic!("Can't use `all_reduce` with a blocking device handle");
         }
 
@@ -1215,7 +1214,7 @@ impl ComputeClient {
     }
 
     /// Prepare this client's stream for a graph capture (see
-    /// [`ComputeServer::graph_prepare`]) — enable the persistent pool + capture
+    /// [`Server::graph_prepare`]) — enable the persistent pool + capture
     /// recording. Call this **before** the warmup run, then
     /// [`start_capture`](Self::start_capture) around the run to record.
     pub fn graph_prepare(&self) -> Result<(), ServerError> {
@@ -1226,7 +1225,7 @@ impl ComputeClient {
     }
 
     /// Begin recording launches on this client's stream into a graph rather
-    /// than executing them (see [`ComputeServer::begin_capture`]). Pin the
+    /// than executing them (see [`Server::begin_capture`]). Pin the
     /// client to a dedicated stream with [`set_stream`](Self::set_stream), then
     /// [`graph_prepare`](Self::graph_prepare) and warm up first.
     ///

--- a/crates/cubecl-runtime/src/client/lazy.rs
+++ b/crates/cubecl-runtime/src/client/lazy.rs
@@ -1,6 +1,6 @@
 //! Allocation controller that lazily reads a device resource into host memory.
 
-use super::ComputeClient;
+use super::Client;
 use crate::server::CopyDescriptor;
 use alloc::boxed::Box;
 use alloc::format;
@@ -14,7 +14,7 @@ use cubecl_zspace::striding::has_contiguous_row_major_strides;
 
 /// Allocation controller that lazily copies a device resource into host memory on first access.
 ///
-/// Constructing the [`Bytes`] is cheap: it only captures the [`ComputeClient`] and a
+/// Constructing the [`Bytes`] is cheap: it only captures the [`Client`] and a
 /// [`CopyDescriptor`], whose [`Binding`](crate::server::Binding) keeps the device allocation
 /// alive. The device-to-host copy — going through the regular read path, including pinned
 /// staging — only happens the first time the bytes are read (e.g. during serialization), and
@@ -29,16 +29,16 @@ use cubecl_zspace::striding::has_contiguous_row_major_strides;
 /// therefore only sound for buffers that are not mutated between [`read_lazy`] and the first
 /// read. This matches the typical use case of serializing frozen weights.
 ///
-/// [`read_lazy`]: ComputeClient::read_lazy
+/// [`read_lazy`]: Client::read_lazy
 pub struct LazyDeviceController {
-    client: ComputeClient,
+    client: Client,
     descriptor: Arc<CopyDescriptor>,
     /// Host bytes, materialized from the device on first access.
     materialized: Once<Bytes>,
 }
 
 impl LazyDeviceController {
-    pub(super) fn new(client: ComputeClient, descriptor: Arc<CopyDescriptor>) -> Self {
+    pub(super) fn new(client: Client, descriptor: Arc<CopyDescriptor>) -> Self {
         Self {
             client,
             descriptor,

--- a/crates/cubecl-runtime/src/config/memory.rs
+++ b/crates/cubecl-runtime/src/config/memory.rs
@@ -25,7 +25,7 @@ pub struct MemoryConfig {
 /// This is a **programmatic** setting, deliberately not a config-file one —
 /// pool layouts are dynamic (e.g. resized per model just before a load) and
 /// must not freeze at startup. Apply it with
-/// [`install_memory_pools`](crate::client::ComputeClient::install_memory_pools):
+/// [`install_memory_pools`](crate::client::Client::install_memory_pools):
 /// it rebuilds the calling stream's pools in place and becomes the layout for
 /// streams created afterwards. Auxiliary pools (pinned CPU, staging, uniforms)
 /// are never affected.

--- a/crates/cubecl-runtime/src/dry_run.rs
+++ b/crates/cubecl-runtime/src/dry_run.rs
@@ -114,7 +114,7 @@ impl Drop for DryRun {
 ///
 /// Thread-local, and the thread that matters is the one issuing the launches,
 /// which is not always the one that asked for them: a task handed to
-/// [`ComputeClient::exclusive`](crate::client::ComputeClient::exclusive) runs on
+/// [`Client::exclusive`](crate::client::Client::exclusive) runs on
 /// the device thread. The guard has to live inside that task, alongside the
 /// launches it covers, not around the call that submits it.
 #[derive(Debug)]

--- a/crates/cubecl-runtime/src/id.rs
+++ b/crates/cubecl-runtime/src/id.rs
@@ -51,10 +51,10 @@ macro_rules! storage_id_type {
 
 /// Identifies a backend-owned captured graph.
 ///
-/// [`end_capture`](crate::server::ComputeServer::end_capture) records a graph,
+/// [`end_capture`](crate::server::Server::end_capture) records a graph,
 /// stores it in the backend's own registry, and returns this lightweight id;
-/// [`replay`](crate::server::ComputeServer::replay) and
-/// [`graph_destroy`](crate::server::ComputeServer::graph_destroy) take the id
+/// [`replay`](crate::server::Server::replay) and
+/// [`graph_destroy`](crate::server::Server::graph_destroy) take the id
 /// back to look the graph up. Referencing the graph by id keeps the raw
 /// executable inside the server — it never crosses the actor boundary in a box —
 /// exactly as memory is referenced by [`Handle`](crate::server::Handle) rather

--- a/crates/cubecl-runtime/src/memory_management/memory_manage.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_manage.rs
@@ -419,7 +419,7 @@ impl MemoryConfiguration {
     /// when present, it wins. There is deliberately no config-file pathway for
     /// pool layouts — they are dynamic (set per model just before a load) and
     /// must not freeze at startup; the override reaches the server through
-    /// [`install_memory_pools`](crate::client::ComputeClient::install_memory_pools).
+    /// [`install_memory_pools`](crate::client::Client::install_memory_pools).
     ///
     /// `page_size` is deliberately not validated against
     /// [`MemoryDeviceProperties::max_page_size`]: that value is a sizing

--- a/crates/cubecl-runtime/src/runtime.rs
+++ b/crates/cubecl-runtime/src/runtime.rs
@@ -3,7 +3,7 @@ use cubecl_common::device::{Device, DeviceId};
 use cubecl_ir::TargetProperties;
 use cubecl_zspace::{Shape, Strides};
 
-use crate::{client::ComputeClient, server::ServerStorage};
+use crate::{client::Client, server::ServerStorage};
 
 /// Runtime for the `CubeCL`.
 pub trait Runtime: Sized + Send + Sync + 'static + core::fmt::Debug + Clone {
@@ -14,8 +14,8 @@ pub trait Runtime: Sized + Send + Sync + 'static + core::fmt::Debug + Clone {
 
     /// Retrieve the compute client from the runtime device, initializing the
     /// server on first use.
-    fn client(device: &Self::Device) -> ComputeClient {
-        ComputeClient::load::<Self::Server>(device.to_id())
+    fn client(device: &Self::Device) -> Client {
+        Client::load::<Self::Server>(device.to_id())
     }
 
     /// Whether a tensor with `shape` and `strides` can be read as is. If the result is false, the

--- a/crates/cubecl-runtime/src/server/base.rs
+++ b/crates/cubecl-runtime/src/server/base.rs
@@ -1,7 +1,7 @@
 use super::Handle;
 use crate::kernel::BufferIOAttr;
 use crate::{
-    client::ComputeClient,
+    client::Client,
     compiler::CompilationError,
     config::{CubeClRuntimeConfig, RuntimeConfig, compilation::BoundsCheckMode},
     dry_run::LaunchMode,
@@ -476,8 +476,8 @@ impl ServerError {
 /// The compute server is responsible for handling resources and computations over resources.
 ///
 /// Everything in the server is mutable, therefore it should be solely accessed through the
-/// [`ComputeClient`] for thread safety.
-pub trait ComputeServer:
+/// [`Client`] for thread safety.
+pub trait Server:
     core::any::Any + Send + core::fmt::Debug + ServerCommunication + device::DeviceService + 'static
 {
     /// Initializes [memory](ManagedMemoryHandle) on the given [stream](StreamId) with the given size.
@@ -576,7 +576,7 @@ pub trait ComputeServer:
 
     /// Prepare `stream_id` for an upcoming graph capture: route allocations
     /// into a stable pool and snapshot it, so every buffer allocated between
-    /// here and [`end_capture`](ComputeServer::end_capture) can be pinned for
+    /// here and [`end_capture`](Server::end_capture) can be pinned for
     /// the graph's lifetime. Call this **before** the warmup run so the capture
     /// window reuses the slices warmup left in the pool rather than allocating
     /// its own — which a hardware-graph backend cannot do at all (a device
@@ -600,10 +600,10 @@ pub trait ComputeServer:
 
     /// Begin recording the launches issued on `stream_id` into a graph instead
     /// of executing them, so the sequence can later be
-    /// [replayed](ComputeServer::replay) without paying the launch path again.
-    /// Call [`graph_prepare`](ComputeServer::graph_prepare) and warm up first.
+    /// [replayed](Server::replay) without paying the launch path again.
+    /// Call [`graph_prepare`](Server::graph_prepare) and warm up first.
     ///
-    /// Between this call and [`end_capture`](ComputeServer::end_capture) the
+    /// Between this call and [`end_capture`](Server::end_capture) the
     /// stream must not synchronize — a read, a sync or a profile either aborts
     /// the capture or is refused — and should not allocate fresh device memory,
     /// which `graph_prepare` plus a warmup run is what avoids. Whether an
@@ -620,9 +620,9 @@ pub trait ComputeServer:
         Err(ServerError::graph_capture_unsupported())
     }
 
-    /// Stop recording (see [`begin_capture`](ComputeServer::begin_capture)),
+    /// Stop recording (see [`begin_capture`](Server::begin_capture)),
     /// store the captured graph in the backend's registry, and return its
-    /// [`GraphId`], ready to [replay](ComputeServer::replay).
+    /// [`GraphId`], ready to [replay](Server::replay).
     fn end_capture(&mut self, stream_id: StreamId) -> Result<GraphId, ServerError> {
         let _ = stream_id;
         Err(ServerError::graph_capture_unsupported())
@@ -640,7 +640,7 @@ pub trait ComputeServer:
     /// there. A failure also leaves the graph's write set carrying it, so a
     /// read of those buffers fails until a replay lands. Unsupported by
     /// default: a [`GraphId`] can only come from
-    /// [`end_capture`](ComputeServer::end_capture).
+    /// [`end_capture`](Server::end_capture).
     fn replay(&mut self, graph: GraphId, stream_id: StreamId) -> Result<(), ServerError> {
         let _ = (graph, stream_id);
         Err(ServerError::graph_capture_unsupported())
@@ -723,10 +723,10 @@ pub trait ComputeServer:
 }
 
 /// The storage a server allocates from, and the native resources it hands
-/// out. Kept off [`ComputeServer`] so that trait is object-safe: a resource's
+/// out. Kept off [`Server`] so that trait is object-safe: a resource's
 /// type is the backend's own, and only a caller that names the backend can
 /// receive one.
-pub trait ServerStorage: ComputeServer {
+pub trait ServerStorage: Server {
     /// The [storage](ComputeStorage) type defines how data is stored and accessed.
     type Storage: ComputeStorage;
     /// Given a resource handle, returns the storage resource.
@@ -774,11 +774,11 @@ pub enum ReduceOperation {
 ///
 /// A collective reads a source buffer and produces a destination one, and owes
 /// the same two answers the rest of the server gives: ask whether the source
-/// carries a failure on the way in (as [`read`](ComputeServer::read) does
+/// carries a failure on the way in (as [`read`](Server::read) does
 /// through
 /// [`FailureStore::ensure_written`](crate::stream::FailureStore::ensure_written)),
 /// and taint the destination on the way out when the operation fails (as a
-/// failed [`launch`](ComputeServer::launch) does). Skipping either lets a
+/// failed [`launch`](Server::launch) does). Skipping either lets a
 /// collective reduce stale bytes across every device in the group, or leave a
 /// destination that reads back clean when nothing wrote it.
 pub trait ServerCommunication {
@@ -1347,7 +1347,7 @@ impl KernelArguments {
 
 /// Binding of a set of scalars of the same type to execute a kernel.
 ///
-/// The [`ComputeServer`] is responsible to convert those info into actual [`Binding`] when launching
+/// The [`Server`] is responsible to convert those info into actual [`Binding`] when launching
 /// kernels.
 #[derive(new, Debug, Default)]
 pub struct MetadataBindingInfo {
@@ -1431,7 +1431,7 @@ pub enum CubeCountSelection {
 
 impl CubeCountSelection {
     /// Creates a [`CubeCount`] while respecting the hardware limits.
-    pub fn new(client: &ComputeClient, num_cubes: u32) -> Self {
+    pub fn new(client: &Client, num_cubes: u32) -> Self {
         let cube_count = cube_count_spread(&client.properties().hardware.max_cube_count, num_cubes);
 
         let num_cubes_actual = cube_count[0] * cube_count[1] * cube_count[2];
@@ -1525,7 +1525,7 @@ impl CubeDim {
     ///
     /// For complex problems, you probably want to have your own logic function to create the
     /// [`CubeDim`], but for simpler problems such as elemwise-operation, this is a great default.
-    pub fn new(client: &ComputeClient, working_units: usize) -> Self {
+    pub fn new(client: &Client, working_units: usize) -> Self {
         let properties = client.properties();
         let plane_size = properties.hardware.plane_size_max;
         let plane_count = Self::calculate_plane_count_per_cube(

--- a/crates/cubecl-runtime/src/server/handle.rs
+++ b/crates/cubecl-runtime/src/server/handle.rs
@@ -155,7 +155,7 @@ pub enum KernelResource {
 /// A buffer binding represents a [Handle] that is bound to managed memory.
 ///
 /// The memory used is known by the compute server.
-/// A buffer binding is only valid after being initlized with [`super::ComputeServer::initialize_bindings`]
+/// A buffer binding is only valid after being initlized with [`super::Server::initialize_bindings`]
 ///
 /// # Notes
 ///

--- a/crates/cubecl-runtime/src/stream/capture.rs
+++ b/crates/cubecl-runtime/src/stream/capture.rs
@@ -1,5 +1,5 @@
 //! The stream-side graph-capture lifecycle, shared by every backend with
-//! graph support (see [`ComputeServer::graph_prepare`](crate::server::ComputeServer::graph_prepare)).
+//! graph support (see [`Server::graph_prepare`](crate::server::Server::graph_prepare)).
 
 use crate::metadata_cache::CacheMode;
 use crate::server::{BufferBinding, ServerError};

--- a/crates/cubecl-runtime/src/throughput/cmma.rs
+++ b/crates/cubecl-runtime/src/throughput/cmma.rs
@@ -1,4 +1,4 @@
-use crate::client::ComputeClient;
+use crate::client::Client;
 use cubecl_ir::ElemType;
 
 /// Configuration for a matrix multiplication (CMMA) operation.
@@ -35,7 +35,7 @@ impl CmmaDims {
 
 /// Resolves the largest supported CMMA or MMA tile size `(m, n, k)`.
 pub fn select_cmma_tile(
-    client: &ComputeClient,
+    client: &Client,
     lhs: ElemType,
     rhs: ElemType,
     acc: ElemType,

--- a/crates/cubecl-runtime/src/tune/local.rs
+++ b/crates/cubecl-runtime/src/tune/local.rs
@@ -1,7 +1,7 @@
 use super::{AutotuneKey, AutotuneOutput, TunableSet, TuneInputs, Tuner};
 #[cfg(feature = "autotune-checks")]
 use crate::tune::AutotuneLoggerExt;
-use crate::{client::ComputeClient, tune::TuneCacheResult};
+use crate::{client::Client, tune::TuneCacheResult};
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use core::{
@@ -61,7 +61,7 @@ where
     ///
     /// The device is part of the key because a set is routinely built from the
     /// device it will run on: a closure captures that device's
-    /// [`ComputeClient`] to ask what it supports, or reads its hardware
+    /// [`Client`] to ask what it supports, or reads its hardware
     /// properties to decide which tunables are worth offering at all. Keyed by
     /// the initializer alone, whichever device tuned first would answer those
     /// questions for every device that followed — promoting kernels onto
@@ -139,7 +139,7 @@ where
     pub fn execute<'a, I: TuneInputs, Out>(
         &self,
         id: &ID,
-        client: &ComputeClient,
+        client: &Client,
         operations: Arc<TunableSet<AK, I, Out>>,
         inputs: <I as TuneInputs>::At<'a>,
     ) -> Out

--- a/crates/cubecl-runtime/src/tune/schedule.rs
+++ b/crates/cubecl-runtime/src/tune/schedule.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 
 use cubecl_common::profile::{Instant, ProfileDuration, TimingMethod};
 
-use crate::client::ComputeClient;
+use crate::client::Client;
 use crate::config::autotune::BenchConfig;
 use crate::tune::sampler::SampleSet;
 use crate::tune::{
@@ -56,7 +56,7 @@ impl Schedule {
         indices: Vec<usize>,
         autotunables: &[&TuneFn<F, Out>],
         inputs: <F as TuneInputs>::At<'a>,
-        client: &ComputeClient,
+        client: &Client,
     ) -> BatchOutcome
     where
         <F as TuneInputs>::At<'a>: Clone + Send,
@@ -94,7 +94,7 @@ impl Schedule {
         indices: Vec<usize>,
         autotunables: &[&TuneFn<F, Out>],
         inputs: <F as TuneInputs>::At<'a>,
-        client: &ComputeClient,
+        client: &Client,
     ) -> BatchOutcome
     where
         <F as TuneInputs>::At<'a>: Clone,
@@ -257,7 +257,7 @@ impl Schedule {
         &self,
         operation: &TuneFn<F, Out>,
         inputs: &<F as TuneInputs>::At<'a>,
-        client: &ComputeClient,
+        client: &Client,
         candidate: &mut Candidate,
     ) -> bool
     where
@@ -295,7 +295,7 @@ impl Schedule {
         &self,
         operation: &TuneFn<F, Out>,
         inputs: &<F as TuneInputs>::At<'a>,
-        client: &ComputeClient,
+        client: &Client,
         candidate: &mut Candidate,
     ) -> bool
     where
@@ -375,7 +375,7 @@ impl Schedule {
         plan: &mut TunePlan,
         autotunables: &[&TuneFn<F, Out>],
         inputs: &<F as TuneInputs>::At<'a>,
-        client: &ComputeClient,
+        client: &Client,
         results: &mut [AutotuneResult],
     ) -> PlanOutcome
     where

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -1,5 +1,5 @@
 use super::{AutotuneError, TuneFn, TuneInputs};
-use crate::client::ComputeClient;
+use crate::client::Client;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use cubecl_common::profile::ProfileDuration;
@@ -26,7 +26,7 @@ impl AutotuneOutput for () {
 pub fn tune_benchmark<'a, F: TuneInputs, Out: AutotuneOutput>(
     operation: &TuneFn<F, Out>,
     inputs: <F as TuneInputs>::At<'a>,
-    client: ComputeClient,
+    client: Client,
 ) -> Result<Vec<ProfileDuration>, AutotuneError> {
     // `scoped` holds exclusive device access for the whole benchmark loop and
     // accepts non-`'static` closures.
@@ -47,7 +47,7 @@ impl<F: TuneInputs, Out: AutotuneOutput> TuneFn<F, Out> {
     pub(crate) fn warmup_once<'a>(
         &self,
         inputs: <F as TuneInputs>::At<'a>,
-        client: &ComputeClient,
+        client: &Client,
     ) -> Result<(), AutotuneError> {
         // We make sure the server is in a correct state.
         let _errs = client.flush();
@@ -61,7 +61,7 @@ impl<F: TuneInputs, Out: AutotuneOutput> TuneFn<F, Out> {
     pub(crate) fn sample_once<'a>(
         &self,
         inputs: <F as TuneInputs>::At<'a>,
-        client: &ComputeClient,
+        client: &Client,
     ) -> Result<ProfileDuration, AutotuneError> {
         // The output is returned so dead code elimination can't drop the work being profiled.
         let profiled = client.profile(move || self.execute(inputs), &self.name);
@@ -80,7 +80,7 @@ impl<F: TuneInputs, Out: AutotuneOutput> TuneFn<F, Out> {
 fn profile_exclusive<'a, F: TuneInputs, Out: AutotuneOutput>(
     operation: &TuneFn<F, Out>,
     inputs: <F as TuneInputs>::At<'a>,
-    client: ComputeClient,
+    client: Client,
 ) -> Result<Vec<ProfileDuration>, AutotuneError> {
     // These launches are the measurement, so they run even inside a dry run:
     // that mode exists to skip the *workload*, not the tuning it is there to
@@ -124,7 +124,7 @@ fn profile_exclusive<'a, F: TuneInputs, Out: AutotuneOutput>(
 fn warmup<'a, F: TuneInputs, Out: AutotuneOutput>(
     operation: &TuneFn<F, Out>,
     inputs: <F as TuneInputs>::At<'a>,
-    client: ComputeClient,
+    client: Client,
 ) -> Result<(), AutotuneError> {
     let num_warmup = 3;
 

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -12,7 +12,7 @@ use cubecl_environment::sync::Mutex;
 use alloc::string::{String, ToString};
 use cubecl_common::benchmark::{BenchmarkComputations, BenchmarkDurations};
 
-use crate::client::ComputeClient;
+use crate::client::Client;
 use crate::config::Logger;
 #[cfg(std_io)]
 use crate::config::autotune::AutotuneLogLevel;
@@ -217,7 +217,7 @@ impl<K: AutotuneKey> Tuner<K> {
         #[cfg_attr(not(autotune_persistence), allow(unused))] checksum: impl FnOnce() -> String
         + Send
         + Sync,
-        client: &ComputeClient,
+        client: &Client,
         mut log_context: Option<crate::tune::AutotuneLogContext>,
     ) -> TuneCacheResult
     where
@@ -335,7 +335,7 @@ impl<K: AutotuneKey> Tuner<K> {
     fn tune_adaptive<'i, F: TuneInputs, Out: AutotuneOutput>(
         &self,
         mut job: TuneJob<'_, 'i, K, F, Out>,
-        client: &ComputeClient,
+        client: &Client,
     ) -> TuneCacheResult
     where
         <F as TuneInputs>::At<'i>: Clone + Send,
@@ -376,7 +376,7 @@ impl<K: AutotuneKey> Tuner<K> {
     fn tune_fixed_samples<'i, F: TuneInputs, Out: AutotuneOutput>(
         &self,
         mut job: TuneJob<'_, 'i, K, F, Out>,
-        client: &ComputeClient,
+        client: &Client,
     ) -> TuneCacheResult
     where
         <F as TuneInputs>::At<'i>: Clone + Send,

--- a/crates/cubecl-runtime/tests/dummy/compute.rs
+++ b/crates/cubecl-runtime/tests/dummy/compute.rs
@@ -1,9 +1,9 @@
 use super::{DummyServer, Marker};
 use cubecl_common::device::{Device, DeviceService};
 use cubecl_ir::MemoryDeviceProperties;
-use cubecl_runtime::server::ComputeServer;
+use cubecl_runtime::server::Server;
 use cubecl_runtime::{
-    client::ComputeClient,
+    client::Client,
     logging::ServerLogger,
     memory_management::{MemoryConfiguration, MemoryManagement, MemoryManagementOptions},
     runtime::Runtime,
@@ -30,7 +30,7 @@ impl Device for DummyDevice {
     }
 }
 
-pub type DummyClient = ComputeClient;
+pub type DummyClient = Client;
 
 impl<M: Marker> DeviceService for DummyServer<M> {
     fn init(device_id: cubecl_common::device::DeviceId) -> Self {
@@ -38,7 +38,7 @@ impl<M: Marker> DeviceService for DummyServer<M> {
     }
 
     fn utilities(&self) -> Arc<dyn std::any::Any + Send + Sync> {
-        ComputeServer::utilities(self) as Arc<dyn std::any::Any + Send + Sync>
+        Server::utilities(self) as Arc<dyn std::any::Any + Send + Sync>
     }
 }
 

--- a/crates/cubecl-runtime/tests/dummy/server.rs
+++ b/crates/cubecl-runtime/tests/dummy/server.rs
@@ -20,9 +20,8 @@ use cubecl_runtime::{
         ErrorGraph, ManagedMemoryHandle, MemoryAllocationMode, MemoryManagement, MemoryUsage,
     },
     server::{
-        BufferBinding, ComputeServer, CopyDescriptor, CubeCount, Handle, KernelArguments,
-        KernelResource, ProfileError, ProfilingToken, ServerCommunication, ServerError,
-        ServerUtilities,
+        BufferBinding, CopyDescriptor, CubeCount, Handle, KernelArguments, KernelResource,
+        ProfileError, ProfilingToken, Server, ServerCommunication, ServerError, ServerUtilities,
     },
     storage::{BytesResource, BytesStorage, ComputeStorage, ManagedResource},
     timestamp_profiler::TimestampProfiler,
@@ -117,7 +116,7 @@ impl KernelTask {
 
 impl<M: Marker> ServerCommunication for DummyServer<M> {}
 
-impl<M: Marker> ComputeServer for DummyServer<M> {
+impl<M: Marker> Server for DummyServer<M> {
     fn logger(&self) -> Arc<ServerLogger> {
         self.utilities.logger.clone()
     }

--- a/crates/cubecl-runtime/tests/dummy/tune/autotune_operations.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/autotune_operations.rs
@@ -1,5 +1,5 @@
 use cubecl_runtime::{
-    client::ComputeClient,
+    client::Client,
     kernel::BufferIOAttr,
     server::{CubeCount, Handle, KernelArguments},
 };
@@ -12,7 +12,7 @@ use crate::dummy::KernelTask;
 /// information that does not count as an input/output.
 pub struct OneKernelAutotuneOperation {
     kernel: KernelTask,
-    client: ComputeClient,
+    client: Client,
 }
 
 impl OneKernelAutotuneOperation {

--- a/crates/cubecl-runtime/tests/integration_test.rs
+++ b/crates/cubecl-runtime/tests/integration_test.rs
@@ -6,7 +6,7 @@ use cubecl_common::bytes::Bytes;
 use cubecl_common::device::{DeviceId, ServiceId};
 use cubecl_environment::stream::StreamId;
 use cubecl_ir::{ElemType, UIntKind};
-use cubecl_runtime::client::ComputeClient;
+use cubecl_runtime::client::Client;
 use cubecl_runtime::server::{CubeCount, Handle, KernelArguments, ServerError};
 use cubecl_runtime::{local_tuner, tune::LocalTuner};
 use dummy::*;
@@ -105,7 +105,7 @@ fn transferring_a_foreign_handle_to_another_client_panics() {
 #[test_log::test]
 fn a_transfer_between_devices_of_the_same_runtime_round_trips() {
     let mut source = test_client(&DummyDevice);
-    let destination = ComputeClient::load::<DummyServer>(DeviceId::new(0, 1));
+    let destination = Client::load::<DummyServer>(DeviceId::new(0, 1));
     let bytes = [1u8, 2, 3, 4];
     let handle = source.create_from_slice(&bytes);
 
@@ -121,7 +121,7 @@ fn a_transfer_between_devices_of_the_same_runtime_round_trips() {
 #[test_log::test]
 fn a_transfer_across_runtimes_goes_through_the_host() {
     let mut source = test_client(&DummyDevice);
-    let destination = ComputeClient::load::<DummyServer<Other>>(DeviceId::new(0, 0));
+    let destination = Client::load::<DummyServer<Other>>(DeviceId::new(0, 0));
     let bytes = [5u8, 6, 7, 8];
     let handle = source.create_from_slice(&bytes);
 
@@ -450,7 +450,7 @@ fn autotune_short_circuit_disabled_benchmarks_all() {
     assert_eq!(obtained, vec![4, 5, 6]);
 }
 
-/// 2-I1 — A panic inside a profiled closure surfaces at the `ComputeClient` caller as
+/// 2-I1 — A panic inside a profiled closure surfaces at the `Client` caller as
 /// the *original* panic (the issue's symptom), instead of an opaque `CallError`.
 #[test_log::test]
 #[cfg(feature = "std")]
@@ -487,7 +487,7 @@ fn profile_returns_ok_on_success() {
     assert_eq!(value, 123);
 }
 
-/// 2-I3 — Design guard: the public `ComputeClient::exclusive` stays *recoverable* — a
+/// 2-I3 — Design guard: the public `Client::exclusive` stays *recoverable* — a
 /// task panic becomes `Err(ServerError::Generic)` (so autotune can skip a failing
 /// candidate) rather than re-raising. The original message is still preserved in the
 /// error string thanks to the `CallError` payload.

--- a/crates/cubecl-std/src/tensor/contiguous/base.rs
+++ b/crates/cubecl-std/src/tensor/contiguous/base.rs
@@ -247,7 +247,7 @@ fn copy_kernel_packed<T: Int, N: Size>(
 }
 
 /// Make a jit tensor contiguous, using the pitched allocator if available.
-/// See [`create_tensor`](cubecl_runtime::client::ComputeClient::create_tensor).
+/// See [`create_tensor`](cubecl_runtime::client::Client::create_tensor).
 /// Handles unpacking and repacking packed tensors (i.e. quantized values).
 /// `shape` refers to the actual (unpacked) shape of the tensor, while `packing` specifies the
 /// number of elements in each storage element.
@@ -255,7 +255,7 @@ fn copy_kernel_packed<T: Int, N: Size>(
 /// # Warning
 /// This assumes `u32` or `u8` packing.
 pub fn into_contiguous_packed(
-    client: &ComputeClient,
+    client: &Client,
     input: TensorBinding,
     packed_dim: usize,
     shape: &[usize],
@@ -287,12 +287,7 @@ pub fn into_contiguous_packed(
 }
 
 /// Make a jit tensor contiguous.
-pub fn copy_gpu_ref(
-    client: &ComputeClient,
-    input: TensorBinding,
-    output: TensorBinding,
-    dtype: ElemType,
-) {
+pub fn copy_gpu_ref(client: &Client, input: TensorBinding, output: TensorBinding, dtype: ElemType) {
     let num_elems: usize = input.shape.iter().product();
 
     // Vectorization is only enabled when the last dimension is contiguous.
@@ -382,7 +377,7 @@ pub fn copy_gpu_ref(
 
 /// Make a jit tensor contiguous.
 pub fn into_contiguous_packed_ref(
-    client: &ComputeClient,
+    client: &Client,
     input: TensorBinding,
     output: TensorBinding,
     packed_dim: usize,

--- a/crates/cubecl-std/src/tensor/contiguous/launch.rs
+++ b/crates/cubecl-std/src/tensor/contiguous/launch.rs
@@ -1,12 +1,8 @@
 use crate::tensor::{TensorHandle, copy_gpu_ref, launch_copy_perpendicular_ref};
-use cubecl_core::{client::ComputeClient, ir::ElemType, prelude::TensorBinding};
+use cubecl_core::{client::Client, ir::ElemType, prelude::TensorBinding};
 
 /// Make a jit tensor contiguous.
-pub fn into_contiguous(
-    client: &ComputeClient,
-    input: TensorBinding,
-    dtype: ElemType,
-) -> TensorHandle {
+pub fn into_contiguous(client: &Client, input: TensorBinding, dtype: ElemType) -> TensorHandle {
     let num_elems: usize = input.shape.iter().product();
 
     let handle = client.empty(num_elems * dtype.size());
@@ -18,9 +14,9 @@ pub fn into_contiguous(
 }
 
 /// Make a jit tensor contiguous, using the pitched allocator if available.
-/// See [`create_tensor`](cubecl_runtime::client::ComputeClient::create_tensor).
+/// See [`create_tensor`](cubecl_runtime::client::Client::create_tensor).
 pub fn into_contiguous_pitched(
-    client: &ComputeClient,
+    client: &Client,
     input: TensorBinding,
     dtype: ElemType,
 ) -> TensorHandle {
@@ -36,12 +32,7 @@ pub fn into_contiguous_pitched(
 }
 
 /// Copies the input tensor into the output tensor following the strides.
-pub fn copy_into(
-    client: &ComputeClient,
-    input: TensorBinding,
-    output: TensorBinding,
-    dtype: ElemType,
-) {
+pub fn copy_into(client: &Client, input: TensorBinding, output: TensorBinding, dtype: ElemType) {
     let rank = input.strides.len();
 
     // It's normally faster on all devices, but since it doesn't parallelize on an axis, it

--- a/crates/cubecl-std/src/tensor/contiguous/perpendicular.rs
+++ b/crates/cubecl-std/src/tensor/contiguous/perpendicular.rs
@@ -100,7 +100,7 @@ fn copy_perpendicular<T: Numeric, N: Size>(
 /// is not the one with a stride of 1 (the vectorized dimension). It optimizes
 /// the copy by using hardware vectorization (Vectors) and an in-register transpose.
 pub fn launch_into_contiguous_perpendicular(
-    client: &ComputeClient,
+    client: &Client,
     input: TensorBinding,
     dtype: ElemType,
 ) -> TensorHandle {
@@ -121,7 +121,7 @@ pub fn launch_into_contiguous_perpendicular(
 /// is not the one with a stride of 1 (the vectorized dimension). It optimizes
 /// the copy by using hardware vectorization (Vectors) and an in-register transpose.
 pub fn launch_copy_perpendicular_ref(
-    client: &ComputeClient,
+    client: &Client,
     input: TensorBinding,
     output: TensorBinding,
     dtype: ElemType,

--- a/crates/cubecl-std/src/tensor/handle.rs
+++ b/crates/cubecl-std/src/tensor/handle.rs
@@ -53,11 +53,7 @@ impl TensorHandle {
         }
     }
 
-    pub fn empty(
-        client: &ComputeClient,
-        shape: impl Into<Shape>,
-        storage: impl Into<Type>,
-    ) -> Self {
+    pub fn empty(client: &Client, shape: impl Into<Shape>, storage: impl Into<Type>) -> Self {
         let storage = storage.into();
         let shape: Shape = shape.into();
         let elem_size = storage.elem_type().size();
@@ -132,7 +128,7 @@ impl TensorHandle {
     }
 }
 impl TensorHandle {
-    pub fn zeros(client: &ComputeClient, shape: impl Into<Shape>, dtype: impl Into<Type>) -> Self {
+    pub fn zeros(client: &Client, shape: impl Into<Shape>, dtype: impl Into<Type>) -> Self {
         let dtype = dtype.into();
         let shape = shape.into();
         let num_elements: usize = shape.iter().product();

--- a/crates/cubecl-std/src/tensor/identity.rs
+++ b/crates/cubecl-std/src/tensor/identity.rs
@@ -36,7 +36,7 @@ fn identity_kernel<C: Numeric, N: Size>(
 /// Launch identity matrix kernel.
 /// Ensure output is a [`TensorHandle`] containing a square matrix.
 /// output will contain the identity matrix.
-pub fn launch(client: &ComputeClient, output: &TensorHandle) {
+pub fn launch(client: &Client, output: &TensorHandle) {
     let dtype = output.dtype;
     launch_ref(client, output.clone().binding(), dtype);
 }
@@ -44,7 +44,7 @@ pub fn launch(client: &ComputeClient, output: &TensorHandle) {
 /// Launch identity matrix kernel by ref.
 /// Ensure output is a [`TensorHandleRef`] containing a square matrix.
 /// output will contain the identity matrix.
-pub fn launch_ref(client: &ComputeClient, output: TensorBinding, dtype: ElemType) {
+pub fn launch_ref(client: &Client, output: TensorBinding, dtype: ElemType) {
     assert_eq!(2, output.shape.len(), "input should be a matrix");
     assert_eq!(
         output.shape[0], output.shape[1],

--- a/crates/cubecl-std/src/tests/erased.rs
+++ b/crates/cubecl-std/src/tests/erased.rs
@@ -66,7 +66,7 @@ fn values(width: usize) -> Vec<f32> {
 /// Each kernel has to land the same bytes a direct copy would, so a wrong width
 /// or a store on the wrong element shows up as a mismatch rather than as a
 /// plausible-looking buffer.
-pub fn test_write_of_tensor<R: Runtime>(client: ComputeClient, width: usize) {
+pub fn test_write_of_tensor<R: Runtime>(client: Client, width: usize) {
     let input = values(width);
     let actual = launch_copy(&client, &input, width, Kernel::Write);
     assert_eq!(
@@ -75,19 +75,19 @@ pub fn test_write_of_tensor<R: Runtime>(client: ComputeClient, width: usize) {
     );
 }
 
-pub fn test_read_of_tensor<R: Runtime>(client: ComputeClient, width: usize) {
+pub fn test_read_of_tensor<R: Runtime>(client: Client, width: usize) {
     let input = values(width);
     let actual = launch_copy(&client, &input, width, Kernel::Read);
     assert_eq!(actual, input, "read through of_tensor at width {width}");
 }
 
-pub fn test_copy_erased<R: Runtime>(client: ComputeClient, width: usize) {
+pub fn test_copy_erased<R: Runtime>(client: Client, width: usize) {
     let input = values(width);
     let actual = launch_copy(&client, &input, width, Kernel::Copy);
     assert_eq!(actual, input, "read and write erased at width {width}");
 }
 
-pub fn test_len_is_in_lines<R: Runtime>(client: ComputeClient, width: usize) {
+pub fn test_len_is_in_lines<R: Runtime>(client: Client, width: usize) {
     let input = values(width);
 
     let handle_in = client.create_from_slice(f32::as_bytes(&input));
@@ -121,7 +121,7 @@ enum Kernel {
     Copy,
 }
 
-fn launch_copy(client: &ComputeClient, input: &[f32], width: usize, kernel: Kernel) -> Vec<f32> {
+fn launch_copy(client: &Client, input: &[f32], width: usize, kernel: Kernel) -> Vec<f32> {
     let lines = input.len() / width;
     let handle_in = client.create_from_slice(f32::as_bytes(input));
     let handle_out = client.empty(size_of_val(input));

--- a/crates/cubecl-std/src/tests/event.rs
+++ b/crates/cubecl-std/src/tests/event.rs
@@ -163,7 +163,7 @@ fn launch_test_3(output: &mut [f32]) {
     test_3(output);
 }
 
-pub fn event_test_1(client: ComputeClient) {
+pub fn event_test_1(client: Client) {
     let output = client.empty(8);
 
     unsafe {
@@ -181,7 +181,7 @@ pub fn event_test_1(client: ComputeClient) {
     assert_eq!(actual, &[20.0, 50.0]);
 }
 
-pub fn event_test_2(client: ComputeClient) {
+pub fn event_test_2(client: Client) {
     let output = client.empty(8);
 
     unsafe {
@@ -199,7 +199,7 @@ pub fn event_test_2(client: ComputeClient) {
     assert_eq!(actual, &[15.0, 30.0]);
 }
 
-pub fn event_test_3(client: ComputeClient) {
+pub fn event_test_3(client: Client) {
     let output = client.empty(12);
 
     unsafe {

--- a/crates/cubecl-std/src/tests/fp4.rs
+++ b/crates/cubecl-std/src/tests/fp4.rs
@@ -49,7 +49,7 @@ fn kernel_decode_packed<N: Size>(words: &[u32], out: &mut [Vector<f32, N>]) {
 ///
 /// No capability gate. The kernel names no 4-bit type — codes ride in `u32` and values in `f32` —
 /// which is exactly the property that lets a backend with no `e2m1` decode one.
-pub fn test_e2m1_codec_matches_host<R: Runtime>(client: ComputeClient) {
+pub fn test_e2m1_codec_matches_host<R: Runtime>(client: Client) {
     // Every code, then every code again under garbage upper bits: a caller may hand over an
     // unmasked field, and the decoder promises to ignore what is above the nibble.
     let codes: Vec<u32> = (0..16u32).chain((0..16u32).map(|c| c | 0xFFF0)).collect();
@@ -145,7 +145,7 @@ fn encode_inputs() -> Vec<f32> {
     values
 }
 
-fn launch_decode(client: &ComputeClient, codes: &[u32]) -> Vec<f32> {
+fn launch_decode(client: &Client, codes: &[u32]) -> Vec<f32> {
     let handle_in = client.create_from_slice(u32::as_bytes(codes));
     let handle_out = client.empty(size_of_val(codes));
 
@@ -166,7 +166,7 @@ fn launch_decode(client: &ComputeClient, codes: &[u32]) -> Vec<f32> {
     f32::from_bytes(&client.read_one_unchecked(handle_out)).to_vec()
 }
 
-fn launch_encode(client: &ComputeClient, values: &[f32]) -> Vec<u32> {
+fn launch_encode(client: &Client, values: &[f32]) -> Vec<u32> {
     let handle_in = client.create_from_slice(f32::as_bytes(values));
     let handle_out = client.empty(size_of_val(values));
 
@@ -187,7 +187,7 @@ fn launch_encode(client: &ComputeClient, values: &[f32]) -> Vec<u32> {
 }
 
 /// Returns two floats per word, the low nibble first.
-fn launch_decode_packed(client: &ComputeClient, words: &[u32]) -> Vec<f32> {
+fn launch_decode_packed(client: &Client, words: &[u32]) -> Vec<f32> {
     let lanes = 2;
     let handle_in = client.create_from_slice(u32::as_bytes(words));
     let handle_out = client.empty(words.len() * lanes * size_of::<f32>());

--- a/crates/cubecl-std/src/tests/reinterpret_slice.rs
+++ b/crates/cubecl-std/src/tests/reinterpret_slice.rs
@@ -11,7 +11,7 @@ fn kernel_read_global<N: Size>(input: &[Vector<i8, N>], output: &mut [f16]) {
     output[UNIT_POS as usize] = list.read(UNIT_POS as usize);
 }
 
-pub fn run_test_read_global<R: Runtime>(client: ComputeClient, vector_size: usize) {
+pub fn run_test_read_global<R: Runtime>(client: Client, vector_size: usize) {
     if !client.features().memory_reinterpret {
         return; // can't run test
     }
@@ -44,7 +44,7 @@ fn kernel_write_global<N: Size>(output: &mut [Vector<i8, N>], input: &[f16]) {
     list.write(UNIT_POS as usize, input[UNIT_POS as usize]);
 }
 
-pub fn run_test_write_global<R: Runtime>(client: ComputeClient, vector_size: usize) {
+pub fn run_test_write_global<R: Runtime>(client: Client, vector_size: usize) {
     if !client.features().memory_reinterpret {
         return; // can't run test
     }
@@ -87,7 +87,7 @@ fn kernel_read_shared_memory(output: &mut [f16]) {
     output[UNIT_POS as usize] = list.read(UNIT_POS as usize);
 }
 
-pub fn run_test_read_shared_memory<R: Runtime>(client: ComputeClient) {
+pub fn run_test_read_shared_memory<R: Runtime>(client: Client) {
     if !client.features().memory_reinterpret {
         return; // can't run test
     }
@@ -121,7 +121,7 @@ fn kernel_write_shared_memory<N: Size>(output: &mut [Vector<i8, N>], input: &[f1
     output[2 * unit_pos + 1] = mem[2 * unit_pos + 1];
 }
 
-pub fn run_test_write_shared_memory<R: Runtime>(client: ComputeClient) {
+pub fn run_test_write_shared_memory<R: Runtime>(client: Client) {
     if !client.features().memory_reinterpret {
         return; // can't run test
     }

--- a/crates/cubecl-std/src/tests/round.rs
+++ b/crates/cubecl-std/src/tests/round.rs
@@ -18,7 +18,7 @@ fn kernel_round_up<F: Float>(input: &[F], out: &mut [F], #[comptime] dtype: Scal
 ///
 /// No capability gate: the kernel is instantiated at `f32` and `dtype` only selects comptime
 /// constants, so the storage type is never named on device.
-pub fn test_round_up_matches_host<R: Runtime>(client: ComputeClient, dtype: ScaleDtype) {
+pub fn test_round_up_matches_host<R: Runtime>(client: Client, dtype: ScaleDtype) {
     // Reaches below every dtype's minimum normal, where the spacing stops halving. The low end
     // runs well past what the narrow dtypes need so that `ue8m0`, whose range reaches 2^-127,
     // is swept over more than its top few exponents.
@@ -57,7 +57,7 @@ pub fn test_round_up_matches_host<R: Runtime>(client: ComputeClient, dtype: Scal
     }
 }
 
-fn launch(client: &ComputeClient, scales: &[f32], dtype: ScaleDtype) -> Vec<f32> {
+fn launch(client: &Client, scales: &[f32], dtype: ScaleDtype) -> Vec<f32> {
     let handle_in = client.create_from_slice(f32::as_bytes(scales));
     let handle_out = client.empty(size_of_val(scales));
 

--- a/crates/cubecl-std/src/tests/trigonometry.rs
+++ b/crates/cubecl-std/src/tests/trigonometry.rs
@@ -12,7 +12,7 @@ fn kernel_to_degrees(input: &[f32], output: &mut [f32]) {
     }
 }
 
-pub fn test_to_degrees<R: Runtime>(client: ComputeClient) {
+pub fn test_to_degrees<R: Runtime>(client: Client) {
     let input_data = vec![0.0, PI / 6.0, PI / 4.0, PI / 2.0, PI, TAU];
     let expected = [0.0, 30.0, 45.0, 90.0, 180.0, 360.0];
 
@@ -50,7 +50,7 @@ fn kernel_to_radians(input: &[f32], output: &mut [f32]) {
     }
 }
 
-pub fn test_to_radians<R: Runtime>(client: ComputeClient) {
+pub fn test_to_radians<R: Runtime>(client: Client) {
     let input_data = vec![0.0, 30.0, 45.0, 90.0, 180.0, 360.0];
     let expected = [0.0, PI / 6.0, PI / 4.0, PI / 2.0, PI, TAU];
 

--- a/crates/cubecl-std/src/tests/view/quantized.rs
+++ b/crates/cubecl-std/src/tests/view/quantized.rs
@@ -73,7 +73,7 @@ pub fn kernel_quantized_view<F: Float, N: Size>(
 
 #[allow(clippy::needless_range_loop)]
 pub fn test_quantized_per_tensor_int<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     vector_size_values: VectorSize,
 ) {
     let vector_size_float = 8 * vector_size_values;
@@ -137,7 +137,7 @@ pub fn test_quantized_per_tensor_int<R: Runtime, F: Float + CubeElement>(
 
 #[allow(clippy::needless_range_loop)]
 pub fn test_quantized_per_tensor_fp4<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     vector_size_values: VectorSize,
 ) {
     if !client.properties().supports_type(e2m1x2::cube_type()) {
@@ -230,7 +230,7 @@ pub fn kernel_global_scale_quantized_view<F: Float, N: Size>(
 
 /// A [`KnownScale::Global`] register reconstructs exactly what the two-binding launch path does:
 /// block scales read per position, the per-tensor scale riding in the register.
-pub fn test_quantized_global_scale<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_quantized_global_scale<R: Runtime, F: Float + CubeElement>(client: Client) {
     let vector_size_float = 8;
     let block = 8;
 
@@ -294,7 +294,7 @@ pub fn kernel_whole_scale_quantized_view<F: Float, N: Size>(
 /// The whole-scale view reconstructs exactly what a per-value scale of the same value would: the
 /// scales buffer is filled with a number that would be wrong if it were read.
 pub fn test_quantized_whole_scale<R: Runtime, F: Float + CubeElement>(
-    client: ComputeClient,
+    client: Client,
     scheme: QuantScheme,
 ) {
     let vector_size_float = 8;
@@ -335,7 +335,7 @@ pub fn test_quantized_whole_scale<R: Runtime, F: Float + CubeElement>(
 ///
 /// Instantiated with a float narrower than the scales by
 /// [`test_quantized_two_level_narrow_float`], which is what makes the block scales overflow `F`.
-pub fn test_quantized_two_level_int<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_quantized_two_level_int<R: Runtime, F: Float + CubeElement>(client: Client) {
     // One block per load, since the view assumes a single scale covers a whole read.
     let vector_size_float = 8;
     let block = 8;
@@ -399,7 +399,7 @@ pub fn test_quantized_two_level_int<R: Runtime, F: Float + CubeElement>(client: 
     }
 }
 
-pub fn test_quantized_two_level_ue4m3<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_quantized_two_level_ue4m3<R: Runtime, F: Float + CubeElement>(client: Client) {
     let usage = client.properties().type_usage(e4m3::elem_type_native());
     if !usage.is_superset(TypeUsage::Conversion | TypeUsage::Buffer) {
         println!("Unsupported, skipping");
@@ -473,7 +473,7 @@ pub fn test_quantized_two_level_ue4m3<R: Runtime, F: Float + CubeElement>(client
 /// Hardcodes the float type because the runtimes that run without a GPU instantiate the generic
 /// tests with `f32`, which cannot observe that: both levels are stored as f32 to begin with, so a
 /// multiply in `F` and a multiply in f32 are the same operation.
-pub fn test_quantized_two_level_narrow_float<R: Runtime>(client: ComputeClient) {
+pub fn test_quantized_two_level_narrow_float<R: Runtime>(client: Client) {
     if !client.properties().supports_type(f16::cube_type()) {
         return;
     }
@@ -491,7 +491,7 @@ pub fn test_quantized_two_level_narrow_float<R: Runtime>(client: ComputeClient) 
 /// fell back to the integer cast would reconstruct the index itself and miss every entry.
 /// Every read method is exercised, since each one pairs the table with its own read of the
 /// values and scales.
-pub fn test_quantized_lookup<R: Runtime, F: Float + CubeElement>(client: ComputeClient) {
+pub fn test_quantized_lookup<R: Runtime, F: Float + CubeElement>(client: Client) {
     let vector_size_float = 8;
 
     let scheme = QuantScheme::default()

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -1,6 +1,6 @@
 use cubecl_core::ir::ElemType;
 use cubecl_runtime::{
-    client::ComputeClient,
+    client::Client,
     runtime::Runtime,
     server::CubeDim,
     throughput::{
@@ -49,7 +49,7 @@ pub fn device_throughput<R: Runtime>(
 /// first run and nothing afterwards.
 ///
 /// Native only, panics on WASM
-pub fn measure_memory_curve(client: &ComputeClient, access: MemoryAccess) -> MemoryCurve {
+pub fn measure_memory_curve(client: &Client, access: MemoryAccess) -> MemoryCurve {
     let points = sweep(client, access, |bytes| {
         ThroughputMode::Memory(MemorySpec::new(access, bytes))
     });
@@ -61,7 +61,7 @@ pub fn measure_memory_curve(client: &ComputeClient, access: MemoryAccess) -> Mem
 /// like the single-size probe, so a curve costs one probe per size on the
 /// first run and nothing afterwards.
 fn sweep(
-    client: &ComputeClient,
+    client: &Client,
     access: MemoryAccess,
     mode: impl Fn(u64) -> ThroughputMode,
 ) -> alloc::vec::Vec<MemoryPoint> {
@@ -80,7 +80,7 @@ fn sweep(
 
 /// The largest working set `access` can be probed at: the largest window one
 /// buffer holds, times the buffers the access touches.
-fn working_set_cap(client: &ComputeClient, access: MemoryAccess) -> u64 {
+fn working_set_cap(client: &Client, access: MemoryAccess) -> u64 {
     let max_alloc = client.properties().memory.max_page_size;
 
     memory_probe::window_cap(max_alloc) * access.buffers()
@@ -96,7 +96,7 @@ fn working_set_cap(client: &ComputeClient, access: MemoryAccess) -> u64 {
 /// no such operation, [`NoTiming`](ThroughputError::NoTiming) where it does
 /// and reported no elapsed time.
 pub fn measure_peak_throughput(
-    client: &ComputeClient,
+    client: &Client,
     key: ThroughputKey,
 ) -> Result<ThroughputValue, ThroughputError> {
     // A throughput probe is a measurement: inside a dry run its launches must
@@ -160,7 +160,7 @@ pub fn measure_peak_throughput(
 ///
 /// Measures compute and memory peak throughputs along with launch overhead for the runtime client.
 pub fn roofline_bounds(
-    client: &ComputeClient,
+    client: &Client,
     compute_key: ThroughputKey,
     work: Work,
     thresholds: Thresholds,
@@ -211,7 +211,7 @@ fn fastest_shape(
 ///
 /// `io_optimized_vector_sizes` is ordered for the loads and stores this probe
 /// issues none of, and its widest is not the fastest on every device.
-fn arithmetic_widths(client: &ComputeClient, dtype: ElemType) -> alloc::vec::Vec<usize> {
+fn arithmetic_widths(client: &Client, dtype: ElemType) -> alloc::vec::Vec<usize> {
     let widths: alloc::vec::Vec<usize> = client.io_optimized_vector_sizes(dtype.size()).collect();
 
     if widths.is_empty() {
@@ -225,7 +225,7 @@ fn arithmetic_widths(client: &ComputeClient, dtype: ElemType) -> alloc::vec::Vec
 ///
 /// A non-empty capability list says the device has tensor hardware, not this
 /// shape of it. `mma` is not consulted: the probe issues `cmma::execute`.
-fn implements_cmma(client: &ComputeClient, dtype: ElemType, config: ComputeCmmaConfig) -> bool {
+fn implements_cmma(client: &Client, dtype: ElemType, config: ComputeCmmaConfig) -> bool {
     client.properties().features.matmul.cmma.iter().any(|it| {
         it.a_type == dtype
             && it.b_type == dtype
@@ -250,7 +250,7 @@ pub struct LaunchConfig {
     pub plane_size: usize,
 }
 
-fn launch_config(client: &ComputeClient, dtype: ElemType) -> LaunchConfig {
+fn launch_config(client: &Client, dtype: ElemType) -> LaunchConfig {
     let hardware = &client.properties().hardware;
 
     let plane_size = hardware.plane_size_max.max(1);

--- a/crates/cubecl-std/src/throughput/runners/compute_cmma.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_cmma.rs
@@ -5,7 +5,7 @@ use cubecl_runtime::throughput::{CmmaDims, ComputeCmmaConfig, KernelConfig, Thro
 use crate::throughput::LaunchConfig;
 
 pub fn build_kernel(
-    client: &ComputeClient,
+    client: &Client,
     key: ThroughputKey,
     cmma_config: ComputeCmmaConfig,
     config: LaunchConfig,

--- a/crates/cubecl-std/src/throughput/runners/compute_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_direct.rs
@@ -4,11 +4,7 @@ use cubecl_runtime::throughput::{KernelConfig, ThroughputKey};
 
 use crate::throughput::LaunchConfig;
 
-pub fn build_kernel(
-    client: &ComputeClient,
-    key: ThroughputKey,
-    config: LaunchConfig,
-) -> KernelConfig {
+pub fn build_kernel(client: &Client, key: ThroughputKey, config: LaunchConfig) -> KernelConfig {
     let client = client.clone();
     let dtype = key.dtype();
 

--- a/crates/cubecl-std/src/throughput/runners/launch_overhead.rs
+++ b/crates/cubecl-std/src/throughput/runners/launch_overhead.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 use cubecl_core as cubecl;
 
 pub fn build_kernel(
-    client: &cubecl_runtime::client::ComputeClient,
+    client: &cubecl_runtime::client::Client,
     _key: cubecl_runtime::throughput::ThroughputKey,
     _config: super::super::LaunchConfig,
 ) -> cubecl_runtime::throughput::KernelConfig {

--- a/crates/cubecl-std/src/throughput/runners/memory_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_direct.rs
@@ -10,7 +10,7 @@ use crate::throughput::{
 /// Builds the copy kernel, moving `working_set` bytes per pass: half read out
 /// of the input buffer, half written into the output one.
 pub fn build_kernel(
-    client: &ComputeClient,
+    client: &Client,
     key: ThroughputKey,
     config: LaunchConfig,
     spec: MemorySpec,

--- a/crates/cubecl-std/src/throughput/runners/memory_probe.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_probe.rs
@@ -92,12 +92,7 @@ impl MemoryProbe {
     /// serves it. A coalesced launch spreads one cube position's addresses
     /// across the full window regardless of cube count, so it has no such
     /// limit.
-    pub fn new(
-        client: &ComputeClient,
-        config: LaunchConfig,
-        line_bytes: usize,
-        spec: MemorySpec,
-    ) -> Self {
+    pub fn new(client: &Client, config: LaunchConfig, line_bytes: usize, spec: MemorySpec) -> Self {
         let blocked = config.plane_size == 1;
         let shape = DeviceShape {
             max_alloc: client.properties().memory.max_page_size as usize,
@@ -148,7 +143,7 @@ impl MemoryProbe {
 /// gives each line its own page, the way a buffer a real kernel reads
 /// already got one from whoever produced it.
 pub fn prime(
-    client: &ComputeClient,
+    client: &Client,
     handle: &Handle,
     pool_lines: usize,
     config: LaunchConfig,

--- a/crates/cubecl-std/src/throughput/runners/memory_read.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_read.rs
@@ -23,7 +23,7 @@ use crate::throughput::{
 /// hundreds of megabytes read that is not worth counting and is deliberately
 /// left out of `ops_count` rather than approximated.
 pub fn build_kernel(
-    client: &ComputeClient,
+    client: &Client,
     key: ThroughputKey,
     config: LaunchConfig,
     spec: MemorySpec,

--- a/crates/cubecl-std/src/throughput/runners/memory_write.rs
+++ b/crates/cubecl-std/src/throughput/runners/memory_write.rs
@@ -17,7 +17,7 @@ use crate::throughput::{LaunchConfig, memory_probe::MemoryProbe};
 ///
 /// Reported `ops_count` is the write count alone.
 pub fn build_kernel(
-    client: &ComputeClient,
+    client: &Client,
     key: ThroughputKey,
     config: LaunchConfig,
     spec: MemorySpec,

--- a/crates/cubecl-wgpu/examples/graph_bench.rs
+++ b/crates/cubecl-wgpu/examples/graph_bench.rs
@@ -123,7 +123,7 @@ fn main() {
     }
 }
 
-fn bench(client: &ComputeClient, config: &Config) {
+fn bench(client: &Client, config: &Config) {
     let a = client.create_from_slice(f32::as_bytes(&vec![0.0f32; config.elems]));
     let b = client.create_from_slice(f32::as_bytes(&vec![0.0f32; config.elems]));
 
@@ -191,7 +191,7 @@ impl Measure {
     }
 }
 
-fn run_pass(client: &ComputeClient, a: &Handle, b: &Handle, config: &Config) {
+fn run_pass(client: &Client, a: &Handle, b: &Handle, config: &Config) {
     let cubes = config.elems.div_ceil(CUBE_DIM as usize) as u32;
     for i in 0..config.kernels {
         let (src, dst) = if i % 2 == 0 { (a, b) } else { (b, a) };
@@ -207,7 +207,7 @@ fn run_pass(client: &ComputeClient, a: &Handle, b: &Handle, config: &Config) {
     }
 }
 
-fn sync(client: &ComputeClient, handle: &Handle) {
+fn sync(client: &Client, handle: &Handle) {
     let _ = client.read_one(handle.clone()).unwrap();
 }
 

--- a/crates/cubecl-wgpu/src/backend/vulkan.rs
+++ b/crates/cubecl-wgpu/src/backend/vulkan.rs
@@ -10,7 +10,7 @@ use cubecl_core::{
     MemoryConfiguration, WgpuCompilationOptions,
     ir::{AddressType, ElemType, FloatKind, IntKind, UIntKind},
     prelude::{CompiledKernel, CubeKernel, KernelDefinition, Visibility},
-    server::{ComputeServer, IoError, KernelArguments},
+    server::{IoError, KernelArguments, Server},
 };
 use cubecl_environment::backtrace::BackTrace;
 use cubecl_ir::{DeviceProperties, Type, features::*};

--- a/crates/cubecl-wgpu/src/compute/schedule.rs
+++ b/crates/cubecl-wgpu/src/compute/schedule.rs
@@ -92,7 +92,7 @@ pub struct WgpuStreamFactory {
     count: u64,
     use_vulkan_compiler: bool,
     /// Programmatic main-GPU pool layout (see
-    /// [`ComputeServer::install_memory_pools`](cubecl_runtime::server::ComputeServer::install_memory_pools)):
+    /// [`Server::install_memory_pools`](cubecl_runtime::server::Server::install_memory_pools)):
     /// streams created after it is set build their main pool from it instead
     /// of the runtime default. Auxiliary pools are unaffected.
     gpu_pools_override: Option<MemoryConfiguration>,

--- a/crates/cubecl-wgpu/src/compute/server.rs
+++ b/crates/cubecl-wgpu/src/compute/server.rs
@@ -44,7 +44,7 @@ use cubecl_runtime::{
     kernel::CubeKernel,
     logging::ServerLogger,
     memory_management::MemoryAllocationMode,
-    server::ComputeServer,
+    server::Server,
     storage::ManagedResource,
     stream::scheduler::{
         SchedulerMultiStream, SchedulerMultiStreamOptions, SchedulerStrategy,
@@ -319,7 +319,7 @@ impl<C: WgpuCompiler> WgpuServer<C> {
     }
 }
 
-impl<C: WgpuCompiler> ComputeServer for WgpuServer<C> {
+impl<C: WgpuCompiler> Server for WgpuServer<C> {
     fn logger(&self) -> Arc<ServerLogger> {
         self.scheduler.logger.clone()
     }

--- a/crates/cubecl-wgpu/src/lib.rs
+++ b/crates/cubecl-wgpu/src/lib.rs
@@ -142,7 +142,7 @@ fn double(@builtin(global_invocation_id) id: vec3<u32>) {
             }
         }
 
-        fn assert_rejected(client: &ComputeClient, out: Handle) {
+        fn assert_rejected(client: &Client, out: Handle) {
             let err = client
                 .read_one(out)
                 .expect_err("two fp8 lanes have no WGSL representation, the launch must fail")

--- a/crates/cubecl-wgpu/src/runtime.rs
+++ b/crates/cubecl-wgpu/src/runtime.rs
@@ -18,7 +18,7 @@ use cubecl_runtime::allocator::ContiguousMemoryLayoutPolicy;
 use cubecl_runtime::logging::ProfileLevel;
 pub use cubecl_runtime::memory_management::MemoryConfiguration;
 use cubecl_runtime::runtime::Runtime;
-use cubecl_runtime::{client::ComputeClient, logging::ServerLogger};
+use cubecl_runtime::{client::Client, logging::ServerLogger};
 use wgpu::{InstanceFlags, RequestAdapterOptions};
 
 /// Runtime that uses the [wgpu] crate with the wgsl compiler. This is used in the Wgpu backend.
@@ -226,7 +226,7 @@ pub fn init_device(setup: WgpuSetup, options: RuntimeOptions) -> WgpuDevice {
 
     let device_id = WgpuDevice::Existing(device_id);
     let server = create_server::<AutoCompiler>(setup, options, device_id.to_id());
-    let _ = ComputeClient::init(device_id.to_id(), server);
+    let _ = Client::init(device_id.to_id(), server);
     device_id
 }
 
@@ -258,7 +258,7 @@ pub async fn init_setup_async<G: GraphicsApi>(
     let setup = create_setup_for_device(device, G::backend()).await;
     let return_setup = setup.clone();
     let server = create_server::<AutoCompiler>(setup, options, device.to_id());
-    let _ = ComputeClient::init(device.to_id(), server);
+    let _ = Client::init(device.to_id(), server);
     return_setup
 }
 

--- a/crates/cubecl-wgpu/tests/graph.rs
+++ b/crates/cubecl-wgpu/tests/graph.rs
@@ -60,7 +60,7 @@ fn wgpu_graph_capture_replay() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -108,7 +108,7 @@ fn wgpu_graph_mid_capture_allocation_is_allowed() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -153,7 +153,7 @@ fn wgpu_graph_input_rewrite() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -210,7 +210,7 @@ fn wgpu_graph_intermediate_recycling() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(bytes);
 
-    let run = |client: &ComputeClient, tmp: &Handle| {
+    let run = |client: &Client, tmp: &Handle| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -299,7 +299,7 @@ fn wgpu_graph_many_launches_dynamic_metadata() {
 
     // One pass: ping-pong `dst = src + 1` between `a` and `b`. The identical
     // sequence is run once as warmup and once recorded.
-    fn run_pass(client: &ComputeClient, a: &Handle, b: &Handle) {
+    fn run_pass(client: &Client, a: &Handle, b: &Handle) {
         for i in 0..PASS_LAUNCHES {
             let (src, dst) = if i % 2 == 0 { (a, b) } else { (b, a) };
             add_one_tensor::launch(
@@ -415,7 +415,7 @@ fn wgpu_graph_lifecycle_state_errors() {
     let n = 4usize;
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -446,7 +446,7 @@ fn wgpu_graph_read_rejected_while_recording() {
     let n = 4usize;
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -485,7 +485,7 @@ fn wgpu_graph_write_rejected_while_recording() {
     let n = 4usize;
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -553,7 +553,7 @@ fn wgpu_graph_write_rejected_while_recording_is_not_read_as_written() {
             client.empty(n * core::mem::size_of::<f32>()),
         )
     });
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -621,7 +621,7 @@ fn wgpu_graph_destroy_leaves_an_enqueued_replay_intact() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(bytes);
 
-    let run = |client: &ComputeClient, tmp: &Handle| {
+    let run = |client: &Client, tmp: &Handle| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -700,7 +700,7 @@ fn wgpu_graph_a_capture_that_never_sealed_is_not_read_as_run() {
             client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0])),
         )
     });
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -774,7 +774,7 @@ fn wgpu_graph_capture_is_sealed_by_the_stream_that_opened_it() {
         )
     });
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -835,7 +835,7 @@ fn wgpu_graph_capture_is_isolated_from_another_stream() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -957,7 +957,7 @@ fn wgpu_graph_a_prepared_capture_that_never_opened_is_disarmed_by_end() {
     let n = 4usize;
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),
@@ -1040,7 +1040,7 @@ fn wgpu_graph_replay_settles_after_a_failed_enqueue() {
     let input = client.create_from_slice(f32::as_bytes(&[1.0, 2.0, 3.0, 4.0]));
     let output = client.empty(n * core::mem::size_of::<f32>());
 
-    let launch = |client: &ComputeClient| {
+    let launch = |client: &Client| {
         add_one::launch(
             client,
             CubeCount::Static(1, 1, 1),

--- a/crates/cubecl/src/lib.rs
+++ b/crates/cubecl/src/lib.rs
@@ -1,12 +1,13 @@
 pub use cubecl_core::*;
 
-use cubecl_core::client::ComputeClient;
+use cubecl_core::client::Client;
 #[cfg(any(
     feature = "cuda",
     feature = "hip",
     feature = "metal-native",
     feature = "wgpu",
-    feature = "cpu"
+    feature = "cpu",
+    test_runtime_default
 ))]
 use cubecl_runtime::runtime::Runtime;
 
@@ -75,7 +76,7 @@ pub use cubecl_runtime::logging;
 /// A device of any runtime this build enables.
 ///
 /// Each runtime has its own device type, and until now the only way to reach a
-/// [`ComputeClient`] was through the runtime, `R::client(&device)`. This enum
+/// [`Client`] was through the runtime, `R::client(&device)`. This enum
 /// is the runtime-independent way: a value names both the runtime and the
 /// device on it, and [`client`](Device::client) hands back the client for it.
 ///
@@ -107,7 +108,7 @@ pub enum Device {
     #[cfg(feature = "metal-native")]
     Metal(cubecl_metal::MetalDevice),
     /// A device of the wgpu runtime, on its default compiler.
-    #[cfg(feature = "wgpu")]
+    #[cfg(any(feature = "wgpu", test_runtime_default))]
     Wgpu(cubecl_wgpu::WgpuDevice),
     /// The device of the CPU runtime.
     #[cfg(feature = "cpu")]
@@ -116,7 +117,7 @@ pub enum Device {
 
 impl Device {
     /// The compute client of this device, initialized on first use.
-    pub fn client(&self) -> ComputeClient {
+    pub fn client(&self) -> Client {
         match *self {
             #[cfg(feature = "cuda")]
             Self::Cuda(ref device) => cubecl_cuda::CudaRuntime::client(device),
@@ -124,7 +125,7 @@ impl Device {
             Self::Hip(ref device) => cubecl_hip::HipRuntime::client(device),
             #[cfg(feature = "metal-native")]
             Self::Metal(ref device) => cubecl_metal::MetalRuntime::client(device),
-            #[cfg(feature = "wgpu")]
+            #[cfg(any(feature = "wgpu", test_runtime_default))]
             Self::Wgpu(ref device) => <cubecl_wgpu::WgpuRuntime>::client(device),
             #[cfg(feature = "cpu")]
             Self::Cpu(ref device) => cubecl_cpu::CpuRuntime::client(device),
@@ -153,7 +154,7 @@ impl From<cubecl_metal::MetalDevice> for Device {
     }
 }
 
-#[cfg(feature = "wgpu")]
+#[cfg(any(feature = "wgpu", test_runtime_default))]
 impl From<cubecl_wgpu::WgpuDevice> for Device {
     fn from(device: cubecl_wgpu::WgpuDevice) -> Self {
         Self::Wgpu(device)
@@ -202,3 +203,47 @@ pub type TestRuntime = hip::HipRuntime;
 
 #[cfg(test_runtime_metal)]
 pub type TestRuntime = metal::MetalRuntime;
+
+/// The [`Device`] of [`TestRuntime`], the runtime this build tests on.
+///
+/// A test reaches its client through [`Device::client`] like any other caller,
+/// which is what keeps it from naming a runtime — or the [`Runtime`] trait —
+/// to get one.
+///
+/// ```no_run
+/// let client = cubecl::test_device().client();
+/// ```
+#[cfg(test_runtime_default)]
+pub fn test_device() -> Device {
+    Device::Wgpu(Default::default())
+}
+
+/// The [`Device`] of [`TestRuntime`], the runtime this build tests on.
+#[cfg(test_runtime_wgpu)]
+pub fn test_device() -> Device {
+    Device::Wgpu(Default::default())
+}
+
+/// The [`Device`] of [`TestRuntime`], the runtime this build tests on.
+#[cfg(test_runtime_cpu)]
+pub fn test_device() -> Device {
+    Device::Cpu(Default::default())
+}
+
+/// The [`Device`] of [`TestRuntime`], the runtime this build tests on.
+#[cfg(test_runtime_cuda)]
+pub fn test_device() -> Device {
+    Device::Cuda(Default::default())
+}
+
+/// The [`Device`] of [`TestRuntime`], the runtime this build tests on.
+#[cfg(test_runtime_hip)]
+pub fn test_device() -> Device {
+    Device::Hip(Default::default())
+}
+
+/// The [`Device`] of [`TestRuntime`], the runtime this build tests on.
+#[cfg(test_runtime_metal)]
+pub fn test_device() -> Device {
+    Device::Metal(Default::default())
+}

--- a/cubecl-book/src/advanced-usage/config.md
+++ b/cubecl-book/src/advanced-usage/config.md
@@ -136,7 +136,7 @@ The `[memory]` section controls memory-related logging and the persistent-memory
 such as model weights.
 
 - `enabled` (default): used only when explicitly requested (e.g.
-  `ComputeClient::memory_persistent_allocation`).
+  `Client::memory_persistent_allocation`).
 - `disabled`: requests to switch to persistent allocation are ignored.
 - `enforced`: every allocation is persistent. May cause out-of-memory errors when tensor sizes
   vary.

--- a/cubecl-book/src/getting-started/simple_reduction.md
+++ b/cubecl-book/src/getting-started/simple_reduction.md
@@ -29,7 +29,7 @@ This example demonstrates how to perform a simple reduction operation on a multi
 ## GpuTensor struct
 The `GpuTensor` struct is a representation of a tensor that resides on the GPU. It contains the data handle, shape, strides, and marker types for the runtime and floating-point type. The `GpuTensor` struct provides methods to create tensors, read data from the GPU, and convert them into tensor arguments for kernel execution. Please note that it is generic over the runtime and floating-point type, allowing it to work with different CubeCL runtimes and floating-point types (e.g., `f16`, `f32`). Also, the strides can be computed using the `compact_strides` function from the `cubecl::std::tensor` module, which will compute the strides for a given shape with a compact representation.
 
-Another important concept is the `ComputeClient` trait, which define what a runtime should implement to be able to run kernels. Each runtime has their own implementation of the `ComputeClient` trait, which provides methods to create tensors and read data from the GPU. The `ComputeClient` can send compute task to a `Server` that will run the kernel on the GPU and schedule the tasks.
+Another important concept is the `Client` trait, which define what a runtime should implement to be able to run kernels. Each runtime has their own implementation of the `Client` trait, which provides methods to create tensors and read data from the GPU. The `Client` can send compute task to a `Server` that will run the kernel on the GPU and schedule the tasks.
 
 ```rust,ignore
 {{#include src/gpu_tensor.rs:0:1}}

--- a/cubecl-book/src/getting-started/src/bin/v3-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v3-gpu.rs
@@ -6,7 +6,7 @@ use cubecl_example::gpu_tensor::GpuTensor; // Change to the path of your own mod
 
 pub struct ReductionBench<R: Runtime, F: Float + CubeElement> {
     input_shape: Vec<usize>,
-    client: ComputeClient,
+    client: Client,
     _f: PhantomData<F>,
 }
 

--- a/cubecl-book/src/getting-started/src/bin/v4-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v4-gpu.rs
@@ -6,7 +6,7 @@ use cubecl_example::gpu_tensor::GpuTensor; // Change to the path of your own mod
 
 pub struct ReductionBench<R: Runtime, F: Float + CubeElement> {
     input_shape: Vec<usize>,
-    client: ComputeClient,
+    client: Client,
     _f: PhantomData<F>,
 }
 

--- a/cubecl-book/src/getting-started/src/bin/v5-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v5-gpu.rs
@@ -6,7 +6,7 @@ use cubecl_example::gpu_tensor::GpuTensor; // Change to the path of your own mod
 
 pub struct ReductionBench<R: Runtime, F: Float + CubeElement> {
     input_shape: Vec<usize>,
-    client: ComputeClient,
+    client: Client,
     _f: PhantomData<F>,
 }
 

--- a/cubecl-book/src/getting-started/src/bin/v6-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v6-gpu.rs
@@ -6,7 +6,7 @@ use cubecl_example::gpu_tensor::GpuTensor; // Change to the path of your own mod
 
 pub struct ReductionBench<R: Runtime, F: Float + CubeElement> {
     input_shape: Vec<usize>,
-    client: ComputeClient,
+    client: Client,
     _f: PhantomData<F>,
 }
 

--- a/cubecl-book/src/getting-started/src/bin/v7-gpu.rs
+++ b/cubecl-book/src/getting-started/src/bin/v7-gpu.rs
@@ -6,7 +6,7 @@ use cubecl_example::gpu_tensor::GpuTensor; // Change to the path of your own mod
 
 pub struct ReductionBench<R: Runtime, F: Float + CubeElement> {
     input_shape: Vec<usize>,
-    client: ComputeClient,
+    client: Client,
     _f: PhantomData<F>,
 }
 

--- a/cubecl-book/src/getting-started/src/gpu_tensor.rs
+++ b/cubecl-book/src/getting-started/src/gpu_tensor.rs
@@ -26,7 +26,7 @@ impl<R: Runtime, F: Float + CubeElement> Clone for GpuTensor<R, F> {
 
 impl<R: Runtime, F: Float + CubeElement> GpuTensor<R, F> {
     /// Create a GpuTensor with a shape filled by number in order
-    pub fn arange(shape: Vec<usize>, client: &ComputeClient) -> Self {
+    pub fn arange(shape: Vec<usize>, client: &Client) -> Self {
         let size = shape.iter().product();
         let data: Vec<F> = (0..size).map(|i| F::from_int(i as i64)).collect();
         let data = client.create(F::as_bytes(&data));
@@ -42,7 +42,7 @@ impl<R: Runtime, F: Float + CubeElement> GpuTensor<R, F> {
     }
 
     /// Create an empty GpuTensor with a shape
-    pub fn empty(shape: Vec<usize>, client: &ComputeClient) -> Self {
+    pub fn empty(shape: Vec<usize>, client: &Client) -> Self {
         let size = shape.iter().product::<usize>() * core::mem::size_of::<F>();
         let data = client.empty(size);
 
@@ -64,7 +64,7 @@ impl<R: Runtime, F: Float + CubeElement> GpuTensor<R, F> {
     }
 
     /// Return the data from the client
-    pub fn read(self, client: &ComputeClient) -> Vec<F> {
+    pub fn read(self, client: &Client) -> Vec<F> {
         let bytes = client.read_one(self.data.binding());
         F::from_bytes(&bytes).to_vec()
     }

--- a/examples/sum_things/src/lib.rs
+++ b/examples/sum_things/src/lib.rs
@@ -99,7 +99,7 @@ impl<K: SumKind> CreateSeries for SumThenMul<K> {
     }
 }
 
-fn launch_basic(client: &ComputeClient, input: Handle, output: Handle, len: usize) {
+fn launch_basic(client: &Client, input: Handle, output: Handle, len: usize) {
     unsafe {
         sum_basic::launch_unchecked::<f32>(
             client,
@@ -112,7 +112,7 @@ fn launch_basic(client: &ComputeClient, input: Handle, output: Handle, len: usiz
     }
 }
 
-fn launch_subgroup(client: &ComputeClient, input: Handle, output: Handle, len: usize) {
+fn launch_subgroup(client: &Client, input: Handle, output: Handle, len: usize) {
     unsafe {
         sum_subgroup::launch_unchecked::<f32>(
             client,
@@ -126,7 +126,7 @@ fn launch_subgroup(client: &ComputeClient, input: Handle, output: Handle, len: u
     }
 }
 
-fn launch_trait<K: SumKind>(client: &ComputeClient, input: Handle, output: Handle, len: usize) {
+fn launch_trait<K: SumKind>(client: &Client, input: Handle, output: Handle, len: usize) {
     unsafe {
         sum_trait::launch_unchecked::<f32, K>(
             client,
@@ -139,12 +139,7 @@ fn launch_trait<K: SumKind>(client: &ComputeClient, input: Handle, output: Handl
     }
 }
 
-fn launch_series<S: CreateSeries>(
-    client: &ComputeClient,
-    input: Handle,
-    output: Handle,
-    len: usize,
-) {
+fn launch_series<S: CreateSeries>(client: &Client, input: Handle, output: Handle, len: usize) {
     unsafe {
         series::launch_unchecked::<f32, S>(
             client,

--- a/examples/throughput/src/lib.rs
+++ b/examples/throughput/src/lib.rs
@@ -1,7 +1,7 @@
 use cubecl::{
     Device,
     ir::{ElemType, FloatKind},
-    prelude::ComputeClient,
+    prelude::Client,
     std::throughput::{measure_memory_curve, measure_peak_throughput},
     throughput::{
         CmmaDims, ComputeCmmaConfig, MemoryAccess, MemoryCurve, ThroughputError, ThroughputKey,
@@ -125,7 +125,7 @@ struct Row {
     key: Option<ThroughputKey>,
 }
 
-fn report(device: &Device, rows: impl FnOnce(&ComputeClient) -> Vec<Row>) {
+fn report(device: &Device, rows: impl FnOnce(&Client) -> Vec<Row>) {
     let client = device.client();
 
     println!(
@@ -147,7 +147,7 @@ fn report(device: &Device, rows: impl FnOnce(&ComputeClient) -> Vec<Row>) {
     }
 }
 
-fn compute_direct_rows(client: &ComputeClient) -> Vec<Row> {
+fn compute_direct_rows(client: &Client) -> Vec<Row> {
     [FloatKind::F32, FloatKind::F16, FloatKind::BF16]
         .into_iter()
         .map(|kind| {
@@ -169,7 +169,7 @@ fn compute_direct_rows(client: &ComputeClient) -> Vec<Row> {
 ///
 /// Consumer parts halve their tensor rate for f32 accumulation, which is the
 /// one a matmul runs on.
-fn compute_cmma_rows(client: &ComputeClient) -> Vec<Row> {
+fn compute_cmma_rows(client: &Client) -> Vec<Row> {
     let dtype = ElemType::Float(FloatKind::F16);
 
     [FloatKind::F16, FloatKind::F32]
@@ -207,11 +207,7 @@ fn compute_cmma_rows(client: &ComputeClient) -> Vec<Row> {
 ///
 /// Read from `cmma` rather than through `select_cmma_tile`, which answers from
 /// `mma` as well: a shape only that instruction has does not run here.
-fn largest_cmma(
-    client: &ComputeClient,
-    dtype: ElemType,
-    accumulator_type: ElemType,
-) -> Option<CmmaDims> {
+fn largest_cmma(client: &Client, dtype: ElemType, accumulator_type: ElemType) -> Option<CmmaDims> {
     client
         .properties()
         .features


### PR DESCRIPTION
Also give consumers a runtime-free way to reach a test client: `test_device()` returns the `Device` of `TestRuntime`, so a test goes through `Device::client` instead of the `Runtime` trait, which the runtime erasure no longer exports. The wgpu arms of `Device` are gated on the `test-runtime` fallback as well as the `wgpu` feature, since that fallback compiles the backend in either way.