### PR TITLE
fix(wgpu): a window with no timing reports the absence, not a zero

### DIFF
--- a/crates/cubecl-core/src/runtime_tests/profiling.rs
+++ b/crates/cubecl-core/src/runtime_tests/profiling.rs
@@ -11,7 +11,7 @@ use cubecl_runtime::runtime::Runtime;
 
 use cubecl::prelude::*;
 use cubecl_common::profile::{Duration, ProfileDuration, TimingMethod};
-use cubecl_runtime::server::Handle;
+use cubecl_runtime::server::{Handle, ProfileError};
 
 /// Long enough that the window has something to measure on any device, short
 /// enough that a nesting test running four of them stays quick.
@@ -75,20 +75,31 @@ fn resolve(profile: ProfileDuration) -> Duration {
     cubecl_environment::future::block_on(profile.resolve()).duration()
 }
 
-/// A window with no GPU work in it measures next to nothing.
+/// A window with no GPU work in it never reports the drain around it.
 ///
-/// The bound is what separates device time from host time: a backend that
-/// times the wall clock around a drained stream reports the drain here, which
-/// is milliseconds of launch latency rather than the microseconds two events
+/// This is what separates device time from host time: a backend that times the
+/// wall clock around a drained stream reports the drain here, which is
+/// milliseconds of launch latency rather than the microseconds two events
 /// recorded back to back on an idle stream are apart.
+///
+/// Two answers are honest. A backend that brackets the window with its own
+/// events has a real measurement of an empty span and reports it, so it must be
+/// tiny. A backend that only reads timestamps its passes wrote has nothing to
+/// read and says so with [`ProfileError::NotMeasured`]; it must not invent a
+/// zero, because zero is the fastest result there is and an absence dressed as
+/// one wins every comparison it enters.
 pub fn test_empty_window_reports_no_device_time<R: Runtime>(client: Client) {
-    let (_, profile) = client.profile(|| {}, "empty").unwrap();
-    let duration = resolve(profile);
-
-    assert!(
-        duration < Duration::from_millis(1),
-        "a window with no GPU work must measure next to nothing, got {duration:?}"
-    );
+    match client.profile(|| {}, "empty") {
+        Ok((_, profile)) => {
+            let duration = resolve(profile);
+            assert!(
+                duration < Duration::from_millis(1),
+                "a window with no GPU work must measure next to nothing, got {duration:?}"
+            );
+        }
+        Err(ProfileError::NotMeasured { .. }) => {}
+        Err(err) => panic!("an empty window must measure or abstain, got {err}"),
+    }
 }
 
 /// Real GPU work measures positive and plausible.

--- a/crates/cubecl-runtime/src/server/base.rs
+++ b/crates/cubecl-runtime/src/server/base.rs
@@ -65,6 +65,21 @@ pub enum ProfileError {
         backtrace: BackTrace,
     },
 
+    /// The profiled window resolved no device timing.
+    ///
+    /// Distinct from a zero duration, which is a measurement that came back
+    /// instant. This is the absence of one: nothing the window enqueued was
+    /// timestamped, so the backend has nothing to report. A caller that only
+    /// wants a number can treat it as zero; a caller comparing candidates must
+    /// not, because an absence that reads as zero is the fastest result there
+    /// is and wins every comparison it enters.
+    #[error("The profiled window resolved no device timing\nBacktrace:\n{backtrace}")]
+    NotMeasured {
+        /// The captured backtrace.
+        #[cfg_attr(std_io, serde(skip))]
+        backtrace: BackTrace,
+    },
+
     /// A launch error happened during profiling
     #[error("A launch error happened during profiling\nCaused by:\n  {0}")]
     Launch(#[from] LaunchError),

--- a/crates/cubecl-wgpu/src/compute/timings.rs
+++ b/crates/cubecl-wgpu/src/compute/timings.rs
@@ -430,13 +430,22 @@ impl QueryProfiler {
                 ProfileTicks::from_start_end(instant_start, instant_end)
             }))
         } else {
-            // If there was no work done between the start and stop of the profile, logically the
-            // time should be 0. We could use a ProfileDuration::from_duration here,
-            // but it seems better to always return things as 'device' timing method.
-            let now = Instant::now();
-            Ok(ProfileDuration::new_device_time(async move {
-                ProfileTicks::from_start_end(now, now)
-            }))
+            // Nothing the window enqueued was timestamped, so there is no timing to resolve.
+            //
+            // This used to answer with `from_start_end(now, now)` — a duration of exactly zero —
+            // on the reading that an empty window logically took no time. But the two cases are
+            // indistinguishable here: a window that dispatched nothing and a window whose work
+            // never reached a timestamped pass both arrive with no query set, and the second is
+            // a kernel that ran. Answering either with zero hands the caller a measurement that
+            // was never taken, and zero is the fastest result there is, so it wins every
+            // comparison it enters. An autotune round short-circuited on one of these and
+            // persisted the slowest candidate it had.
+            //
+            // So the absence stays an absence. A caller that wants a number for an empty window
+            // can map this to zero itself, having decided that is what it means.
+            Err(ProfileError::NotMeasured {
+                backtrace: BackTrace::capture(),
+            })
         }
     }
 


### PR DESCRIPTION
`QueryProfiler::stop_profile` answered a window whose query sets never resolved with `from_start_end(now, now)` -- a duration of exactly zero -- on the reading that an empty window logically took no time.

Two cases arrive there and they are indistinguishable: a window that dispatched nothing, and a window whose work never reached a timestamped pass. The second is a kernel that ran. Answering either with zero hands the caller a measurement that was never taken, and zero is the fastest result there is, so it wins every comparison it enters.

Autotune is the caller that pays for it. A round whose first sample came back at 0ns short-circuits on that row, skips the remaining candidates, and persists it. Observed downstream in an attention tune: 601 of 602 rows never measured and the default -- the slowest row in the table -- was cached as the winner, 1.6x off the best.

So the absence stays an absence: a new `ProfileError::NotMeasured` that a caller wanting a number for an empty window can map to zero itself, having decided that is what it means. The tuner already treats a failed sample as a candidate that cannot win, which is the right answer here.

The device-timing test that profiles an empty window now accepts either honest answer -- a tiny measured span from a backend that brackets the window with its own events, or `NotMeasured` from one that only reads timestamps its passes wrote -- and rejects a fabricated zero.

The event-based profiler (cuda, hip, metal-native) already does this: an unreadable window reports a large sentinel "so nothing mistakes it for a fast one". `cubecl-metal`'s `stop_profile` still returns `Duration::ZERO` both for an empty buffer list and for non-finite GPU timestamps; that is the same class of bug on a path this change does not touch.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [cubek repo](https://github.com/Tracel-AI/cubek)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/cubek/blob/main/Cargo.toml#L22=L23) with this PR hash.
- [ ] Fix any broken tests or compilation errors in cubek.
- [ ] Submit a PR in cubek with your fixes and link it here.
- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/main/Cargo.toml#L223=L226) with this PR and the cubek PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
