### PR TITLE
Fix WGSL runtime on WASM

### DIFF
--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -77,7 +77,8 @@ fn working_set_cap(client: &Client, access: MemoryAccess) -> u64 {
 
 /// Computes the peak throughput for a given runtime and key.
 ///
-/// Native only, panics on WASM
+/// Returns [`Unsupported`](ThroughputError::Unsupported) on WASM, where the
+/// synchronous sampling loop can't wait for GPU work.
 ///
 /// # Errors
 ///
@@ -88,6 +89,10 @@ pub fn measure_peak_throughput(
     client: &Client,
     key: ThroughputKey,
 ) -> Result<ThroughputValue, ThroughputError> {
+    if cfg!(target_family = "wasm") {
+        return Err(ThroughputError::Unsupported);
+    }
+
     // A throughput probe is a measurement: inside a dry run its launches must
     // still execute, or they would be timed anyway and cache a garbage peak in
     // the device-level throughput store. The guard is read where the launch is

--- a/crates/cubecl-std/src/throughput/base.rs
+++ b/crates/cubecl-std/src/throughput/base.rs
@@ -33,7 +33,7 @@ pub fn device_throughput<R: Runtime>(
 /// exactly like the single-size probe, so a curve costs one probe per size on
 /// the first run and nothing afterwards.
 ///
-/// Native only, panics on WASM
+/// Returns an empty curve on WASM.
 pub fn measure_memory_curve(client: &Client, access: MemoryAccess) -> MemoryCurve {
     let points = {
         // Every point of a sweep asks for the same pool, so the sweep holds one.

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -85,7 +85,7 @@ impl WgslCompiler {
         compilation_options: &WgpuCompilationOptions,
     ) -> Result<wgsl::ComputeShader, CompilationError> {
         #[cfg(target_family = "wasm")]
-        crate::compiler::wgsl::ops::ensure_linked();
+        crate::compiler::wgsl::ops::wasm_inventory_root();
 
         let errors = value.body.pop_errors();
         if !errors.is_empty() {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/compiler.rs
@@ -84,6 +84,9 @@ impl WgslCompiler {
         value: kernel::KernelDefinition,
         compilation_options: &WgpuCompilationOptions,
     ) -> Result<wgsl::ComputeShader, CompilationError> {
+        #[cfg(target_family = "wasm")]
+        crate::compiler::wgsl::ops::ensure_linked();
+
         let errors = value.body.pop_errors();
         if !errors.is_empty() {
             let mut reason = "Can't compile wgsl kernel".to_string();

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/atomic.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/atomic.rs
@@ -1,11 +1,11 @@
 use cubecl_ir::dialect::atomic::*;
 
 use crate::compiler::wgsl::{
-    to_wgsl::{keep_wgsl_ops_linked, wgsl_op, wgsl_op_with_out},
+    to_wgsl::{wasm_inventory_root, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
 
-keep_wgsl_ops_linked!(AtomicExchangeOp);
+wasm_inventory_root!(AtomicExchangeOp);
 
 wgsl_op_with_out!(AtomicExchangeOp; |op, ctx| {
     let ptr = op.ptr(ctx).name(ctx);

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/atomic.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/atomic.rs
@@ -1,9 +1,11 @@
 use cubecl_ir::dialect::atomic::*;
 
 use crate::compiler::wgsl::{
-    to_wgsl::{wgsl_op, wgsl_op_with_out},
+    to_wgsl::{keep_wgsl_ops_linked, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
+
+keep_wgsl_ops_linked!(AtomicExchangeOp);
 
 wgsl_op_with_out!(AtomicExchangeOp; |op, ctx| {
     let ptr = op.ptr(ctx).name(ctx);

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/bitwise.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/bitwise.rs
@@ -4,8 +4,10 @@ use pliron::builtin::types::{IntegerType, Signedness};
 
 use crate::compiler::wgsl::{
     lower::lower_unop,
-    to_wgsl::{TypeExtWgsl, wgsl_op_with_out},
+    to_wgsl::{TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op_with_out},
 };
+
+keep_wgsl_ops_linked!(BitwiseAndOp);
 
 wgsl_op_with_out!(BitwiseAndOp; |op, ctx| {
     format!("{} & {}", op.lhs(ctx).name(ctx), op.rhs(ctx).name(ctx))

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/bitwise.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/bitwise.rs
@@ -4,10 +4,10 @@ use pliron::builtin::types::{IntegerType, Signedness};
 
 use crate::compiler::wgsl::{
     lower::lower_unop,
-    to_wgsl::{TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op_with_out},
+    to_wgsl::{TypeExtWgsl, wasm_inventory_root, wgsl_op_with_out},
 };
 
-keep_wgsl_ops_linked!(BitwiseAndOp);
+wasm_inventory_root!(BitwiseAndOp);
 
 wgsl_op_with_out!(BitwiseAndOp; |op, ctx| {
     format!("{} & {}", op.lhs(ctx).name(ctx), op.rhs(ctx).name(ctx))

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/branch.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/branch.rs
@@ -4,9 +4,11 @@ use pliron::r#type::Typed;
 
 use crate::compiler::wgsl::{
     block_to_wgsl,
-    to_wgsl::{TypeExtWgsl, wgsl_op},
+    to_wgsl::{TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op},
     value::WgslValue,
 };
+
+keep_wgsl_ops_linked!(IfOp);
 
 wgsl_op!(YieldOp, |_, _| String::new());
 wgsl_op!(ConditionOp, |op, ctx| {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/branch.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/branch.rs
@@ -4,11 +4,11 @@ use pliron::r#type::Typed;
 
 use crate::compiler::wgsl::{
     block_to_wgsl,
-    to_wgsl::{TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op},
+    to_wgsl::{TypeExtWgsl, wasm_inventory_root, wgsl_op},
     value::WgslValue,
 };
 
-keep_wgsl_ops_linked!(IfOp);
+wasm_inventory_root!(IfOp);
 
 wgsl_op!(YieldOp, |_, _| String::new());
 wgsl_op!(ConditionOp, |op, ctx| {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/cmp.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/cmp.rs
@@ -1,8 +1,8 @@
 use cubecl_ir::dialect::cmp::*;
 
-use crate::compiler::wgsl::to_wgsl::{keep_wgsl_ops_linked, wgsl_op_with_out};
+use crate::compiler::wgsl::to_wgsl::{wasm_inventory_root, wgsl_op_with_out};
 
-keep_wgsl_ops_linked!(IEqualOp);
+wasm_inventory_root!(IEqualOp);
 
 wgsl_op_with_out!(SMinOp, UMinOp, FMinOp; |op, ctx| {
     format!("min({}, {})", op.lhs(ctx).name(ctx), op.rhs(ctx).name(ctx))

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/cmp.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/cmp.rs
@@ -1,6 +1,8 @@
 use cubecl_ir::dialect::cmp::*;
 
-use crate::compiler::wgsl::to_wgsl::wgsl_op_with_out;
+use crate::compiler::wgsl::to_wgsl::{keep_wgsl_ops_linked, wgsl_op_with_out};
+
+keep_wgsl_ops_linked!(IEqualOp);
 
 wgsl_op_with_out!(SMinOp, UMinOp, FMinOp; |op, ctx| {
     format!("min({}, {})", op.lhs(ctx).name(ctx), op.rhs(ctx).name(ctx))

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/general.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/general.rs
@@ -16,9 +16,11 @@ use pliron::{
 
 use crate::compiler::wgsl::{
     lower::lower_binop,
-    to_wgsl::{AttrToWgsl, TypeExtWgsl, wgsl_op, wgsl_op_with_out},
+    to_wgsl::{AttrToWgsl, TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
+
+keep_wgsl_ops_linked!(BoolAndOp);
 
 wgsl_op_with_out!(BoolAndOp; |op, ctx| {
     format!("{} && {}", op.lhs(ctx).name(ctx), op.rhs(ctx).name(ctx))

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/general.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/general.rs
@@ -16,11 +16,11 @@ use pliron::{
 
 use crate::compiler::wgsl::{
     lower::lower_binop,
-    to_wgsl::{AttrToWgsl, TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op, wgsl_op_with_out},
+    to_wgsl::{AttrToWgsl, TypeExtWgsl, wasm_inventory_root, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
 
-keep_wgsl_ops_linked!(BoolAndOp);
+wasm_inventory_root!(BoolAndOp);
 
 wgsl_op_with_out!(BoolAndOp; |op, ctx| {
     format!("{} && {}", op.lhs(ctx).name(ctx), op.rhs(ctx).name(ctx))

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/math.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/math.rs
@@ -7,8 +7,10 @@ use pliron::builtin::types::{IntegerType, Signedness};
 
 use crate::compiler::wgsl::{
     lower::{LowerOp, lower_binop, lower_unop},
-    to_wgsl::wgsl_op_with_out,
+    to_wgsl::{keep_wgsl_ops_linked, wgsl_op_with_out},
 };
+
+keep_wgsl_ops_linked!(IAddOp);
 
 #[op_interface_impl]
 impl LowerOp for Dp4aOp {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/math.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/math.rs
@@ -7,10 +7,10 @@ use pliron::builtin::types::{IntegerType, Signedness};
 
 use crate::compiler::wgsl::{
     lower::{LowerOp, lower_binop, lower_unop},
-    to_wgsl::{keep_wgsl_ops_linked, wgsl_op_with_out},
+    to_wgsl::{wasm_inventory_root, wgsl_op_with_out},
 };
 
-keep_wgsl_ops_linked!(IAddOp);
+wasm_inventory_root!(IAddOp);
 
 #[op_interface_impl]
 impl LowerOp for Dp4aOp {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/memory.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/memory.rs
@@ -8,11 +8,11 @@ use crate::compiler::wgsl::{
     AddressOfOp, GlobalVariableOp,
     lower::LowerOp,
     ops::general::attr_to_wgsl,
-    to_wgsl::{TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op, wgsl_op_with_out},
+    to_wgsl::{TypeExtWgsl, wasm_inventory_root, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
 
-keep_wgsl_ops_linked!(DeclareLocalOp);
+wasm_inventory_root!(DeclareLocalOp);
 
 #[cube_op(name = "wgsl.declare_local")]
 #[result_ty(argument)]

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/memory.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/memory.rs
@@ -8,9 +8,11 @@ use crate::compiler::wgsl::{
     AddressOfOp, GlobalVariableOp,
     lower::LowerOp,
     ops::general::attr_to_wgsl,
-    to_wgsl::{TypeExtWgsl, wgsl_op, wgsl_op_with_out},
+    to_wgsl::{TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
+
+keep_wgsl_ops_linked!(DeclareLocalOp);
 
 #[cube_op(name = "wgsl.declare_local")]
 #[result_ty(argument)]

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/mod.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/mod.rs
@@ -10,17 +10,15 @@ pub mod sync;
 pub mod vector;
 
 #[cfg(target_family = "wasm")]
-pub(crate) fn ensure_linked() {
-    // Pliron uses inventory for Wasm interface registration. A concrete reference
-    // keeps each module's constructors in the final binary.
-    atomic::ensure_linked();
-    bitwise::ensure_linked();
-    branch::ensure_linked();
-    cmp::ensure_linked();
-    general::ensure_linked();
-    math::ensure_linked();
-    memory::ensure_linked();
-    plane::ensure_linked();
-    sync::ensure_linked();
-    vector::ensure_linked();
+pub(crate) fn wasm_inventory_root() {
+    atomic::wasm_inventory_root();
+    bitwise::wasm_inventory_root();
+    branch::wasm_inventory_root();
+    cmp::wasm_inventory_root();
+    general::wasm_inventory_root();
+    math::wasm_inventory_root();
+    memory::wasm_inventory_root();
+    plane::wasm_inventory_root();
+    sync::wasm_inventory_root();
+    vector::wasm_inventory_root();
 }

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/mod.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/mod.rs
@@ -8,3 +8,19 @@ pub mod memory;
 pub mod plane;
 pub mod sync;
 pub mod vector;
+
+#[cfg(target_family = "wasm")]
+pub(crate) fn ensure_linked() {
+    // Pliron uses inventory for Wasm interface registration. A concrete reference
+    // keeps each module's constructors in the final binary.
+    atomic::ensure_linked();
+    bitwise::ensure_linked();
+    branch::ensure_linked();
+    cmp::ensure_linked();
+    general::ensure_linked();
+    math::ensure_linked();
+    memory::ensure_linked();
+    plane::ensure_linked();
+    sync::ensure_linked();
+    vector::ensure_linked();
+}

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/plane.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/plane.rs
@@ -4,10 +4,10 @@ use cubecl_ir::{dialect::plane::*, interfaces::TypedExt, prelude::*};
 use crate::compiler::wgsl::{
     RequiresFeatureOp,
     lower::LowerOp,
-    to_wgsl::{keep_wgsl_ops_linked, wgsl_op_with_out},
+    to_wgsl::{wasm_inventory_root, wgsl_op_with_out},
 };
 
-keep_wgsl_ops_linked!(AllOp);
+wasm_inventory_root!(AllOp);
 
 macro_rules! requires_subgroups {
     ($($ty:ty),* $(,)?) => {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/plane.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/plane.rs
@@ -1,7 +1,55 @@
 use cubecl_core::{self as cubecl, prelude::*};
 use cubecl_ir::{dialect::plane::*, interfaces::TypedExt, prelude::*};
 
-use crate::compiler::wgsl::{lower::LowerOp, to_wgsl::wgsl_op_with_out};
+use crate::compiler::wgsl::{
+    RequiresFeatureOp,
+    lower::LowerOp,
+    to_wgsl::{keep_wgsl_ops_linked, wgsl_op_with_out},
+};
+
+keep_wgsl_ops_linked!(AllOp);
+
+macro_rules! requires_subgroups {
+    ($($ty:ty),* $(,)?) => {
+        $(#[op_interface_impl]
+        impl RequiresFeatureOp for $ty {
+            fn required_feature(&self, _ctx: &Context) -> String {
+                "subgroups".into()
+            }
+        })*
+    };
+}
+
+requires_subgroups!(
+    AllOp,
+    AnyOp,
+    ISumOp,
+    FSumOp,
+    InclusiveISumOp,
+    InclusiveFSumOp,
+    ExclusiveISumOp,
+    ExclusiveFSumOp,
+    IProdOp,
+    FProdOp,
+    InclusiveIProdOp,
+    InclusiveFProdOp,
+    ExclusiveIProdOp,
+    ExclusiveFProdOp,
+    SMinOp,
+    UMinOp,
+    FMinOp,
+    SMaxOp,
+    UMaxOp,
+    FMaxOp,
+    BallotOp,
+    BroadcastOp,
+    ShuffleOp,
+    ShuffleXorOp,
+    ShuffleUpOp,
+    ShuffleDownOp,
+    UniformLoadOp,
+    AtomicUniformLoadOp,
+);
 
 // wgsl_op_with_out!(ElectOp; |_, _| "subgroupElect()".into());
 

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/plane.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/plane.rs
@@ -47,8 +47,6 @@ requires_subgroups!(
     ShuffleXorOp,
     ShuffleUpOp,
     ShuffleDownOp,
-    UniformLoadOp,
-    AtomicUniformLoadOp,
 );
 
 // wgsl_op_with_out!(ElectOp; |_, _| "subgroupElect()".into());

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/sync.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/sync.rs
@@ -1,8 +1,8 @@
 use cubecl_ir::dialect::synchronization::{SyncOp, SyncScope};
 
-use crate::compiler::wgsl::to_wgsl::{keep_wgsl_ops_linked, wgsl_op};
+use crate::compiler::wgsl::to_wgsl::{wasm_inventory_root, wgsl_op};
 
-keep_wgsl_ops_linked!(SyncOp);
+wasm_inventory_root!(SyncOp);
 
 wgsl_op!(SyncOp, |op, ctx| {
     match op.scope(ctx).0 {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/sync.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/sync.rs
@@ -1,6 +1,8 @@
 use cubecl_ir::dialect::synchronization::{SyncOp, SyncScope};
 
-use crate::compiler::wgsl::to_wgsl::wgsl_op;
+use crate::compiler::wgsl::to_wgsl::{keep_wgsl_ops_linked, wgsl_op};
+
+keep_wgsl_ops_linked!(SyncOp);
 
 wgsl_op!(SyncOp, |op, ctx| {
     match op.scope(ctx).0 {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/vector.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/vector.rs
@@ -4,9 +4,11 @@ use itertools::Itertools;
 
 use crate::compiler::wgsl::{
     lower::lower_unop,
-    to_wgsl::{TypeExtWgsl, wgsl_op, wgsl_op_with_out},
+    to_wgsl::{TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
+
+keep_wgsl_ops_linked!(CompositeConstructOp);
 
 wgsl_op_with_out!(CompositeConstructOp; |op, ctx| {
     assert!(op.result_type(ctx).is_vector(ctx));

--- a/crates/cubecl-wgpu/src/compiler/wgsl/ops/vector.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/ops/vector.rs
@@ -4,11 +4,11 @@ use itertools::Itertools;
 
 use crate::compiler::wgsl::{
     lower::lower_unop,
-    to_wgsl::{TypeExtWgsl, keep_wgsl_ops_linked, wgsl_op, wgsl_op_with_out},
+    to_wgsl::{TypeExtWgsl, wasm_inventory_root, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
 
-keep_wgsl_ops_linked!(CompositeConstructOp);
+wasm_inventory_root!(CompositeConstructOp);
 
 wgsl_op_with_out!(CompositeConstructOp; |op, ctx| {
     assert!(op.result_type(ctx).is_vector(ctx));

--- a/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/shader.rs
@@ -28,7 +28,7 @@ use pliron::{
 };
 
 use crate::compiler::wgsl::{
-    builtin::{ATTR_BUILTIN, BuiltInAttr},
+    builtin::{ATTR_BUILTIN, BuiltIn, BuiltInAttr},
     to_wgsl::{OpExtWgsl, OpToWgsl, TypeExtWgsl, wgsl_op, wgsl_op_with_out},
     value::WgslValue,
 };
@@ -194,6 +194,18 @@ impl Pass for EnableFeaturesPass {
                 feats.insert(op.required_feature(ctx));
             },
         );
+        visit_all_ops_of_type::<FuncOp, _>(ctx, &mut feats, op, |ctx, feats, op| {
+            for i in 0..op.get_entry_block(ctx).arguments(ctx).len() {
+                if let Some(builtin) = op.get_arg_attr::<BuiltInAttr>(ctx, i, &ATTR_BUILTIN)
+                    && matches!(
+                        builtin.0,
+                        BuiltIn::SubgroupSize | BuiltIn::SubgroupId | BuiltIn::SubgroupInvocationId
+                    )
+                {
+                    feats.insert("subgroups".to_string());
+                }
+            }
+        });
 
         let mut res = PassResult::default();
         if !feats.is_empty() {

--- a/crates/cubecl-wgpu/src/compiler/wgsl/to_wgsl.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/to_wgsl.rs
@@ -53,6 +53,17 @@ macro_rules! wgsl_op_with_out {
 }
 pub(crate) use wgsl_op_with_out;
 
+macro_rules! keep_wgsl_ops_linked {
+    ($ty:ty) => {
+        #[cfg(target_family = "wasm")]
+        #[inline(never)]
+        pub(super) fn ensure_linked() {
+            core::hint::black_box(<$ty as $crate::compiler::wgsl::to_wgsl::OpToWgsl>::to_wgsl);
+        }
+    };
+}
+pub(crate) use keep_wgsl_ops_linked;
+
 pub(crate) fn closure_inference_hack<T, R>(
     val: &T,
     ctx: &Context,

--- a/crates/cubecl-wgpu/src/compiler/wgsl/to_wgsl.rs
+++ b/crates/cubecl-wgpu/src/compiler/wgsl/to_wgsl.rs
@@ -53,16 +53,16 @@ macro_rules! wgsl_op_with_out {
 }
 pub(crate) use wgsl_op_with_out;
 
-macro_rules! keep_wgsl_ops_linked {
+macro_rules! wasm_inventory_root {
     ($ty:ty) => {
         #[cfg(target_family = "wasm")]
         #[inline(never)]
-        pub(super) fn ensure_linked() {
+        pub(super) fn wasm_inventory_root() {
             core::hint::black_box(<$ty as $crate::compiler::wgsl::to_wgsl::OpToWgsl>::to_wgsl);
         }
     };
 }
-pub(crate) use keep_wgsl_ops_linked;
+pub(crate) use wasm_inventory_root;
 
 pub(crate) fn closure_inference_hack<T, R>(
     val: &T,


### PR DESCRIPTION
- retain WGSL operation interface registrations in WebAssembly binaries
- request the WebGPU `subgroups` extension only for subgroup operations
- skip synchronous throughput probes on WebAssembly, where client synchronization is unsupported


This makes Brush runnable again on WebGPU + WASM
