### PR TITLE
Fix CPU-only LLVM linking while preserving the public API

### DIFF
--- a/.github/workflows/cpu-jit.yml
+++ b/.github/workflows/cpu-jit.yml
@@ -1,0 +1,26 @@
+name: CPU JIT
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  macos-cpu:
+    # The Apple silicon LLVM bundle contains AArch64 but no AMDGPU target.
+    # Executables catch native link dependencies that cargo check misses.
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+      - uses: tracel-ai/github-actions/install-rust@v11
+        with:
+          rust-toolchain: stable
+          cache-key: cpu-jit-macos
+      - name: Link and execute CPU kernels with default features
+        run: cargo test --locked -p cubecl-cpu --test cpu_jit
+      - name: Link and execute CPU kernels with minimal features
+        run: cargo test --locked -p cubecl-cpu --no-default-features --features std --test cpu_jit
+      - name: Check the public LLVM API without native AMDGPU support
+        run: cargo test --locked -p cubecl-llvm --no-default-features --features std --test compatibility
+      - name: Check the default AMDGPU compiler and its tests
+        run: cargo check --locked -p cubecl-llvm --tests

--- a/crates/cubecl-cpu/Cargo.toml
+++ b/crates/cubecl-cpu/Cargo.toml
@@ -21,7 +21,6 @@ default = [
     "cubecl-runtime/default",
     "cubecl-common/default",
     "cubecl-core/default",
-    "cubecl-llvm/default",
 ]
 
 pliron-dump = ["cubecl-llvm/pliron-dump"]

--- a/crates/cubecl-cpu/tests/cpu_jit.rs
+++ b/crates/cubecl-cpu/tests/cpu_jit.rs
@@ -1,0 +1,36 @@
+//! Link and execute the CPU compiler with only the host LLVM target available.
+use cubecl_core::{self as cubecl, prelude::*};
+use cubecl_cpu::CpuRuntime;
+use cubecl_environment::future::block_on;
+use cubecl_runtime::runtime::Runtime;
+
+#[cube(launch)]
+fn affine(input: &[f32], output: &mut [f32]) {
+    if ABSOLUTE_POS < output.len() {
+        output[ABSOLUTE_POS] = input[ABSOLUTE_POS] * 2.0 + 1.0;
+    }
+}
+
+#[test]
+fn cpu_jit_executes_across_cubes_and_handles_a_partial_cube() {
+    let client = CpuRuntime::client(&Default::default());
+    let input: Vec<f32> = (0..259).map(|i| i as f32 - 128.0).collect();
+    let source = client.create_from_slice(f32::as_bytes(&input));
+    let output = client.empty(input.len() * size_of::<f32>());
+
+    let cube_dim = CubeDim::new(&client, 4);
+    let cubes = input.len().div_ceil(cube_dim.num_elems() as usize);
+    affine::launch(
+        &client,
+        CubeCount::new_1d(cubes as u32),
+        cube_dim,
+        // SAFETY: both buffers contain input.len() f32 slots. The kernel bounds
+        // checks any units in the final cube that are outside those slots.
+        unsafe { BufferArg::from_raw_parts(source, input.len()) },
+        unsafe { BufferArg::from_raw_parts(output.clone(), input.len()) },
+    );
+    block_on(client.sync_buffers([&output])).unwrap();
+    let bytes = client.read_one(output).unwrap();
+    let expected: Vec<f32> = input.iter().map(|x| x * 2.0 + 1.0).collect();
+    assert_eq!(f32::from_bytes(&bytes), expected);
+}

