### PR TITLE
feat(device): make `Device` a device in its own right

### DIFF
--- a/crates/cubecl/build.rs
+++ b/crates/cubecl/build.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 fn main() {
     let enable_runtime = cfg!(feature = "test-runtime");
 
+    println!("cargo:rustc-check-cfg=cfg(any_runtime)");
     println!("cargo:rustc-check-cfg=cfg(test_runtime_default)");
     println!("cargo:rustc-check-cfg=cfg(test_runtime_cpu)");
     println!("cargo:rustc-check-cfg=cfg(test_runtime_cuda)");
@@ -10,21 +11,28 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(test_runtime_metal)");
     println!("cargo:rustc-check-cfg=cfg(test_runtime_wgpu)");
 
+    let map = BTreeMap::from([
+        ("cpu", cfg!(feature = "cpu")),
+        ("cuda", cfg!(feature = "cuda")),
+        ("hip", cfg!(feature = "hip")),
+        ("metal", cfg!(feature = "metal-native")),
+        ("wgpu", cfg!(feature = "wgpu")),
+    ]);
+
+    let enabled_features = map
+        .iter()
+        .filter(|(_, enabled)| **enabled)
+        .map(|(k, _)| *k)
+        .collect::<Vec<_>>();
+
+    // Whether this build has a runtime to reach at all. `Device` and everything
+    // behind it are conditional on this, rather than each item repeating the
+    // list of runtime features. `test-runtime` falls back to wgpu, so it counts.
+    if enable_runtime || !enabled_features.is_empty() {
+        println!("cargo:rustc-cfg=any_runtime");
+    }
+
     if enable_runtime {
-        let map = BTreeMap::from([
-            ("cpu", cfg!(feature = "cpu")),
-            ("cuda", cfg!(feature = "cuda")),
-            ("hip", cfg!(feature = "hip")),
-            ("metal", cfg!(feature = "metal-native")),
-            ("wgpu", cfg!(feature = "wgpu")),
-        ]);
-
-        let enabled_features = map
-            .iter()
-            .filter(|(_, enabled)| **enabled)
-            .map(|(k, _)| *k)
-            .collect::<Vec<_>>();
-
         if enabled_features.is_empty() || enabled_features.len() > 1 {
             println!("cargo:rustc-cfg=test_runtime_default");
         } else {

--- a/crates/cubecl/src/lib.rs
+++ b/crates/cubecl/src/lib.rs
@@ -1,14 +1,11 @@
+extern crate alloc;
+
 pub use cubecl_core::*;
 
 use cubecl_core::client::Client;
-#[cfg(any(
-    feature = "cuda",
-    feature = "hip",
-    feature = "metal-native",
-    feature = "wgpu",
-    feature = "cpu",
-    test_runtime_default
-))]
+#[cfg(any_runtime)]
+use cubecl_core::device::{Device as DeviceIdentity, DeviceId};
+#[cfg(any_runtime)]
 use cubecl_runtime::runtime::Runtime;
 
 pub use cubecl_ir::features;
@@ -115,6 +112,168 @@ pub enum Device {
     Cpu(cubecl_cpu::CpuDevice),
 }
 
