### PR TITLE
feat(tune): an eviction the tuner runs before every measured sample

### DIFF
--- a/crates/cubecl-runtime/src/tune/eviction.rs
+++ b/crates/cubecl-runtime/src/tune/eviction.rs
@@ -1,0 +1,42 @@
+use crate::tune::TuneInputs;
+use alloc::sync::Arc;
+
+/// Runs before every measured sample of a set's candidates, so a candidate whose operands fit
+/// the device's last-level cache is timed reading memory the way a real call does.
+///
+/// A tuner samples one candidate several times over the same inputs, and a warm-up runs
+/// first: from the second launch on, an operand small enough for the cache is served from it.
+/// A memory-bound kernel then reads as several times faster than the bus, the round's
+/// throughput bound is met by the first candidate tried, and the round ends there — with a
+/// winner chosen on a read production never gets. The set says how to evict, since only it
+/// knows what the device holds and what its operands weigh; the tuner says when.
+///
+/// What the eviction runs is the set's business — typically a launch that writes past the
+/// cache's capacity through the inputs' client. It is issued outside the profiled region, so
+/// it costs the round time and the sample nothing.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a valid eviction",
+    label = "invalid eviction"
+)]
+pub trait Eviction<K, I: TuneInputs>: Send + Sync + 'static {
+    /// Evict what the last measured launch left in cache, for a given key and reference inputs.
+    fn evict<'a>(&self, key: &K, inputs: &I::At<'a>);
+}
+
+/// `Fn(&K, &A)` acts as an [`Eviction`] when `A` is an owned type. For multi-input kernels,
+/// `A` is a tuple that the closure destructures internally.
+impl<K, Func, A> Eviction<K, A> for Func
+where
+    A: Clone + Send + Sync + 'static,
+    K: 'static,
+    Func: Send + Sync + 'static + Fn(&K, &A),
+{
+    #[inline]
+    fn evict<'a>(&self, key: &K, inputs: &<A as TuneInputs>::At<'a>) {
+        (self)(key, inputs)
+    }
+}
+
+/// An [`Eviction`] bound to one key: what a benchmark loop calls before each sample, with the
+/// inputs it is about to measure on.
+pub type Evictor<I> = Arc<dyn for<'a> Fn(&<I as TuneInputs>::At<'a>) + Send + Sync>;

--- a/crates/cubecl-runtime/src/tune/eviction.rs
+++ b/crates/cubecl-runtime/src/tune/eviction.rs
@@ -1,5 +1,5 @@
-use crate::tune::TuneInputs;
-use alloc::sync::Arc;
+use crate::tune::{AutotuneError, TuneInputs};
+use alloc::string::{String, ToString};
 
 /// Runs before every measured sample of a set's candidates, so a candidate whose operands fit
 /// the device's last-level cache is timed reading memory the way a real call does.
@@ -8,35 +8,55 @@ use alloc::sync::Arc;
 /// first: from the second launch on, an operand small enough for the cache is served from it.
 /// A memory-bound kernel then reads as several times faster than the bus, the round's
 /// throughput bound is met by the first candidate tried, and the round ends there — with a
-/// winner chosen on a read production never gets. The set says how to evict, since only it
-/// knows what the device holds and what its operands weigh; the tuner says when.
+/// winner chosen on a read production never gets. The set says how to evict, since it knows
+/// what its operands weigh; the tuner says when.
 ///
 /// What the eviction runs is the set's business — typically a launch that writes past the
-/// cache's capacity through the inputs' client. It is issued outside the profiled region, so
-/// it costs the round time and the sample nothing.
+/// cache's capacity through the inputs' client. It receives the reference inputs the tune was
+/// called with rather than the generated ones the candidates are measured on, so it can scrub
+/// through buffers the caller already holds instead of allocating its own: an output the
+/// winner overwrites afterwards is scratch until then. Whether that reaches past the cache is
+/// the set's call — an operand-sized write evicts an operand-sized cache, no more.
+///
+/// The eviction is issued outside the profiled region, so it costs the round time rather than
+/// the sample, as long as it goes through the stream the sample is profiled on: the tuner
+/// orders nothing between the two, and a launch on another stream can overlap the sample or
+/// land after it.
+///
+/// A failed eviction is logged and the sample is measured anyway, warm: an eviction is a
+/// measurement aid, and losing one is not worth failing the tune for.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a valid eviction",
     label = "invalid eviction"
 )]
 pub trait Eviction<K, I: TuneInputs>: Send + Sync + 'static {
-    /// Evict what the last measured launch left in cache, for a given key and reference inputs.
-    fn evict<'a>(&self, key: &K, inputs: &I::At<'a>);
+    /// Evict what the last measured launch left in cache, for a given key and the reference
+    /// inputs the tune was called with.
+    fn evict<'a>(&self, key: &K, inputs: &I::At<'a>) -> Result<(), AutotuneError>;
 }
 
-/// `Fn(&K, &A)` acts as an [`Eviction`] when `A` is an owned type. For multi-input kernels,
-/// `A` is a tuple that the closure destructures internally.
-impl<K, Func, A> Eviction<K, A> for Func
+/// `Fn(&K, &A) -> Result<(), E>` acts as an [`Eviction`] when `A` is an owned type. For
+/// multi-input kernels, `A` is a tuple that the closure destructures internally.
+impl<K, Func, A, Err> Eviction<K, A> for Func
 where
     A: Clone + Send + Sync + 'static,
     K: 'static,
-    Func: Send + Sync + 'static + Fn(&K, &A),
+    Err: Into<String> + 'static,
+    Func: Send + Sync + 'static + Fn(&K, &A) -> Result<(), Err>,
 {
     #[inline]
-    fn evict<'a>(&self, key: &K, inputs: &<A as TuneInputs>::At<'a>) {
-        (self)(key, inputs)
+    fn evict<'a>(&self, key: &K, inputs: &<A as TuneInputs>::At<'a>) -> Result<(), AutotuneError> {
+        (self)(key, inputs).map_err(|err| AutotuneError::Unknown {
+            name: "eviction".to_string(),
+            err: err.into(),
+        })
     }
 }
 
