### PR TITLE
fix(throughput): stop reporting ceilings the hardware beats

### DIFF
--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -156,8 +156,8 @@ impl BenchmarkComputations {
     }
 }
 
-/// Launches the warmup makes however long they take: one to compile, and the
-/// four a kernel slower than the budget gets today.
+/// Launches the warmup makes however long they take: one to compile the kernel
+/// and four to settle the device.
 #[cfg(feature = "std")]
 const MIN_WARMUP_RUNS: usize = 5;
 
@@ -187,10 +187,9 @@ pub trait Benchmark {
     ///
     /// A device answers from idle clocks and takes hundreds of milliseconds to
     /// reach the ones it sustains, which a warmup counted in launches gives a
-    /// microsecond kernel no way to reach. 500 ms is where that stops showing:
-    /// a 4070 Ti SUPER under Vulkan reports every reduce row at its full rate
-    /// from there, and 12 of 36 rows below it. A sweep of thousands of rows can
-    /// buy the wall clock back with `BENCH_WARMUP_MS`, and pay in accuracy.
+    /// microsecond kernel no way to reach. Under half a second a GPU still
+    /// samples a clock step low. A sweep of thousands of rows can buy the wall
+    /// clock back with `BENCH_WARMUP_MS`, and pay in accuracy.
     fn warmup_budget(&self) -> Duration {
         const DEFAULT_MS: u64 = 500;
         #[cfg(feature = "std")]

--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -294,13 +294,25 @@ pub trait Benchmark {
             // answers at the clocks a sampled run will see.
             let budget = self.warmup_budget();
             let warmup = Instant::now();
-            let mut warmups = 0;
+            let (mut warmups, mut failures) = (0, 0);
             while warmups < MIN_WARMUP_RUNS || warmup.elapsed() < budget {
                 let warmed: Result<crate::profile::ProfileTicks, _> = execute(&args);
-                if warmed.is_err() {
-                    break;
+
+                match warmed {
+                    Ok(_) => warmups += 1,
+                    // One failure is not the device saying no: cutting the
+                    // warmup short there would leave the samples reading cold
+                    // clocks and report that as the kernel's speed. A kernel
+                    // that cannot run at all stops after the launches its
+                    // warmup owed it, rather than failing for the whole budget.
+                    Err(_) => {
+                        failures += 1;
+
+                        if failures >= MIN_WARMUP_RUNS {
+                            break;
+                        }
+                    }
                 }
-                warmups += 1;
             }
 
             // Real execution.
@@ -399,6 +411,8 @@ mod tests {
     struct TimedBench {
         per_execution: Duration,
         executions: Cell<usize>,
+        /// Launches that fail before any of them succeed.
+        failures: Cell<usize>,
     }
 
     impl TimedBench {
@@ -406,7 +420,14 @@ mod tests {
             Self {
                 per_execution,
                 executions: Cell::new(0),
+                failures: Cell::new(0),
             }
+        }
+
+        fn failing(self, launches: usize) -> Self {
+            self.failures.set(launches);
+
+            self
         }
     }
 
@@ -418,6 +439,13 @@ mod tests {
 
         fn execute(&self, _input: Self::Input) -> Result<Self::Output, String> {
             self.executions.set(self.executions.get() + 1);
+
+            if self.failures.get() > 0 {
+                self.failures.set(self.failures.get() - 1);
+
+                return Err(String::from("the launch failed"));
+            }
+
             let start = Instant::now();
             while start.elapsed() < self.per_execution {}
 
@@ -451,6 +479,30 @@ mod tests {
             start.elapsed()
         );
         assert!(bench.executions.get() > MIN_WARMUP_RUNS);
+    }
+
+    /// One launch failing is not the device saying no, and cutting the warmup
+    /// there would leave the samples reading idle clocks and report that as the
+    /// kernel's speed.
+    #[test_log::test]
+    fn one_failed_launch_does_not_end_the_warmup() {
+        let bench = TimedBench::new(Duration::ZERO).failing(1);
+        let start = Instant::now();
+
+        bench.run(TimingMethod::System).expect("the bench runs");
+
+        assert!(start.elapsed() >= bench.warmup_budget(), "left early");
+    }
+
+    /// A kernel that cannot run at all stops after the launches its warmup owed
+    /// it, rather than spending the whole budget failing.
+    #[test_log::test]
+    fn a_launch_that_always_fails_stops_the_warmup() {
+        let bench = TimedBench::new(Duration::ZERO).failing(usize::MAX);
+        let start = Instant::now();
+
+        assert!(bench.run(TimingMethod::System).is_err());
+        assert!(start.elapsed() < bench.warmup_budget(), "kept failing");
     }
 
     /// A budget that added launches to a kernel already filling it would make

--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -156,6 +156,11 @@ impl BenchmarkComputations {
     }
 }
 
+/// Launches the warmup makes however long they take: one to compile, and the
+/// four a kernel slower than the budget gets today.
+#[cfg(feature = "std")]
+const MIN_WARMUP_RUNS: usize = 5;
+
 /// Benchmark trait.
 pub trait Benchmark {
     /// Benchmark input arguments.
@@ -177,6 +182,31 @@ pub trait Benchmark {
     /// It is important to return the output since otherwise deadcode optimization might optimize
     /// away code that should be benchmarked.
     fn execute(&self, input: Self::Input) -> Result<Self::Output, String>;
+
+    /// Wall clock the warmup holds the device for before sampling starts.
+    ///
+    /// A device answers from idle clocks and takes hundreds of milliseconds to
+    /// reach the ones it sustains, which a warmup counted in launches gives a
+    /// microsecond kernel no way to reach. 500 ms is where that stops showing:
+    /// a 4070 Ti SUPER under Vulkan reports every reduce row at its full rate
+    /// from there, and 12 of 36 rows below it. A sweep of thousands of rows can
+    /// buy the wall clock back with `BENCH_WARMUP_MS`, and pay in accuracy.
+    fn warmup_budget(&self) -> Duration {
+        const DEFAULT_MS: u64 = 500;
+        #[cfg(feature = "std")]
+        {
+            Duration::from_millis(
+                std::env::var("BENCH_WARMUP_MS")
+                    .map(|val| str::parse::<u64>(&val).unwrap_or(DEFAULT_MS))
+                    .unwrap_or(DEFAULT_MS),
+            )
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            Duration::from_millis(DEFAULT_MS)
+        }
+    }
 
     /// Number of samples per run required to have a statistical significance.
     fn num_samples(&self) -> usize {
@@ -261,12 +291,17 @@ pub trait Benchmark {
             };
             let args = self.prepare();
 
-            // Triggers JIT-compilation and perform a Warmup
-            //
-            // We are using 5 iterations, where the first one probably triggers the JIT-compilation
-            // and it is then followed by 4 warmup executions.
-            for _ in 0..5 {
-                let _duration: Result<crate::profile::ProfileTicks, _> = execute(&args);
+            // Compiles on the first launch, then holds the device until it
+            // answers at the clocks a sampled run will see.
+            let budget = self.warmup_budget();
+            let warmup = Instant::now();
+            let mut warmups = 0;
+            while warmups < MIN_WARMUP_RUNS || warmup.elapsed() < budget {
+                let warmed: Result<crate::profile::ProfileTicks, _> = execute(&args);
+                if warmed.is_err() {
+                    break;
+                }
+                warmups += 1;
             }
 
             // Real execution.
@@ -358,6 +393,81 @@ where
 mod tests {
     use super::*;
     use alloc::vec;
+    use core::cell::Cell;
+
+    /// A device that answers in whatever time it is given, counting the
+    /// launches it was asked for.
+    struct TimedBench {
+        per_execution: Duration,
+        executions: Cell<usize>,
+    }
+
+    impl TimedBench {
+        fn new(per_execution: Duration) -> Self {
+            Self {
+                per_execution,
+                executions: Cell::new(0),
+            }
+        }
+    }
+
+    impl Benchmark for TimedBench {
+        type Input = ();
+        type Output = ();
+
+        fn prepare(&self) -> Self::Input {}
+
+        fn execute(&self, _input: Self::Input) -> Result<Self::Output, String> {
+            self.executions.set(self.executions.get() + 1);
+            let start = Instant::now();
+            while start.elapsed() < self.per_execution {}
+
+            Ok(())
+        }
+
+        fn num_samples(&self) -> usize {
+            1
+        }
+
+        fn name(&self) -> String {
+            "timed".into()
+        }
+
+        fn sync(&self) {}
+    }
+
+    /// The warmup is there to lift a device off its idle clocks, which takes
+    /// hundreds of milliseconds whatever the kernel costs. Counted in launches
+    /// it would leave a fast one sampled cold.
+    #[test_log::test]
+    fn a_kernel_the_launch_count_cannot_warm_is_held_for_the_budget() {
+        let bench = TimedBench::new(Duration::ZERO);
+        let start = Instant::now();
+
+        bench.run(TimingMethod::System).expect("the bench runs");
+
+        assert!(
+            start.elapsed() >= bench.warmup_budget(),
+            "warmed {:?}",
+            start.elapsed()
+        );
+        assert!(bench.executions.get() > MIN_WARMUP_RUNS);
+    }
+
+    /// A budget that added launches to a kernel already filling it would make
+    /// every slow row pay a warmup it does not need.
+    #[test_log::test]
+    fn a_kernel_that_fills_the_budget_pays_no_extra_launch() {
+        let mut bench = TimedBench::new(Duration::ZERO);
+        bench.per_execution = bench.warmup_budget() / 4;
+
+        let durations = bench.run(TimingMethod::System).expect("the bench runs");
+
+        assert_eq!(
+            bench.executions.get(),
+            MIN_WARMUP_RUNS + durations.durations.len()
+        );
+    }
 
     #[test_log::test]
     fn test_min_max_median_durations_even_number_of_samples() {

--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -185,11 +185,9 @@ pub trait Benchmark {
 
     /// Wall clock the warmup holds the device for before sampling starts.
     ///
-    /// A device answers from idle clocks and takes hundreds of milliseconds to
-    /// reach the ones it sustains, which a warmup counted in launches gives a
-    /// microsecond kernel no way to reach. Under half a second a GPU still
-    /// samples a clock step low. A sweep of thousands of rows can buy the wall
-    /// clock back with `BENCH_WARMUP_MS`, and pay in accuracy.
+    /// A device takes hundreds of milliseconds to reach the clocks it sustains,
+    /// and under half a second a GPU still samples a step low. `BENCH_WARMUP_MS`
+    /// buys the wall clock back and pays in accuracy.
     fn warmup_budget(&self) -> Duration {
         const DEFAULT_MS: u64 = 500;
         #[cfg(feature = "std")]
@@ -300,11 +298,8 @@ pub trait Benchmark {
 
                 match warmed {
                     Ok(_) => warmups += 1,
-                    // One failure is not the device saying no: cutting the
-                    // warmup short there would leave the samples reading cold
-                    // clocks and report that as the kernel's speed. A kernel
-                    // that cannot run at all stops after the launches its
-                    // warmup owed it, rather than failing for the whole budget.
+                    // Stopping on one failure would leave the samples reading
+                    // cold clocks and report that as the kernel's speed.
                     Err(_) => {
                         failures += 1;
 

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -80,12 +80,12 @@ fn register_supported_types(props: &mut DeviceProperties) {
     }
 }
 
-/// The part, so a measured ceiling is not served to every CPU of an architecture.
 fn host_cpu_name(system: &System) -> String {
     system
         .cpus()
         .first()
         .map(|cpu| cpu.brand().trim())
+        // sysinfo reports no brand on Windows for ARM.
         .filter(|brand| !brand.is_empty())
         .map_or_else(|| format!("CPU {}", std::env::consts::ARCH), String::from)
 }

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -16,7 +16,7 @@ use cubecl_runtime::runtime::Runtime;
 use cubecl_runtime::{allocator::ContiguousMemoryLayoutPolicy, logging::ServerLogger};
 use cubecl_std::tensor::is_contiguous;
 use std::sync::Arc;
-use sysinfo::System;
+use sysinfo::{CpuRefreshKind, System};
 
 #[derive(Default)]
 pub struct RuntimeOptions {
@@ -80,11 +80,23 @@ fn register_supported_types(props: &mut DeviceProperties) {
     }
 }
 
+/// The part, so that a measured ceiling is not served to every CPU sharing an
+/// architecture. Falls back to the architecture where a platform reports no brand.
+fn host_cpu_name(system: &System) -> String {
+    system
+        .cpus()
+        .first()
+        .map(|cpu| cpu.brand().trim())
+        .filter(|brand| !brand.is_empty())
+        .map_or_else(|| format!("CPU {}", std::env::consts::ARCH), String::from)
+}
+
 impl DeviceService for CpuServer {
     fn init(device_id: cubecl_common::device::DeviceId) -> Self {
         let options = RuntimeOptions::default();
         let mut system = System::new();
         system.refresh_memory();
+        system.refresh_cpu_list(CpuRefreshKind::nothing());
         // Bounds the allocator's page size, not a kernel's shared memory.
         let total_memory = system
             .cgroup_limits()
@@ -147,7 +159,7 @@ impl DeviceService for CpuServer {
             // namespace to match against. The architecture is the honest
             // fingerprint: it is what the generated code is valid for.
             DeviceIdentity {
-                name: "CPU".to_string(),
+                name: host_cpu_name(&system),
                 fingerprint: format!("cpu_{}", std::env::consts::ARCH),
             },
         );

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -16,7 +16,7 @@ use cubecl_runtime::runtime::Runtime;
 use cubecl_runtime::{allocator::ContiguousMemoryLayoutPolicy, logging::ServerLogger};
 use cubecl_std::tensor::is_contiguous;
 use std::sync::Arc;
-use sysinfo::{CpuRefreshKind, System};
+use sysinfo::System;
 
 #[derive(Default)]
 pub struct RuntimeOptions {
@@ -80,22 +80,11 @@ fn register_supported_types(props: &mut DeviceProperties) {
     }
 }
 
-fn host_cpu_name(system: &System) -> String {
-    system
-        .cpus()
-        .first()
-        .map(|cpu| cpu.brand().trim())
-        // sysinfo reports no brand on Windows for ARM.
-        .filter(|brand| !brand.is_empty())
-        .map_or_else(|| format!("CPU {}", std::env::consts::ARCH), String::from)
-}
-
 impl DeviceService for CpuServer {
     fn init(device_id: cubecl_common::device::DeviceId) -> Self {
         let options = RuntimeOptions::default();
         let mut system = System::new();
         system.refresh_memory();
-        system.refresh_cpu_list(CpuRefreshKind::nothing());
         // Bounds the allocator's page size, not a kernel's shared memory.
         let total_memory = system
             .cgroup_limits()
@@ -158,7 +147,7 @@ impl DeviceService for CpuServer {
             // namespace to match against. The architecture is the honest
             // fingerprint: it is what the generated code is valid for.
             DeviceIdentity {
-                name: host_cpu_name(&system),
+                name: "CPU".to_string(),
                 fingerprint: format!("cpu_{}", std::env::consts::ARCH),
             },
         );

--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -80,8 +80,7 @@ fn register_supported_types(props: &mut DeviceProperties) {
     }
 }
 
-/// The part, so that a measured ceiling is not served to every CPU sharing an
-/// architecture. Falls back to the architecture where a platform reports no brand.
+/// The part, so a measured ceiling is not served to every CPU of an architecture.
 fn host_cpu_name(system: &System) -> String {
     system
         .cpus()

--- a/crates/cubecl-runtime/src/client.rs
+++ b/crates/cubecl-runtime/src/client.rs
@@ -1657,7 +1657,7 @@ impl Client {
         key: ThroughputKey,
         probe: impl FnOnce() -> Result<ThroughputValue, ThroughputError>,
     ) -> Result<ThroughputValue, ThroughputError> {
-        let cache = ThroughputCache::get_for_device(self.name(), &self.properties().identity);
+        let cache = ThroughputCache::get_for_device(self.name(), self.properties());
         let mut throughputs = ThroughputBenchmarker::new(cache);
         throughputs.measure(key, probe)
     }

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -56,6 +56,10 @@ impl MemoryAccess {
 #[cfg_attr(std_io, derive(serde::Serialize, serde::Deserialize))]
 pub enum ThroughputMode {
     /// Compute direct calculation without special hardware acceleration.
+    ///
+    /// The ceiling is for operands of `dtype`, not for arithmetic a device
+    /// performs in it: where converting to f32 retires more of them, that is
+    /// the rate a kernel of this type reaches, and what the probe reports.
     ComputeDirect {
         /// The data type of the computation.
         dtype: ElemType,

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 /// What the probes measure, as opposed to which release ran them. Bump it when
 /// a probe changes what it reports.
-pub const PROBE_VERSION: u32 = 1;
+pub const PROBE_VERSION: u32 = 2;
 
 /// Bytes one buffer of a [`ThroughputMode::Memory`] probe moves per pass at its
 /// default working set. The probe's buffer is a multiple of this, and both are

--- a/crates/cubecl-runtime/src/throughput/base.rs
+++ b/crates/cubecl-runtime/src/throughput/base.rs
@@ -57,9 +57,8 @@ impl MemoryAccess {
 pub enum ThroughputMode {
     /// Compute direct calculation without special hardware acceleration.
     ///
-    /// The ceiling is for operands of `dtype`, not for arithmetic a device
-    /// performs in it: where converting to f32 retires more of them, that is
-    /// the rate a kernel of this type reaches, and what the probe reports.
+    /// The ceiling is for operands of `dtype`, not arithmetic performed in it:
+    /// where converting to f32 retires more, that is what the probe reports.
     ComputeDirect {
         /// The data type of the computation.
         dtype: ElemType,

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -28,13 +28,18 @@ const SAMPLE_BUDGET: Duration = Duration::from_millis(200);
 /// the ones after it can go stale.
 const SAMPLE_PATIENCE: usize = 12;
 
-/// Wall clock a shape is ranked over, which is enough to order shapes and not
-/// enough to report a peak. Shapes that matter are 10% apart or more, and ones
-/// within a couple of percent are interchangeable by definition.
-const RANK_BUDGET: Duration = Duration::from_millis(30);
+/// Wall clock one launch of a shape is grown or cut toward, so that a sweep
+/// times every shape over the same span and none of them wears a larger share
+/// of the fixed cost of a launch than the rest.
+const TARGET_DURATION: Duration = Duration::from_millis(20);
 
-/// Samples a ranking pass may spend on one shape.
-const RANK_PATIENCE: usize = 2;
+/// Samples a ranking pass keeps the fastest of, per shape.
+///
+/// A count and not a wall clock, so every shape of a sweep is ordered on the
+/// same number of draws. Under a time budget a shape whose pass happens to be
+/// short draws more of them, and the lowest of more draws is lower, which
+/// decides a close pair on how long its passes are rather than on their rate.
+const RANK_SAMPLES: usize = 3;
 
 /// Configuration and payload for a benchmarkable compute kernel.
 pub struct KernelConfig {
@@ -45,6 +50,16 @@ pub struct KernelConfig {
     /// Iterations a launch must carry however quickly they turn out to run,
     /// which a duration target cannot express.
     pub min_iterations: usize,
+}
+
+/// What a ranking pass found: how fast the shape answered, and the iteration
+/// count it settled on for the next shape to start from.
+pub struct Ranked {
+    /// The shape's rate, measured briefly enough to order it and not to report
+    /// it.
+    pub value: ThroughputValue,
+    /// What one launch of this shape was timed over.
+    pub iterations: usize,
 }
 
 /// A marker for measuring throughput of compute kernels.
@@ -136,28 +151,65 @@ impl ThroughputBenchmarker {
     }
 
     /// Times one shape briefly, to order it against the others rather than to
-    /// report its peak.
+    /// report its peak, and reports the iteration count the next shape should
+    /// start from.
     ///
-    /// Takes the iteration count from [`warm`](Self::warm) so every shape in a
-    /// sweep is timed over the same amount of work, and never fewer passes than
-    /// the shape needs to be measuring what it claims.
-    pub fn rank(kernel_config: &KernelConfig, iterations: usize) -> ThroughputValue {
-        let iterations = iterations.max(kernel_config.min_iterations).max(1);
-        // One launch discarded. The shape the sweep warmed on has its buffers
-        // and page tables settled and the rest do not, and a first launch on a
-        // freshly written pool is slow enough that they would rank on that
-        // rather than on their rate.
-        let _ = (kernel_config.sample)(iterations);
-        let duration = Self::sample_peak_duration(
-            iterations,
-            &kernel_config.sample,
-            RANK_BUDGET,
-            RANK_PATIENCE,
-        );
+    /// Two launches are spent before timing. The shape a sweep warmed on has
+    /// its buffers, its pages and its compiled kernel settled and the rest do
+    /// not, and a first launch carries all of that, enough that shapes would
+    /// rank on which of them the sweep had already touched. The second is what
+    /// this shape's own iteration count is settled from, so a shape retiring
+    /// ten times more per pass than the one before it is still timed over
+    /// [`TARGET_DURATION`] and carries the same share of a launch's fixed cost.
+    ///
+    /// `iterations` is where that starts, so passing what the previous shape
+    /// settled on keeps those two launches near the target too.
+    pub fn rank(kernel_config: &KernelConfig, iterations: usize) -> Ranked {
+        let settling = iterations.max(kernel_config.min_iterations).max(1);
+        // What a shape costs the first time is what it costs to compile and to
+        // fault in, not what a pass of it costs, so the first launch is spent
+        // and a second one is what the count is settled from. Reading the first
+        // ranks a shape the sweep has not compiled before below one it has.
+        let _ = (kernel_config.sample)(settling);
+        let took = (kernel_config.sample)(settling);
 
-        ThroughputValue {
-            ops_count: kernel_config.ops_count,
-            duration,
+        let iterations = Self::retarget(settling, took)
+            .max(kernel_config.min_iterations)
+            .max(1);
+
+        let mut fastest = Duration::MAX;
+        for _ in 0..RANK_SAMPLES {
+            fastest = fastest.min((kernel_config.sample)(iterations));
+        }
+
+        let duration = fastest / iterations as u32;
+
+        Ranked {
+            value: ThroughputValue {
+                ops_count: kernel_config.ops_count,
+                duration,
+            },
+            iterations,
+        }
+    }
+
+    /// The count that would have taken [`TARGET_DURATION`], given what
+    /// `iterations` of them took.
+    ///
+    /// A timer reading zero says nothing to scale by, so the count stands.
+    fn retarget(iterations: usize, took: Duration) -> usize {
+        let took = took.as_secs_f64();
+
+        if took <= 0.0 {
+            return iterations;
+        }
+
+        let scaled = iterations as f64 * (TARGET_DURATION.as_secs_f64() / took);
+
+        if scaled.is_finite() {
+            (scaled as usize).max(1)
+        } else {
+            iterations
         }
     }
 
@@ -183,7 +235,7 @@ impl ThroughputBenchmarker {
         const MAX_BLIND_ITERATIONS: usize = 1 << 10;
         const PLATEAU_TOL: f64 = 0.03;
         const PATIENCE: usize = 3;
-        const TARGET_DURATION_MS: f64 = 20.0;
+        let target_ms = TARGET_DURATION.as_secs_f64() * 1000.0;
 
         let mut best = f64::INFINITY;
         let mut stable = 0;
@@ -193,11 +245,11 @@ impl ThroughputBenchmarker {
 
         for _ in 0..MAX_WARMUP {
             let duration = sample(iterations).as_secs_f64() * 1000.0;
-            if duration < TARGET_DURATION_MS {
+            if duration < target_ms {
                 let (extra_iters, ceiling) = if duration > 1e-6 {
                     let duration_per_iter = duration / iterations as f64;
                     (
-                        ((TARGET_DURATION_MS - duration) / duration_per_iter).ceil() as usize,
+                        ((target_ms - duration) / duration_per_iter).ceil() as usize,
                         MAX_ITERATIONS,
                     )
                 } else {
@@ -412,8 +464,12 @@ mod tests {
 
         let iterations = ThroughputBenchmarker::warm(&fast);
         let start = Instant::now();
-        let fast_rate = ThroughputBenchmarker::rank(&fast, iterations).ops_per_s();
-        let slow_rate = ThroughputBenchmarker::rank(&slow, iterations).ops_per_s();
+        let fast_rate = ThroughputBenchmarker::rank(&fast, iterations)
+            .value
+            .ops_per_s();
+        let slow_rate = ThroughputBenchmarker::rank(&slow, iterations)
+            .value
+            .ops_per_s();
 
         assert!(fast_rate > slow_rate, "{fast_rate} against {slow_rate}");
         assert!(
@@ -421,6 +477,48 @@ mod tests {
             "ranked two shapes in {:?}",
             start.elapsed()
         );
+    }
+
+    /// Shapes of one sweep differ in what a pass costs, and timing a fast one
+    /// over a tenth of the span would make it wear ten times the share of a
+    /// launch's fixed cost. Each settles its own count toward the target.
+    #[test]
+    fn ranking_times_each_shape_over_the_same_span() {
+        let config = |per_iter_nanos: u64| KernelConfig {
+            sample: Box::new(move |iterations| {
+                Duration::from_nanos(per_iter_nanos * iterations as u64)
+            }),
+            ops_count: 1,
+            min_iterations: 1,
+        };
+
+        let slow = ThroughputBenchmarker::rank(&config(1000), 1000);
+        let fast = ThroughputBenchmarker::rank(&config(100), 1000);
+
+        assert_eq!(slow.iterations, 20_000);
+        assert_eq!(fast.iterations, 200_000);
+    }
+
+    /// A shape's first launch carries compiling and faulting it in, which is
+    /// not what a pass of it costs. Settling the count from that ranks a shape
+    /// the sweep has not seen before below one it has.
+    #[test]
+    fn ranking_settles_its_count_after_the_first_launch() {
+        let launches = Cell::new(0);
+        let config = KernelConfig {
+            sample: Box::new(move |iterations| {
+                launches.set(launches.get() + 1);
+                let per_iter = if launches.get() == 1 { 100_000 } else { 1_000 };
+
+                Duration::from_nanos(per_iter * iterations as u64)
+            }),
+            ops_count: 1,
+            min_iterations: 1,
+        };
+
+        let ranked = ThroughputBenchmarker::rank(&config, 1_000);
+
+        assert_eq!(ranked.iterations, 20_000);
     }
 
     /// Every shape of a sweep is timed over the same work, or a shape that
@@ -434,9 +532,10 @@ mod tests {
             min_iterations: needed,
         };
 
-        let value = ThroughputBenchmarker::rank(&config, 1);
+        let ranked = ThroughputBenchmarker::rank(&config, 1);
 
-        assert_eq!(value.duration, Duration::from_nanos(1));
+        assert_eq!(ranked.value.duration, Duration::from_nanos(1));
+        assert!(ranked.iterations >= needed);
     }
 
     /// A working timer still drives the count to the duration target.

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -19,6 +19,23 @@ const WARMUP_BUDGET: Duration = Duration::from_secs(2);
 /// clock transition, which takes hundreds of milliseconds.
 const PLATEAU_FLOOR: Duration = Duration::from_millis(250);
 
+/// Wall clock one shape's peak is sampled over. A sample count would price a
+/// probe filling the duration target forty times one whose pass is microseconds.
+const SAMPLE_BUDGET: Duration = Duration::from_millis(200);
+
+/// Samples that may go by without improving before the peak is accepted. Also
+/// the floor on samples, since the first always improves on infinity and only
+/// the ones after it can go stale.
+const SAMPLE_PATIENCE: usize = 12;
+
+/// Wall clock a shape is ranked over, which is enough to order shapes and not
+/// enough to report a peak. Shapes that matter are 10% apart or more, and ones
+/// within a couple of percent are interchangeable by definition.
+const RANK_BUDGET: Duration = Duration::from_millis(30);
+
+/// Samples a ranking pass may spend on one shape.
+const RANK_PATIENCE: usize = 2;
+
 /// Configuration and payload for a benchmarkable compute kernel.
 pub struct KernelConfig {
     /// A closure that executes the kernel for the given number of iterations and returns the duration.
@@ -76,7 +93,67 @@ impl ThroughputBenchmarker {
         let sample = kernel_config.sample;
 
         let iterations = Self::warmup(kernel_config.min_iterations, WARMUP_BUDGET, &sample);
-        let duration = Self::sample_peak_duration(iterations, &sample);
+        let duration =
+            Self::sample_peak_duration(iterations, &sample, SAMPLE_BUDGET, SAMPLE_PATIENCE);
+
+        ThroughputValue {
+            ops_count: kernel_config.ops_count,
+            duration,
+        }
+    }
+
+    /// Warms the device on one shape and reports the iteration count a sample of
+    /// it should carry, for [`rank`](Self::rank) to reuse across the rest.
+    ///
+    /// A warmup is most of what timing a shape costs, and it is the device it
+    /// warms rather than the shape, so a sweep pays for one.
+    pub fn warm(kernel_config: &KernelConfig) -> usize {
+        Self::warmup(
+            kernel_config.min_iterations,
+            WARMUP_BUDGET,
+            &kernel_config.sample,
+        )
+    }
+
+    /// Keeps the fastest sample of a shape the device is already warm on, at the
+    /// iteration count [`warm`](Self::warm) settled.
+    ///
+    /// A warmup is what a measurement mostly costs, so a sweep that has already
+    /// paid one must not pay it again for the shape it picked.
+    pub fn sample_at(kernel_config: &KernelConfig, iterations: usize) -> ThroughputValue {
+        let iterations = iterations.max(kernel_config.min_iterations).max(1);
+        let duration = Self::sample_peak_duration(
+            iterations,
+            &kernel_config.sample,
+            SAMPLE_BUDGET,
+            SAMPLE_PATIENCE,
+        );
+
+        ThroughputValue {
+            ops_count: kernel_config.ops_count,
+            duration,
+        }
+    }
+
+    /// Times one shape briefly, to order it against the others rather than to
+    /// report its peak.
+    ///
+    /// Takes the iteration count from [`warm`](Self::warm) so every shape in a
+    /// sweep is timed over the same amount of work, and never fewer passes than
+    /// the shape needs to be measuring what it claims.
+    pub fn rank(kernel_config: &KernelConfig, iterations: usize) -> ThroughputValue {
+        let iterations = iterations.max(kernel_config.min_iterations).max(1);
+        // One launch discarded. The shape the sweep warmed on has its buffers
+        // and page tables settled and the rest do not, and a first launch on a
+        // freshly written pool is slow enough that they would rank on that
+        // rather than on their rate.
+        let _ = (kernel_config.sample)(iterations);
+        let duration = Self::sample_peak_duration(
+            iterations,
+            &kernel_config.sample,
+            RANK_BUDGET,
+            RANK_PATIENCE,
+        );
 
         ThroughputValue {
             ops_count: kernel_config.ops_count,
@@ -160,6 +237,8 @@ impl ThroughputBenchmarker {
     fn sample_peak_duration(
         iterations: usize,
         sample_once: impl Fn(usize) -> Duration,
+        budget: Duration,
+        patience: usize,
     ) -> Duration {
         debug_assert!(
             iterations > 0,
@@ -168,12 +247,6 @@ impl ThroughputBenchmarker {
 
         const MAX_SAMPLES: usize = 200;
         const REL_TOL: f64 = 0.01;
-        // Also the floor on samples, since the first always improves on
-        // infinity and only the ones after it can go stale.
-        const PATIENCE: usize = 12;
-        // A sample count prices them all the same, and a probe filling the
-        // duration target costs forty times one whose pass is microseconds.
-        const SAMPLE_BUDGET: Duration = Duration::from_millis(200);
 
         let mut best = f64::INFINITY;
         let mut stale = 0;
@@ -190,7 +263,7 @@ impl ThroughputBenchmarker {
                 best = best.min(s);
                 stale += 1;
             }
-            if stale >= PATIENCE || start.elapsed() >= SAMPLE_BUDGET {
+            if stale >= patience || start.elapsed() >= budget {
                 break;
             }
         }
@@ -256,10 +329,15 @@ mod tests {
     #[test]
     fn a_timer_reading_zero_still_stops_sampling() {
         let calls = Cell::new(0);
-        let _ = ThroughputBenchmarker::sample_peak_duration(1, |_| {
-            calls.set(calls.get() + 1);
-            Duration::ZERO
-        });
+        let _ = ThroughputBenchmarker::sample_peak_duration(
+            1,
+            |_| {
+                calls.set(calls.get() + 1);
+                Duration::ZERO
+            },
+            SAMPLE_BUDGET,
+            SAMPLE_PATIENCE,
+        );
 
         assert!(calls.get() < 200, "ran {} samples", calls.get());
     }
@@ -318,6 +396,47 @@ mod tests {
             "kept {:?}",
             value.duration
         );
+    }
+
+    /// A sweep ranks shapes to order them, not to report them, so it must
+    /// separate a slow shape from a fast one without paying for a measurement
+    /// of each.
+    #[test]
+    fn ranking_orders_shapes_for_less_than_one_measurement() {
+        let config = |per_iter_nanos: u64| KernelConfig {
+            sample: Box::new(timed_device(move || per_iter_nanos)),
+            ops_count: 1,
+            min_iterations: 1,
+        };
+        let (fast, slow) = (config(1000), config(3000));
+
+        let iterations = ThroughputBenchmarker::warm(&fast);
+        let start = Instant::now();
+        let fast_rate = ThroughputBenchmarker::rank(&fast, iterations).ops_per_s();
+        let slow_rate = ThroughputBenchmarker::rank(&slow, iterations).ops_per_s();
+
+        assert!(fast_rate > slow_rate, "{fast_rate} against {slow_rate}");
+        assert!(
+            start.elapsed() < PLATEAU_FLOOR + SAMPLE_BUDGET,
+            "ranked two shapes in {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// Every shape of a sweep is timed over the same work, or a shape that
+    /// happened to be warmed at a different count would rank on that instead.
+    #[test]
+    fn ranking_never_carries_fewer_passes_than_a_shape_needs() {
+        let needed = 64;
+        let config = KernelConfig {
+            sample: Box::new(|iterations| Duration::from_nanos(iterations as u64)),
+            ops_count: 1,
+            min_iterations: needed,
+        };
+
+        let value = ThroughputBenchmarker::rank(&config, 1);
+
+        assert_eq!(value.duration, Duration::from_nanos(1));
     }
 
     /// A working timer still drives the count to the duration target.

--- a/crates/cubecl-runtime/src/throughput/benchmarker.rs
+++ b/crates/cubecl-runtime/src/throughput/benchmarker.rs
@@ -33,12 +33,8 @@ const SAMPLE_PATIENCE: usize = 12;
 /// of the fixed cost of a launch than the rest.
 const TARGET_DURATION: Duration = Duration::from_millis(20);
 
-/// Samples a ranking pass keeps the fastest of, per shape.
-///
-/// A count and not a wall clock, so every shape of a sweep is ordered on the
-/// same number of draws. Under a time budget a shape whose pass happens to be
-/// short draws more of them, and the lowest of more draws is lower, which
-/// decides a close pair on how long its passes are rather than on their rate.
+/// Samples a ranking pass keeps the fastest of. A count and not a wall clock:
+/// under a budget a short pass draws more, and the fastest of more is faster.
 const RANK_SAMPLES: usize = 3;
 
 /// Configuration and payload for a benchmarkable compute kernel.
@@ -117,11 +113,8 @@ impl ThroughputBenchmarker {
         }
     }
 
-    /// Warms the device on one shape and reports the iteration count a sample of
-    /// it should carry, for [`rank`](Self::rank) to reuse across the rest.
-    ///
-    /// A warmup is most of what timing a shape costs, and it is the device it
-    /// warms rather than the shape, so a sweep pays for one.
+    /// Warms the device on one shape and reports the count a sample should carry.
+    /// It is the device that is warmed, not the shape, so a sweep pays once.
     pub fn warm(kernel_config: &KernelConfig) -> usize {
         Self::warmup(
             kernel_config.min_iterations,
@@ -131,10 +124,7 @@ impl ThroughputBenchmarker {
     }
 
     /// Keeps the fastest sample of a shape the device is already warm on, at the
-    /// iteration count [`warm`](Self::warm) settled.
-    ///
-    /// A warmup is what a measurement mostly costs, so a sweep that has already
-    /// paid one must not pay it again for the shape it picked.
+    /// count [`warm`](Self::warm) settled.
     pub fn sample_at(kernel_config: &KernelConfig, iterations: usize) -> ThroughputValue {
         let iterations = iterations.max(kernel_config.min_iterations).max(1);
         let duration = Self::sample_peak_duration(
@@ -151,25 +141,11 @@ impl ThroughputBenchmarker {
     }
 
     /// Times one shape briefly, to order it against the others rather than to
-    /// report its peak, and reports the iteration count the next shape should
-    /// start from.
-    ///
-    /// Two launches are spent before timing. The shape a sweep warmed on has
-    /// its buffers, its pages and its compiled kernel settled and the rest do
-    /// not, and a first launch carries all of that, enough that shapes would
-    /// rank on which of them the sweep had already touched. The second is what
-    /// this shape's own iteration count is settled from, so a shape retiring
-    /// ten times more per pass than the one before it is still timed over
-    /// [`TARGET_DURATION`] and carries the same share of a launch's fixed cost.
-    ///
-    /// `iterations` is where that starts, so passing what the previous shape
-    /// settled on keeps those two launches near the target too.
+    /// report its peak, and reports the count the next shape starts from.
     pub fn rank(kernel_config: &KernelConfig, iterations: usize) -> Ranked {
         let settling = iterations.max(kernel_config.min_iterations).max(1);
-        // What a shape costs the first time is what it costs to compile and to
-        // fault in, not what a pass of it costs, so the first launch is spent
-        // and a second one is what the count is settled from. Reading the first
-        // ranks a shape the sweep has not compiled before below one it has.
+        // A first launch is what compiling and faulting in cost, so it is spent
+        // and the count settled from a second.
         let _ = (kernel_config.sample)(settling);
         let took = (kernel_config.sample)(settling);
 
@@ -193,10 +169,8 @@ impl ThroughputBenchmarker {
         }
     }
 
-    /// The count that would have taken [`TARGET_DURATION`], given what
-    /// `iterations` of them took.
-    ///
-    /// A timer reading zero says nothing to scale by, so the count stands.
+    /// The count that would have taken [`TARGET_DURATION`]. A timer reading zero
+    /// says nothing to scale by, so the count stands.
     fn retarget(iterations: usize, took: Duration) -> usize {
         let took = took.as_secs_f64();
 

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -93,9 +93,9 @@ impl ThroughputCache {
 /// whichever card was pinned. Two cards this cannot separate are one part, and
 /// share a peak.
 ///
-/// `capacity` and `parallelism` join the part because a name does not move when
-/// the hardware under it does: a machine that gains DIMMs, or a container given
-/// a fraction of its host's cores, reaches a different ceiling on the same part.
+/// `capacity` and `parallelism` join it because neither moves with the part:
+/// added DIMMs, or a container's share of its host's cores, change the ceiling
+/// under one name.
 fn device_key(runtime: &str, identity: &DeviceIdentity, capacity: u64, parallelism: u32) -> String {
     let DeviceIdentity { name, fingerprint } = identity;
     // A namespace is a path, and a runtime names itself `wgpu<spirv>`.
@@ -189,8 +189,6 @@ mod tests {
         );
     }
 
-    /// A CPU names itself the same before and after its DIMMs change, and the
-    /// memory ceiling it reaches does not.
     #[test]
     fn a_machine_that_gains_memory_does_not_reuse_its_ceiling() {
         let xeon = identity("Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz", "cpu_x86_64");
@@ -201,8 +199,6 @@ mod tests {
         );
     }
 
-    /// Two containers on one host are one part with two ceilings: the cores a
-    /// cgroup grants bound how much of the memory system a probe can reach.
     #[test]
     fn a_container_given_fewer_cores_does_not_reuse_the_host_ceiling() {
         let xeon = identity("Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz", "cpu_x86_64");

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -7,7 +7,7 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use cubecl_environment::collections::HashMap;
 use cubecl_environment::sync::Mutex;
-use cubecl_ir::DeviceIdentity;
+use cubecl_ir::{DeviceIdentity, DeviceProperties};
 
 /// The namespace segment naming which generation of probes wrote a value.
 #[cfg(std_io)]
@@ -28,8 +28,17 @@ pub struct ThroughputCache {
 
 impl ThroughputCache {
     /// Gets or creates the global `ThroughputCache` for one device.
-    pub fn get_for_device(runtime: &str, identity: &DeviceIdentity) -> Arc<Mutex<Self>> {
-        let name = device_key(runtime, identity);
+    pub fn get_for_device(runtime: &str, properties: &DeviceProperties) -> Arc<Mutex<Self>> {
+        let hardware = &properties.hardware;
+        let name = device_key(
+            runtime,
+            &properties.identity,
+            properties.memory.max_page_size,
+            hardware
+                .num_cpu_cores
+                .or(hardware.num_streaming_multiprocessors)
+                .unwrap_or(0),
+        );
         let mut cache_map = GLOBAL_CACHE.lock();
         let cache_map = cache_map.get_or_insert_with(HashMap::new);
 
@@ -83,13 +92,17 @@ impl ThroughputCache {
 /// The part, never the device index, which `CUDA_VISIBLE_DEVICES` makes 0 for
 /// whichever card was pinned. Two cards this cannot separate are one part, and
 /// share a peak.
-fn device_key(runtime: &str, identity: &DeviceIdentity) -> String {
+///
+/// `capacity` and `parallelism` join the part because a name does not move when
+/// the hardware under it does: a machine that gains DIMMs, or a container given
+/// a fraction of its host's cores, reaches a different ceiling on the same part.
+fn device_key(runtime: &str, identity: &DeviceIdentity, capacity: u64, parallelism: u32) -> String {
     let DeviceIdentity { name, fingerprint } = identity;
     // A namespace is a path, and a runtime names itself `wgpu<spirv>`.
     let segment = |text: &str| text.replace(|c: char| !c.is_ascii_alphanumeric(), "-");
 
     format!(
-        "{}_{}_{}",
+        "{}_{}_{}_mem{capacity}_par{parallelism}",
         segment(runtime),
         segment(fingerprint),
         segment(name)
@@ -152,18 +165,51 @@ mod tests {
     use super::*;
     use alloc::string::ToString;
 
+    fn identity(name: &str, fingerprint: &str) -> DeviceIdentity {
+        DeviceIdentity {
+            name: name.to_string(),
+            fingerprint: fingerprint.to_string(),
+        }
+    }
+
     /// Two cards in one machine were served each other's peaks: pinning either
     /// makes it index 0, and the index was all that told them apart.
     #[test]
     fn two_parts_of_one_architecture_do_not_share_an_entry() {
-        let turing = |name: &str| DeviceIdentity {
-            name: name.to_string(),
-            fingerprint: "ptx_sm75".to_string(),
-        };
+        let turing = |name: &str| identity(name, "ptx_sm75");
 
         assert_ne!(
-            device_key("cuda", &turing("NVIDIA GeForce RTX 2060")),
-            device_key("cuda", &turing("NVIDIA GeForce GTX 1660 SUPER")),
+            device_key("cuda", &turing("NVIDIA GeForce RTX 2060"), 6 << 30, 30),
+            device_key(
+                "cuda",
+                &turing("NVIDIA GeForce GTX 1660 SUPER"),
+                6 << 30,
+                22
+            ),
+        );
+    }
+
+    /// A CPU names itself the same before and after its DIMMs change, and the
+    /// memory ceiling it reaches does not.
+    #[test]
+    fn a_machine_that_gains_memory_does_not_reuse_its_ceiling() {
+        let xeon = identity("Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz", "cpu_x86_64");
+
+        assert_ne!(
+            device_key("cpu", &xeon, 32 << 30, 16),
+            device_key("cpu", &xeon, 64 << 30, 16),
+        );
+    }
+
+    /// Two containers on one host are one part with two ceilings: the cores a
+    /// cgroup grants bound how much of the memory system a probe can reach.
+    #[test]
+    fn a_container_given_fewer_cores_does_not_reuse_the_host_ceiling() {
+        let xeon = identity("Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz", "cpu_x86_64");
+
+        assert_ne!(
+            device_key("cpu", &xeon, 64 << 30, 16),
+            device_key("cpu", &xeon, 64 << 30, 4),
         );
     }
 
@@ -173,10 +219,9 @@ mod tests {
     fn a_device_key_is_one_path_segment() {
         let key = device_key(
             "wgpu<spirv>",
-            &DeviceIdentity {
-                name: "Intel(R) Arc(tm) B390 (PTL)".to_string(),
-                fingerprint: "spirv_32902_45184".to_string(),
-            },
+            &identity("Intel(R) Arc(tm) B390 (PTL)", "spirv_32902_45184"),
+            1 << 31,
+            0,
         );
 
         assert!(

--- a/crates/cubecl-runtime/src/throughput/cache.rs
+++ b/crates/cubecl-runtime/src/throughput/cache.rs
@@ -92,10 +92,6 @@ impl ThroughputCache {
 /// The part, never the device index, which `CUDA_VISIBLE_DEVICES` makes 0 for
 /// whichever card was pinned. Two cards this cannot separate are one part, and
 /// share a peak.
-///
-/// `capacity` and `parallelism` join it because neither moves with the part:
-/// added DIMMs, or a container's share of its host's cores, change the ceiling
-/// under one name.
 fn device_key(runtime: &str, identity: &DeviceIdentity, capacity: u64, parallelism: u32) -> String {
     let DeviceIdentity { name, fingerprint } = identity;
     // A namespace is a path, and a runtime names itself `wgpu<spirv>`.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use cubecl_common::device::ServiceId;
 use cubecl_core::ir::{ElemType, FloatKind};
 use cubecl_environment::{collections::HashMap, sync::Mutex};
 use cubecl_runtime::{
@@ -66,7 +66,7 @@ pub fn measure_memory_curve(client: &Client, access: MemoryAccess) -> MemoryCurv
         })
     };
 
-    client.memory_cleanup();
+    cleanup_unless_pooled(client);
 
     MemoryCurve::new(access, points)
 }
@@ -121,9 +121,7 @@ pub fn measure_peak_throughput(
 
     let value = client.measure_throughput(key, || probe(client, key));
 
-    if !pooling(&device_key(client)) {
-        client.memory_cleanup();
-    }
+    cleanup_unless_pooled(client);
 
     value
 }
@@ -140,26 +138,26 @@ pub fn measure_peak_throughput(
 /// Counted per device and not as a flag, so a sweep that ends cannot release
 /// the pool another one is still measuring against.
 struct PooledProbes {
-    device: String,
+    service: ServiceId,
 }
 
 /// How many sweeps are holding each device's pools open.
-static POOLED_PROBES: Mutex<Option<HashMap<String, usize>>> = Mutex::new(None);
+static POOLED_PROBES: Mutex<Option<HashMap<ServiceId, usize>>> = Mutex::new(None);
 
 impl PooledProbes {
     fn enter(client: &Client) -> Self {
-        Self::enter_device(device_key(client))
+        Self::enter_service(client.service_id())
     }
 
-    fn enter_device(device: String) -> Self {
+    fn enter_service(service: ServiceId) -> Self {
         let mut pooled = POOLED_PROBES.lock();
 
         *pooled
             .get_or_insert_with(HashMap::new)
-            .entry(device.clone())
+            .entry(service)
             .or_insert(0) += 1;
 
-        Self { device }
+        Self { service }
     }
 }
 
@@ -170,23 +168,32 @@ impl Drop for PooledProbes {
             return;
         };
 
-        if let Some(holders) = sweeps.get_mut(&self.device) {
+        if let Some(holders) = sweeps.get_mut(&self.service) {
             *holders -= 1;
 
             if *holders == 0 {
-                sweeps.remove(&self.device);
+                sweeps.remove(&self.service);
             }
         }
     }
 }
 
-/// Whether any sweep is holding `device`'s pools open.
-fn pooling(device: &str) -> bool {
+/// Releases what `client` holds, unless a sweep is still measuring against it.
+///
+/// Decided while holding the lock: a sweep entered between reading the count
+/// and releasing would have the pool it is about to measure taken from it.
+fn cleanup_unless_pooled(client: &Client) {
     let pooled = POOLED_PROBES.lock();
 
+    if !holds(&pooled, client.service_id()) {
+        client.memory_cleanup();
+    }
+}
+
+fn holds(pooled: &Option<HashMap<ServiceId, usize>>, service: ServiceId) -> bool {
     pooled
         .as_ref()
-        .is_some_and(|sweeps| sweeps.contains_key(device))
+        .is_some_and(|sweeps| sweeps.contains_key(&service))
 }
 
 /// Measures `key`, in the fastest shape its probe can be launched in.
@@ -351,8 +358,13 @@ fn ranked_shape<S: Copy>(shapes: &[S], build: impl Fn(S) -> KernelConfig) -> Opt
 
     for shape in shapes {
         let config = build(*shape);
-        let iterations = *warmed.get_or_insert_with(|| ThroughputBenchmarker::warm(&config));
-        let rate = ThroughputBenchmarker::rank(&config, iterations).ops_per_s();
+        let start = *warmed.get_or_insert_with(|| ThroughputBenchmarker::warm(&config));
+        let ranked = ThroughputBenchmarker::rank(&config, start);
+        let rate = ranked.value.ops_per_s();
+
+        // The next shape starts from what this one settled on, so a sweep whose
+        // shapes drift in cost keeps its settling launch near the target.
+        warmed = Some(ranked.iterations);
 
         if rate.is_finite() && fastest.is_none_or(|(best, _)| rate > best) {
             fastest = Some((rate, *shape));
@@ -413,13 +425,14 @@ fn with_units(client: &Client, config: LaunchConfig, units: u32) -> LaunchConfig
 
 /// The worker count each device streams each access fastest at, once one probe
 /// of that access has swept for it.
-static SATURATING_WORKERS: Mutex<Option<HashMap<(String, MemoryAccess), u32>>> = Mutex::new(None);
+static SATURATING_WORKERS: Mutex<Option<HashMap<(ServiceId, MemoryAccess), u32>>> =
+    Mutex::new(None);
 
 fn remembered_workers(client: &Client, access: MemoryAccess) -> Option<u32> {
     let workers = SATURATING_WORKERS.lock();
     let workers = workers.as_ref()?;
 
-    workers.get(&(device_key(client), access)).copied()
+    workers.get(&(client.service_id(), access)).copied()
 }
 
 fn remember_workers(client: &Client, access: MemoryAccess, units: u32) {
@@ -427,19 +440,7 @@ fn remember_workers(client: &Client, access: MemoryAccess, units: u32) {
 
     workers
         .get_or_insert_with(HashMap::new)
-        .insert((device_key(client), access), units);
-}
-
-/// Names one device, so two of them do not share a worker count.
-fn device_key(client: &Client) -> String {
-    let identity = &client.properties().identity;
-
-    alloc::format!(
-        "{}_{}_{}",
-        client.name(),
-        identity.fingerprint,
-        identity.name
-    )
+        .insert((client.service_id(), access), units);
 }
 
 /// The element types the arithmetic ceiling for `dtype` is measured in.
@@ -549,7 +550,17 @@ fn launch_config(client: &Client, dtype: ElemType) -> LaunchConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cubecl_common::device::DeviceId;
     use cubecl_core::ir::{IntKind, UIntKind};
+
+    /// A service to key pooled state on, distinct per `index`.
+    fn service(index: u16) -> ServiceId {
+        ServiceId::of::<u8>(DeviceId::new(0, index))
+    }
+
+    fn pooled(service: ServiceId) -> bool {
+        holds(&POOLED_PROBES.lock(), service)
+    }
 
     const F32: ElemType = ElemType::Float(FloatKind::F32);
 
@@ -557,17 +568,17 @@ mod tests {
     /// other is still measuring against, which is what a single flag would do.
     #[test]
     fn a_sweep_that_ends_leaves_an_overlapping_one_pooled() {
-        let device = String::from("overlapping");
-        let held = PooledProbes::enter_device(device.clone());
+        let device = service(1);
+        let held = PooledProbes::enter_service(device);
 
         {
-            let _ends_first = PooledProbes::enter_device(device.clone());
-            assert!(pooling(&device));
+            let _ends_first = PooledProbes::enter_service(device);
+            assert!(pooled(device));
         }
 
-        assert!(pooling(&device), "one sweep is still running");
+        assert!(pooled(device), "one sweep is still running");
         drop(held);
-        assert!(!pooling(&device));
+        assert!(!pooled(device));
     }
 
     /// The same, across threads, where the two sweeps genuinely overlap rather
@@ -576,41 +587,38 @@ mod tests {
     fn a_sweep_on_another_thread_keeps_its_own_device_pooled() {
         use std::sync::{Arc, Barrier};
 
-        let device = String::from("threaded");
+        let device = service(2);
         let (entered, ended) = (Arc::new(Barrier::new(2)), Arc::new(Barrier::new(2)));
 
         let holder = std::thread::spawn({
-            let (device, entered, ended) = (device.clone(), entered.clone(), ended.clone());
+            let (entered, ended) = (entered.clone(), ended.clone());
 
             move || {
-                let _pooled = PooledProbes::enter_device(device);
+                let _pooled = PooledProbes::enter_service(device);
                 entered.wait();
                 ended.wait();
             }
         });
 
         {
-            let _pooled = PooledProbes::enter_device(device.clone());
+            let _pooled = PooledProbes::enter_service(device);
             entered.wait();
         }
 
-        assert!(
-            pooling(&device),
-            "the other thread's sweep is still running"
-        );
+        assert!(pooled(device), "the other thread's sweep is still running");
         ended.wait();
         holder.join().expect("the holding thread finishes");
-        assert!(!pooling(&device));
+        assert!(!pooled(device));
     }
 
-    /// Pools are a device's own, so one device's sweep says nothing about
-    /// another's.
+    /// Pools are a device's own, and two cards of the same model are two
+    /// devices: a sweep on one says nothing about the other.
     #[test]
     fn a_sweep_pools_only_the_device_it_measures() {
-        let _pooled = PooledProbes::enter_device(String::from("measured"));
+        let _pooled = PooledProbes::enter_service(service(3));
 
-        assert!(pooling("measured"));
-        assert!(!pooling("untouched"));
+        assert!(pooled(service(3)));
+        assert!(!pooled(service(4)));
     }
 
     /// The reported value is a full measurement of the winner, not the

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -232,6 +232,11 @@ pub fn roofline_bounds(
 /// What the device answers fastest, of the shapes a probe can be launched in,
 /// and the shape that answered it.
 ///
+/// The shapes are ranked against each other briefly and only the winner is
+/// measured, since a full measurement is mostly warmup and a warmup warms the
+/// device rather than the shape. Ranking orders shapes that are 10% apart or
+/// more; ones it cannot separate are interchangeable.
+///
 /// Built one at a time and dropped on the way out: a memory probe's pool is a
 /// large fraction of what the device will allocate, and holding every shape's
 /// at once would ask for several of them.
@@ -241,12 +246,50 @@ fn fastest_shape<S: Copy>(
     shapes: alloc::vec::Vec<S>,
     build: impl Fn(S) -> KernelConfig,
 ) -> Result<(ThroughputValue, S), ThroughputError> {
-    shapes
-        .into_iter()
-        .map(|shape| (ThroughputBenchmarker::sample(build(shape)), shape))
-        .filter(|(value, _)| value.ops_per_s().is_finite())
-        .max_by(|(a, _), (b, _)| a.ops_per_s().total_cmp(&b.ops_per_s()))
+    let (fastest, warmed) = match shapes.len() {
+        0 => return Err(ThroughputError::NoTiming),
+        1 => (shapes[0], None),
+        _ => {
+            let (fastest, iterations) =
+                ranked_shape(&shapes, &build).ok_or(ThroughputError::NoTiming)?;
+
+            (fastest, Some(iterations))
+        }
+    };
+
+    let config = build(fastest);
+    let value = match warmed {
+        Some(iterations) => ThroughputBenchmarker::sample_at(&config, iterations),
+        None => ThroughputBenchmarker::sample(config),
+    };
+
+    value
+        .ops_per_s()
+        .is_finite()
+        .then_some((value, fastest))
         .ok_or(ThroughputError::NoTiming)
+}
+
+/// The shape that answers fastest over a ranking pass, and the iteration count
+/// the device was warmed at, which the winner is then measured over.
+///
+/// Warmed once, on the first shape, and every shape timed over that same count,
+/// so they are ordered on what they do rather than on which of them was warmed.
+fn ranked_shape<S: Copy>(shapes: &[S], build: impl Fn(S) -> KernelConfig) -> Option<(S, usize)> {
+    let mut warmed = None;
+    let mut fastest: Option<(f64, S)> = None;
+
+    for shape in shapes {
+        let config = build(*shape);
+        let iterations = *warmed.get_or_insert_with(|| ThroughputBenchmarker::warm(&config));
+        let rate = ThroughputBenchmarker::rank(&config, iterations).ops_per_s();
+
+        if rate.is_finite() && fastest.is_none_or(|(best, _)| rate > best) {
+            fastest = Some((rate, *shape));
+        }
+    }
+
+    Some((fastest?.1, warmed?))
 }
 
 /// The launch shapes a memory probe is measured in.
@@ -439,6 +482,25 @@ mod tests {
     use cubecl_core::ir::{IntKind, UIntKind};
 
     const F32: ElemType = ElemType::Float(FloatKind::F32);
+
+    /// The reported value is a full measurement of the winner, not the
+    /// ranking pass that found it.
+    #[test]
+    fn the_shape_that_ranks_fastest_is_the_one_measured() {
+        // A shape here is its rate: the faster it is, the less time a pass takes.
+        let build = |rate: u64| KernelConfig {
+            sample: alloc::boxed::Box::new(move |iterations| {
+                core::time::Duration::from_nanos(iterations as u64 * 1000 / rate)
+            }),
+            ops_count: 1,
+            min_iterations: 1,
+        };
+
+        let (value, fastest) = fastest_shape(alloc::vec![1, 4, 2], build).expect("a shape ran");
+
+        assert_eq!(fastest, 4);
+        assert!(value.ops_per_s().is_finite());
+    }
 
     /// The full launch is measured first, so a device whose peak is there
     /// keeps the shape it had before the sweep existed.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -1,5 +1,4 @@
 use alloc::string::String;
-use core::sync::atomic::{AtomicBool, Ordering};
 use cubecl_core::ir::{ElemType, FloatKind};
 use cubecl_environment::{collections::HashMap, sync::Mutex};
 use cubecl_runtime::{
@@ -30,7 +29,7 @@ const CPU_CHAIN_DEPTH: usize = 64;
 
 /// Worker counts a memory probe is swept over before the fastest is kept, once
 /// per device and access. Five halvings reach a sixteenth of the cores, and
-/// each one costs a warmup and a sample.
+/// each one costs a ranking pass.
 const MEMORY_WORKER_SHAPES: usize = 5;
 
 /// Units a GPU probe asks for. A wider cube measures no faster, and makes the
@@ -60,7 +59,7 @@ pub fn device_throughput<R: Runtime>(
 pub fn measure_memory_curve(client: &Client, access: MemoryAccess) -> MemoryCurve {
     let points = {
         // Every point of a sweep asks for the same pool, so the sweep holds one.
-        let _pooled = PooledProbes::enter();
+        let _pooled = PooledProbes::enter(client);
 
         sweep(client, access, |bytes| {
             ThroughputMode::Memory(MemorySpec::new(access, bytes))
@@ -122,36 +121,72 @@ pub fn measure_peak_throughput(
 
     let value = client.measure_throughput(key, || probe(client, key));
 
-    if !POOLED_PROBES.load(Ordering::Relaxed) {
+    if !pooling(&device_key(client)) {
         client.memory_cleanup();
     }
 
     value
 }
 
-/// Probes measured while one of these is alive leave their pools with the
-/// allocator instead of returning them.
+/// A device whose probes leave their pools with the allocator rather than
+/// returning them, for as long as one of these is alive.
 ///
-/// Releasing a pool makes the next probe fault a gigabyte of fresh pages back
-/// in, which costs more than twice what measuring it does: 1.2 s against 0.5 s
-/// a point. The shapes of one sweep already share a pool this way, since
-/// nothing is released until the probe returns.
-struct PooledProbes;
+/// Releasing a pool costs the probe that asks for the next one more than the
+/// measurement itself, since the allocation faults its pages back in one by
+/// one. The shapes of a single probe already share a pool, nothing being
+/// released until that probe returns; this widens that to a caller measuring
+/// many.
+///
+/// Counted per device and not as a flag, so a sweep that ends cannot release
+/// the pool another one is still measuring against.
+struct PooledProbes {
+    device: String,
+}
 
-static POOLED_PROBES: AtomicBool = AtomicBool::new(false);
+/// How many sweeps are holding each device's pools open.
+static POOLED_PROBES: Mutex<Option<HashMap<String, usize>>> = Mutex::new(None);
 
 impl PooledProbes {
-    fn enter() -> Self {
-        POOLED_PROBES.store(true, Ordering::Relaxed);
+    fn enter(client: &Client) -> Self {
+        Self::enter_device(device_key(client))
+    }
 
-        Self
+    fn enter_device(device: String) -> Self {
+        let mut pooled = POOLED_PROBES.lock();
+
+        *pooled
+            .get_or_insert_with(HashMap::new)
+            .entry(device.clone())
+            .or_insert(0) += 1;
+
+        Self { device }
     }
 }
 
 impl Drop for PooledProbes {
     fn drop(&mut self) {
-        POOLED_PROBES.store(false, Ordering::Relaxed);
+        let mut pooled = POOLED_PROBES.lock();
+        let Some(sweeps) = pooled.as_mut() else {
+            return;
+        };
+
+        if let Some(holders) = sweeps.get_mut(&self.device) {
+            *holders -= 1;
+
+            if *holders == 0 {
+                sweeps.remove(&self.device);
+            }
+        }
     }
+}
+
+/// Whether any sweep is holding `device`'s pools open.
+fn pooling(device: &str) -> bool {
+    let pooled = POOLED_PROBES.lock();
+
+    pooled
+        .as_ref()
+        .is_some_and(|sweeps| sweeps.contains_key(device))
 }
 
 /// Measures `key`, in the fastest shape its probe can be launched in.
@@ -332,11 +367,9 @@ fn ranked_shape<S: Copy>(shapes: &[S], build: impl Fn(S) -> KernelConfig) -> Opt
 /// A GPU keeps the cube it was pinned to: a wider one measures no faster, and
 /// makes these probes report several times the bus rate.
 ///
-/// A CPU sweeps its worker count once per access and then keeps the count that
-/// won, at every working set. That count does not move with the window: four
-/// workers win all seventeen read points of a Ryzen 7 5700X's curve, by 10 to
-/// 22%, and the whole ranking barely shifts across them. Sweeping every point
-/// instead costs the curve 2.7x for an answer it already has.
+/// A CPU sweeps its worker count once per access and keeps the winner for every
+/// working set: what saturates a memory system is a property of the controller,
+/// not of the window a probe moves through it.
 fn memory_shapes(
     client: &Client,
     config: LaunchConfig,
@@ -359,9 +392,10 @@ fn memory_shapes(
 /// Worker counts a CPU probe is swept over, the full launch first and halvings
 /// of it after.
 ///
-/// How many threads saturate the memory system is a property of the controller
-/// rather than of the core count: one per hardware thread reads 44 GB/s of a
-/// Ryzen 7 5700X's 51.2, where a quarter of them reads 50. Little's law derives
+/// How many threads saturate a memory system is a property of the controller
+/// rather than of the core count, and it falls either side of the full launch:
+/// where one core nearly saturates the bus, a fraction of the threads beats all
+/// of them, and where it does not, every thread is needed. Little's law derives
 /// the count from the bandwidth, which is the thing being measured, so it is
 /// swept instead.
 fn worker_counts(units: usize) -> alloc::vec::Vec<usize> {
@@ -410,10 +444,11 @@ fn device_key(client: &Client) -> String {
 
 /// The element types the arithmetic ceiling for `dtype` is measured in.
 ///
-/// A device emulating `dtype`'s fma retires a ninth of its f32 rate on a Ryzen
-/// 7 5700X, and a kernel with those operands converts and accumulates in f32
-/// rather than pay that, so the emulated rate is no ceiling. Both are measured:
-/// packed f16 retires two per f32 lane and wins where the hardware has it.
+/// A device with no fma of its own for `dtype` emulates one per operation, at a
+/// fraction of its f32 rate, and a kernel with those operands converts and
+/// accumulates in f32 rather than pay that, so the emulated rate is no ceiling.
+/// Both are measured: packed f16 retires two per f32 lane and wins where the
+/// hardware has it.
 fn arithmetic_dtypes(client: &Client, dtype: ElemType) -> alloc::vec::Vec<ElemType> {
     let mut dtypes = alloc::vec![dtype];
 
@@ -517,6 +552,66 @@ mod tests {
     use cubecl_core::ir::{IntKind, UIntKind};
 
     const F32: ElemType = ElemType::Float(FloatKind::F32);
+
+    /// A sweep that ends while another is running must not release the pool the
+    /// other is still measuring against, which is what a single flag would do.
+    #[test]
+    fn a_sweep_that_ends_leaves_an_overlapping_one_pooled() {
+        let device = String::from("overlapping");
+        let held = PooledProbes::enter_device(device.clone());
+
+        {
+            let _ends_first = PooledProbes::enter_device(device.clone());
+            assert!(pooling(&device));
+        }
+
+        assert!(pooling(&device), "one sweep is still running");
+        drop(held);
+        assert!(!pooling(&device));
+    }
+
+    /// The same, across threads, where the two sweeps genuinely overlap rather
+    /// than nest.
+    #[test]
+    fn a_sweep_on_another_thread_keeps_its_own_device_pooled() {
+        use std::sync::{Arc, Barrier};
+
+        let device = String::from("threaded");
+        let (entered, ended) = (Arc::new(Barrier::new(2)), Arc::new(Barrier::new(2)));
+
+        let holder = std::thread::spawn({
+            let (device, entered, ended) = (device.clone(), entered.clone(), ended.clone());
+
+            move || {
+                let _pooled = PooledProbes::enter_device(device);
+                entered.wait();
+                ended.wait();
+            }
+        });
+
+        {
+            let _pooled = PooledProbes::enter_device(device.clone());
+            entered.wait();
+        }
+
+        assert!(
+            pooling(&device),
+            "the other thread's sweep is still running"
+        );
+        ended.wait();
+        holder.join().expect("the holding thread finishes");
+        assert!(!pooling(&device));
+    }
+
+    /// Pools are a device's own, so one device's sweep says nothing about
+    /// another's.
+    #[test]
+    fn a_sweep_pools_only_the_device_it_measures() {
+        let _pooled = PooledProbes::enter_device(String::from("measured"));
+
+        assert!(pooling("measured"));
+        assert!(!pooling("untouched"));
+    }
 
     /// The reported value is a full measurement of the winner, not the
     /// ranking pass that found it.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use core::sync::atomic::{AtomicBool, Ordering};
 use cubecl_core::ir::{ElemType, FloatKind};
 use cubecl_environment::{collections::HashMap, sync::Mutex};
 use cubecl_runtime::{
@@ -57,9 +58,16 @@ pub fn device_throughput<R: Runtime>(
 ///
 /// Native only, panics on WASM
 pub fn measure_memory_curve(client: &Client, access: MemoryAccess) -> MemoryCurve {
-    let points = sweep(client, access, |bytes| {
-        ThroughputMode::Memory(MemorySpec::new(access, bytes))
-    });
+    let points = {
+        // Every point of a sweep asks for the same pool, so the sweep holds one.
+        let _pooled = PooledProbes::enter();
+
+        sweep(client, access, |bytes| {
+            ThroughputMode::Memory(MemorySpec::new(access, bytes))
+        })
+    };
+
+    client.memory_cleanup();
 
     MemoryCurve::new(access, points)
 }
@@ -114,9 +122,36 @@ pub fn measure_peak_throughput(
 
     let value = client.measure_throughput(key, || probe(client, key));
 
-    client.memory_cleanup();
+    if !POOLED_PROBES.load(Ordering::Relaxed) {
+        client.memory_cleanup();
+    }
 
     value
+}
+
+/// Probes measured while one of these is alive leave their pools with the
+/// allocator instead of returning them.
+///
+/// Releasing a pool makes the next probe fault a gigabyte of fresh pages back
+/// in, which costs more than twice what measuring it does: 1.2 s against 0.5 s
+/// a point. The shapes of one sweep already share a pool this way, since
+/// nothing is released until the probe returns.
+struct PooledProbes;
+
+static POOLED_PROBES: AtomicBool = AtomicBool::new(false);
+
+impl PooledProbes {
+    fn enter() -> Self {
+        POOLED_PROBES.store(true, Ordering::Relaxed);
+
+        Self
+    }
+}
+
+impl Drop for PooledProbes {
+    fn drop(&mut self) {
+        POOLED_PROBES.store(false, Ordering::Relaxed);
+    }
 }
 
 /// Measures `key`, in the fastest shape its probe can be launched in.

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -1,4 +1,6 @@
+use alloc::string::String;
 use cubecl_core::ir::ElemType;
+use cubecl_environment::{collections::HashMap, sync::Mutex};
 use cubecl_runtime::{
     client::Client,
     runtime::Runtime,
@@ -24,6 +26,11 @@ use crate::throughput::{
 /// probes with blocked addressing pin their own count back to one (see
 /// [`MemoryProbe::new`](crate::throughput::memory_probe::MemoryProbe::new)).
 const CPU_CHAIN_DEPTH: usize = 64;
+
+/// Worker counts a memory probe is swept over before the fastest is kept, once
+/// per device and access. Five halvings reach a sixteenth of the cores, and
+/// each one costs a warmup and a sample.
+const MEMORY_WORKER_SHAPES: usize = 5;
 
 /// Units a GPU probe asks for. A wider cube measures no faster, and makes the
 /// memory probes report several times the bus rate.
@@ -105,25 +112,42 @@ pub fn measure_peak_throughput(
     // issued, which for these is this thread.
     let _measurement = cubecl_runtime::dry_run::RealRun::new();
 
+    let value = client.measure_throughput(key, || probe(client, key));
+
+    client.memory_cleanup();
+
+    value
+}
+
+/// Measures `key`, in the fastest shape its probe can be launched in.
+///
+/// # Errors
+///
+/// [`Unsupported`](ThroughputError::Unsupported) where the device implements
+/// no such operation, [`NoTiming`](ThroughputError::NoTiming) where it does
+/// and reported no elapsed time.
+fn probe(client: &Client, key: ThroughputKey) -> Result<ThroughputValue, ThroughputError> {
     let launch_config = launch_config(client, key.dtype());
 
-    let candidates = match key.mode {
+    match key.mode {
         ThroughputMode::ComputeDirect { dtype } => {
             // A type the backend cannot lower panics rather than answering.
             if !client.properties().features.supports_type(dtype) {
                 return Err(ThroughputError::Unsupported);
             }
 
-            arithmetic_widths(client, dtype)
+            let shapes = arithmetic_widths(client, dtype)
                 .into_iter()
-                .map(|vector_size| {
-                    let config = LaunchConfig {
-                        vector_size,
-                        ..launch_config
-                    };
-                    compute_direct::build_kernel(client, key, config)
+                .map(|vector_size| LaunchConfig {
+                    vector_size,
+                    ..launch_config
                 })
-                .collect()
+                .collect();
+
+            fastest_shape(shapes, |config| {
+                compute_direct::build_kernel(client, key, config)
+            })
+            .map(|(value, _)| value)
         }
         ThroughputMode::ComputeCmma {
             dtype,
@@ -132,28 +156,31 @@ pub fn measure_peak_throughput(
             if !implements_cmma(client, dtype, cmma_config) {
                 return Err(ThroughputError::Unsupported);
             }
-            alloc::vec![compute_cmma::build_kernel(
-                client,
-                key,
-                cmma_config,
-                launch_config
-            )]
+
+            fastest_shape(alloc::vec![launch_config], |config| {
+                compute_cmma::build_kernel(client, key, cmma_config, config)
+            })
+            .map(|(value, _)| value)
         }
-        ThroughputMode::Memory(spec) => alloc::vec![match spec.access {
-            MemoryAccess::Copy => memory_direct::build_kernel(client, key, launch_config, spec),
-            MemoryAccess::Read => memory_read::build_kernel(client, key, launch_config, spec),
-            MemoryAccess::Write => memory_write::build_kernel(client, key, launch_config, spec),
-        }],
-        ThroughputMode::Launch => {
-            alloc::vec![launch_overhead::build_kernel(client, key, launch_config)]
+        ThroughputMode::Memory(spec) => {
+            let (value, fastest) = fastest_shape(
+                memory_shapes(client, launch_config, spec.access),
+                |config| match spec.access {
+                    MemoryAccess::Copy => memory_direct::build_kernel(client, key, config, spec),
+                    MemoryAccess::Read => memory_read::build_kernel(client, key, config, spec),
+                    MemoryAccess::Write => memory_write::build_kernel(client, key, config, spec),
+                },
+            )?;
+
+            remember_workers(client, spec.access, fastest.cube_dim.num_elems());
+
+            Ok(value)
         }
-    };
-
-    let value = client.measure_throughput(key, || fastest_shape(candidates));
-
-    client.memory_cleanup();
-
-    value
+        ThroughputMode::Launch => fastest_shape(alloc::vec![launch_config], |config| {
+            launch_overhead::build_kernel(client, key, config)
+        })
+        .map(|(value, _)| value),
+    }
 }
 
 /// Calculates roofline autotune bounds for a given [`Work`] amount and compute throughput key.
@@ -193,18 +220,105 @@ pub fn roofline_bounds(
     }
 }
 
-/// What the device answers fastest, of the shapes a probe can be launched in.
+/// What the device answers fastest, of the shapes a probe can be launched in,
+/// and the shape that answered it.
+///
+/// Built one at a time and dropped on the way out: a memory probe's pool is a
+/// large fraction of what the device will allocate, and holding every shape's
+/// at once would ask for several of them.
 ///
 /// A rate that is not finite is a shape that did not run, not a slow one.
 fn fastest_shape(
-    candidates: alloc::vec::Vec<KernelConfig>,
-) -> Result<ThroughputValue, ThroughputError> {
-    candidates
+    shapes: alloc::vec::Vec<LaunchConfig>,
+    build: impl Fn(LaunchConfig) -> KernelConfig,
+) -> Result<(ThroughputValue, LaunchConfig), ThroughputError> {
+    shapes
         .into_iter()
-        .map(ThroughputBenchmarker::sample)
-        .filter(|value| value.ops_per_s().is_finite())
-        .max_by(|a, b| a.ops_per_s().total_cmp(&b.ops_per_s()))
+        .map(|shape| (ThroughputBenchmarker::sample(build(shape)), shape))
+        .filter(|(value, _)| value.ops_per_s().is_finite())
+        .max_by(|(a, _), (b, _)| a.ops_per_s().total_cmp(&b.ops_per_s()))
         .ok_or(ThroughputError::NoTiming)
+}
+
+/// The launch shapes a memory probe is measured in.
+///
+/// A GPU keeps the cube it was pinned to: a wider one measures no faster, and
+/// makes these probes report several times the bus rate.
+///
+/// A CPU sweeps its worker count once per access and then keeps the count that
+/// won, at every working set. That count does not move with the window: four
+/// workers win all seventeen read points of a Ryzen 7 5700X's curve, by 10 to
+/// 22%, and the whole ranking barely shifts across them. Sweeping every point
+/// instead costs the curve 2.7x for an answer it already has.
+fn memory_shapes(
+    client: &Client,
+    config: LaunchConfig,
+    access: MemoryAccess,
+) -> alloc::vec::Vec<LaunchConfig> {
+    if client.properties().hardware.num_cpu_cores.is_none() {
+        return alloc::vec![config];
+    }
+
+    if let Some(units) = remembered_workers(client, access) {
+        return alloc::vec![with_units(client, config, units)];
+    }
+
+    worker_counts(config.cube_dim.num_elems() as usize)
+        .into_iter()
+        .map(|units| with_units(client, config, units as u32))
+        .collect()
+}
+
+/// Worker counts a CPU probe is swept over, the full launch first and halvings
+/// of it after.
+///
+/// How many threads saturate the memory system is a property of the controller
+/// rather than of the core count: one per hardware thread reads 44 GB/s of a
+/// Ryzen 7 5700X's 51.2, where a quarter of them reads 50. Little's law derives
+/// the count from the bandwidth, which is the thing being measured, so it is
+/// swept instead.
+fn worker_counts(units: usize) -> alloc::vec::Vec<usize> {
+    core::iter::successors(Some(units.max(1)), |units| (*units > 1).then(|| units / 2))
+        .take(MEMORY_WORKER_SHAPES)
+        .collect()
+}
+
+fn with_units(client: &Client, config: LaunchConfig, units: u32) -> LaunchConfig {
+    LaunchConfig {
+        cube_dim: CubeDim::new(client, units as usize),
+        ..config
+    }
+}
+
+/// The worker count each device streams each access fastest at, once one probe
+/// of that access has swept for it.
+static SATURATING_WORKERS: Mutex<Option<HashMap<(String, MemoryAccess), u32>>> = Mutex::new(None);
+
+fn remembered_workers(client: &Client, access: MemoryAccess) -> Option<u32> {
+    let workers = SATURATING_WORKERS.lock();
+    let workers = workers.as_ref()?;
+
+    workers.get(&(device_key(client), access)).copied()
+}
+
+fn remember_workers(client: &Client, access: MemoryAccess, units: u32) {
+    let mut workers = SATURATING_WORKERS.lock();
+
+    workers
+        .get_or_insert_with(HashMap::new)
+        .insert((device_key(client), access), units);
+}
+
+/// Names one device, so two of them do not share a worker count.
+fn device_key(client: &Client) -> String {
+    let identity = &client.properties().identity;
+
+    alloc::format!(
+        "{}_{}_{}",
+        client.name(),
+        identity.fingerprint,
+        identity.name
+    )
 }
 
 /// The vector widths an arithmetic probe is measured at.
@@ -279,5 +393,25 @@ fn launch_config(client: &Client, dtype: ElemType) -> LaunchConfig {
         cube_count: cube_count as usize,
         vector_size,
         plane_size: plane_size as usize,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The full launch is measured first, so a device whose peak is there
+    /// keeps the shape it had before the sweep existed.
+    #[test]
+    fn the_sweep_starts_at_the_full_launch_and_halves_to_the_budget() {
+        assert_eq!(worker_counts(16), alloc::vec![16, 8, 4, 2, 1]);
+        assert_eq!(worker_counts(128), alloc::vec![128, 64, 32, 16, 8]);
+    }
+
+    /// Every count is a launch, so one core must not be handed an empty sweep
+    /// and reported as untimeable.
+    #[test]
+    fn one_core_is_still_a_shape() {
+        assert_eq!(worker_counts(1), alloc::vec![1]);
     }
 }

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -1,5 +1,5 @@
 use alloc::string::String;
-use cubecl_core::ir::ElemType;
+use cubecl_core::ir::{ElemType, FloatKind};
 use cubecl_environment::{collections::HashMap, sync::Mutex};
 use cubecl_runtime::{
     client::Client,
@@ -136,16 +136,25 @@ fn probe(client: &Client, key: ThroughputKey) -> Result<ThroughputValue, Through
                 return Err(ThroughputError::Unsupported);
             }
 
-            let shapes = arithmetic_widths(client, dtype)
+            let shapes = arithmetic_dtypes(client, dtype)
                 .into_iter()
-                .map(|vector_size| LaunchConfig {
-                    vector_size,
-                    ..launch_config
+                .flat_map(|dtype| {
+                    arithmetic_widths(client, dtype)
+                        .into_iter()
+                        .map(move |vector_size| {
+                            (
+                                dtype,
+                                LaunchConfig {
+                                    vector_size,
+                                    ..launch_config
+                                },
+                            )
+                        })
                 })
                 .collect();
 
-            fastest_shape(shapes, |config| {
-                compute_direct::build_kernel(client, key, config)
+            fastest_shape(shapes, |(dtype, config)| {
+                compute_direct::build_kernel(client, dtype, config)
             })
             .map(|(value, _)| value)
         }
@@ -228,10 +237,10 @@ pub fn roofline_bounds(
 /// at once would ask for several of them.
 ///
 /// A rate that is not finite is a shape that did not run, not a slow one.
-fn fastest_shape(
-    shapes: alloc::vec::Vec<LaunchConfig>,
-    build: impl Fn(LaunchConfig) -> KernelConfig,
-) -> Result<(ThroughputValue, LaunchConfig), ThroughputError> {
+fn fastest_shape<S: Copy>(
+    shapes: alloc::vec::Vec<S>,
+    build: impl Fn(S) -> KernelConfig,
+) -> Result<(ThroughputValue, S), ThroughputError> {
     shapes
         .into_iter()
         .map(|shape| (ThroughputBenchmarker::sample(build(shape)), shape))
@@ -321,6 +330,34 @@ fn device_key(client: &Client) -> String {
     )
 }
 
+/// The element types the arithmetic ceiling for `dtype` is measured in.
+///
+/// A device emulating `dtype`'s fma retires a ninth of its f32 rate on a Ryzen
+/// 7 5700X, and a kernel with those operands converts and accumulates in f32
+/// rather than pay that, so the emulated rate is no ceiling. Both are measured:
+/// packed f16 retires two per f32 lane and wins where the hardware has it.
+fn arithmetic_dtypes(client: &Client, dtype: ElemType) -> alloc::vec::Vec<ElemType> {
+    let mut dtypes = alloc::vec![dtype];
+
+    if let Some(accumulator) = promoted_dtype(dtype)
+        && client.properties().features.supports_type(accumulator)
+    {
+        dtypes.push(accumulator);
+    }
+
+    dtypes
+}
+
+/// What a kernel with `dtype` operands accumulates in when the device has no
+/// arithmetic of its own for them, or `None` where `dtype` is already the
+/// widest of the two.
+fn promoted_dtype(dtype: ElemType) -> Option<ElemType> {
+    let accumulator = ElemType::Float(FloatKind::F32);
+    let narrower_float = matches!(dtype, ElemType::Float(_)) && dtype.size() < accumulator.size();
+
+    narrower_float.then_some(accumulator)
+}
+
 /// The vector widths an arithmetic probe is measured at.
 ///
 /// `io_optimized_vector_sizes` is ordered for the loads and stores this probe
@@ -399,6 +436,9 @@ fn launch_config(client: &Client, dtype: ElemType) -> LaunchConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cubecl_core::ir::{IntKind, UIntKind};
+
+    const F32: ElemType = ElemType::Float(FloatKind::F32);
 
     /// The full launch is measured first, so a device whose peak is there
     /// keeps the shape it had before the sweep existed.
@@ -413,5 +453,27 @@ mod tests {
     #[test]
     fn one_core_is_still_a_shape() {
         assert_eq!(worker_counts(1), alloc::vec![1]);
+    }
+
+    /// Where the device does the arithmetic itself, its rate is the ceiling and
+    /// a second measurement of the same thing costs a probe for nothing.
+    #[test]
+    fn nothing_as_wide_as_the_accumulator_is_promoted() {
+        assert_eq!(promoted_dtype(F32), None);
+        assert_eq!(promoted_dtype(ElemType::Float(FloatKind::F64)), None);
+    }
+
+    /// The probe retires a multiply for an integer, which no float rate bounds.
+    #[test]
+    fn an_integer_is_not_promoted() {
+        assert_eq!(promoted_dtype(ElemType::Int(IntKind::I8)), None);
+        assert_eq!(promoted_dtype(ElemType::UInt(UIntKind::U16)), None);
+    }
+
+    #[test]
+    fn every_float_narrower_than_the_accumulator_is_promoted() {
+        for dtype in [FloatKind::F16, FloatKind::BF16, FloatKind::E4M3] {
+            assert_eq!(promoted_dtype(ElemType::Float(dtype)), Some(F32));
+        }
     }
 }

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -1,40 +1,19 @@
-use cubecl_common::device::ServiceId;
-use cubecl_core::ir::{ElemType, FloatKind};
-use cubecl_environment::{collections::HashMap, sync::Mutex};
+use cubecl_core::ir::ElemType;
 use cubecl_runtime::{
     client::Client,
     runtime::Runtime,
-    server::CubeDim,
     throughput::{
-        ComputeCmmaConfig, KernelConfig, MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec,
-        ThroughputBenchmarker, ThroughputError, ThroughputKey, ThroughputMode, ThroughputValue,
-        sweep_size, working_set_sweep,
+        MemoryAccess, MemoryCurve, MemoryPoint, MemorySpec, ThroughputError, ThroughputKey,
+        ThroughputMode, ThroughputValue, sweep_size, working_set_sweep,
     },
     tune::{Bounds, Thresholds, Work, calculate_bounds},
 };
 
 use crate::throughput::{
+    Arithmetic, CooperativeMatrix, LaunchConfig, PooledProbes, ShapeSweep, WorkerSweep,
     compute_cmma, compute_direct, launch_overhead, memory_direct, memory_probe, memory_read,
     memory_write,
 };
-
-/// Independent cube positions each CPU worker interleaves, so a compute
-/// pass pipelines past instruction latency instead of serializing on one
-/// dependency chain. A depth, not a machine guess: a handful hides any
-/// core's fma latency, excess is free because the iteration budget is
-/// time-calibrated, and nothing about the launch scales with it. Memory
-/// probes with blocked addressing pin their own count back to one (see
-/// [`MemoryProbe::new`](crate::throughput::memory_probe::MemoryProbe::new)).
-const CPU_CHAIN_DEPTH: usize = 64;
-
-/// Worker counts a memory probe is swept over before the fastest is kept, once
-/// per device and access. Five halvings reach a sixteenth of the cores, and
-/// each one costs a ranking pass.
-const MEMORY_WORKER_SHAPES: usize = 5;
-
-/// Units a GPU probe asks for. A wider cube measures no faster, and makes the
-/// memory probes report several times the bus rate.
-const PROBE_UNITS_PER_CUBE: u32 = 256;
 
 /// Measure peak throughput on `device` for each of the given `keys`.
 pub fn device_throughput<R: Runtime>(
@@ -51,9 +30,8 @@ pub fn device_throughput<R: Runtime>(
 /// kilobytes up to as much as the device will allocate.
 ///
 /// One point per size in [`working_set_sweep`], each measured and cached
-/// exactly like the single-size probe — [`measure_peak_throughput`] with a
-/// [`ThroughputMode::Memory`] key — so a curve costs one probe per size on the
-/// first run and nothing afterwards.
+/// exactly like the single-size probe, so a curve costs one probe per size on
+/// the first run and nothing afterwards.
 ///
 /// Native only, panics on WASM
 pub fn measure_memory_curve(client: &Client, access: MemoryAccess) -> MemoryCurve {
@@ -66,14 +44,11 @@ pub fn measure_memory_curve(client: &Client, access: MemoryAccess) -> MemoryCurv
         })
     };
 
-    cleanup_unless_pooled(client);
+    PooledProbes::cleanup_unless_held(client);
 
     MemoryCurve::new(access, points)
 }
 
-/// One measured point per size in [`working_set_sweep`], each cached exactly
-/// like the single-size probe, so a curve costs one probe per size on the
-/// first run and nothing afterwards.
 fn sweep(
     client: &Client,
     access: MemoryAccess,
@@ -121,76 +96,14 @@ pub fn measure_peak_throughput(
 
     let value = client.measure_throughput(key, || probe(client, key));
 
-    cleanup_unless_pooled(client);
+    PooledProbes::cleanup_unless_held(client);
 
     value
 }
 
-/// A device whose probes leave their pools with the allocator, for as long as
-/// one of these is alive, since faulting the next one back in costs more than
-/// the measurement. Counted per device, so a sweep that ends cannot release the
-/// pool another is still measuring against.
-struct PooledProbes {
-    service: ServiceId,
-}
-
-/// How many sweeps are holding each device's pools open.
-static POOLED_PROBES: Mutex<Option<HashMap<ServiceId, usize>>> = Mutex::new(None);
-
-impl PooledProbes {
-    fn enter(client: &Client) -> Self {
-        Self::enter_service(client.service_id())
-    }
-
-    fn enter_service(service: ServiceId) -> Self {
-        let mut pooled = POOLED_PROBES.lock();
-
-        *pooled
-            .get_or_insert_with(HashMap::new)
-            .entry(service)
-            .or_insert(0) += 1;
-
-        Self { service }
-    }
-}
-
-impl Drop for PooledProbes {
-    fn drop(&mut self) {
-        let mut pooled = POOLED_PROBES.lock();
-        let Some(sweeps) = pooled.as_mut() else {
-            return;
-        };
-
-        if let Some(holders) = sweeps.get_mut(&self.service) {
-            *holders -= 1;
-
-            if *holders == 0 {
-                sweeps.remove(&self.service);
-            }
-        }
-    }
-}
-
-/// Releases what `client` holds, unless a sweep is still measuring against it.
-/// Decided under the lock: a sweep entering between the read and the release
-/// would lose the pool it is about to measure.
-fn cleanup_unless_pooled(client: &Client) {
-    let pooled = POOLED_PROBES.lock();
-
-    if !holds(&pooled, client.service_id()) {
-        client.memory_cleanup();
-    }
-}
-
-fn holds(pooled: &Option<HashMap<ServiceId, usize>>, service: ServiceId) -> bool {
-    pooled
-        .as_ref()
-        .is_some_and(|sweeps| sweeps.contains_key(&service))
-}
-
 /// Measures `key`, in the fastest shape its probe can be launched in.
 fn probe(client: &Client, key: ThroughputKey) -> Result<ThroughputValue, ThroughputError> {
-    let launch_config = launch_config(client, key.dtype());
+    let launch_config = LaunchConfig::for_device(client, key.dtype());
 
     match key.mode {
         ThroughputMode::ComputeDirect { dtype } => {
@@ -199,60 +112,67 @@ fn probe(client: &Client, key: ThroughputKey) -> Result<ThroughputValue, Through
                 return Err(ThroughputError::Unsupported);
             }
 
-            let shapes = arithmetic_dtypes(client, dtype)
-                .into_iter()
-                .flat_map(|dtype| {
-                    arithmetic_widths(client, dtype)
-                        .into_iter()
-                        .map(move |vector_size| {
-                            (
-                                dtype,
-                                LaunchConfig {
-                                    vector_size,
-                                    ..launch_config
-                                },
-                            )
-                        })
-                })
-                .collect();
-
-            fastest_shape(shapes, |(dtype, config)| {
-                compute_direct::build_kernel(client, dtype, config)
-            })
-            .map(|(value, _)| value)
+            ShapeSweep::new(compute_direct_shapes(client, dtype, launch_config))
+                .fastest(|(dtype, config)| compute_direct::build_kernel(client, dtype, config))
+                .map(|(value, _)| value)
         }
         ThroughputMode::ComputeCmma {
             dtype,
             config: cmma_config,
         } => {
-            if !implements_cmma(client, dtype, cmma_config) {
+            if !CooperativeMatrix::implemented(client, dtype, cmma_config) {
                 return Err(ThroughputError::Unsupported);
             }
 
-            fastest_shape(alloc::vec![launch_config], |config| {
-                compute_cmma::build_kernel(client, key, cmma_config, config)
-            })
-            .map(|(value, _)| value)
+            ShapeSweep::new(alloc::vec![launch_config])
+                .fastest(|config| compute_cmma::build_kernel(client, key, cmma_config, config))
+                .map(|(value, _)| value)
         }
         ThroughputMode::Memory(spec) => {
-            let (value, fastest) = fastest_shape(
-                memory_shapes(client, launch_config, spec.access),
-                |config| match spec.access {
-                    MemoryAccess::Copy => memory_direct::build_kernel(client, key, config, spec),
-                    MemoryAccess::Read => memory_read::build_kernel(client, key, config, spec),
-                    MemoryAccess::Write => memory_write::build_kernel(client, key, config, spec),
-                },
-            )?;
+            let (value, fastest) = ShapeSweep::new(WorkerSweep::shapes(
+                client,
+                launch_config,
+                spec.access,
+            ))
+            .fastest(|config| match spec.access {
+                MemoryAccess::Copy => memory_direct::build_kernel(client, key, config, spec),
+                MemoryAccess::Read => memory_read::build_kernel(client, key, config, spec),
+                MemoryAccess::Write => memory_write::build_kernel(client, key, config, spec),
+            })?;
 
-            remember_workers(client, spec.access, fastest.cube_dim.num_elems());
+            WorkerSweep::remember(client, spec.access, fastest.cube_dim.num_elems());
 
             Ok(value)
         }
-        ThroughputMode::Launch => fastest_shape(alloc::vec![launch_config], |config| {
-            launch_overhead::build_kernel(client, key, config)
-        })
-        .map(|(value, _)| value),
+        ThroughputMode::Launch => ShapeSweep::new(alloc::vec![launch_config])
+            .fastest(|config| launch_overhead::build_kernel(client, key, config))
+            .map(|(value, _)| value),
     }
+}
+
+/// Every operand type and vector width the arithmetic ceiling for `dtype` is
+/// measured over.
+fn compute_direct_shapes(
+    client: &Client,
+    dtype: ElemType,
+    launch_config: LaunchConfig,
+) -> alloc::vec::Vec<(ElemType, LaunchConfig)> {
+    Arithmetic::dtypes(client, dtype)
+        .into_iter()
+        .flat_map(|dtype| {
+            Arithmetic::widths(client, dtype)
+                .into_iter()
+                .map(move |vector_size| {
+                    (
+                        dtype,
+                        LaunchConfig {
+                            vector_size,
+                            ..launch_config
+                        },
+                    )
+                })
+        })
+        .collect()
 }
 
 /// Calculates roofline autotune bounds for a given [`Work`] amount and compute throughput key.
@@ -289,351 +209,5 @@ pub fn roofline_bounds(
         launch_overhead: measure_peak_throughput(client, launch_key)
             .map(|value| value.duration_per_op())
             .unwrap_or_default(),
-    }
-}
-
-/// What the device answers fastest, of the shapes a probe can be launched in.
-///
-/// Shapes are built one at a time: a memory probe's pool is a large fraction of
-/// what the device will allocate. A rate that is not finite did not run.
-fn fastest_shape<S: Copy>(
-    shapes: alloc::vec::Vec<S>,
-    build: impl Fn(S) -> KernelConfig,
-) -> Result<(ThroughputValue, S), ThroughputError> {
-    let (fastest, warmed) = match shapes.len() {
-        0 => return Err(ThroughputError::NoTiming),
-        1 => (shapes[0], None),
-        _ => {
-            let (fastest, iterations) =
-                ranked_shape(&shapes, &build).ok_or(ThroughputError::NoTiming)?;
-
-            (fastest, Some(iterations))
-        }
-    };
-
-    let config = build(fastest);
-    let value = match warmed {
-        Some(iterations) => ThroughputBenchmarker::sample_at(&config, iterations),
-        None => ThroughputBenchmarker::sample(config),
-    };
-
-    value
-        .ops_per_s()
-        .is_finite()
-        .then_some((value, fastest))
-        .ok_or(ThroughputError::NoTiming)
-}
-
-/// The shape that answers fastest over a ranking pass, and the count the device
-/// was warmed at. Every shape is timed at that same count, so they are ordered
-/// on what they do rather than on which was warmed.
-fn ranked_shape<S: Copy>(shapes: &[S], build: impl Fn(S) -> KernelConfig) -> Option<(S, usize)> {
-    let mut warmed = None;
-    let mut fastest: Option<(f64, S)> = None;
-
-    for shape in shapes {
-        let config = build(*shape);
-        let start = *warmed.get_or_insert_with(|| ThroughputBenchmarker::warm(&config));
-        let ranked = ThroughputBenchmarker::rank(&config, start);
-        let rate = ranked.value.ops_per_s();
-
-        // The next shape starts from what this one settled on, so a sweep whose
-        // shapes drift in cost keeps its settling launch near the target.
-        warmed = Some(ranked.iterations);
-
-        if rate.is_finite() && fastest.is_none_or(|(best, _)| rate > best) {
-            fastest = Some((rate, *shape));
-        }
-    }
-
-    Some((fastest?.1, warmed?))
-}
-
-/// The launch shapes a memory probe is measured in. A GPU keeps the cube it was
-/// pinned to, since a wider one reports several times the bus rate. A CPU sweeps
-/// its worker count once per access and keeps the winner for every working set.
-fn memory_shapes(
-    client: &Client,
-    config: LaunchConfig,
-    access: MemoryAccess,
-) -> alloc::vec::Vec<LaunchConfig> {
-    if client.properties().hardware.num_cpu_cores.is_none() {
-        return alloc::vec![config];
-    }
-
-    if let Some(units) = remembered_workers(client, access) {
-        return alloc::vec![with_units(client, config, units)];
-    }
-
-    worker_counts(config.cube_dim.num_elems() as usize)
-        .into_iter()
-        .map(|units| with_units(client, config, units as u32))
-        .collect()
-}
-
-/// Worker counts a CPU probe is swept over, the full launch first and halvings
-/// after. Little's law would derive the count from the bandwidth, which is the
-/// thing being measured, so it is swept instead.
-fn worker_counts(units: usize) -> alloc::vec::Vec<usize> {
-    core::iter::successors(Some(units.max(1)), |units| (*units > 1).then(|| units / 2))
-        .take(MEMORY_WORKER_SHAPES)
-        .collect()
-}
-
-fn with_units(client: &Client, config: LaunchConfig, units: u32) -> LaunchConfig {
-    LaunchConfig {
-        cube_dim: CubeDim::new(client, units as usize),
-        ..config
-    }
-}
-
-/// The worker count each device streams each access fastest at, once one probe
-/// of that access has swept for it.
-static SATURATING_WORKERS: Mutex<Option<HashMap<(ServiceId, MemoryAccess), u32>>> =
-    Mutex::new(None);
-
-fn remembered_workers(client: &Client, access: MemoryAccess) -> Option<u32> {
-    let workers = SATURATING_WORKERS.lock();
-    let workers = workers.as_ref()?;
-
-    workers.get(&(client.service_id(), access)).copied()
-}
-
-fn remember_workers(client: &Client, access: MemoryAccess, units: u32) {
-    let mut workers = SATURATING_WORKERS.lock();
-
-    workers
-        .get_or_insert_with(HashMap::new)
-        .insert((client.service_id(), access), units);
-}
-
-/// The element types the arithmetic ceiling for `dtype` is measured in. Without
-/// a native fma a kernel converts and accumulates in f32 rather than pay the
-/// emulated rate, so both are measured and the faster kept.
-fn arithmetic_dtypes(client: &Client, dtype: ElemType) -> alloc::vec::Vec<ElemType> {
-    let mut dtypes = alloc::vec![dtype];
-
-    if let Some(accumulator) = promoted_dtype(dtype)
-        && client.properties().features.supports_type(accumulator)
-    {
-        dtypes.push(accumulator);
-    }
-
-    dtypes
-}
-
-/// What a kernel with `dtype` operands accumulates in when the device has no
-/// arithmetic of its own for them, or `None` where `dtype` is already the
-/// widest of the two.
-fn promoted_dtype(dtype: ElemType) -> Option<ElemType> {
-    let accumulator = ElemType::Float(FloatKind::F32);
-    let narrower_float = matches!(dtype, ElemType::Float(_)) && dtype.size() < accumulator.size();
-
-    narrower_float.then_some(accumulator)
-}
-
-/// The vector widths an arithmetic probe is measured at.
-///
-/// `io_optimized_vector_sizes` is ordered for the loads and stores this probe
-/// issues none of, and its widest is not the fastest on every device.
-fn arithmetic_widths(client: &Client, dtype: ElemType) -> alloc::vec::Vec<usize> {
-    let widths: alloc::vec::Vec<usize> = client.io_optimized_vector_sizes(dtype.size()).collect();
-
-    if widths.is_empty() {
-        alloc::vec![1]
-    } else {
-        widths
-    }
-}
-
-/// Whether the device implements the cooperative matrix the probe launches.
-///
-/// A non-empty capability list says the device has tensor hardware, not this
-/// shape of it. `mma` is not consulted: the probe issues `cmma::execute`.
-fn implements_cmma(client: &Client, dtype: ElemType, config: ComputeCmmaConfig) -> bool {
-    client.properties().features.matmul.cmma.iter().any(|it| {
-        it.a_type == dtype
-            && it.b_type == dtype
-            && it.cd_type == config.accumulator_type
-            && it.m as usize == config.cmma_dims.m
-            && it.n as usize == config.cmma_dims.n
-            && it.k as usize == config.cmma_dims.k
-    })
-}
-
-/// Hardware execution parameters for launching a compute kernel.
-#[derive(Clone, Copy)]
-pub struct LaunchConfig {
-    /// The cube the probe launches, resolved once so `ops_count` cannot
-    /// describe a launch that did not happen.
-    pub cube_dim: CubeDim,
-    /// The total number of cubes to dispatch.
-    pub cube_count: usize,
-    /// The vectorization factor (e.g., 4 for `vec4` operations).
-    pub vector_size: usize,
-    /// The number of threads in a hardware execution plane.
-    pub plane_size: usize,
-}
-
-fn launch_config(client: &Client, dtype: ElemType) -> LaunchConfig {
-    let hardware = &client.properties().hardware;
-
-    let plane_size = hardware.plane_size_max.max(1);
-    let vector_size = client
-        .io_optimized_vector_sizes(dtype.size())
-        .next()
-        .unwrap_or(1);
-
-    // A CPU has no SMs, so `sms * 32` cubes is the wrong grid to size from:
-    // a cube's units are its real dispatched workers here, while its cube
-    // count is only a loop inside each of them. `num_cpu_cores` units, one
-    // per core, is the real worker count.
-    let (units, cube_count) = match hardware.num_cpu_cores {
-        Some(cores) => (cores, CPU_CHAIN_DEPTH as u32),
-        None => {
-            let sms = hardware.num_streaming_multiprocessors.unwrap_or(64);
-            (
-                PROBE_UNITS_PER_CUBE,
-                (sms * 32).min(hardware.max_cube_count.0),
-            )
-        }
-    };
-
-    LaunchConfig {
-        cube_dim: CubeDim::new(client, units as usize),
-        cube_count: cube_count as usize,
-        vector_size,
-        plane_size: plane_size as usize,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use cubecl_common::device::DeviceId;
-    use cubecl_core::ir::{IntKind, UIntKind};
-
-    /// A service to key pooled state on, distinct per `index`.
-    fn service(index: u16) -> ServiceId {
-        ServiceId::of::<u8>(DeviceId::new(0, index))
-    }
-
-    fn pooled(service: ServiceId) -> bool {
-        holds(&POOLED_PROBES.lock(), service)
-    }
-
-    const F32: ElemType = ElemType::Float(FloatKind::F32);
-
-    /// A sweep that ends while another is running must not release the pool the
-    /// other is still measuring against, which is what a single flag would do.
-    #[test]
-    fn a_sweep_that_ends_leaves_an_overlapping_one_pooled() {
-        let device = service(1);
-        let held = PooledProbes::enter_service(device);
-
-        {
-            let _ends_first = PooledProbes::enter_service(device);
-            assert!(pooled(device));
-        }
-
-        assert!(pooled(device), "one sweep is still running");
-        drop(held);
-        assert!(!pooled(device));
-    }
-
-    /// The same, across threads, where the two sweeps genuinely overlap rather
-    /// than nest.
-    #[test]
-    fn a_sweep_on_another_thread_keeps_its_own_device_pooled() {
-        use std::sync::{Arc, Barrier};
-
-        let device = service(2);
-        let (entered, ended) = (Arc::new(Barrier::new(2)), Arc::new(Barrier::new(2)));
-
-        let holder = std::thread::spawn({
-            let (entered, ended) = (entered.clone(), ended.clone());
-
-            move || {
-                let _pooled = PooledProbes::enter_service(device);
-                entered.wait();
-                ended.wait();
-            }
-        });
-
-        {
-            let _pooled = PooledProbes::enter_service(device);
-            entered.wait();
-        }
-
-        assert!(pooled(device), "the other thread's sweep is still running");
-        ended.wait();
-        holder.join().expect("the holding thread finishes");
-        assert!(!pooled(device));
-    }
-
-    /// Pools are a device's own, and two cards of the same model are two
-    /// devices: a sweep on one says nothing about the other.
-    #[test]
-    fn a_sweep_pools_only_the_device_it_measures() {
-        let _pooled = PooledProbes::enter_service(service(3));
-
-        assert!(pooled(service(3)));
-        assert!(!pooled(service(4)));
-    }
-
-    /// The reported value is a full measurement of the winner, not the
-    /// ranking pass that found it.
-    #[test]
-    fn the_shape_that_ranks_fastest_is_the_one_measured() {
-        // A shape here is its rate: the faster it is, the less time a pass takes.
-        let build = |rate: u64| KernelConfig {
-            sample: alloc::boxed::Box::new(move |iterations| {
-                core::time::Duration::from_nanos(iterations as u64 * 1000 / rate)
-            }),
-            ops_count: 1,
-            min_iterations: 1,
-        };
-
-        let (value, fastest) = fastest_shape(alloc::vec![1, 4, 2], build).expect("a shape ran");
-
-        assert_eq!(fastest, 4);
-        assert!(value.ops_per_s().is_finite());
-    }
-
-    /// The full launch is measured first, so a device whose peak is there
-    /// keeps the shape it had before the sweep existed.
-    #[test]
-    fn the_sweep_starts_at_the_full_launch_and_halves_to_the_budget() {
-        assert_eq!(worker_counts(16), alloc::vec![16, 8, 4, 2, 1]);
-        assert_eq!(worker_counts(128), alloc::vec![128, 64, 32, 16, 8]);
-    }
-
-    /// Every count is a launch, so one core must not be handed an empty sweep
-    /// and reported as untimeable.
-    #[test]
-    fn one_core_is_still_a_shape() {
-        assert_eq!(worker_counts(1), alloc::vec![1]);
-    }
-
-    /// Where the device does the arithmetic itself, its rate is the ceiling and
-    /// a second measurement of the same thing costs a probe for nothing.
-    #[test]
-    fn nothing_as_wide_as_the_accumulator_is_promoted() {
-        assert_eq!(promoted_dtype(F32), None);
-        assert_eq!(promoted_dtype(ElemType::Float(FloatKind::F64)), None);
-    }
-
-    /// The probe retires a multiply for an integer, which no float rate bounds.
-    #[test]
-    fn an_integer_is_not_promoted() {
-        assert_eq!(promoted_dtype(ElemType::Int(IntKind::I8)), None);
-        assert_eq!(promoted_dtype(ElemType::UInt(UIntKind::U16)), None);
-    }
-
-    #[test]
-    fn every_float_narrower_than_the_accumulator_is_promoted() {
-        for dtype in [FloatKind::F16, FloatKind::BF16, FloatKind::E4M3] {
-            assert_eq!(promoted_dtype(ElemType::Float(dtype)), Some(F32));
-        }
     }
 }

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -126,17 +126,10 @@ pub fn measure_peak_throughput(
     value
 }
 
-/// A device whose probes leave their pools with the allocator rather than
-/// returning them, for as long as one of these is alive.
-///
-/// Releasing a pool costs the probe that asks for the next one more than the
-/// measurement itself, since the allocation faults its pages back in one by
-/// one. The shapes of a single probe already share a pool, nothing being
-/// released until that probe returns; this widens that to a caller measuring
-/// many.
-///
-/// Counted per device and not as a flag, so a sweep that ends cannot release
-/// the pool another one is still measuring against.
+/// A device whose probes leave their pools with the allocator, for as long as
+/// one of these is alive, since faulting the next one back in costs more than
+/// the measurement. Counted per device, so a sweep that ends cannot release the
+/// pool another is still measuring against.
 struct PooledProbes {
     service: ServiceId,
 }
@@ -179,9 +172,8 @@ impl Drop for PooledProbes {
 }
 
 /// Releases what `client` holds, unless a sweep is still measuring against it.
-///
-/// Decided while holding the lock: a sweep entered between reading the count
-/// and releasing would have the pool it is about to measure taken from it.
+/// Decided under the lock: a sweep entering between the read and the release
+/// would lose the pool it is about to measure.
 fn cleanup_unless_pooled(client: &Client) {
     let pooled = POOLED_PROBES.lock();
 
@@ -197,12 +189,6 @@ fn holds(pooled: &Option<HashMap<ServiceId, usize>>, service: ServiceId) -> bool
 }
 
 /// Measures `key`, in the fastest shape its probe can be launched in.
-///
-/// # Errors
-///
-/// [`Unsupported`](ThroughputError::Unsupported) where the device implements
-/// no such operation, [`NoTiming`](ThroughputError::NoTiming) where it does
-/// and reported no elapsed time.
 fn probe(client: &Client, key: ThroughputKey) -> Result<ThroughputValue, ThroughputError> {
     let launch_config = launch_config(client, key.dtype());
 
@@ -306,19 +292,10 @@ pub fn roofline_bounds(
     }
 }
 
-/// What the device answers fastest, of the shapes a probe can be launched in,
-/// and the shape that answered it.
+/// What the device answers fastest, of the shapes a probe can be launched in.
 ///
-/// The shapes are ranked against each other briefly and only the winner is
-/// measured, since a full measurement is mostly warmup and a warmup warms the
-/// device rather than the shape. Ranking orders shapes that are 10% apart or
-/// more; ones it cannot separate are interchangeable.
-///
-/// Built one at a time and dropped on the way out: a memory probe's pool is a
-/// large fraction of what the device will allocate, and holding every shape's
-/// at once would ask for several of them.
-///
-/// A rate that is not finite is a shape that did not run, not a slow one.
+/// Shapes are built one at a time: a memory probe's pool is a large fraction of
+/// what the device will allocate. A rate that is not finite did not run.
 fn fastest_shape<S: Copy>(
     shapes: alloc::vec::Vec<S>,
     build: impl Fn(S) -> KernelConfig,
@@ -347,11 +324,9 @@ fn fastest_shape<S: Copy>(
         .ok_or(ThroughputError::NoTiming)
 }
 
-/// The shape that answers fastest over a ranking pass, and the iteration count
-/// the device was warmed at, which the winner is then measured over.
-///
-/// Warmed once, on the first shape, and every shape timed over that same count,
-/// so they are ordered on what they do rather than on which of them was warmed.
+/// The shape that answers fastest over a ranking pass, and the count the device
+/// was warmed at. Every shape is timed at that same count, so they are ordered
+/// on what they do rather than on which was warmed.
 fn ranked_shape<S: Copy>(shapes: &[S], build: impl Fn(S) -> KernelConfig) -> Option<(S, usize)> {
     let mut warmed = None;
     let mut fastest: Option<(f64, S)> = None;
@@ -374,14 +349,9 @@ fn ranked_shape<S: Copy>(shapes: &[S], build: impl Fn(S) -> KernelConfig) -> Opt
     Some((fastest?.1, warmed?))
 }
 
-/// The launch shapes a memory probe is measured in.
-///
-/// A GPU keeps the cube it was pinned to: a wider one measures no faster, and
-/// makes these probes report several times the bus rate.
-///
-/// A CPU sweeps its worker count once per access and keeps the winner for every
-/// working set: what saturates a memory system is a property of the controller,
-/// not of the window a probe moves through it.
+/// The launch shapes a memory probe is measured in. A GPU keeps the cube it was
+/// pinned to, since a wider one reports several times the bus rate. A CPU sweeps
+/// its worker count once per access and keeps the winner for every working set.
 fn memory_shapes(
     client: &Client,
     config: LaunchConfig,
@@ -402,14 +372,8 @@ fn memory_shapes(
 }
 
 /// Worker counts a CPU probe is swept over, the full launch first and halvings
-/// of it after.
-///
-/// How many threads saturate a memory system is a property of the controller
-/// rather than of the core count, and it falls either side of the full launch:
-/// where one core nearly saturates the bus, a fraction of the threads beats all
-/// of them, and where it does not, every thread is needed. Little's law derives
-/// the count from the bandwidth, which is the thing being measured, so it is
-/// swept instead.
+/// after. Little's law would derive the count from the bandwidth, which is the
+/// thing being measured, so it is swept instead.
 fn worker_counts(units: usize) -> alloc::vec::Vec<usize> {
     core::iter::successors(Some(units.max(1)), |units| (*units > 1).then(|| units / 2))
         .take(MEMORY_WORKER_SHAPES)
@@ -443,13 +407,9 @@ fn remember_workers(client: &Client, access: MemoryAccess, units: u32) {
         .insert((client.service_id(), access), units);
 }
 
-/// The element types the arithmetic ceiling for `dtype` is measured in.
-///
-/// A device with no fma of its own for `dtype` emulates one per operation, at a
-/// fraction of its f32 rate, and a kernel with those operands converts and
-/// accumulates in f32 rather than pay that, so the emulated rate is no ceiling.
-/// Both are measured: packed f16 retires two per f32 lane and wins where the
-/// hardware has it.
+/// The element types the arithmetic ceiling for `dtype` is measured in. Without
+/// a native fma a kernel converts and accumulates in f32 rather than pay the
+/// emulated rate, so both are measured and the faster kept.
 fn arithmetic_dtypes(client: &Client, dtype: ElemType) -> alloc::vec::Vec<ElemType> {
     let mut dtypes = alloc::vec![dtype];
 

--- a/crates/cubecl-std/src/throughput/launch.rs
+++ b/crates/cubecl-std/src/throughput/launch.rs
@@ -1,0 +1,72 @@
+use cubecl_core::ir::ElemType;
+use cubecl_runtime::{client::Client, server::CubeDim};
+
+/// Independent cube positions each CPU worker interleaves, so a compute
+/// pass pipelines past instruction latency instead of serializing on one
+/// dependency chain. A depth, not a machine guess: a handful hides any
+/// core's fma latency, excess is free because the iteration budget is
+/// time-calibrated, and nothing about the launch scales with it. Memory
+/// probes with blocked addressing pin their own count back to one (see
+/// [`MemoryProbe::new`](crate::throughput::memory_probe::MemoryProbe::new)).
+const CPU_CHAIN_DEPTH: usize = 64;
+
+/// Units a GPU probe asks for. A wider cube measures no faster, and makes the
+/// memory probes report several times the bus rate.
+const PROBE_UNITS_PER_CUBE: u32 = 256;
+
+/// Hardware execution parameters for launching a compute kernel.
+#[derive(Clone, Copy)]
+pub struct LaunchConfig {
+    /// The cube the probe launches, resolved once so `ops_count` cannot
+    /// describe a launch that did not happen.
+    pub cube_dim: CubeDim,
+    /// The total number of cubes to dispatch.
+    pub cube_count: usize,
+    /// The vectorization factor (e.g., 4 for `vec4` operations).
+    pub vector_size: usize,
+    /// The number of threads in a hardware execution plane.
+    pub plane_size: usize,
+}
+
+impl LaunchConfig {
+    /// The launch a probe of `dtype` is issued in on this device.
+    pub(super) fn for_device(client: &Client, dtype: ElemType) -> Self {
+        let hardware = &client.properties().hardware;
+
+        let plane_size = hardware.plane_size_max.max(1);
+        let vector_size = client
+            .io_optimized_vector_sizes(dtype.size())
+            .next()
+            .unwrap_or(1);
+
+        // A CPU has no SMs, so `sms * 32` cubes is the wrong grid to size from:
+        // a cube's units are its real dispatched workers here, while its cube
+        // count is only a loop inside each of them. `num_cpu_cores` units, one
+        // per core, is the real worker count.
+        let (units, cube_count) = match hardware.num_cpu_cores {
+            Some(cores) => (cores, CPU_CHAIN_DEPTH as u32),
+            None => {
+                let sms = hardware.num_streaming_multiprocessors.unwrap_or(64);
+                (
+                    PROBE_UNITS_PER_CUBE,
+                    (sms * 32).min(hardware.max_cube_count.0),
+                )
+            }
+        };
+
+        Self {
+            cube_dim: CubeDim::new(client, units as usize),
+            cube_count: cube_count as usize,
+            vector_size,
+            plane_size: plane_size as usize,
+        }
+    }
+
+    /// The same launch, dispatched across `units` workers.
+    pub(super) fn with_units(self, client: &Client, units: u32) -> Self {
+        Self {
+            cube_dim: CubeDim::new(client, units as usize),
+            ..self
+        }
+    }
+}

--- a/crates/cubecl-std/src/throughput/mod.rs
+++ b/crates/cubecl-std/src/throughput/mod.rs
@@ -1,5 +1,16 @@
 mod base;
+mod launch;
+mod operands;
+mod pooling;
 mod runners;
+mod shape;
+mod workers;
 
 pub use base::*;
+pub use launch::*;
 pub use runners::*;
+
+use operands::{Arithmetic, CooperativeMatrix};
+use pooling::PooledProbes;
+use shape::ShapeSweep;
+use workers::WorkerSweep;

--- a/crates/cubecl-std/src/throughput/operands.rs
+++ b/crates/cubecl-std/src/throughput/operands.rs
@@ -1,0 +1,94 @@
+use cubecl_core::ir::{ElemType, FloatKind};
+use cubecl_runtime::{client::Client, throughput::ComputeCmmaConfig};
+
+/// The operand types and vector widths an arithmetic ceiling is measured in.
+pub(super) struct Arithmetic;
+
+impl Arithmetic {
+    /// Without an fma of its own for `dtype` a device emulates one per
+    /// operation, and a kernel converts and accumulates in f32 rather than pay
+    /// that, so both are measured and the faster kept.
+    pub(super) fn dtypes(client: &Client, dtype: ElemType) -> alloc::vec::Vec<ElemType> {
+        let mut dtypes = alloc::vec![dtype];
+
+        if let Some(accumulator) = Self::promoted(dtype)
+            && client.properties().features.supports_type(accumulator)
+        {
+            dtypes.push(accumulator);
+        }
+
+        dtypes
+    }
+
+    /// `io_optimized_vector_sizes` is ordered for the loads and stores this
+    /// probe issues none of, and its widest is not the fastest on every device.
+    pub(super) fn widths(client: &Client, dtype: ElemType) -> alloc::vec::Vec<usize> {
+        let widths: alloc::vec::Vec<usize> =
+            client.io_optimized_vector_sizes(dtype.size()).collect();
+
+        if widths.is_empty() {
+            alloc::vec![1]
+        } else {
+            widths
+        }
+    }
+
+    /// What a kernel with `dtype` operands accumulates in when the device has no
+    /// arithmetic of its own for them, or `None` where `dtype` is already the
+    /// widest of the two.
+    fn promoted(dtype: ElemType) -> Option<ElemType> {
+        let accumulator = ElemType::Float(FloatKind::F32);
+        let narrower_float =
+            matches!(dtype, ElemType::Float(_)) && dtype.size() < accumulator.size();
+
+        narrower_float.then_some(accumulator)
+    }
+}
+
+/// The cooperative matrix a compute-cmma probe launches.
+pub(super) struct CooperativeMatrix;
+
+impl CooperativeMatrix {
+    /// A non-empty capability list says the device has tensor hardware, not this
+    /// shape of it. `mma` is not consulted: the probe issues `cmma::execute`.
+    pub(super) fn implemented(client: &Client, dtype: ElemType, config: ComputeCmmaConfig) -> bool {
+        client.properties().features.matmul.cmma.iter().any(|it| {
+            it.a_type == dtype
+                && it.b_type == dtype
+                && it.cd_type == config.accumulator_type
+                && it.m as usize == config.cmma_dims.m
+                && it.n as usize == config.cmma_dims.n
+                && it.k as usize == config.cmma_dims.k
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cubecl_core::ir::{IntKind, UIntKind};
+
+    const F32: ElemType = ElemType::Float(FloatKind::F32);
+
+    /// Where the device does the arithmetic itself, its rate is the ceiling and
+    /// a second measurement of the same thing costs a probe for nothing.
+    #[test]
+    fn nothing_as_wide_as_the_accumulator_is_promoted() {
+        assert_eq!(Arithmetic::promoted(F32), None);
+        assert_eq!(Arithmetic::promoted(ElemType::Float(FloatKind::F64)), None);
+    }
+
+    /// The probe retires a multiply for an integer, which no float rate bounds.
+    #[test]
+    fn an_integer_is_not_promoted() {
+        assert_eq!(Arithmetic::promoted(ElemType::Int(IntKind::I8)), None);
+        assert_eq!(Arithmetic::promoted(ElemType::UInt(UIntKind::U16)), None);
+    }
+
+    #[test]
+    fn every_float_narrower_than_the_accumulator_is_promoted() {
+        for dtype in [FloatKind::F16, FloatKind::BF16, FloatKind::E4M3] {
+            assert_eq!(Arithmetic::promoted(ElemType::Float(dtype)), Some(F32));
+        }
+    }
+}

--- a/crates/cubecl-std/src/throughput/pooling.rs
+++ b/crates/cubecl-std/src/throughput/pooling.rs
@@ -1,0 +1,137 @@
+use cubecl_common::device::ServiceId;
+use cubecl_environment::{collections::HashMap, sync::Mutex};
+use cubecl_runtime::client::Client;
+
+/// How many sweeps are holding each device's pools open.
+static POOLED_PROBES: Mutex<Option<HashMap<ServiceId, usize>>> = Mutex::new(None);
+
+/// A device whose probes leave their pools with the allocator, for as long as
+/// one of these is alive, since faulting the next one back in costs more than
+/// the measurement. Counted per device, so a sweep that ends cannot release the
+/// pool another is still measuring against.
+pub(super) struct PooledProbes {
+    service: ServiceId,
+}
+
+impl PooledProbes {
+    pub(super) fn enter(client: &Client) -> Self {
+        Self::enter_service(client.service_id())
+    }
+
+    fn enter_service(service: ServiceId) -> Self {
+        let mut pooled = POOLED_PROBES.lock();
+
+        *pooled
+            .get_or_insert_with(HashMap::new)
+            .entry(service)
+            .or_insert(0) += 1;
+
+        Self { service }
+    }
+
+    /// Releases what `client` holds, unless a sweep is still measuring against
+    /// it. Decided under the lock: a sweep entering between the read and the
+    /// release would lose the pool it is about to measure.
+    pub(super) fn cleanup_unless_held(client: &Client) {
+        let pooled = POOLED_PROBES.lock();
+
+        if !Self::held_by(&pooled, client.service_id()) {
+            client.memory_cleanup();
+        }
+    }
+
+    fn held_by(pooled: &Option<HashMap<ServiceId, usize>>, service: ServiceId) -> bool {
+        pooled
+            .as_ref()
+            .is_some_and(|sweeps| sweeps.contains_key(&service))
+    }
+}
+
+impl Drop for PooledProbes {
+    fn drop(&mut self) {
+        let mut pooled = POOLED_PROBES.lock();
+        let Some(sweeps) = pooled.as_mut() else {
+            return;
+        };
+
+        if let Some(holders) = sweeps.get_mut(&self.service) {
+            *holders -= 1;
+
+            if *holders == 0 {
+                sweeps.remove(&self.service);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cubecl_common::device::DeviceId;
+
+    /// A service to key pooled state on, distinct per `index`.
+    fn service(index: u16) -> ServiceId {
+        ServiceId::of::<u8>(DeviceId::new(0, index))
+    }
+
+    fn pooled(service: ServiceId) -> bool {
+        PooledProbes::held_by(&POOLED_PROBES.lock(), service)
+    }
+
+    /// A sweep that ends while another is running must not release the pool the
+    /// other is still measuring against, which is what a single flag would do.
+    #[test]
+    fn a_sweep_that_ends_leaves_an_overlapping_one_pooled() {
+        let device = service(1);
+        let held = PooledProbes::enter_service(device);
+
+        {
+            let _ends_first = PooledProbes::enter_service(device);
+            assert!(pooled(device));
+        }
+
+        assert!(pooled(device), "one sweep is still running");
+        drop(held);
+        assert!(!pooled(device));
+    }
+
+    /// The same, across threads, where the two sweeps genuinely overlap rather
+    /// than nest.
+    #[test]
+    fn a_sweep_on_another_thread_keeps_its_own_device_pooled() {
+        use std::sync::{Arc, Barrier};
+
+        let device = service(2);
+        let (entered, ended) = (Arc::new(Barrier::new(2)), Arc::new(Barrier::new(2)));
+
+        let holder = std::thread::spawn({
+            let (entered, ended) = (entered.clone(), ended.clone());
+
+            move || {
+                let _pooled = PooledProbes::enter_service(device);
+                entered.wait();
+                ended.wait();
+            }
+        });
+
+        {
+            let _pooled = PooledProbes::enter_service(device);
+            entered.wait();
+        }
+
+        assert!(pooled(device), "the other thread's sweep is still running");
+        ended.wait();
+        holder.join().expect("the holding thread finishes");
+        assert!(!pooled(device));
+    }
+
+    /// Pools are a device's own, and two cards of the same model are two
+    /// devices: a sweep on one says nothing about the other.
+    #[test]
+    fn a_sweep_pools_only_the_device_it_measures() {
+        let _pooled = PooledProbes::enter_service(service(3));
+
+        assert!(pooled(service(3)));
+        assert!(!pooled(service(4)));
+    }
+}

--- a/crates/cubecl-std/src/throughput/runners/compute_direct.rs
+++ b/crates/cubecl-std/src/throughput/runners/compute_direct.rs
@@ -1,12 +1,11 @@
 use cubecl::prelude::*;
 use cubecl_core::{self as cubecl, frontend::fma, ir::ElemType};
-use cubecl_runtime::throughput::{KernelConfig, ThroughputKey};
+use cubecl_runtime::throughput::KernelConfig;
 
 use crate::throughput::LaunchConfig;
 
-pub fn build_kernel(client: &Client, key: ThroughputKey, config: LaunchConfig) -> KernelConfig {
+pub fn build_kernel(client: &Client, dtype: ElemType, config: LaunchConfig) -> KernelConfig {
     let client = client.clone();
-    let dtype = key.dtype();
 
     let use_fma = matches!(dtype, ElemType::Float(_));
 

--- a/crates/cubecl-std/src/throughput/shape.rs
+++ b/crates/cubecl-std/src/throughput/shape.rs
@@ -1,0 +1,97 @@
+use cubecl_runtime::throughput::{
+    KernelConfig, ThroughputBenchmarker, ThroughputError, ThroughputValue,
+};
+
+/// The shapes a probe can be launched in, ranked against each other so that
+/// only the winner is measured in full.
+pub(super) struct ShapeSweep<S> {
+    shapes: alloc::vec::Vec<S>,
+}
+
+impl<S: Copy> ShapeSweep<S> {
+    pub(super) fn new(shapes: alloc::vec::Vec<S>) -> Self {
+        Self { shapes }
+    }
+
+    /// What the device answers fastest, and the shape that answered it.
+    ///
+    /// Shapes are built one at a time: a memory probe's pool is a large fraction
+    /// of what the device will allocate. A rate that is not finite did not run.
+    pub(super) fn fastest(
+        &self,
+        build: impl Fn(S) -> KernelConfig,
+    ) -> Result<(ThroughputValue, S), ThroughputError> {
+        let (fastest, warmed) = match self.shapes.len() {
+            0 => return Err(ThroughputError::NoTiming),
+            1 => (self.shapes[0], None),
+            _ => {
+                let (fastest, iterations) = self.ranked(&build).ok_or(ThroughputError::NoTiming)?;
+
+                (fastest, Some(iterations))
+            }
+        };
+
+        let config = build(fastest);
+        let value = match warmed {
+            Some(iterations) => ThroughputBenchmarker::sample_at(&config, iterations),
+            None => ThroughputBenchmarker::sample(config),
+        };
+
+        value
+            .ops_per_s()
+            .is_finite()
+            .then_some((value, fastest))
+            .ok_or(ThroughputError::NoTiming)
+    }
+
+    /// The shape that answers fastest over a ranking pass, and the count the
+    /// device was warmed at. Every shape is timed at that same count, so they
+    /// are ordered on what they do rather than on which was warmed.
+    fn ranked(&self, build: impl Fn(S) -> KernelConfig) -> Option<(S, usize)> {
+        let mut warmed = None;
+        let mut fastest: Option<(f64, S)> = None;
+
+        for shape in &self.shapes {
+            let config = build(*shape);
+            let start = *warmed.get_or_insert_with(|| ThroughputBenchmarker::warm(&config));
+            let ranked = ThroughputBenchmarker::rank(&config, start);
+            let rate = ranked.value.ops_per_s();
+
+            // The next shape starts from what this one settled on, so a sweep
+            // whose shapes drift in cost keeps its settling launch near target.
+            warmed = Some(ranked.iterations);
+
+            if rate.is_finite() && fastest.is_none_or(|(best, _)| rate > best) {
+                fastest = Some((rate, *shape));
+            }
+        }
+
+        Some((fastest?.1, warmed?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reported value is a full measurement of the winner, not the
+    /// ranking pass that found it.
+    #[test]
+    fn the_shape_that_ranks_fastest_is_the_one_measured() {
+        // A shape here is its rate: the faster it is, the less time a pass takes.
+        let build = |rate: u64| KernelConfig {
+            sample: alloc::boxed::Box::new(move |iterations| {
+                core::time::Duration::from_nanos(iterations as u64 * 1000 / rate)
+            }),
+            ops_count: 1,
+            min_iterations: 1,
+        };
+
+        let (value, fastest) = ShapeSweep::new(alloc::vec![1, 4, 2])
+            .fastest(build)
+            .expect("a shape ran");
+
+        assert_eq!(fastest, 4);
+        assert!(value.ops_per_s().is_finite());
+    }
+}

--- a/crates/cubecl-std/src/throughput/workers.rs
+++ b/crates/cubecl-std/src/throughput/workers.rs
@@ -1,0 +1,88 @@
+use cubecl_common::device::ServiceId;
+use cubecl_environment::{collections::HashMap, sync::Mutex};
+use cubecl_runtime::{client::Client, throughput::MemoryAccess};
+
+use crate::throughput::LaunchConfig;
+
+/// Worker counts a memory probe is swept over before the fastest is kept, once
+/// per device and access. Five halvings reach a sixteenth of the cores, and
+/// each one costs a ranking pass.
+const MEMORY_WORKER_SHAPES: usize = 5;
+
+/// The worker count each device streams each access fastest at, once one probe
+/// of that access has swept for it.
+static SATURATING_WORKERS: Mutex<Option<HashMap<(ServiceId, MemoryAccess), u32>>> =
+    Mutex::new(None);
+
+/// How many workers a memory probe is launched across, swept once per device
+/// and access and remembered for every working set after.
+pub(super) struct WorkerSweep;
+
+impl WorkerSweep {
+    /// The launch shapes a memory probe is measured in. A GPU keeps the cube it
+    /// was pinned to, since a wider one reports several times the bus rate. A
+    /// CPU sweeps instead, because what saturates a memory system is a property
+    /// of the controller and not of the window a probe moves through it.
+    pub(super) fn shapes(
+        client: &Client,
+        config: LaunchConfig,
+        access: MemoryAccess,
+    ) -> alloc::vec::Vec<LaunchConfig> {
+        if client.properties().hardware.num_cpu_cores.is_none() {
+            return alloc::vec![config];
+        }
+
+        if let Some(units) = Self::remembered(client, access) {
+            return alloc::vec![config.with_units(client, units)];
+        }
+
+        Self::counts(config.cube_dim.num_elems() as usize)
+            .into_iter()
+            .map(|units| config.with_units(client, units as u32))
+            .collect()
+    }
+
+    /// The full launch first and halvings after. Little's law would derive the
+    /// count from the bandwidth, which is the thing being measured, so it is
+    /// swept instead.
+    fn counts(units: usize) -> alloc::vec::Vec<usize> {
+        core::iter::successors(Some(units.max(1)), |units| (*units > 1).then(|| units / 2))
+            .take(MEMORY_WORKER_SHAPES)
+            .collect()
+    }
+
+    fn remembered(client: &Client, access: MemoryAccess) -> Option<u32> {
+        let workers = SATURATING_WORKERS.lock();
+        let workers = workers.as_ref()?;
+
+        workers.get(&(client.service_id(), access)).copied()
+    }
+
+    pub(super) fn remember(client: &Client, access: MemoryAccess, units: u32) {
+        let mut workers = SATURATING_WORKERS.lock();
+
+        workers
+            .get_or_insert_with(HashMap::new)
+            .insert((client.service_id(), access), units);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The full launch is measured first, so a device whose peak is there
+    /// keeps the shape it had before the sweep existed.
+    #[test]
+    fn the_sweep_starts_at_the_full_launch_and_halves_to_the_budget() {
+        assert_eq!(WorkerSweep::counts(16), alloc::vec![16, 8, 4, 2, 1]);
+        assert_eq!(WorkerSweep::counts(128), alloc::vec![128, 64, 32, 16, 8]);
+    }
+
+    /// Every count is a launch, so one core must not be handed an empty sweep
+    /// and reported as untimeable.
+    #[test]
+    fn one_core_is_still_a_shape() {
+        assert_eq!(WorkerSweep::counts(1), alloc::vec![1]);
+    }
+}

--- a/examples/throughput/README.md
+++ b/examples/throughput/README.md
@@ -53,6 +53,12 @@ The two are different answers, and neither is a slow one.
 The two accumulator rows are separate because consumer parts halve their tensor
 rate for f32 accumulation, and that is the rate a matmul runs on.
 
+An arithmetic row is the rate a kernel with operands of that type reaches, not
+the rate the device retires that type at. A device with no fma of its own for a
+narrow float emulates one per operation, and a kernel converts and accumulates
+in f32 rather than pay that, so the row reports the f32 rate. Hardware with
+packed f16 retires two per f32 lane and reports its own.
+
 Memory counts the bytes a kernel asks for, not the traffic that reaches DRAM: an
 ordinary store also pays read-for-ownership where the hardware does, so on a CPU
 the write and copy figures land near half the bus while read lands near all of


### PR DESCRIPTION
Three probes reported a number the hardware beats.

|                                           |     before |       after |
| ----------------------------------------- | ---------: | ----------: |
| memory read ceiling, 5700X                | 44.07 GB/s |   49.5 GB/s |
| `f16` arithmetic ceiling, 5700X           | 116.4 GOPS | 1.0656 TOPS |
| `f16` arithmetic ceiling, Xeon E5-2620 v4 | 54.25 GOPS |  577.4 GOPS |
| `bf16` arithmetic ceiling, RTX 2060       | 109.2 MOPS | 7.4473 TOPS |
| reduce bench rows at full rate, Vulkan    |    8 of 36 |    36 of 36 |

- **Memory was probed at one worker count**, one unit per core; a 5700X saturates at 4 of 16. Now swept per device and access, then cached.
- **`f16` and `bf16` were probed with an accumulator of their own width**, which nothing compiles: every backend promotes to `f32`. Now probed with the accumulator they run with.
- **Warmup was five launches**, a fixed count whatever the kernel cost. Now a 500 ms budget, `BENCH_WARMUP_MS` to override.

## Cost

Shapes are ranked on a short sample and only the winner is measured; a curve sweep keeps the pool its points share.

|                         | before |  after |
| ----------------------- | -----: | -----: |
| `roofline_bounds`, cuda |  4.5 s |  2.7 s |
| `roofline_bounds`, cpu  |  5.2 s |  6.4 s |
| `all`, cuda             | 15.4 s |  8.2 s |
| `all`, cpu              | 11.4 s | 13.4 s |
| `memory_curve`, cpu     | 80.1 s | 43.0 s |

`roofline_bounds` is the consumer path: one compute key, one memory key, launch, once per process. `all` and `memory_curve` are the example sweeping every key. cpu loses, and buys the worker sweep.

## Cache

- `PROBE_VERSION` 1 → 2, so ceilings cached before this are purged, not served.
- The key was the device name and the compilation fingerprint, neither of which moves when the hardware under it does. Device capacity and core count join it, so added DIMMs or a container's CPU quota no longer inherit another machine's ceiling.

## Xeon E5-2620 v4: the memory finding does not reproduce

Read 46.4 GB/s on both trees, same curve point for point from 512 KiB to 512 MiB. A plain AVX2 reader, outside cubecl:

| threads |    1 |    2 |    4 |    6 |        8 |   16 |
| ------- | ---: | ---: | ---: | ---: | -------: | ---: |
| GB/s    | 10.9 | 20.5 | 35.7 | 46.2 | **48.5** | 46.1 |

- Probe 46.4 against reader 46.1 at the same concurrency: the probe is honest.
- Ceiling about 48.6 GB/s, 71% of the 68.3 pin rate with all four channels populated. Core-side, not DRAM: SMT subtracts, 16 threads is slower than 8.
- The sweep's gain is per-device: 12% on a 5700X, zero here.
- 4.5% still on the table, since the optimum is 8 threads. Independent of this PR.

## Coverage

5700X + RTX 4070 Ti SUPER, Core Ultra X7 358H + Arc B390, Xeon E5-2620 v4 + RTX 2060 + RX 5600 XT: three CPUs, two NVIDIA architectures over CUDA, RDNA1 over Vulkan, WGSL. Three passes per row, cache off, exclusive lock. Everything not named above is unchanged within noise.

No HIP: the AMD box carries ROCm's runtime without its SDK, so `cubecl-hip-sys` finds no `hipconfig` and the crate does not link.