+/// Which runtime a [`Device`] belongs to.
+///
+/// The discriminants are fixed per runtime rather than assigned by whichever
+/// runtimes a build enables, so a [`DeviceId`] means the same thing in every
+/// build that can read it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum RuntimeId {
+    /// The CUDA runtime.
+    Cuda = 0,
+    /// The HIP runtime.
+    Hip = 1,
+    /// The native Metal runtime.
+    Metal = 2,
+    /// The wgpu runtime.
+    Wgpu = 3,
+    /// The CPU runtime.
+    Cpu = 4,
+}
+
+/// A runtime's own device types get the low five bits of a [`DeviceId`]'s type
+/// id, the runtime itself the three above them. That split is what lets one id
+/// name a device across every runtime, and it stays inside one byte on purpose:
+/// a caller that nests these ids in an encoding of its own — burn's dispatch
+/// backend does — still has the high byte to spend.
+///
+/// Five bits is room for 32 device types per runtime, against the six the
+/// widest runtime here declares.
+#[cfg(any_runtime)]
+const RUNTIME_TYPE_ID_MASK: u16 = 0x001F;
+#[cfg(any_runtime)]
+const RUNTIME_TYPE_ID_SHIFT: u32 = 5;
+
+impl TryFrom<u16> for RuntimeId {
+    type Error = u16;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Cuda),
+            1 => Ok(Self::Hip),
+            2 => Ok(Self::Metal),
+            3 => Ok(Self::Wgpu),
+            4 => Ok(Self::Cpu),
+            other => Err(other),
+        }
+    }
+}
+
+impl Device {
+    /// Whether a tensor with `shape` and `strides` can be read as it lies, or
+    /// has to be made contiguous first. A property of the runtime, which is why
+    /// it is asked of the device rather than of the client.
+    #[cfg(any_runtime)]
+    pub fn can_read_tensor(
+        &self,
+        shape: &cubecl_core::zspace::Shape,
+        strides: &cubecl_core::zspace::Strides,
+    ) -> bool {
+        match *self {
+            #[cfg(feature = "cuda")]
+            Self::Cuda(_) => cubecl_cuda::CudaRuntime::can_read_tensor(shape, strides),
+            #[cfg(feature = "hip")]
+            Self::Hip(_) => cubecl_hip::HipRuntime::can_read_tensor(shape, strides),
+            #[cfg(feature = "metal-native")]
+            Self::Metal(_) => cubecl_metal::MetalRuntime::can_read_tensor(shape, strides),
+            #[cfg(any(feature = "wgpu", test_runtime_default))]
+            Self::Wgpu(_) => <cubecl_wgpu::WgpuRuntime>::can_read_tensor(shape, strides),
+            #[cfg(feature = "cpu")]
+            Self::Cpu(_) => cubecl_cpu::CpuRuntime::can_read_tensor(shape, strides),
+        }
+    }
+
+    /// The ids of every device sharing `device_id`'s runtime and device type.
+    ///
+    /// Takes and returns ids in [`Device`]'s own encoding, so a caller holding
+    /// one id can ask what else is on that device's runtime without unpacking
+    /// the runtime itself.
+    #[cfg(any_runtime)]
+    pub fn enumerate(device_id: DeviceId) -> alloc::vec::Vec<DeviceId> {
+        let runtime = RuntimeId::try_from(device_id.type_id >> RUNTIME_TYPE_ID_SHIFT);
+        let type_id = device_id.type_id & RUNTIME_TYPE_ID_MASK;
+
+        let ids = match runtime {
+            #[cfg(feature = "cuda")]
+            Ok(RuntimeId::Cuda) => cubecl_cuda::CudaRuntime::enumerate_devices(type_id),
+            #[cfg(feature = "hip")]
+            Ok(RuntimeId::Hip) => cubecl_hip::HipRuntime::enumerate_devices(type_id),
+            #[cfg(feature = "metal-native")]
+            Ok(RuntimeId::Metal) => cubecl_metal::MetalRuntime::enumerate_devices(type_id),
+            #[cfg(any(feature = "wgpu", test_runtime_default))]
+            Ok(RuntimeId::Wgpu) => <cubecl_wgpu::WgpuRuntime>::enumerate_devices(type_id),
+            #[cfg(feature = "cpu")]
+            Ok(RuntimeId::Cpu) => cubecl_cpu::CpuRuntime::enumerate_devices(type_id),
+            _ => alloc::vec::Vec::new(),
+        };
+
+        let tag = device_id.type_id & !RUNTIME_TYPE_ID_MASK;
+        ids.into_iter()
+            .map(|id| DeviceId::new(tag | (id.type_id & RUNTIME_TYPE_ID_MASK), id.index_id))
+            .collect()
+    }
+
+    /// Every device of every runtime this build enables.
+    ///
+    /// What a caller listing "the devices" wants, now that one type covers them
+    /// all — a runtime with no hardware present contributes nothing.
+    #[cfg(any_runtime)]
+    pub fn enumerate_all() -> alloc::vec::Vec<Self> {
+        #[allow(unused_mut)]
+        let mut devices = alloc::vec::Vec::new();
+
+        #[cfg(feature = "cuda")]
+        devices.extend(
+            cubecl_cuda::CudaRuntime::enumerate_all_devices()
+                .into_iter()
+                .map(|id| Self::Cuda(DeviceIdentity::from_id(id))),
+        );
+        #[cfg(feature = "hip")]
+        devices.extend(
+            cubecl_hip::HipRuntime::enumerate_all_devices()
+                .into_iter()
+                .map(|id| Self::Hip(DeviceIdentity::from_id(id))),
+        );
+        #[cfg(feature = "metal-native")]
+        devices.extend(
+            cubecl_metal::MetalRuntime::enumerate_all_devices()
+                .into_iter()
+                .map(|id| Self::Metal(DeviceIdentity::from_id(id))),
+        );
+        #[cfg(any(feature = "wgpu", test_runtime_default))]
+        devices.extend(
+            <cubecl_wgpu::WgpuRuntime>::enumerate_all_devices()
+                .into_iter()
+                .map(|id| Self::Wgpu(DeviceIdentity::from_id(id))),
+        );
+        #[cfg(feature = "cpu")]
+        devices.extend(
+            cubecl_cpu::CpuRuntime::enumerate_all_devices()
+                .into_iter()
+                .map(|id| Self::Cpu(DeviceIdentity::from_id(id))),
+        );
+
+        devices
+    }
+
+    /// The runtime this device belongs to.
+    pub fn runtime(&self) -> RuntimeId {
+        match *self {
+            #[cfg(feature = "cuda")]
+            Self::Cuda(_) => RuntimeId::Cuda,
+            #[cfg(feature = "hip")]
+            Self::Hip(_) => RuntimeId::Hip,
+            #[cfg(feature = "metal-native")]
+            Self::Metal(_) => RuntimeId::Metal,
+            #[cfg(any(feature = "wgpu", test_runtime_default))]
+            Self::Wgpu(_) => RuntimeId::Wgpu,
+            #[cfg(feature = "cpu")]
+            Self::Cpu(_) => RuntimeId::Cpu,
+        }
+    }
+}
+
 impl Device {
     /// The compute client of this device, initialized on first use.
     pub fn client(&self) -> Client {
@@ -130,6 +289,89 @@ impl Device {
             #[cfg(feature = "cpu")]
             Self::Cpu(ref device) => cubecl_cpu::CpuRuntime::client(device),
         }
+    }
+}
+
+#[cfg(any_runtime)]
+impl Default for Device {
+    /// The default device of the most capable runtime this build enables.
+    ///
+    /// The order is the one a caller who did not choose would want — a discrete
+    /// accelerator over the portable path over the CPU — not the order the
+    /// features are declared in.
+    fn default() -> Self {
+        #[cfg(feature = "cuda")]
+        return Self::Cuda(Default::default());
+        #[cfg(all(feature = "hip", not(feature = "cuda")))]
+        return Self::Hip(Default::default());
+        #[cfg(all(feature = "metal-native", not(any(feature = "cuda", feature = "hip"))))]
+        return Self::Metal(Default::default());
+        #[cfg(all(
+            any(feature = "wgpu", test_runtime_default),
+            not(any(feature = "cuda", feature = "hip", feature = "metal-native"))
+        ))]
+        return Self::Wgpu(Default::default());
+        #[cfg(all(
+            feature = "cpu",
+            not(any(
+                feature = "cuda",
+                feature = "hip",
+                feature = "metal-native",
+                feature = "wgpu",
+                test_runtime_default
+            ))
+        ))]
+        return Self::Cpu(Default::default());
+    }
+}
+
+#[cfg(any_runtime)]
+impl DeviceIdentity for Device {
+    /// # Panics
+    ///
+    /// Where `device_id` names a runtime this build does not enable. An id only
+    /// travels between builds of the same application, so this is a build
+    /// mismatch rather than input to validate.
+    fn from_id(device_id: DeviceId) -> Self {
+        let runtime = RuntimeId::try_from(device_id.type_id >> RUNTIME_TYPE_ID_SHIFT);
+        let inner = DeviceId::new(device_id.type_id & RUNTIME_TYPE_ID_MASK, device_id.index_id);
+
+        match runtime {
+            #[cfg(feature = "cuda")]
+            Ok(RuntimeId::Cuda) => Self::Cuda(DeviceIdentity::from_id(inner)),
+            #[cfg(feature = "hip")]
+            Ok(RuntimeId::Hip) => Self::Hip(DeviceIdentity::from_id(inner)),
+            #[cfg(feature = "metal-native")]
+            Ok(RuntimeId::Metal) => Self::Metal(DeviceIdentity::from_id(inner)),
+            #[cfg(any(feature = "wgpu", test_runtime_default))]
+            Ok(RuntimeId::Wgpu) => Self::Wgpu(DeviceIdentity::from_id(inner)),
+            #[cfg(feature = "cpu")]
+            Ok(RuntimeId::Cpu) => Self::Cpu(DeviceIdentity::from_id(inner)),
+            other => panic!(
+                "device id {device_id} names the runtime {other:?}, which this build does not enable"
+            ),
+        }
+    }
+
+    fn to_id(&self) -> DeviceId {
+        let inner = match *self {
+            #[cfg(feature = "cuda")]
+            Self::Cuda(ref device) => DeviceIdentity::to_id(device),
+            #[cfg(feature = "hip")]
+            Self::Hip(ref device) => DeviceIdentity::to_id(device),
+            #[cfg(feature = "metal-native")]
+            Self::Metal(ref device) => DeviceIdentity::to_id(device),
+            #[cfg(any(feature = "wgpu", test_runtime_default))]
+            Self::Wgpu(ref device) => DeviceIdentity::to_id(device),
+            #[cfg(feature = "cpu")]
+            Self::Cpu(ref device) => DeviceIdentity::to_id(device),
+        };
+
+        DeviceId::new(
+            ((self.runtime() as u16) << RUNTIME_TYPE_ID_SHIFT)
+                | (inner.type_id & RUNTIME_TYPE_ID_MASK),
+            inner.index_id,
+        )
     }
 }
 