--- a/crates/cubecl-hip/Cargo.toml
+++ b/crates/cubecl-hip/Cargo.toml
@@ -61,6 +61,7 @@ cubecl-cpp = { path = "../cubecl-cpp", version = "=0.11.0-pre.3", default-featur
 ] }
 cubecl-hip-sys = { version = "7.1.5280200" }
 cubecl-llvm = { path = "../cubecl-llvm", version = "=0.11.0-pre.3", default-features = false, features = [
+    "amdgpu",
     "std",
 ] }
 cubecl-runtime = { path = "../cubecl-runtime", version = "=0.11.0-pre.3", default-features = false, features = [

--- a/crates/cubecl-llvm/Cargo.toml
+++ b/crates/cubecl-llvm/Cargo.toml
@@ -16,7 +16,10 @@ workspace = true
 
 
 [features]
-default = ["std", "cubecl-core/default", "cubecl-runtime/default"]
+default = ["std", "amdgpu", "cubecl-core/default", "cubecl-runtime/default"]
+
+# Native AMDGPU code generation and linking; public IR and artifact types remain available.
+amdgpu = ["dep:cc"]
 
 pliron-dump = []
 std = ["cubecl-core/std", "cubecl-runtime/std"]
@@ -46,5 +49,5 @@ thiserror = { workspace = true }
 llvm-sys = { workspace = true }
 
 [build-dependencies]
-cc = { workspace = true }
+cc = { workspace = true, optional = true }
 tracel-llvm-bundler = { workspace = true }

--- a/crates/cubecl-llvm/README.md
+++ b/crates/cubecl-llvm/README.md
@@ -15,6 +15,36 @@ Either one arrives as a `PlironArtifact`, which a runtime calls into.
 LLVM is vendored through `tracel-llvm-bundler` by this crate's `build.rs`, so
 there is no system LLVM to install.
 
+## CPU-only builds and the `amdgpu` feature
+
+`amdgpu` controls native AMDGPU code generation, the C++ shims, and LLD linking.
+It remains enabled by default for direct `cubecl-llvm` users. `cubecl-hip` enables
+it explicitly; `cubecl-cpu` uses LLVM without its default features, including
+when the CPU crate's own defaults are enabled. CPU builds therefore need only
+the host LLVM target, such as AArch64 on Apple silicon.
+
+For direct CPU-only use:
+
+```toml
+cubecl-llvm = { version = "=0.11.0-pre.3", default-features = false, features = ["std"] }
+```
+
+The public modules, `LlvmTarget` variants, `PlironOptions::arch`, `AmdGpuModule`,
+and `PlironArtifact` variants remain available in either configuration. Existing
+struct literals and exhaustive matches continue to compile. With `amdgpu`
+disabled, requesting AMDGPU compilation or object linking returns an error
+explaining which feature to enable, before changing IR or creating files.
+Device-library linking remains a no-op when no libraries are needed. The legacy
+unsafe `lower_printf_to_hostcall` helper returns a boolean, so it cannot report
+an error: without the feature, an actual printf rewrite panics before modifying
+the module; modules without printf calls remain a no-op.
+
+Cargo combines dependency features. A program that also enables HIP or depends
+on `cubecl-llvm` with its defaults needs an LLVM bundle containing AMDGPU as well
+as the host target. Disabling `amdgpu` changes native AMDGPU availability for
+existing direct users of `default-features = false`; those users must opt in if
+they need AMDGPU code generation.
+
 ## Layout
 
 | Module             | What it does                                                                  |
@@ -30,7 +60,7 @@ there is no system LLVM to install.
 
 The AMDGPU target reaches three parts of LLVM that have no C API: LLD's ELF
 driver, the bitcode linker's `--only-needed` mode, and the AMDGPU `printf`
-emitter. `build.rs` compiles `amdgpu/cpp_shims/` alongside the crate to wrap
+emitter. With `amdgpu` enabled, `build.rs` compiles `amdgpu/cpp_shims/` alongside the crate to wrap
 them.
 
 ## Debugging the compiler

--- a/crates/cubecl-llvm/build.rs
+++ b/crates/cubecl-llvm/build.rs
@@ -6,6 +6,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rustc-cfg=feature=\"pliron-dump\"");
     }
 
+    #[cfg(feature = "amdgpu")]
+    build_amdgpu_shims()?;
+
+    tracel_llvm_bundler::llvm_sys::link()?;
+
+    Ok(())
+}
+
+#[cfg(feature = "amdgpu")]
+fn build_amdgpu_shims() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/lld.cpp");
     println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/device_libs.cpp");
     println!("cargo::rerun-if-changed=src/amdgpu/cpp_shims/printf.cpp");
@@ -28,8 +38,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("cargo:rustc-link-lib=static=lldELF");
     println!("cargo:rustc-link-lib=static=lldCommon");
-
-    tracel_llvm_bundler::llvm_sys::link()?;
 
     Ok(())
 }

