### PR TITLE
fix(ir): decline the self-operand folds when the result is a vector

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/vector.rs
+++ b/crates/cubecl-core/src/runtime_tests/vector.rs
@@ -113,6 +113,39 @@ pub fn test_vector_loop_unroll<R: Runtime, F: Float + CubeElement>(client: Clien
     }
 }
 
+/// `x - x` and `x ^ x` fold to a constant the optimizer has to build for the operation's own
+/// type, which is a vector here. The buffer starts non-zero because a fold that cannot build one
+/// leaves the kernel uncompiled and the output untouched, which reads as the zeros expected here.
+#[allow(clippy::eq_op, reason = "the equal operands are what the folds key on")]
+#[cube(launch_unchecked)]
+pub fn kernel_vector_self_operand_folds<F: Float, N: Size>(output: &mut [Vector<F, N>]) {
+    if UNIT_POS == 0 {
+        let float = output[0];
+        let int = Vector::<u32, N>::cast_from(float);
+        output[0] = (float - float) + Vector::<F, N>::cast_from((int - int) ^ (int ^ int));
+    }
+}
+
+pub fn test_vector_self_operand_folds<R: Runtime, F: Float + CubeElement>(client: Client) {
+    for vector_size in client.io_optimized_vector_sizes(size_of::<F>()) {
+        let handle = client.create_from_slice(F::as_bytes(&vec![F::new(9.0); vector_size]));
+        unsafe {
+            kernel_vector_self_operand_folds::launch_unchecked::<F>(
+                &client,
+                CubeCount::new_single(),
+                CubeDim::new_single(),
+                vector_size,
+                BufferArg::from_raw_parts(handle.clone(), 1),
+            )
+        }
+
+        let actual = client.read_one_unchecked(handle);
+        let actual = F::from_bytes(&actual);
+
+        assert_eq!(&actual[..vector_size], vec![F::new(0.0); vector_size]);
+    }
+}
+
 #[cube(launch_unchecked)]
 pub fn kernel_vector_conditional<F: Float, N: Size>(
     input: &[Vector<F, N>],
@@ -337,6 +370,15 @@ macro_rules! testgen_vector {
             cubecl_core::runtime_tests::vector::test_vector_index_assign::<TestRuntime, FloatType>(
                 client,
             );
+        }
+
+        #[$crate::runtime_tests::test_log::test]
+        fn test_vector_self_operand_folds() {
+            let client = TestRuntime::client(&Default::default());
+            cubecl_core::runtime_tests::vector::test_vector_self_operand_folds::<
+                TestRuntime,
+                FloatType,
+            >(client);
         }
 
         #[$crate::runtime_tests::test_log::test]

--- a/crates/cubecl-ir/src/dialect/bitwise.rs
+++ b/crates/cubecl-ir/src/dialect/bitwise.rs
@@ -95,10 +95,11 @@ simplify!(BitwiseOrOp, {
 pure_binop!("bitwise.xor", BitwiseXorOp);
 const_eval!(BitwiseXorOp, {
     [IndexAttr, IntegerAttr(u8, u16, u32, u64)]: |lhs, rhs| lhs ^ rhs,
-    // x ^ x -> 0
+    // x ^ x -> 0. Only for one lane: `int_attr` carries no vectorization.
     custom: |_, _| {
-        if self.lhs(ctx) == self.rhs(ctx) {
-            Some(int_attr(ctx, self.result_type(ctx), 0))
+        let result = self.get_result(ctx);
+        if self.lhs(ctx) == self.rhs(ctx) && result.vector_size(ctx) == 1 {
+            Some(int_attr(ctx, result.get_type(ctx), 0))
         } else {
             None
         }

--- a/crates/cubecl-ir/src/dialect/math.rs
+++ b/crates/cubecl-ir/src/dialect/math.rs
@@ -295,10 +295,11 @@ simplify!(SaturatingUAddOp, {
 pure_binop!("math.i_sub", ISubOp);
 const_eval!(ISubOp, {
     [IndexAttr, IntegerAttr(i8, i16, i32, i64), IntegerAttr(u8, u16, u32, u64)]: |lhs, rhs| lhs.wrapping_sub(rhs),
-    // x - x -> 0
+    // x - x -> 0. Only for one lane: `int_attr` carries no vectorization.
     custom: |_, _| {
-        if self.lhs(ctx) == self.rhs(ctx) {
-            Some(int_attr(ctx, self.result_type(ctx), 0))
+        let result = self.get_result(ctx);
+        if self.lhs(ctx) == self.rhs(ctx) && result.vector_size(ctx) == 1 {
+            Some(int_attr(ctx, result.get_type(ctx), 0))
         } else {
             None
         }
@@ -314,10 +315,11 @@ simplify!(ISubOp, {
 pure_binop!("math.f_sub", FSubOp);
 const_eval!(FSubOp, {
     FloatAttr(f16, bf16, f32, f64): |lhs, rhs| lhs - rhs,
-    // x - x -> 0
+    // x - x -> 0. Only for one lane: `float_attr` carries no vectorization.
     custom: |_, _| {
-        if self.lhs(ctx) == self.rhs(ctx) {
-            Some(float_attr(ctx, self.result_type(ctx), 0.0))
+        let result = self.get_result(ctx);
+        if self.lhs(ctx) == self.rhs(ctx) && result.vector_size(ctx) == 1 {
+            Some(float_attr(ctx, result.get_type(ctx), 0.0))
         } else {
             None
         }


### PR DESCRIPTION
`x - x -> 0` and `x ^ x -> 0` build their zero from the operation's result type, and `int_attr`
and `float_attr` construct a scalar attribute only, so a vectorized operation panics inside them.
It panics on the compile worker, so nothing propagates, the launch never happens, and the output
reads back as whatever the buffer held.

The `x / x -> 1` folds already guard on `vector_size(ctx) == 1`. This extends that to `ISubOp`,
`FSubOp` and `BitwiseXorOp`. They decline rather than splat because `cubecl-ir` has no vector
constant attribute to build.

The test seeds its buffer with `9.0` instead of expecting zeros, since an uncompiled kernel leaves
a fresh buffer at zeros too and would pass.

Scope is the panic only. cubecl folds no constants on vectorized values at all, but LLVM does it
for free at IR construction, so backends moving to `cubecl-llvm` inherit it (AMDGPU in #1571,
CUDA in #1609) and the rest hand off to vendor compilers that fold it anyway. Building it here
would duplicate the layer below on a shrinking set of backends.
