### PR TITLE
fix(llvm): gate the last AmdGpu match arm on the amdgpu feature

### DIFF
--- a/crates/cubecl-llvm/src/shared/base.rs
+++ b/crates/cubecl-llvm/src/shared/base.rs
@@ -162,6 +162,7 @@ impl Compiler for PlironCompiler {
     fn lang_tag(&self) -> &'static str {
         match self.target {
             LlvmTarget::Cpu => "mlir",
+            #[cfg(feature = "amdgpu")]
             LlvmTarget::AmdGpu => "llvm",
         }
     }


### PR DESCRIPTION
#1597 made `amdgpu` a feature and gated the module, the LLD shims, and the `LlvmTarget::AmdGpu` arms of `extension()` and `compile_ir()` on it, but `lang_tag()`'s arm was missed. `LlvmTarget` has no `AmdGpu` variant without the feature, so `cubecl-llvm` did not compile without it -- which is every macOS build, where the bundled LLVM carries only the AArch64 target and the AMDGPU initializers do not exist to link against.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