--- a/crates/cubecl-llvm/src/amdgpu/codegen.rs
+++ b/crates/cubecl-llvm/src/amdgpu/codegen.rs
@@ -6,6 +6,7 @@ use pliron_llvm::attributes::set_data_layout;
 use pliron_llvm::llvm_sys::core::LLVMContext;
 use pliron_llvm::to_llvm_ir;
 use std::ffi::{CStr, CString};
+#[cfg(feature = "amdgpu")]
 use std::sync::Once;
 
 use crate::amdgpu::device_libs::{DeviceLibs, link_device_libs};
@@ -38,15 +39,19 @@ const WAVE32: &str = "+wavefrontsize32";
 /// but handed the target machine, which is what makes it target-aware.
 const PASS_PIPELINE: &CStr = c"default<O3>";
 
+#[cfg(feature = "amdgpu")]
 static INIT_AMDGPU: Once = Once::new();
 
-fn init_amdgpu() {
+fn init_amdgpu() -> Result<(), String> {
+    super::require_amdgpu()?;
+    #[cfg(feature = "amdgpu")]
     INIT_AMDGPU.call_once(|| unsafe {
         llvm_sys::target::LLVMInitializeAMDGPUTargetInfo();
         llvm_sys::target::LLVMInitializeAMDGPUTarget();
         llvm_sys::target::LLVMInitializeAMDGPUTargetMC();
         llvm_sys::target::LLVMInitializeAMDGPUAsmPrinter();
     });
+    Ok(())
 }
 
 /// Subtarget feature string for `arch`, empty on the wave64 parts.
@@ -59,6 +64,8 @@ fn features_for(arch: &GfxArch) -> &'static str {
 }
 
 /// Lowers `module` to LLVM IR, compiles it to AMDGPU machine code, and links it.