@@ -246,4 +488,34 @@ pub fn test_device() -> Device {
 #[cfg(test_runtime_metal)]
 pub fn test_device() -> Device {
     Device::Metal(Default::default())
+}
+
+#[cfg(all(test, any_runtime))]
+mod tests {
+    use super::*;
+
+    /// The id has to survive the trip in both directions, or a device stored by
+    /// id comes back as a different device — on a different runtime, even.
+    #[test]
+    fn a_device_id_round_trips_through_its_runtime() {
+        let device = Device::default();
+
+        let restored = <Device as DeviceIdentity>::from_id(DeviceIdentity::to_id(&device));
+
+        assert_eq!(device, restored);
+    }
+
+    /// The runtime rides in the high byte, which is what keeps two runtimes'
+    /// devices from colliding on one id.
+    #[test]
+    fn a_device_id_names_its_runtime() {
+        let device = Device::default();
+
+        let id = DeviceIdentity::to_id(&device);
+
+        assert_eq!(
+            RuntimeId::try_from(id.type_id >> RUNTIME_TYPE_ID_SHIFT),
+            Ok(device.runtime())
+        );
+    }
 }


### PR DESCRIPTION
The erasure left `Device` as a way to reach a client and nothing else, so a consumer that wants one device type across runtimes — burn's backend, whose tensors carry a device — still had to name a runtime to get `Default`, `to_id` and `from_id`.

An id carries its runtime in the three bits above the runtime's own device type, so ids from two runtimes cannot collide, and the pair stays inside one byte: a caller nesting these ids in an encoding of its own — burn's dispatch backend does — still has the high byte to spend. The runtime tags are fixed per runtime rather than per build.

`can_read_tensor`, `enumerate` and `enumerate_all` come along because they are the rest of what a caller reads off `Runtime`, and all three are answerable from a device.

A build with no runtime has no `Device` to speak of, which `any_runtime` now says in one place instead of five copies of the feature list.
