### PR TITLE
feat(zspace): the stride and shape mutators refuse a storage-tiled metadata

### DIFF
--- a/crates/cubecl-std/src/tensor/handle.rs
+++ b/crates/cubecl-std/src/tensor/handle.rs
@@ -53,6 +53,21 @@ impl TensorHandle {
         }
     }
 
+    /// A tensor over `metadata` as it is, tiling included: the constructor for a handle rebuilt
+    /// from another's metadata, where [`new`](Self::new) would rebuild an untiled one from the
+    /// shape and strides alone.
+    pub fn from_metadata(
+        handle: server::Handle,
+        metadata: Metadata,
+        storage: impl Into<Type>,
+    ) -> Self {
+        Self {
+            handle,
+            metadata: Box::new(metadata),
+            dtype: storage.into().elem_type(),
+        }
+    }
+
     pub fn empty(client: &Client, shape: impl Into<Shape>, storage: impl Into<Type>) -> Self {
         let storage = storage.into();
         let shape: Shape = shape.into();

--- a/crates/cubecl-zspace/src/metadata.rs
+++ b/crates/cubecl-zspace/src/metadata.rs
@@ -100,7 +100,10 @@ impl Metadata {
         &self.shape
     }
 
+    /// The shape, to rewrite in place. A storage-tiled tensor's dims are its tiling's fragments,
+    /// which a rewrite would leave stale, so it refuses like the dim-changing ops do.
     pub fn shape_mut(&mut self) -> &mut Shape {
+        self.assert_untiled("shape_mut");
         &mut self.shape
     }
 
@@ -108,7 +111,11 @@ impl Metadata {
         &self.strides
     }
 
+    /// The strides, to rewrite in place. Refuses on a storage-tiled tensor, as
+    /// [`shape_mut`](Self::shape_mut) does: its strides step its tiles, and a rewrite would
+    /// keep the tiling over strides that no longer do.
     pub fn strides_mut(&mut self) -> &mut Strides {
+        self.assert_untiled("strides_mut");
         &mut self.strides
     }
 


### PR DESCRIPTION

shape_mut and strides_mut rewrote in place around the assert the dim-changing ops carry, so a caller could keep a tiling over dims that no longer step its tiles. They now refuse like swap and permute do. TensorHandle::from_metadata builds a handle over a metadata as it is, tiling included, where new rebuilds an untiled one from the parts.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