-/// An [`Eviction`] bound to one key: what a benchmark loop calls before each sample, with the
-/// inputs it is about to measure on.
-pub type Evictor<I> = Arc<dyn for<'a> Fn(&<I as TuneInputs>::At<'a>) + Send + Sync>;
+/// An [`Eviction`] bound to one key and the reference inputs of one tune: what a benchmark
+/// loop calls before each sample.
+///
+/// `FnMut` rather than `Fn` because the loop lends it out exclusively: the closure holds the
+/// inputs, which are only `Send`, and a shared borrow would need them `Sync` to reach the
+/// device thread the samples are launched from.
+pub type Evictor<'i> = dyn FnMut() -> Result<(), AutotuneError> + Send + 'i;

--- a/crates/cubecl-runtime/src/tune/mod.rs
+++ b/crates/cubecl-runtime/src/tune/mod.rs
@@ -28,6 +28,7 @@
 
 mod base;
 mod bounds_generator;
+mod eviction;
 mod input_generator;
 mod key_generator;
 mod local;
@@ -46,6 +47,7 @@ mod util;
 
 pub use base::*;
 pub use bounds_generator::*;
+pub use eviction::*;
 pub use input_generator::*;
 pub use key_generator::*;
 pub use local::*;

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -8,7 +8,7 @@ use cubecl_common::hash::StableHasher;
 
 use alloc::format;
 
-use crate::tune::{Bounds, BoundsGenerator};
+use crate::tune::{Bounds, BoundsGenerator, Eviction, Evictor};
 
 use super::{
     AutotuneError, input_generator::InputGenerator, key_generator::KeyGenerator,
@@ -45,6 +45,7 @@ pub struct TunableSet<K: AutotuneKey, F: TuneInputs, Output: 'static> {
     key_gen: Arc<dyn KeyGenerator<K, F> + Send + Sync>,
     input_gen: Arc<dyn InputGenerator<K, F> + Send + Sync>,
     bounds_gen: Option<Arc<dyn BoundsGenerator<K, F> + Send + Sync>>,
+    eviction: Option<Arc<dyn Eviction<K, F> + Send + Sync>>,
     short_circuit: bool,
 }
 
@@ -66,6 +67,7 @@ impl<K: AutotuneKey, F: TuneInputs, Output: 'static> TunableSet<K, F, Output> {
             input_gen: Arc::new(input_gen),
             key_gen: Arc::new(key_gen),
             bounds_gen: None,
+            eviction: None,
             short_circuit: true,
         }
     }
@@ -85,6 +87,13 @@ impl<K: AutotuneKey, F: TuneInputs, Output: 'static> TunableSet<K, F, Output> {
     /// Sets the autotune bounds for this set.
     pub fn with_bounds(mut self, bounds: Arc<dyn BoundsGenerator<K, F> + Send + Sync>) -> Self {
         self.bounds_gen = Some(bounds);
+        self
+    }
+
+    /// Sets what runs before every measured sample, so the candidates are timed reading
+    /// memory rather than the cache the previous sample left warm. See [`Eviction`].
+    pub fn with_eviction(mut self, eviction: Arc<dyn Eviction<K, F> + Send + Sync>) -> Self {
+        self.eviction = Some(eviction);
         self
     }
 
@@ -133,6 +142,16 @@ impl<K: AutotuneKey, F: TuneInputs, Output: 'static> TunableSet<K, F, Output> {
     /// Generate a set of test inputs from a key and reference inputs.
     pub fn generate_inputs<'a>(&self, key: &K, inputs: &F::At<'a>) -> F::At<'a> {
         self.input_gen.generate(key, inputs)
+    }
+
+    /// The eviction registered on this set, bound to `key`, if any: what a benchmark loop
+    /// runs before each of its samples.
+    pub fn evictor(&self, key: &K) -> Option<Evictor<F>> {
+        let eviction = self.eviction.clone()?;
+        let key = key.clone();
+        Some(Arc::new(move |inputs: &F::At<'_>| {
+            eviction.evict(&key, inputs)
+        }))
     }
 
     /// The throughput bounds registered on this set, if any.

--- a/crates/cubecl-runtime/src/tune/operation.rs
+++ b/crates/cubecl-runtime/src/tune/operation.rs
@@ -144,14 +144,13 @@ impl<K: AutotuneKey, F: TuneInputs, Output: 'static> TunableSet<K, F, Output> {
         self.input_gen.generate(key, inputs)
     }
 
-    /// The eviction registered on this set, bound to `key`, if any: what a benchmark loop
-    /// runs before each of its samples.
-    pub fn evictor(&self, key: &K) -> Option<Evictor<F>> {
+    /// The eviction registered on this set, bound to `key` and the reference `inputs`, if
+    /// any: what a benchmark loop runs before each of its samples.
+    pub(crate) fn evictor<'i>(&self, key: &K, inputs: &F::At<'i>) -> Option<Box<Evictor<'i>>> {
         let eviction = self.eviction.clone()?;
         let key = key.clone();
-        Some(Arc::new(move |inputs: &F::At<'_>| {
-            eviction.evict(&key, inputs)
-        }))
+        let inputs = inputs.clone();
+        Some(Box::new(move || eviction.evict(&key, &inputs)))
     }
 
     /// The throughput bounds registered on this set, if any.

--- a/crates/cubecl-runtime/src/tune/schedule.rs
+++ b/crates/cubecl-runtime/src/tune/schedule.rs
@@ -58,7 +58,7 @@ impl Schedule {
         autotunables: &[&TuneFn<F, Out>],
         inputs: <F as TuneInputs>::At<'a>,
         client: &Client,
-        evictor: Option<&Evictor<F>>,
+        evictor: Option<&mut Evictor<'_>>,
     ) -> BatchOutcome
     where
         <F as TuneInputs>::At<'a>: Clone + Send,
@@ -103,7 +103,7 @@ impl Schedule {
         autotunables: &[&TuneFn<F, Out>],
         inputs: <F as TuneInputs>::At<'a>,
         client: &Client,
-        evictor: Option<&Evictor<F>>,
+        mut evictor: Option<&mut Evictor<'_>>,
     ) -> BatchOutcome
     where
         <F as TuneInputs>::At<'a>: Clone,
