### PR TITLE
Fix allocator page-index overflow after 65,536 pages

### DIFF
--- a/crates/cubecl-runtime/src/memory_management/memory_pool/direct_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/direct_pool.rs
@@ -214,7 +214,7 @@ impl MemoryPool for DirectPool {
             }
         };
         let mut location = self.location_base;
-        location.slice = index as u32;
+        location.slice = index;
         slice.descriptor().update_location(location);
 
         let handle = slice.handle.clone();

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/exclusive_pool.rs
@@ -209,7 +209,7 @@ impl MemoryPool for ExclusiveMemoryPool {
         let (idx, page) = self.alloc_page(storage, size)?;
         let handle = page.slice.handle.clone();
         let mut location = self.location_base;
-        location.page = idx as u16;
+        location.page = idx;
         handle.descriptor().update_location(location);
         self.largest_alloc = self.largest_alloc.max(size);
 
@@ -261,10 +261,7 @@ impl MemoryPool for ExclusiveMemoryPool {
                 }
 
                 let page_index = self.pages_tmp.len();
-                page.slice
-                    .handle
-                    .descriptor()
-                    .update_page(page_index as u16);
+                page.slice.handle.descriptor().update_page(page_index);
                 self.pages_tmp.push(page);
             }
 

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/handle.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/handle.rs
@@ -83,10 +83,10 @@ impl Eq for ManagedMemoryDescriptor {}
 pub(crate) struct MemoryLocation {
     /// The memory pool index in the global memory management.
     pub pool: u8,
-    /// The memory page index in a memory pool.
-    pub page: u16,
-    /// The memory slice index in a memory page.
-    pub slice: u32,
+    /// Index into the pool's page vector; must represent every valid `Vec` index.
+    pub page: usize,
+    /// Index into the page's slice vector; never narrowed when splitting or compacting.
+    pub slice: usize,
     /// Whether the memory location is known/initialized.
     pub init: u8,
 }
@@ -98,7 +98,7 @@ impl ManagedMemoryDescriptor {
     }
 
     /// Update only the slice position for the given [`ManagedMemoryId`].
