### PR TITLE
fix(llvm): gate the AMDGPU arm of lang_tag

### DIFF
--- a/crates/cubecl-llvm/src/shared/base.rs
+++ b/crates/cubecl-llvm/src/shared/base.rs
@@ -162,6 +162,7 @@ impl Compiler for PlironCompiler {
     fn lang_tag(&self) -> &'static str {
         match self.target {
             LlvmTarget::Cpu => "mlir",
+            #[cfg(feature = "amdgpu")]
             LlvmTarget::AmdGpu => "llvm",
         }
     }


### PR DESCRIPTION
`lang_tag` is the one match on `LlvmTarget` whose `AmdGpu` arm is not behind
`#[cfg(feature = "amdgpu")]`. The variant itself only exists under that feature, so building
`cubecl-llvm` without it fails on the arm:

```
error[E0599]: no variant, associated function, or constant named `AmdGpu` found for enum `LlvmTarget`
   --> crates/cubecl-llvm/src/shared/base.rs:165:25
```

Every sibling is already gated: `file_extension` just above it, the `compile_ir` dispatch below it,
`fma_contraction`, and both arms in `polyfill/synchronization.rs`. This is the one that was missed
in #1597.

No CI leg builds the crate without default features, and there is no macOS job, so nothing catches
this on main today. Verified by hand both ways:

| build | before | after |
| --- | --- | --- |
| `cargo check -p cubecl-llvm --no-default-features --features std` | fails | passes |
| `cargo check -p cubecl-llvm` | passes | passes |

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
