### PR TITLE
fix(cpu): report the host CPU as the device name

### DIFF
--- a/crates/cubecl-cpu/src/runtime.rs
+++ b/crates/cubecl-cpu/src/runtime.rs
@@ -16,7 +16,7 @@ use cubecl_runtime::runtime::Runtime;
 use cubecl_runtime::{allocator::ContiguousMemoryLayoutPolicy, logging::ServerLogger};
 use cubecl_std::tensor::is_contiguous;
 use std::sync::Arc;
-use sysinfo::System;
+use sysinfo::{CpuRefreshKind, System};
 
 #[derive(Default)]
 pub struct RuntimeOptions {
@@ -80,11 +80,22 @@ fn register_supported_types(props: &mut DeviceProperties) {
     }
 }
 
+fn host_cpu_name(system: &System) -> String {
+    system
+        .cpus()
+        .first()
+        .map(|cpu| cpu.brand().trim())
+        // sysinfo reports no brand on Windows for ARM.
+        .filter(|brand| !brand.is_empty())
+        .map_or_else(|| format!("CPU {}", std::env::consts::ARCH), String::from)
+}
+
 impl DeviceService for CpuServer {
     fn init(device_id: cubecl_common::device::DeviceId) -> Self {
         let options = RuntimeOptions::default();
         let mut system = System::new();
         system.refresh_memory();
+        system.refresh_cpu_list(CpuRefreshKind::nothing());
         // Bounds the allocator's page size, not a kernel's shared memory.
         let total_memory = system
             .cgroup_limits()
@@ -147,7 +158,7 @@ impl DeviceService for CpuServer {
             // namespace to match against. The architecture is the honest
             // fingerprint: it is what the generated code is valid for.
             DeviceIdentity {
-                name: "CPU".to_string(),
+                name: host_cpu_name(&system),
                 fingerprint: format!("cpu_{}", std::env::consts::ARCH),
             },
         );


### PR DESCRIPTION
`DeviceIdentity::name` on `cubecl-cpu` was the constant `CPU`, so nothing keyed to a device name could tell one x86-64 part from another.

The throughput cache is one such consumer. Three CPUs filed their memory read ceilings into a single entry:

| device               | read ceiling |
| -------------------- | -----------: |
| Core Ultra X7 358H   |     123 GB/s |
| Ryzen 7 5700X        |    49.5 GB/s |
| Xeon E5-2620 v4      |    46.4 GB/s |

The brand comes from the `sysinfo::System` already built beside it for the memory limits, so no new dependency and no second pass over the host.

`fingerprint` is untouched. It exists to keep a compiled artifact off a machine that cannot run it, and the architecture is the honest answer for a JIT that persists nothing.

## Platforms

| platform                    | source                          | result                  |
| --------------------------- | ------------------------------- | ----------------------- |
| Linux x86                   | `/proc/cpuinfo` `model name`    | brand                   |
| Linux ARM                   | `CPU implementer` + `CPU part`  | brand                   |
| macOS x86 and Apple Silicon | `machdep.cpu.brand_string`      | brand                   |
| Windows x86/x86_64          | CPUID `0x80000002-4`            | brand                   |
| Windows on ARM              | not implemented by sysinfo      | falls back to `CPU aarch64` |

That fallback is what every platform reported until now.

## Worth a look

- `DeviceIdentity::name` is public, so this changes what every consumer of a CPU device name sees, not only the throughput cache. Anything matching on the literal `CPU` changes behaviour.
- It puts the host CPU brand into a value written to the on-disk cache namespace, and into any log that prints the device.

Split out of #1607, which motivated it. Neither depends on the other.