-    pub(crate) fn update_slice(&self, slice: u32) {
+    pub(crate) fn update_slice(&self, slice: usize) {
         self.location.update(|mut loc| {
             loc.slice = slice;
             loc
@@ -106,7 +106,7 @@ impl ManagedMemoryDescriptor {
     }
 
     /// Update only the memory page position for the given [`ManagedMemoryId`].
-    pub fn update_page(&self, page: u16) {
+    pub fn update_page(&self, page: usize) {
         self.location.update(|mut loc| {
             loc.page = page;
             loc
@@ -119,17 +119,17 @@ impl ManagedMemoryDescriptor {
     }
 
     pub(crate) fn slice(&self) -> usize {
-        self.location.get().slice as usize
+        self.location.get().slice
     }
 
     pub(crate) fn page(&self) -> usize {
-        self.location.get().page as usize
+        self.location.get().page
     }
 }
 
 impl MemoryLocation {
     /// Creates a new memory location.
-    pub(crate) fn new(pool: u8, page: u16, slice: u32) -> Self {
+    pub(crate) fn new(pool: u8, page: usize, slice: usize) -> Self {
         Self {
             pool,
             page,

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/memory_page.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/memory_page.rs
@@ -56,7 +56,7 @@ impl MemoryPage {
         };
 
         let slice = Slice::new(storage, 0);
-        let slice_pos = this.slices.len() as u32;
+        let slice_pos = this.slices.len();
         let mut location = this.location_base;
         location.slice = slice_pos;
         slice.handle.descriptor().update_location(location);
@@ -230,7 +230,7 @@ impl MemoryPage {
         }
     }
 
-    pub fn update_page(&mut self, page: u16) {
+    pub fn update_page(&mut self, page: usize) {
         self.location_base.page = page;
 
         for slice in self.slices.iter() {
@@ -279,10 +279,7 @@ impl MemoryPage {
                 }
                 MemoryTaskStatus::Ignoring => {
                     let slice_pos_updated = self.slices_tmp.len();
-                    slice
-                        .handle
-                        .descriptor()
-                        .update_slice(slice_pos_updated as u32);
+                    slice.handle.descriptor().update_slice(slice_pos_updated);
                     self.slices_tmp.push(slice);
                 }
                 MemoryTaskStatus::Completed => {
@@ -294,7 +291,7 @@ impl MemoryPage {
                     storage.utilization = StorageUtilization { offset, size };
                     let page = Slice::new(storage, 0);
                     let mut location = self.location_base;
-                    location.slice = slice_pos_updated as u32;
+                    location.slice = slice_pos_updated;
                     page.descriptor().update_location(location);
                     self.slices_tmp.push(page);
                     task = tasks.next();
@@ -318,14 +315,14 @@ impl MemoryPage {
         let mut index_current = 0;
         for mut slice in self.slices.drain(..) {
             if index_current == index_previous {
-                let slice_pos_updated = self.slices_tmp.len() as u32;
+                let slice_pos_updated = self.slices_tmp.len();
                 slice.storage.utilization.size = reserved_size_previous;
                 slice.handle.descriptor().update_slice(slice_pos_updated);
                 self.slices_tmp.push(slice);
                 index_current += 1;
 
                 // New slice
-                let slice_pos_updated = self.slices_tmp.len() as u32;
+                let slice_pos_updated = self.slices_tmp.len();
                 let new_slice = new_slice.take().unwrap();
                 let mut location = self.location_base;
                 location.slice = slice_pos_updated;
@@ -334,7 +331,7 @@ impl MemoryPage {
                 self.slices_tmp.push(new_slice);
                 index_current += 1;
             } else {
-                let slice_pos_updated = self.slices_tmp.len() as u32;
+                let slice_pos_updated = self.slices_tmp.len();
                 slice.handle.descriptor().update_slice(slice_pos_updated);
                 self.slices_tmp.push(slice);
                 index_current += 1;

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/persistent_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/persistent_pool.rs
@@ -175,7 +175,7 @@ impl MemoryPool for PersistentPool {
         let slice_id = slice.descriptor();
         let slice_pos = self.slices.len();
         let mut location = self.location_base;
-        location.slice = slice_pos as u32;
+        location.slice = slice_pos;
         slice_id.update_location(location);
 
         match self.sizes.get_mut(&effective_size) {
@@ -234,7 +234,7 @@ impl MemoryPool for PersistentPool {
                 } else {
                     let slice_pos = slices.len();
                     let effective_size = slice.effective_size();
-                    slice.descriptor().update_slice(slice_pos as u32);
+                    slice.descriptor().update_slice(slice_pos);
                     slices.push(slice);
 
                     match sizes.get_mut(&effective_size) {

--- a/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
+++ b/crates/cubecl-runtime/src/memory_management/memory_pool/sliced_pool.rs
@@ -20,7 +20,7 @@ pub struct SlicedPool {
     location_base: MemoryLocation,
     /// Max number of pages (`floor(max_pool_size / page_size)`).
     /// `None` keeps unbounded growth.
-    max_pages: Option<u16>,
+    max_pages: Option<u64>,
     /// The most pages ever held at once. Pages are only freed by an explicit
     /// cleanup, so this is the pool's true high-water mark whenever one runs
     /// mid-workload.
@@ -49,7 +49,7 @@ impl SlicedPool {
                 } else {
                     page_size
                 };
-                let max_pages = (cap / page_size).min(u16::MAX as u64) as u16;
+                let max_pages = cap / page_size;
                 (page_size, Some(max_pages))
             }
             None => (page_size, None),
@@ -74,7 +74,7 @@ impl SlicedPool {
             kind: MemoryPoolKind::Sliced {
                 page_size: self.page_size,
                 max_slice_size: self.max_alloc_size,
-                max_pool_size: self.max_pages.map(|pages| pages as u64 * self.page_size),
+                max_pool_size: self.max_pages.map(|pages| pages * self.page_size),
             },
             usage: self.get_memory_usage(),
             pages: self.pages.len() as u64,
@@ -95,7 +95,7 @@ impl SlicedPool {
         mapping: PageMapping,
     ) -> Result<usize, IoError> {
         let mut location_base = self.location_base;
-        location_base.page = self.pages.len() as u16;
+        location_base.page = self.pages.len();
 
         // A lazy page gets a minted id with no device memory behind it: it
         // carves, coalesces and counts toward the high-water exactly like a
@@ -181,11 +181,11 @@ impl MemoryPool for SlicedPool {
         // found no fit, so hitting the cap here means the working set truly
         // exceeds the budget.
         if let Some(max_pages) = self.max_pages
-            && self.pages.len() >= max_pages as usize
+            && self.pages.len() as u64 >= max_pages
         {
             return Err(IoError::PoolCapacityExceeded {
                 size,
-                capacity: max_pages as u64 * self.page_size,
+                capacity: max_pages * self.page_size,
                 in_use: self.get_memory_usage().bytes_in_use,
                 backtrace: BackTrace::capture(),
             });
@@ -285,7 +285,7 @@ impl MemoryPool for SlicedPool {
                     storage.dealloc(id);
                 }
             } else {
-                let page_pos = self.pages_tmp.len() as u16;
+                let page_pos = self.pages_tmp.len();
                 page.update_page(page_pos);
                 self.pages_tmp.push((page, id));
             }
@@ -324,7 +324,7 @@ impl Display for SlicedPool {
         if let Some(max_pages) = self.max_pages {
             f.write_fmt(format_args!(
                 " max_pool_size={}",
-                BytesFormat::new(max_pages as u64 * self.page_size)
+                BytesFormat::new(max_pages * self.page_size)
             ))?;
         }
         f.write_str("\n")?;

--- a/crates/cubecl-runtime/tests/allocation_indices.rs
+++ b/crates/cubecl-runtime/tests/allocation_indices.rs
@@ -1,0 +1,105 @@
+//! Pool locations must survive allocation, binding and compaction past `u16::MAX`.
+#![cfg(feature = "storage-bytes")]
+#![forbid(unsafe_code)]
+
+use cubecl_ir::MemoryDeviceProperties;
+use cubecl_runtime::{
+    logging::ServerLogger,
+    memory_management::{
+        ErrorGraph, ManagedMemoryHandle, MemoryConfiguration, MemoryManagement,
+        MemoryManagementOptions, MemoryPoolOptions, PoolType,
+    },
+    storage::BytesStorage,
+};
+use std::{collections::HashSet, sync::Arc};
+
+fn exercise(pool_type: PoolType) {
+    let mut pool = MemoryManagement::from_configuration(
+        BytesStorage::default(),
+        &MemoryDeviceProperties {
+            max_page_size: 32,
+            alignment: 8,
+        },
+        MemoryConfiguration::Custom {
+            pool_options: vec![MemoryPoolOptions {
+                pool_type,
+                dealloc_period: None,
+            }],
+        },
+        Arc::new(ServerLogger::default()),
+        MemoryManagementOptions::new("allocation index regression"),
+    );
+    let mut failures = ErrorGraph::default();
+    let mut retained = Vec::new();
+    let mut addresses = HashSet::new();
+    for index in 0..65_538 {
+        // A full page forces sliced pools across the boundary too. The first
+        // allocation is smaller to catch both aliasing and an undersized result.
+        let requested = if index == 0 { 8 } else { 32 };
+        let reserved = pool.reserve(requested, &mut failures).unwrap();
+        let assigned = ManagedMemoryHandle::new();
+        pool.bind(reserved, assigned.clone(), 0, &mut failures)
+            .unwrap();
+        let resource = pool
+            .get_resource(assigned.clone().binding(), None, None)
+            .unwrap();
+        let (pointer, length) = resource.get_write_ptr_and_length();
+        assert_eq!(length, requested as usize, "allocation {index}");
+        assert!(
+            addresses.insert(pointer as usize),
+            "allocation {index} aliases live storage"
+        );
+        retained.push((assigned, pointer as usize, length));
+    }
+
+    // Remove pages on both sides of the old boundary, compact, and verify the
+    // surviving frontend handles still locate exactly their original storage.
+    retained = retained
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, value)| (i % 3 != 1).then_some(value))
+        .collect();
+    pool.cleanup(true, &mut failures);
+    for (handle, address, length) in &retained {
+        let resource = pool
+            .get_resource(handle.clone().binding(), None, None)
+            .unwrap();
+        let (pointer, actual_length) = resource.get_write_ptr_and_length();
+        assert_eq!(pointer as usize, *address);
+        assert_eq!(actual_length, *length);
+    }
+    let extra = pool.reserve(32, &mut failures).unwrap();
+    let resource = pool.get_resource(extra.binding(), None, None).unwrap();
+    let (pointer, length) = resource.get_write_ptr_and_length();
+    assert_eq!(length, 32);
+    assert!(
+        !retained
+            .iter()
+            .any(|(_, address, _)| *address == pointer as usize)
+    );
+}
+
+#[test]
+fn exclusive_pages_preserve_large_indices() {
+    exercise(PoolType::ExclusivePages { max_alloc_size: 32 });
+}
+
+#[test]
+#[cfg(not(exclusive_memory_only))]
+fn sliced_pages_preserve_large_indices() {
+    exercise(PoolType::SlicedPages {
+        page_size: 32,
+        max_slice_size: 32,
+        max_pool_size: None,
+    });
+}
+
+#[test]
+#[cfg(not(exclusive_memory_only))]
+fn configured_capacity_can_exceed_u16_pages() {
+    exercise(PoolType::SlicedPages {
+        page_size: 32,
+        max_slice_size: 32,
+        max_pool_size: Some(65_538 * 32),
+    });
+}


### PR DESCRIPTION
The allocator stores page positions in 16 bits, so a pool's 65,537th page wraps back to page zero. A new allocation can then point to memory that is still in use; in the reproducer, a 32-byte request returns the first live 8-byte buffer. This can corrupt data even though the application has kept its buffers alive and has not run out of memory.

This change uses `usize` for page and slice positions throughout allocation, splitting and compaction, and lets sliced pools use their configured capacity without truncating the page count. The regression tests keep 65,538 allocations alive, check that each has its own correctly sized storage, and verify that surviving handles still point to the same memory after cleanup and reuse. All 409 common/runtime tests pass, as do Clippy, formatting, and the build without default features. The full workspace check currently stops on an existing unused `StreamId` import in `cubecl-metal`.