+///
+/// Returns an error without modifying the module when `amdgpu` is disabled.
 pub fn emit_code_object(
     ctx: &Context,
     module: ModuleOp,
@@ -68,6 +75,7 @@ pub fn emit_code_object(
     shared_memory_size: usize,
     io: Vec<BufferIOAttr>,
 ) -> Result<AmdGpuModule, String> {
+    super::require_amdgpu()?;
     let llvm_ctx = LLVMContext::default();
 
     set_data_layout(ctx, module, DATA_LAYOUT.to_string());
@@ -189,7 +197,7 @@ fn compile_to_object(
         LLVMDisposeTargetMachine, LLVMGetTargetFromTriple, LLVMRelocMode,
     };
 
-    init_amdgpu();
+    init_amdgpu()?;
 
     let cpu =
         CString::new(arch.name()).map_err(|_| format!("arch '{}' contains a NUL", arch.name()))?;
@@ -439,6 +447,7 @@ entry:
     /// The shared memory block reaches the code object as LDS: the slices become `ds_`
     /// accesses with their offset folded in, the generic pointers the rest of the pipeline
     /// works with are inferred away, and the barrier is the hardware's own.
+    #[cfg(feature = "amdgpu")]
     #[test]
     fn shared_memory_becomes_lds() {
         let ir = r#"
@@ -488,6 +497,7 @@ entry:
     /// RDNA4 splits `k` between the halves of the wave and takes half the A/B fragment RDNA3
     /// does. Getting the fragment width wrong fails to select rather than computing the wrong
     /// answer, so this pins both.
+    #[cfg(feature = "amdgpu")]
     #[test]
     fn wmma_reaches_the_code_object() {
         for (name, ab) in [("gfx1201", "<8 x half>"), ("gfx1100", "<16 x half>")] {
@@ -525,6 +535,7 @@ entry:
     /// Codegen produces a relocatable ELF, and LLD turns it into the `ET_DYN`
     /// shared object `hipModuleLoadData` requires. `e_type` is the 16-bit LE
     /// field at offset 16: 1 = `ET_REL`, 3 = `ET_DYN`.
+    #[cfg(feature = "amdgpu")]
     #[test]
     fn emits_a_linked_shared_object() {
         let ir = r#"

--- a/crates/cubecl-llvm/src/amdgpu/device_libs.rs
+++ b/crates/cubecl-llvm/src/amdgpu/device_libs.rs
@@ -3,15 +3,20 @@
 //! Only the definitions the kernel calls are taken. They arrive `linkonce_odr hidden`, so the
 //! optimization pipeline inlines them and strips the rest back out.
 
+#[cfg(feature = "amdgpu")]
 use std::collections::HashMap;
+#[cfg(feature = "amdgpu")]
 use std::ffi::{CStr, c_char};
+#[cfg(feature = "amdgpu")]
 use std::path::PathBuf;
+#[cfg(feature = "amdgpu")]
 use std::sync::{Mutex, OnceLock};
 
 use llvm_sys::prelude::LLVMModuleRef;
 
 use cubecl_core::ir::amd::GfxArch;
 
+#[cfg(feature = "amdgpu")]
 unsafe extern "C" {
     /// See `cpp_shims/device_libs.cpp`. Returns null on success, else an owned message.
     fn cubecl_link_device_bitcode(
@@ -28,11 +33,15 @@ unsafe extern "C" {
 ///
 /// `CUBECL_ROCM_DEVICE_LIB_PATH` names the directory itself and is the escape hatch for an
 /// install none of the rest find. `HIP_DEVICE_LIB_PATH` is what hipcc itself reads.
+#[cfg(feature = "amdgpu")]
 const DEVICE_LIB_PATH_VARS: [&str; 2] = ["CUBECL_ROCM_DEVICE_LIB_PATH", "HIP_DEVICE_LIB_PATH"];
+#[cfg(feature = "amdgpu")]
 const ROCM_ROOT_VARS: [&str; 2] = ["ROCM_PATH", "HIP_PATH"];
+#[cfg(feature = "amdgpu")]
 const DEFAULT_ROCM_ROOTS: [&str; 2] = ["/opt/rocm", "/usr"];
 
 /// The `amdgcn/bitcode` directory of the `ROCm` install, found once per process.
+#[cfg(feature = "amdgpu")]
 fn bitcode_dir() -> Result<&'static PathBuf, String> {
     static DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
 
@@ -66,6 +75,7 @@ fn bitcode_dir() -> Result<&'static PathBuf, String> {
 
 /// The bitcode of `name`, read once and kept: every kernel compiled for a given device links
 /// the same few hundred kilobytes.
+#[cfg(feature = "amdgpu")]
 fn device_lib(name: &str) -> Result<&'static [u8], String> {
     static CACHE: OnceLock<Mutex<HashMap<String, &'static [u8]>>> = OnceLock::new();
     let cache = CACHE.get_or_init(Mutex::default);
@@ -105,6 +115,7 @@ impl DeviceLibs {
 /// Each library leaves control globals undefined, one bitcode file per global. The math options
 /// take the conservative side: operands are not assumed finite and reassociation is not assumed
 /// safe. The other three follow the device and the code object.
+#[cfg(any(test, feature = "amdgpu"))]
 fn device_libs_for(arch: &GfxArch, needs: DeviceLibs, code_object_version: u32) -> Vec<String> {
     let mut libs = Vec::new();
 
@@ -135,6 +146,7 @@ fn device_libs_for(arch: &GfxArch, needs: DeviceLibs, code_object_version: u32) 
 ///
 /// # Safety
 /// `module` must be a live LLVM module, already stamped with the AMDGPU triple and layout.
+#[cfg(feature = "amdgpu")]
 pub unsafe fn link_device_libs(
     module: LLVMModuleRef,
     arch: &GfxArch,
@@ -158,6 +170,24 @@ pub unsafe fn link_device_libs(
     Ok(())
 }
 
+/// Returns an error when device libraries are needed and `amdgpu` is disabled.
+/// A module that needs no device libraries remains a no-op.
+///
+/// # Safety
+/// `module` must be a live LLVM module, already stamped with the AMDGPU triple and layout.
+#[cfg(not(feature = "amdgpu"))]
+pub unsafe fn link_device_libs(
+    _module: LLVMModuleRef,
+    _arch: &GfxArch,
+    needs: DeviceLibs,
+    _code_object_version: u32,
+) -> Result<(), String> {
+    if needs.any() {
+        super::require_amdgpu()?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,6 +200,24 @@ mod tests {
         math: false,
         printf: true,
     };
+
+    #[cfg(not(feature = "amdgpu"))]
+    #[test]
+    fn disabled_device_libraries_allow_only_the_noop_case() {
+        use llvm_sys::core::*;
+        unsafe {
+            let ctx = LLVMContextCreate();
+            let module = LLVMModuleCreateWithNameInContext(c"k".as_ptr(), ctx);
+            LLVMSetTarget(module, c"amdgcn-amd-amdhsa".as_ptr());
+            LLVMSetDataLayout(module, c"A5".as_ptr());
+            let arch = GfxArch::parse("gfx1201");
+            assert!(link_device_libs(module, &arch, DeviceLibs::default(), 500).is_ok());
+            let error = link_device_libs(module, &arch, MATH, 500).unwrap_err();
+            assert!(error.contains("cubecl-llvm/amdgpu"), "{error}");
+            LLVMDisposeModule(module);
+            LLVMContextDispose(ctx);
+        }
+    }
 
     /// The ISA control library is named by the bare architecture number, and comes along
     /// whichever library asked.

--- a/crates/cubecl-llvm/src/amdgpu/lld.rs
+++ b/crates/cubecl-llvm/src/amdgpu/lld.rs
@@ -3,21 +3,28 @@
 //! LLD exposes no C API, so `cpp_shims/lld.cpp` wraps `lld::elf::link` in an
 //! `extern "C"` entry point that `build.rs` compiles and links in.
 
+#[cfg(feature = "amdgpu")]
 use std::ffi::{CString, c_char};
+#[cfg(feature = "amdgpu")]
 use std::path::Path;
+#[cfg(feature = "amdgpu")]
 use std::sync::Mutex;
+#[cfg(feature = "amdgpu")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(feature = "amdgpu")]
 unsafe extern "C" {
     /// See `cpp_shims/lld.cpp`. Returns `true` when the link succeeded.
     fn cubecl_lld_elf_link(argv: *const *const c_char, argc: usize) -> bool;
 }
 
 /// LLD keeps global linker context, so concurrent calls corrupt each other.
+#[cfg(feature = "amdgpu")]
 static LLD_LOCK: Mutex<()> = Mutex::new(());
 
 /// Keeps temp directories unique. The pid alone collides between threads, letting one
 /// call's cleanup delete a sibling's directory.
+#[cfg(feature = "amdgpu")]
 static CALL_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Links a relocatable AMDGPU ELF into a loadable `ET_DYN` code object.
@@ -26,6 +33,7 @@ static CALL_COUNTER: AtomicUsize = AtomicUsize::new(0);
 /// name is not part of that path: it comes from a user's own types and carries whatever
 /// `::`, `<` and `>` those spell. The pid and counter already make the directory unique, and
 /// the name is what the error says rather than what the filesystem sees.
+#[cfg(feature = "amdgpu")]
 pub fn link_relocatable(object: &[u8], name: &str) -> Result<Vec<u8>, String> {
     let unique = CALL_COUNTER.fetch_add(1, Ordering::Relaxed);
     let dir = std::env::temp_dir().join(format!("cubecl-lld-{}-{unique}", std::process::id()));
@@ -34,6 +42,7 @@ pub fn link_relocatable(object: &[u8], name: &str) -> Result<Vec<u8>, String> {
     result
 }
 
+#[cfg(feature = "amdgpu")]
 fn link_in(dir: &Path, object: &[u8], name: &str) -> Result<Vec<u8>, String> {
     std::fs::create_dir_all(dir).map_err(|e| format!("temp dir: {e}"))?;
     let obj_path = dir.join("kernel.o");
@@ -60,4 +69,10 @@ fn link_in(dir: &Path, object: &[u8], name: &str) -> Result<Vec<u8>, String> {
     } else {
         Err(format!("lld failed to link '{name}'; see stderr above"))
     }
+}
+
+/// Returns an error without creating temporary files when `amdgpu` is disabled.
+#[cfg(not(feature = "amdgpu"))]
+pub fn link_relocatable(_object: &[u8], _name: &str) -> Result<Vec<u8>, String> {
+    Err(super::AMDGPU_DISABLED.into())
 }

--- a/crates/cubecl-llvm/src/amdgpu/mod.rs
+++ b/crates/cubecl-llvm/src/amdgpu/mod.rs
@@ -13,3 +13,15 @@ pub mod plane_reduce;
 pub mod printf;
 pub mod shared_memory;
 pub mod synchronization;
+
+pub(crate) const AMDGPU_DISABLED: &str =
+    "AMDGPU code generation requires the `cubecl-llvm/amdgpu` feature";
+
+/// Shared by the compiler and direct code-generation/linking entry points.
+pub(crate) fn require_amdgpu() -> Result<(), String> {
+    if cfg!(feature = "amdgpu") {
+        Ok(())
+    } else {
+        Err(AMDGPU_DISABLED.into())
+    }
+}

--- a/crates/cubecl-llvm/src/amdgpu/printf.rs
+++ b/crates/cubecl-llvm/src/amdgpu/printf.rs
@@ -5,8 +5,11 @@
 //! emitter for it.
 
 use llvm_sys::core::*;
-use llvm_sys::prelude::{LLVMModuleRef, LLVMValueRef};
+use llvm_sys::prelude::LLVMModuleRef;
+#[cfg(feature = "amdgpu")]
+use llvm_sys::prelude::LLVMValueRef;
 
+#[cfg(feature = "amdgpu")]
 unsafe extern "C" {
     /// See `cpp_shims/printf.cpp`. Consumes the call, which must not be used afterwards.
     fn cubecl_emit_amdgpu_printf(call: LLVMValueRef);
@@ -16,6 +19,10 @@ unsafe extern "C" {
 ///
 /// Returns whether anything was rewritten, i.e. whether OCKL has to be linked in behind it. A
 /// kernel that never prints asks for nothing.
+///
+/// # Panics
+/// Panics before modifying the module if it contains a `printf` call and
+/// `amdgpu` is disabled. This legacy boolean API cannot return an error.
 ///
 /// # Safety
 /// `module` must be a live LLVM module.
@@ -38,6 +45,10 @@ pub unsafe fn lower_printf_to_hostcall(module: LLVMModuleRef) -> bool {
         }
 
         let lowered = !calls.is_empty();
+        if lowered {
+            super::require_amdgpu().expect("AMDGPU printf lowering should be enabled");
+        }
+        #[cfg(feature = "amdgpu")]
         for call in calls {
             cubecl_emit_amdgpu_printf(call);
         }
@@ -99,6 +110,7 @@ define void @k(double %d) {
 
     /// The call becomes the hostcall conversation, and the `printf` that a GPU has no answer
     /// for is gone from the module entirely.
+    #[cfg(feature = "amdgpu")]
     #[test]
     fn printf_becomes_the_hostcall_sequence() {
         unsafe {
@@ -118,6 +130,20 @@ define void @k(double %d) {
                 "the libc declaration should be gone:\n{ir}"
             );
 
+            LLVMDisposeModule(module);
+            LLVMContextDispose(ctx);
+        }
+    }
+
+    #[cfg(not(feature = "amdgpu"))]
+    #[test]
+    fn disabled_printf_lowering_leaves_the_module_unchanged() {
+        unsafe {
+            let (ctx, module) = parse(WITH_PRINTF);
+            let before = print(module);
+            let result = std::panic::catch_unwind(|| lower_printf_to_hostcall(module));
+            assert!(result.is_err());
+            assert_eq!(print(module), before);
             LLVMDisposeModule(module);
             LLVMContextDispose(ctx);
         }

--- a/crates/cubecl-llvm/src/shared/base.rs
+++ b/crates/cubecl-llvm/src/shared/base.rs
@@ -169,6 +169,7 @@ impl PlironCompiler {
         match self.target {
             LlvmTarget::Cpu => Ok(PlironArtifact::Jit(self.compile_cpu(kernel)?)),
             LlvmTarget::AmdGpu => {
+                crate::amdgpu::require_amdgpu().map_err(generic)?;
                 let arch = options.arch.as_ref().ok_or_else(|| {
                     generic("the AMDGPU target needs the device it compiles for".to_string())
                 })?;

--- a/crates/cubecl-llvm/tests/compatibility.rs
+++ b/crates/cubecl-llvm/tests/compatibility.rs
@@ -1,0 +1,90 @@
+//! Exercise the public API as a downstream crate, including CPU-only builds.
+use cubecl_core::{Compiler, ir::amd::GfxArch};
+use cubecl_environment::bytes::Bytes;
+use cubecl_llvm::{AmdGpuModule, LlvmTarget, PlironArtifact, PlironCompiler, PlironOptions};
+
+#[test]
+fn public_options_targets_and_artifacts_remain_available() {
+    let options = PlironOptions { arch: None };
+    assert!(options.arch.is_none());
+    let gpu_options = PlironOptions {
+        arch: Some(GfxArch::parse("gfx1201")),
+    };
+    assert_eq!(gpu_options.arch.unwrap().name(), "gfx1201");
+
+    // Callers can still match every target and artifact, even when they only
+    // execute CPU kernels or inspect artifacts compiled by another process.
+    for target in [LlvmTarget::Cpu, LlvmTarget::AmdGpu] {
+        let expected = match target {
+            LlvmTarget::Cpu => "plir",
+            LlvmTarget::AmdGpu => "ll",
+        };
+        assert_eq!(PlironCompiler { target }.extension(), expected);
+    }
+    let artifact = PlironArtifact::AmdGpuCode(AmdGpuModule {
+        code_object: Bytes::from_bytes_vec(vec![]),
+        entrypoint: "k".into(),
+        ir: "define void @k() { ret void }".into(),
+        asm: None,
+        shared_memory_size: 0,
+        io: vec![],
+    });
+    match &artifact {
+        PlironArtifact::Jit(_) => panic!("expected an AMDGPU artifact"),
+        PlironArtifact::AmdGpuCode(module) => assert_eq!(module.entrypoint, "k"),
+    }
+    assert!(artifact.to_string().contains("@k"));
+}
+
+#[cfg(not(feature = "amdgpu"))]
+#[test]
+fn unavailable_amdgpu_returns_a_compilation_error() {
+    use cubecl_core::CompilationError;
+
+    for arch in [None, Some(GfxArch::parse("gfx1201"))] {
+        let kernel = empty_kernel();
+        let mut compiler = PlironCompiler {
+            target: LlvmTarget::AmdGpu,
+        };
+        match compiler.compile(kernel, &PlironOptions { arch }) {
+            Err(CompilationError::Generic { reason, .. }) => {
+                assert!(reason.contains("cubecl-llvm/amdgpu"), "{reason}");
+            }
+            _ => panic!("a disabled AMDGPU compiler must report the missing feature"),
+        }
+    }
+}
+
+#[cfg(not(feature = "amdgpu"))]
+#[test]
+fn direct_amdgpu_codegen_and_linking_report_the_missing_feature() {
+    use cubecl_llvm::amdgpu::{codegen::emit_code_object, lld::link_relocatable};
+    use pliron::printable::Printable;
+
+    let kernel = empty_kernel();
+    let module = kernel.body.state().module;
+    let ctx = kernel.body.ctx();
+    let before = module.disp(ctx).to_string();
+    let result = emit_code_object(ctx, module, "k", &GfxArch::parse("gfx1201"), 1, 0, vec![]);
+    let error = result.unwrap_err();
+    assert!(error.contains("cubecl-llvm/amdgpu"), "{error}");
+    assert_eq!(module.disp(ctx).to_string(), before);
+    let error = link_relocatable(&[], "k").unwrap_err();
+    assert!(error.contains("cubecl-llvm/amdgpu"), "{error}");
+}
+
+#[cfg(not(feature = "amdgpu"))]
+fn empty_kernel() -> cubecl_core::prelude::KernelDefinition {
+    use cubecl_core::{
+        compute::KernelBuilder,
+        ir::{
+            AddressType,
+            settings::{Dim3, ExecutionMode, KernelSettings},
+        },
+    };
+    KernelBuilder::new(
+        KernelSettings::new(Dim3::new_single(), ExecutionMode::Checked, AddressType::U32)
+            .kernel_name("k"),
+    )
+    .build()
+}


### PR DESCRIPTION
Selecting CubeCL's CPU runtime on Apple silicon currently pulls in the AMDGPU compiler too. The bundled LLVM has the AArch64 target needed for the CPU, but lacks the AMDGPU initialization functions, so CPU programs fail at the final link step. CPU users should be able to use the supplied host LLVM without installing an AMD-capable toolchain.

This adds an `amdgpu` feature for native AMDGPU code generation and linking. It stays on by default for direct LLVM users and is enabled explicitly by HIP, while the CPU runtime stops forwarding LLVM's defaults. The public modules, options fields and enum variants remain available in either configuration, so existing struct literals and matches still compile. Requests for unavailable AMDGPU compilation or linking return a clear error; the existing unsafe printf helper, whose boolean return type cannot carry an error, panics before changing the module if a rewrite is requested without the feature. CPU execution and LLVM compatibility tests pass on the AArch64-only bundle, and both feature configurations pass Clippy. Full workspace validation still stops on the existing unused `StreamId` import in `cubecl-metal`.