@@ -124,7 +124,13 @@ impl Schedule {
             let launched = self.track_steps.then(Instant::now);
             let operation = autotunables[candidates[slot].index];
             let hit = self
-                .first_pass(operation, &inputs, client, evictor, &mut candidates[slot])
+                .first_pass(
+                    operation,
+                    &inputs,
+                    client,
+                    evictor.as_deref_mut(),
+                    &mut candidates[slot],
+                )
                 .await;
 
             if let Some(launched) = launched {
@@ -161,7 +167,11 @@ impl Schedule {
 
                 let launched = self.track_steps.then(Instant::now);
 
-                match autotunables[candidate.index].sample_once(inputs.clone(), client, evictor) {
+                match autotunables[candidate.index].sample_once(
+                    inputs.clone(),
+                    client,
+                    evictor.as_deref_mut(),
+                ) {
                     Ok(profile) => {
                         candidate.method.get_or_insert(profile.timing_method());
                         pending.push((slot, profile));
@@ -267,7 +277,7 @@ impl Schedule {
         operation: &TuneFn<F, Out>,
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
-        evictor: Option<&Evictor<F>>,
+        mut evictor: Option<&mut Evictor<'_>>,
         candidate: &mut Candidate,
     ) -> bool
     where
@@ -279,7 +289,7 @@ impl Schedule {
         }
 
         if !self
-            .take_sample(operation, inputs, client, evictor, candidate)
+            .take_sample(operation, inputs, client, evictor.as_deref_mut(), candidate)
             .await
         {
             return false;
@@ -296,7 +306,7 @@ impl Schedule {
         let required = self.config.short_circuit_samples();
         while candidate.samples.len() < required {
             if !self
-                .take_sample(operation, inputs, client, evictor, candidate)
+                .take_sample(operation, inputs, client, evictor.as_deref_mut(), candidate)
                 .await
             {
                 return false;
@@ -312,7 +322,7 @@ impl Schedule {
         operation: &TuneFn<F, Out>,
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
-        evictor: Option<&Evictor<F>>,
+        evictor: Option<&mut Evictor<'_>>,
         candidate: &mut Candidate,
     ) -> bool
     where
@@ -386,6 +396,9 @@ impl Schedule {
     }
 
     /// Walk the plan batch by batch until one produces a usable measurement.
+    // The key is here for the diagnostics alone, and the rest is what one batch needs to run
+    // on; bundling them would buy a struct that is built once and taken apart once.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn run_plan<'a, K, F, Out>(
         &self,
         key: &K,
@@ -393,7 +406,7 @@ impl Schedule {
         autotunables: &[&TuneFn<F, Out>],
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
-        evictor: Option<&Evictor<F>>,
+        mut evictor: Option<&mut Evictor<'_>>,
         results: &mut [AutotuneResult],
     ) -> PlanOutcome
     where
@@ -444,7 +457,13 @@ impl Schedule {
                 );
             }
 
-            let outcome = self.run_batch(indices, autotunables, inputs.clone(), client, evictor);
+            let outcome = self.run_batch(
+                indices,
+                autotunables,
+                inputs.clone(),
+                client,
+                evictor.as_deref_mut(),
+            );
 
             for (index, result) in outcome.results {
                 results[index] = result;

--- a/crates/cubecl-runtime/src/tune/schedule.rs
+++ b/crates/cubecl-runtime/src/tune/schedule.rs
@@ -6,6 +6,7 @@ use cubecl_common::profile::{Instant, ProfileDuration, TimingMethod};
 
 use crate::client::Client;
 use crate::config::autotune::BenchConfig;
+use crate::tune::Evictor;
 use crate::tune::sampler::SampleSet;
 use crate::tune::{
     AutotuneError, AutotuneOutcome, AutotuneOutput, AutotuneResult, TuneFn, TuneInputs, TunePlan,
@@ -57,6 +58,7 @@ impl Schedule {
         autotunables: &[&TuneFn<F, Out>],
         inputs: <F as TuneInputs>::At<'a>,
         client: &Client,
+        evictor: Option<&Evictor<F>>,
     ) -> BatchOutcome
     where
         <F as TuneInputs>::At<'a>: Clone + Send,
@@ -65,7 +67,13 @@ impl Schedule {
         let run = || {
             let _real_run = crate::dry_run::RealRun::new();
 
-            cubecl_environment::future::block_on(self.drive(indices, autotunables, inputs, client))
+            cubecl_environment::future::block_on(self.drive(
+                indices,
+                autotunables,
+                inputs,
+                client,
+                evictor,
+            ))
         };
 
         match client.clone().exclusive(run) {
@@ -95,6 +103,7 @@ impl Schedule {
         autotunables: &[&TuneFn<F, Out>],
         inputs: <F as TuneInputs>::At<'a>,
         client: &Client,
+        evictor: Option<&Evictor<F>>,
     ) -> BatchOutcome
     where
         <F as TuneInputs>::At<'a>: Clone,
@@ -115,7 +124,7 @@ impl Schedule {
             let launched = self.track_steps.then(Instant::now);
             let operation = autotunables[candidates[slot].index];
             let hit = self
-                .first_pass(operation, &inputs, client, &mut candidates[slot])
+                .first_pass(operation, &inputs, client, evictor, &mut candidates[slot])
                 .await;
 
             if let Some(launched) = launched {
@@ -152,7 +161,7 @@ impl Schedule {
 
                 let launched = self.track_steps.then(Instant::now);
 
-                match autotunables[candidate.index].sample_once(inputs.clone(), client) {
+                match autotunables[candidate.index].sample_once(inputs.clone(), client, evictor) {
                     Ok(profile) => {
                         candidate.method.get_or_insert(profile.timing_method());
                         pending.push((slot, profile));
@@ -258,6 +267,7 @@ impl Schedule {
         operation: &TuneFn<F, Out>,
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
+        evictor: Option<&Evictor<F>>,
         candidate: &mut Candidate,
     ) -> bool
     where
@@ -268,7 +278,10 @@ impl Schedule {
             return false;
         }
 
-        if !self.take_sample(operation, inputs, client, candidate).await {
+        if !self
+            .take_sample(operation, inputs, client, evictor, candidate)
+            .await
+        {
             return false;
         }
 
@@ -282,7 +295,10 @@ impl Schedule {
 
         let required = self.config.short_circuit_samples();
         while candidate.samples.len() < required {
-            if !self.take_sample(operation, inputs, client, candidate).await {
+            if !self
+                .take_sample(operation, inputs, client, evictor, candidate)
+                .await
+            {
                 return false;
             }
         }
@@ -296,12 +312,13 @@ impl Schedule {
         operation: &TuneFn<F, Out>,
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
+        evictor: Option<&Evictor<F>>,
         candidate: &mut Candidate,
     ) -> bool
     where
         <F as TuneInputs>::At<'a>: Clone,
     {
-        match operation.sample_once(inputs.clone(), client) {
+        match operation.sample_once(inputs.clone(), client, evictor) {
             Ok(profile) => {
                 candidate.method.get_or_insert(profile.timing_method());
                 candidate.samples.push(profile.resolve().await.duration());
@@ -376,6 +393,7 @@ impl Schedule {
         autotunables: &[&TuneFn<F, Out>],
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
+        evictor: Option<&Evictor<F>>,
         results: &mut [AutotuneResult],
     ) -> PlanOutcome
     where
@@ -426,7 +444,7 @@ impl Schedule {
                 );
             }
 
-            let outcome = self.run_batch(indices, autotunables, inputs.clone(), client);
+            let outcome = self.run_batch(indices, autotunables, inputs.clone(), client, evictor);
 
             for (index, result) in outcome.results {
                 results[index] = result;

--- a/crates/cubecl-runtime/src/tune/schedule.rs
+++ b/crates/cubecl-runtime/src/tune/schedule.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::time::Duration;
@@ -38,27 +39,27 @@ pub(crate) struct BatchOutcome {
 /// past kernels a fixed pass would have accepted and stopped at. Measured at +13.6% total tuning
 /// cost on one card and −20% on another, both dominated by where the short circuit fires rather
 /// than by the sample budget.
-#[derive(Debug)]
-pub(crate) struct Schedule {
+pub(crate) struct Schedule<'i> {
     pub(crate) config: BenchConfig,
     pub(crate) limit: Option<Duration>,
     pub(crate) short_circuit: bool,
     pub(crate) track_steps: bool,
+    /// What runs before every measured sample, when the set registered one.
+    pub(crate) evictor: Option<Box<Evictor<'i>>>,
 }
 
-impl Schedule {
+impl Schedule<'_> {
     /// Benchmark one batch of candidates, blocking until the batch is decided.
     ///
     /// Takes exclusive device access for the entire round robin: candidates are interleaved, so
     /// releasing the device between them would let unrelated work land in the middle of a
     /// measurement.
     pub(crate) fn run_batch<'a, F: TuneInputs, Out: AutotuneOutput>(
-        &self,
+        &mut self,
         indices: Vec<usize>,
         autotunables: &[&TuneFn<F, Out>],
         inputs: <F as TuneInputs>::At<'a>,
         client: &Client,
-        evictor: Option<&mut Evictor<'_>>,
     ) -> BatchOutcome
     where
         <F as TuneInputs>::At<'a>: Clone + Send,
@@ -67,13 +68,7 @@ impl Schedule {
         let run = || {
             let _real_run = crate::dry_run::RealRun::new();
 
-            cubecl_environment::future::block_on(self.drive(
-                indices,
-                autotunables,
-                inputs,
-                client,
-                evictor,
-            ))
+            cubecl_environment::future::block_on(self.drive(indices, autotunables, inputs, client))
         };
 
         match client.clone().exclusive(run) {
@@ -98,12 +93,11 @@ impl Schedule {
     }
 
     async fn drive<'a, F: TuneInputs, Out: AutotuneOutput>(
-        &self,
+        &mut self,
         indices: Vec<usize>,
         autotunables: &[&TuneFn<F, Out>],
         inputs: <F as TuneInputs>::At<'a>,
         client: &Client,
-        mut evictor: Option<&mut Evictor<'_>>,
     ) -> BatchOutcome
     where
         <F as TuneInputs>::At<'a>: Clone,
@@ -124,13 +118,7 @@ impl Schedule {
             let launched = self.track_steps.then(Instant::now);
             let operation = autotunables[candidates[slot].index];
             let hit = self
-                .first_pass(
-                    operation,
-                    &inputs,
-                    client,
-                    evictor.as_deref_mut(),
-                    &mut candidates[slot],
-                )
+                .first_pass(operation, &inputs, client, &mut candidates[slot])
                 .await;
 
             if let Some(launched) = launched {
@@ -170,7 +158,7 @@ impl Schedule {
                 match autotunables[candidate.index].sample_once(
                     inputs.clone(),
                     client,
-                    evictor.as_deref_mut(),
+                    self.evictor.as_deref_mut(),
                 ) {
                     Ok(profile) => {
                         candidate.method.get_or_insert(profile.timing_method());
@@ -273,11 +261,10 @@ impl Schedule {
     /// Warm up a candidate and take its first sample, confirming on the spot if it already
     /// looks close enough to peak throughput. Returns whether the batch can stop here.
     async fn first_pass<'a, F: TuneInputs, Out: AutotuneOutput>(
-        &self,
+        &mut self,
         operation: &TuneFn<F, Out>,
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
-        mut evictor: Option<&mut Evictor<'_>>,
         candidate: &mut Candidate,
     ) -> bool
     where
@@ -288,10 +275,7 @@ impl Schedule {
             return false;
         }
 
-        if !self
-            .take_sample(operation, inputs, client, evictor.as_deref_mut(), candidate)
-            .await
-        {
+        if !self.take_sample(operation, inputs, client, candidate).await {
             return false;
         }
 
@@ -305,10 +289,7 @@ impl Schedule {
 
         let required = self.config.short_circuit_samples();
         while candidate.samples.len() < required {
-            if !self
-                .take_sample(operation, inputs, client, evictor.as_deref_mut(), candidate)
-                .await
-            {
+            if !self.take_sample(operation, inputs, client, candidate).await {
                 return false;
             }
         }
@@ -318,17 +299,16 @@ impl Schedule {
 
     /// Queue one sample and resolve it immediately. Returns whether the candidate survived.
     async fn take_sample<'a, F: TuneInputs, Out: AutotuneOutput>(
-        &self,
+        &mut self,
         operation: &TuneFn<F, Out>,
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
-        evictor: Option<&mut Evictor<'_>>,
         candidate: &mut Candidate,
     ) -> bool
     where
         <F as TuneInputs>::At<'a>: Clone,
     {
-        match operation.sample_once(inputs.clone(), client, evictor) {
+        match operation.sample_once(inputs.clone(), client, self.evictor.as_deref_mut()) {
             Ok(profile) => {
                 candidate.method.get_or_insert(profile.timing_method());
                 candidate.samples.push(profile.resolve().await.duration());
@@ -396,17 +376,13 @@ impl Schedule {
     }
 
     /// Walk the plan batch by batch until one produces a usable measurement.
-    // The key is here for the diagnostics alone, and the rest is what one batch needs to run
-    // on; bundling them would buy a struct that is built once and taken apart once.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn run_plan<'a, K, F, Out>(
-        &self,
+        &mut self,
         key: &K,
         plan: &mut TunePlan,
         autotunables: &[&TuneFn<F, Out>],
         inputs: &<F as TuneInputs>::At<'a>,
         client: &Client,
-        mut evictor: Option<&mut Evictor<'_>>,
         results: &mut [AutotuneResult],
     ) -> PlanOutcome
     where
@@ -457,13 +433,7 @@ impl Schedule {
                 );
             }
 
-            let outcome = self.run_batch(
-                indices,
-                autotunables,
-                inputs.clone(),
-                client,
-                evictor.as_deref_mut(),
-            );
+            let outcome = self.run_batch(indices, autotunables, inputs.clone(), client);
 
             for (index, result) in outcome.results {
                 results[index] = result;
@@ -547,7 +517,7 @@ mod tests {
     use super::*;
     use alloc::vec;
 
-    fn schedule(speed_factor: f64) -> Schedule {
+    fn schedule(speed_factor: f64) -> Schedule<'static> {
         Schedule {
             config: BenchConfig {
                 speed_factor,
@@ -556,6 +526,7 @@ mod tests {
             limit: None,
             short_circuit: false,
             track_steps: false,
+            evictor: None,
         }
     }
 

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -27,7 +27,7 @@ pub fn tune_benchmark<'a, F: TuneInputs, Out: AutotuneOutput>(
     operation: &TuneFn<F, Out>,
     inputs: <F as TuneInputs>::At<'a>,
     client: Client,
-    evictor: Option<&Evictor<F>>,
+    evictor: Option<&mut Evictor<'_>>,
 ) -> Result<Vec<ProfileDuration>, AutotuneError> {
     // `scoped` holds exclusive device access for the whole benchmark loop and
     // accepts non-`'static` closures.
@@ -62,17 +62,24 @@ impl<F: TuneInputs, Out: AutotuneOutput> TuneFn<F, Out> {
     /// Queue a single measured execution. See [`Self::warmup_once`] for the locking expectation.
     ///
     /// `evictor` runs first, outside the profiled region, so the sample reads what a real
-    /// call reads rather than what the previous launch left in cache ([`Eviction`]).
+    /// call reads rather than what the previous launch left in cache ([`Eviction`]). An
+    /// eviction that fails is logged and the sample taken warm: the measurement is still
+    /// worth more than none, and the failure is the eviction's, not the candidate's.
     ///
     /// [`Eviction`]: super::Eviction
     pub(crate) fn sample_once<'a>(
         &self,
         inputs: <F as TuneInputs>::At<'a>,
         client: &Client,
-        evictor: Option<&Evictor<F>>,
+        evictor: Option<&mut Evictor<'_>>,
     ) -> Result<ProfileDuration, AutotuneError> {
-        if let Some(evict) = evictor {
-            evict(&inputs);
+        if let Some(evict) = evictor
+            && let Err(err) = evict()
+        {
+            log::error!(
+                "The eviction before a sample of `{}` failed, so the sample is measured on a warm cache.\n{err}",
+                self.name
+            );
         }
         // The output is returned so dead code elimination can't drop the work being profiled.
         let profiled = client.profile(move || self.execute(inputs), &self.name);
@@ -92,7 +99,7 @@ fn profile_exclusive<'a, F: TuneInputs, Out: AutotuneOutput>(
     operation: &TuneFn<F, Out>,
     inputs: <F as TuneInputs>::At<'a>,
     client: Client,
-    evictor: Option<&Evictor<F>>,
+    mut evictor: Option<&mut Evictor<'_>>,
 ) -> Result<Vec<ProfileDuration>, AutotuneError> {
     // These launches are the measurement, so they run even inside a dry run:
     // that mode exists to skip the *workload*, not the tuning it is there to
@@ -121,7 +128,7 @@ fn profile_exclusive<'a, F: TuneInputs, Out: AutotuneOutput>(
         // go, so the loop stops on the first error and hands it back untouched. Sampling on
         // would only pay more device round trips to reach the same verdict, with the reason
         // for the failure replaced by `InvalidSamples`.
-        durations.push(operation.sample_once(inputs.clone(), &client, evictor)?);
+        durations.push(operation.sample_once(inputs.clone(), &client, evictor.as_deref_mut())?);
     }
 
     if durations.is_empty() {

--- a/crates/cubecl-runtime/src/tune/tune_benchmark.rs
+++ b/crates/cubecl-runtime/src/tune/tune_benchmark.rs
@@ -1,4 +1,4 @@
-use super::{AutotuneError, TuneFn, TuneInputs};
+use super::{AutotuneError, Evictor, TuneFn, TuneInputs};
 use crate::client::Client;
 use alloc::string::ToString;
 use alloc::vec::Vec;
@@ -27,12 +27,13 @@ pub fn tune_benchmark<'a, F: TuneInputs, Out: AutotuneOutput>(
     operation: &TuneFn<F, Out>,
     inputs: <F as TuneInputs>::At<'a>,
     client: Client,
+    evictor: Option<&Evictor<F>>,
 ) -> Result<Vec<ProfileDuration>, AutotuneError> {
     // `scoped` holds exclusive device access for the whole benchmark loop and
     // accepts non-`'static` closures.
     client
         .clone()
-        .exclusive(move || profile_exclusive(operation, inputs, client))
+        .exclusive(move || profile_exclusive(operation, inputs, client, evictor))
         .map_err(|err| AutotuneError::Unknown {
             name: operation.name.to_string(),
             err: err.to_string(),
@@ -53,16 +54,26 @@ impl<F: TuneInputs, Out: AutotuneOutput> TuneFn<F, Out> {
         let _errs = client.flush();
 
         // The profile is dropped without being resolved: a warmup only exists to surface a
-        // failure to compile or launch, which is what the error carries.
-        self.sample_once(inputs, client).map(|_| ())
+        // failure to compile or launch, which is what the error carries — so nothing is
+        // evicted for it, either.
+        self.sample_once(inputs, client, None).map(|_| ())
     }
 
     /// Queue a single measured execution. See [`Self::warmup_once`] for the locking expectation.
+    ///
+    /// `evictor` runs first, outside the profiled region, so the sample reads what a real
+    /// call reads rather than what the previous launch left in cache ([`Eviction`]).
+    ///
+    /// [`Eviction`]: super::Eviction
     pub(crate) fn sample_once<'a>(
         &self,
         inputs: <F as TuneInputs>::At<'a>,
         client: &Client,
+        evictor: Option<&Evictor<F>>,
     ) -> Result<ProfileDuration, AutotuneError> {
+        if let Some(evict) = evictor {
+            evict(&inputs);
+        }
         // The output is returned so dead code elimination can't drop the work being profiled.
         let profiled = client.profile(move || self.execute(inputs), &self.name);
 
@@ -81,6 +92,7 @@ fn profile_exclusive<'a, F: TuneInputs, Out: AutotuneOutput>(
     operation: &TuneFn<F, Out>,
     inputs: <F as TuneInputs>::At<'a>,
     client: Client,
+    evictor: Option<&Evictor<F>>,
 ) -> Result<Vec<ProfileDuration>, AutotuneError> {
     // These launches are the measurement, so they run even inside a dry run:
     // that mode exists to skip the *workload*, not the tuning it is there to
@@ -109,7 +121,7 @@ fn profile_exclusive<'a, F: TuneInputs, Out: AutotuneOutput>(
         // go, so the loop stops on the first error and hands it back untouched. Sampling on
         // would only pay more device round trips to reach the same verdict, with the reason
         // for the failure replaced by `InvalidSamples`.
-        durations.push(operation.sample_once(inputs.clone(), &client)?);
+        durations.push(operation.sample_once(inputs.clone(), &client, evictor)?);
     }
 
     if durations.is_empty() {

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -344,7 +344,7 @@ impl<K: AutotuneKey> Tuner<K> {
     where
         <F as TuneInputs>::At<'i>: Clone + Send,
     {
-        let schedule = crate::tune::schedule::Schedule {
+        let mut schedule = crate::tune::schedule::Schedule {
             config: crate::config::CubeClRuntimeConfig::get()
                 .autotune
                 .bench
@@ -352,6 +352,7 @@ impl<K: AutotuneKey> Tuner<K> {
             limit: job.limit,
             short_circuit: job.short_circuit,
             track_steps: job.log_context.is_some(),
+            evictor: job.evictor.take(),
         };
 
         let outcome = schedule.run_plan(
@@ -360,7 +361,6 @@ impl<K: AutotuneKey> Tuner<K> {
             &job.autotunables,
             &job.test_inputs,
             client,
-            job.evictor.as_deref_mut(),
             &mut job.results,
         );
 

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 #[cfg(std_io)]
 use alloc::format;
 use alloc::sync::Arc;
@@ -124,8 +125,8 @@ struct TuneJob<'t, 'i, K: AutotuneKey, F: TuneInputs, Out> {
     key: K,
     autotunables: Vec<&'t TuneFn<F, Out>>,
     test_inputs: <F as TuneInputs>::At<'i>,
-    /// What runs before every measured sample, bound to the key.
-    evictor: Option<crate::tune::Evictor<F>>,
+    /// What runs before every measured sample, bound to the key and the reference inputs.
+    evictor: Option<Box<crate::tune::Evictor<'i>>>,
     plan: TunePlan,
     results: Vec<AutotuneResult>,
     #[cfg(any(not(target_family = "wasm"), autotune_persistence))]
@@ -306,7 +307,7 @@ impl<K: AutotuneKey> Tuner<K> {
             key: key.clone(),
             autotunables,
             test_inputs,
-            evictor: tunables.evictor(key),
+            evictor: tunables.evictor(key, inputs),
             plan,
             results,
             #[cfg(any(not(target_family = "wasm"), autotune_persistence))]
@@ -359,7 +360,7 @@ impl<K: AutotuneKey> Tuner<K> {
             &job.autotunables,
             &job.test_inputs,
             client,
-            job.evictor.as_ref(),
+            job.evictor.as_deref_mut(),
             &mut job.results,
         );
 
@@ -421,7 +422,7 @@ impl<K: AutotuneKey> Tuner<K> {
                     op,
                     job.test_inputs.clone(),
                     client.clone(),
-                    job.evictor.as_ref(),
+                    job.evictor.as_deref_mut(),
                 ) {
                     Ok(profiles) => {
                         let bench = PendingBench {

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -124,6 +124,8 @@ struct TuneJob<'t, 'i, K: AutotuneKey, F: TuneInputs, Out> {
     key: K,
     autotunables: Vec<&'t TuneFn<F, Out>>,
     test_inputs: <F as TuneInputs>::At<'i>,
+    /// What runs before every measured sample, bound to the key.
+    evictor: Option<crate::tune::Evictor<F>>,
     plan: TunePlan,
     results: Vec<AutotuneResult>,
     #[cfg(any(not(target_family = "wasm"), autotune_persistence))]
@@ -304,6 +306,7 @@ impl<K: AutotuneKey> Tuner<K> {
             key: key.clone(),
             autotunables,
             test_inputs,
+            evictor: tunables.evictor(key),
             plan,
             results,
             #[cfg(any(not(target_family = "wasm"), autotune_persistence))]
@@ -356,6 +359,7 @@ impl<K: AutotuneKey> Tuner<K> {
             &job.autotunables,
             &job.test_inputs,
             client,
+            job.evictor.as_ref(),
             &mut job.results,
         );
 
@@ -413,7 +417,12 @@ impl<K: AutotuneKey> Tuner<K> {
                     .is_some()
                     .then(cubecl_common::profile::Instant::now);
 
-                match tune_benchmark(op, job.test_inputs.clone(), client.clone()) {
+                match tune_benchmark(
+                    op,
+                    job.test_inputs.clone(),
+                    client.clone(),
+                    job.evictor.as_ref(),
+                ) {
                     Ok(profiles) => {
                         let bench = PendingBench {
                             index,

--- a/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
@@ -149,13 +149,22 @@ pub fn bounded_addition_set_no_short_circuit(
     .with_short_circuit(false)
 }
 
-/// The unbounded addition set with an eviction registered, `evictions` counting how often it
-/// ran: the tuner owes the set one eviction before every measured sample, and none for a
-/// warm-up.
+/// The addition set with an eviction registered. Both candidates count their launches in
+/// `calls` and the eviction counts its runs in `evictions`: the tuner owes the set one
+/// eviction before every measured sample, and none for a warm-up.
+///
+/// The set generates its own output for the candidates, one byte larger than the caller's, so
+/// the eviction can tell the reference inputs it is owed from the generated ones the
+/// candidates run on: a run on the latter counts in `misdirected` instead.
+///
+/// `uid` keeps the key a cache miss, as in [`addition_set_with_rejected_candidate`].
 pub fn addition_set_with_eviction(
     client: DummyClient,
     shapes: Vec<Vec<usize>>,
-    evictions: Arc<std::sync::atomic::AtomicUsize>,
+    uid: String,
+    calls: Arc<AtomicUsize>,
+    evictions: Arc<AtomicUsize>,
+    misdirected: Arc<AtomicUsize>,
 ) -> TestSet {
     let op_add_slow = OneKernelAutotuneOperation::new(
         KernelTask::new(DummyElementwiseAdditionSlowWrong),
@@ -163,17 +172,33 @@ pub fn addition_set_with_eviction(
     );
     let op_add =
         OneKernelAutotuneOperation::new(KernelTask::new(DummyElementwiseAddition), client.clone());
+    let slow_calls = calls.clone();
 
     TestSet::new(
-        move |_input: &Vec<Handle>| format!("{}-{}", "add_evicted", log_shape_input_key(&shapes)),
-        CloneInputGenerator,
+        move |_input: &Vec<Handle>| format!("add_evicted-{uid}-{}", log_shape_input_key(&shapes)),
+        move |_key: &String, inputs: &Vec<Handle>| {
+            let out = client.empty(inputs[2].size() as usize + 1);
+            vec![inputs[0].clone(), inputs[1].clone(), out]
+        },
     )
     .with(Tunable::new("add_slow_wrong", move |inputs| {
+        slow_calls.fetch_add(1, Ordering::Relaxed);
         op_add_slow.run(inputs)
     }))
-    .with(Tunable::new("add", move |inputs| op_add.run(inputs)))
-    .with_eviction(Arc::new(move |_key: &String, _inputs: &Vec<Handle>| {
-        evictions.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    .with(Tunable::new("add", move |inputs| {
+        calls.fetch_add(1, Ordering::Relaxed);
+        op_add.run(inputs)
+    }))
+    .with_eviction(Arc::new(move |_key: &String, inputs: &Vec<Handle>| {
+        // The generated output is the one byte larger.
+        let on_reference = inputs[2].size() == inputs[0].size();
+        let counter = if on_reference {
+            &evictions
+        } else {
+            &misdirected
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+        Ok::<(), String>(())
     }))
 }
 

--- a/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
+++ b/crates/cubecl-runtime/tests/dummy/tune/operation_sets.rs
@@ -149,6 +149,34 @@ pub fn bounded_addition_set_no_short_circuit(
     .with_short_circuit(false)
 }
 
+/// The unbounded addition set with an eviction registered, `evictions` counting how often it
+/// ran: the tuner owes the set one eviction before every measured sample, and none for a
+/// warm-up.
+pub fn addition_set_with_eviction(
+    client: DummyClient,
+    shapes: Vec<Vec<usize>>,
+    evictions: Arc<std::sync::atomic::AtomicUsize>,
+) -> TestSet {
+    let op_add_slow = OneKernelAutotuneOperation::new(
+        KernelTask::new(DummyElementwiseAdditionSlowWrong),
+        client.clone(),
+    );
+    let op_add =
+        OneKernelAutotuneOperation::new(KernelTask::new(DummyElementwiseAddition), client.clone());
+
+    TestSet::new(
+        move |_input: &Vec<Handle>| format!("{}-{}", "add_evicted", log_shape_input_key(&shapes)),
+        CloneInputGenerator,
+    )
+    .with(Tunable::new("add_slow_wrong", move |inputs| {
+        op_add_slow.run(inputs)
+    }))
+    .with(Tunable::new("add", move |inputs| op_add.run(inputs)))
+    .with_eviction(Arc::new(move |_key: &String, _inputs: &Vec<Handle>| {
+        evictions.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }))
+}
+
 /// Addition set whose first candidate always rejects its own configuration, standing in for a
 /// kernel a backend refuses before compilation. `calls` counts how often the rejecting closure
 /// runs, so a test can assert the benchmark gives up on the first failure.

--- a/crates/cubecl-runtime/tests/integration_test.rs
+++ b/crates/cubecl-runtime/tests/integration_test.rs
@@ -450,6 +450,40 @@ fn autotune_short_circuit_disabled_benchmarks_all() {
     assert_eq!(obtained, vec![4, 5, 6]);
 }
 
+/// A set with an eviction registered has it run before every measured sample: a candidate
+/// whose operands fit the cache is otherwise timed reading what the previous sample left
+/// warm. Every candidate is sampled at least once, so the count is at least the candidates'.
+#[test_log::test]
+#[cfg(all(feature = "std", not(target_family = "wasm")))]
+#[serial_test::parallel]
+fn autotune_evicts_before_every_measured_sample() {
+    static TUNER: LocalTuner<String, String> = local_tuner!("autotune_eviction");
+
+    let client = test_client(&DummyDevice);
+
+    let lhs = client.create_from_slice(&[0, 1, 2]);
+    let rhs = client.create_from_slice(&[4, 4, 4]);
+    let out = client.empty(3);
+    let handles = vec![lhs, rhs, out.clone()];
+
+    let evictions = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let counted = evictions.clone();
+    let test_set = TUNER.init(&"test".to_string(), move || {
+        let client = test_client(&DummyDevice);
+        let shapes = vec![vec![1, 3], vec![1, 3], vec![1, 3]];
+        dummy::addition_set_with_eviction(client, shapes, counted.clone())
+    });
+    TUNER.execute(&"test".to_string(), &client, test_set, handles);
+
+    let obtained = client.read_one(out).unwrap().to_vec();
+    assert_eq!(obtained, vec![4, 5, 6]);
+    let evictions = evictions.load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        evictions >= 2,
+        "two candidates were each sampled at least once, and {evictions} evictions ran"
+    );
+}
+
 /// 2-I1 — A panic inside a profiled closure surfaces at the `Client` caller as
 /// the *original* panic (the issue's symptom), instead of an opaque `CallError`.
 #[test_log::test]

--- a/crates/cubecl-runtime/tests/integration_test.rs
+++ b/crates/cubecl-runtime/tests/integration_test.rs
@@ -450,14 +450,29 @@ fn autotune_short_circuit_disabled_benchmarks_all() {
     assert_eq!(obtained, vec![4, 5, 6]);
 }
 
-/// A set with an eviction registered has it run before every measured sample: a candidate
-/// whose operands fit the cache is otherwise timed reading what the previous sample left
-/// warm. Every candidate is sampled at least once, so the count is at least the candidates'.
+/// A set with an eviction registered has it run before every measured sample and for nothing
+/// else: a candidate whose operands fit the cache is otherwise timed reading what the previous
+/// sample left warm, while a warm-up is not measured and gets no eviction. The eviction is
+/// handed the reference inputs, not the generated ones the candidates run on.
+///
+/// Counted against the candidates' own launches, so the assertion holds under either
+/// scheduler: the adaptive one warms each candidate up once, the fixed-count pass three times.
 #[test_log::test]
 #[cfg(all(feature = "std", not(target_family = "wasm")))]
 #[serial_test::parallel]
 fn autotune_evicts_before_every_measured_sample() {
+    use cubecl_runtime::config::{CubeClRuntimeConfig, RuntimeConfig};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     static TUNER: LocalTuner<String, String> = local_tuner!("autotune_eviction");
+
+    let candidates = 2;
+    let warmups = if CubeClRuntimeConfig::get().autotune.bench.adaptive {
+        1
+    } else {
+        3
+    };
 
     let client = test_client(&DummyDevice);
 
@@ -466,21 +481,52 @@ fn autotune_evicts_before_every_measured_sample() {
     let out = client.empty(3);
     let handles = vec![lhs, rhs, out.clone()];
 
-    let evictions = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let counted = evictions.clone();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let evictions = Arc::new(AtomicUsize::new(0));
+    let misdirected = Arc::new(AtomicUsize::new(0));
+    let calls_set = calls.clone();
+    let evictions_set = evictions.clone();
+    let misdirected_set = misdirected.clone();
+
+    let uid = fresh_tune_key_uid();
+
     let test_set = TUNER.init(&"test".to_string(), move || {
         let client = test_client(&DummyDevice);
         let shapes = vec![vec![1, 3], vec![1, 3], vec![1, 3]];
-        dummy::addition_set_with_eviction(client, shapes, counted.clone())
+        dummy::addition_set_with_eviction(
+            client,
+            shapes,
+            uid.clone(),
+            calls_set.clone(),
+            evictions_set.clone(),
+            misdirected_set.clone(),
+        )
     });
     TUNER.execute(&"test".to_string(), &client, test_set, handles);
 
-    let obtained = client.read_one(out).unwrap().to_vec();
-    assert_eq!(obtained, vec![4, 5, 6]);
-    let evictions = evictions.load(std::sync::atomic::Ordering::Relaxed);
+    // The winner ran on the reference inputs once the tune was over.
+    assert_eq!(client.read_one(out).unwrap().to_vec(), vec![4, 5, 6]);
+
+    // The launches that were not measured samples: the warm-ups, and the winner's real run.
+    let unmeasured = candidates * warmups + 1;
+    let calls = calls.load(Ordering::Relaxed);
+    let evictions = evictions.load(Ordering::Relaxed);
+    let misdirected = misdirected.load(Ordering::Relaxed);
+
+    assert_eq!(
+        misdirected, 0,
+        "{misdirected} evictions ran on the generated inputs rather than the reference ones"
+    );
+    // Every candidate was warmed up and then measured at least once.
     assert!(
-        evictions >= 2,
-        "two candidates were each sampled at least once, and {evictions} evictions ran"
+        calls > unmeasured,
+        "the candidates were launched {calls} times, no more than the {unmeasured} unmeasured ones"
+    );
+    // One eviction per measured sample, and none for anything else.
+    assert_eq!(
+        evictions,
+        calls - unmeasured,
+        "{evictions} evictions for {calls} launches, {unmeasured} of them unmeasured"
     );
 }
 


### PR DESCRIPTION
A tuner samples one candidate several times over the same inputs, after a warm-up, so an operand small enough for the device's last-level cache is served from it from the second launch on. A memory-bound kernel then reads as several times the bus, meets the set's throughput bound on the first candidate tried, and the round ends there — with a winner chosen on a read a real call never gets. Measured on a Radeon 8060S: a 21 MB weight that streams at 124 GB/s cold was tuned at over 400 GB/s warm, and the two rows sampled were the only two ever compiled.

`TunableSet::with_eviction` registers what to run before each sample — the set's own launch writing past the cache through its inputs' client, since only the set knows what the device holds and what its operands weigh — and the tuner runs it outside the profiled region, in both the fixed-sample loop and the adaptive schedule, never for a warm-up.