### PR TITLE
fix: metal kernel corruption

### DIFF
--- a/crates/cubecl-common/src/benchmark.rs
+++ b/crates/cubecl-common/src/benchmark.rs
@@ -286,8 +286,9 @@ pub trait Benchmark {
                 // A window that carried no measurement is a failed run here, not
                 // a fast one: this harness has an error channel, so it uses it
                 // rather than letting an absence become a zero in `durations`.
-                cubecl_environment::future::block_on(profile.resolve())
-                    .ok_or_else(|| alloc::string::String::from("the profiled window carried no measurement"))
+                cubecl_environment::future::block_on(profile.resolve()).ok_or_else(|| {
+                    alloc::string::String::from("the profiled window carried no measurement")
+                })
             };
             let args = self.prepare();
 

--- a/crates/cubecl-common/src/profile.rs
+++ b/crates/cubecl-common/src/profile.rs
@@ -92,7 +92,10 @@ impl ProfileDuration {
     pub fn new_device_time(
         future: impl Future<Output = ProfileTicks> + Send + 'static,
     ) -> ProfileDuration {
-        Self::new(Box::pin(async move { Some(future.await) }), TimingMethod::Device)
+        Self::new(
+            Box::pin(async move { Some(future.await) }),
+            TimingMethod::Device,
+        )
     }
 
     /// Create a new `ProfileDuration` from a future that may resolve to no

--- a/crates/cubecl-cpp/src/metal/mma.rs
+++ b/crates/cubecl-cpp/src/metal/mma.rs
@@ -12,7 +12,7 @@ use cubecl_core::{
 use crate::{
     metal::{metal_op, ty::metal_ty},
     shared::{
-        CppValue, DeclareMatrixOp,
+        CompilationOptions, CppValue, DeclareMatrixOp,
         ty::{TypeExtCPP, TypeToCPP},
         wmma_api_base::{self, as_scalar_ptr},
     },
@@ -85,7 +85,9 @@ metal_op!(CastOp, |op, ctx| {
     let output = op.output(ctx).name(ctx);
     let output_ty = matrix_ty(ctx, op.output(ctx));
     let ty = output_ty.elem_ty.to_cpp(ctx);
-    let elements_held_by_each_thread = elements_held_by_each_thread(&output_ty.shape);
+    let threads_per_simdgroup = ctx.aux_ty::<CompilationOptions>().warp_size;
+    let elements_held_by_each_thread =
+        elements_held_by_each_thread(&output_ty.shape, threads_per_simdgroup);
     format!(
         "
 simdgroup_barrier(mem_flags::mem_none);
@@ -95,9 +97,8 @@ for(int e=0; e<{elements_held_by_each_thread}; e++) {{
     )
 });
 
-fn elements_held_by_each_thread(shape: &MatrixShape) -> usize {
-    const THREADS_PER_SIMDGROUP: usize = 32;
-    (shape.m * shape.n) / THREADS_PER_SIMDGROUP
+fn elements_held_by_each_thread(shape: &MatrixShape, threads_per_simdgroup: usize) -> usize {
+    (shape.m * shape.n) / threads_per_simdgroup
 }
 
 fn matrix_ty(ctx: &Context, ty: impl Typed) -> Ref<'_, MatrixType> {

--- a/crates/cubecl-cpp/src/metal/mma.rs
+++ b/crates/cubecl-cpp/src/metal/mma.rs
@@ -83,15 +83,22 @@ metal_op!(MultiplyAccumulateOp, |op, ctx| {
 metal_op!(CastOp, |op, ctx| {
     let input = op.input(ctx).name(ctx);
     let output = op.output(ctx).name(ctx);
-    let ty = matrix_ty(ctx, op.output(ctx)).elem_ty.to_cpp(ctx);
+    let output_ty = matrix_ty(ctx, op.output(ctx));
+    let ty = output_ty.elem_ty.to_cpp(ctx);
+    let elements_held_by_each_thread = elements_held_by_each_thread(&output_ty.shape);
     format!(
         "
 simdgroup_barrier(mem_flags::mem_none);
-for(int e=0; e<8; e++) {{
+for(int e=0; e<{elements_held_by_each_thread}; e++) {{
     {output}->thread_elements()[e] = {ty}({input}->thread_elements()[e]);
 }}"
     )
 });
+
+fn elements_held_by_each_thread(shape: &MatrixShape) -> usize {
+    const THREADS_PER_SIMDGROUP: usize = 32;
+    (shape.m * shape.n) / THREADS_PER_SIMDGROUP
+}
 
 fn matrix_ty(ctx: &Context, ty: impl Typed) -> Ref<'_, MatrixType> {
     let ty = ty.unwrap_ptr(ctx).deref(ctx);

--- a/crates/cubecl-cpp/src/metal/signature.rs
+++ b/crates/cubecl-cpp/src/metal/signature.rs
@@ -15,7 +15,8 @@ use pliron::{
 use crate::{
     metal::{BuiltInAttr, metal_op},
     shared::{
-        CppValue, branch::block_to_cpp, signature::LoadInfoOp, ty::TypeExtCPP, type_definitions,
+        CompilationOptions, CppValue, branch::block_to_cpp, signature::LoadInfoOp, ty::TypeExtCPP,
+        type_definitions,
     },
 };
 
@@ -39,9 +40,13 @@ metal_op!(FuncOp, |op, ctx| {
     let func_ty = ty.downcast_ref::<FunctionType>().unwrap();
     let return_ty = func_ty.res_types()[0].to_cpp(ctx);
     let attributes = if let Some(abi) = op.get_entrypoint_abi(ctx) {
+        let threads_per_simdgroup = ctx.aux_ty::<CompilationOptions>().warp_size as u32;
         format!(
             r#"[[max_total_threads_per_threadgroup({})]] [[kernel]] {return_ty}"#,
-            max_total_threads_never_declaring_a_single_simdgroup(abi.cube_dim.num_elems()),
+            max_total_threads_never_declaring_a_single_simdgroup(
+                abi.cube_dim.num_elems(),
+                threads_per_simdgroup,
+            ),
         )
     } else {
         return_ty
@@ -58,10 +63,12 @@ metal_op!(FuncOp, |op, ctx| {
     format!("{attributes} {func_name}({params}) {{\n{body}\n}}\n")
 });
 
-fn max_total_threads_never_declaring_a_single_simdgroup(cube_dim_total: u32) -> u32 {
-    const THREADS_PER_SIMDGROUP: u32 = 32;
-    const SMALLEST_BOUND_COMPILED_CORRECTLY: u32 = 2 * THREADS_PER_SIMDGROUP;
-    cube_dim_total.max(SMALLEST_BOUND_COMPILED_CORRECTLY)
+fn max_total_threads_never_declaring_a_single_simdgroup(
+    cube_dim_total: u32,
+    threads_per_simdgroup: u32,
+) -> u32 {
+    let smallest_bound_compiled_correctly = 2 * threads_per_simdgroup;
+    cube_dim_total.max(smallest_bound_compiled_correctly)
 }
 
 fn gen_param(ctx: &Context, func: &FuncOp, i: usize, arg: Value) -> String {

--- a/crates/cubecl-cpp/src/metal/signature.rs
+++ b/crates/cubecl-cpp/src/metal/signature.rs
@@ -41,7 +41,7 @@ metal_op!(FuncOp, |op, ctx| {
     let attributes = if let Some(abi) = op.get_entrypoint_abi(ctx) {
         format!(
             r#"[[max_total_threads_per_threadgroup({})]] [[kernel]] {return_ty}"#,
-            abi.cube_dim.num_elems(),
+            max_total_threads_never_declaring_a_single_simdgroup(abi.cube_dim.num_elems()),
         )
     } else {
         return_ty
@@ -57,6 +57,12 @@ metal_op!(FuncOp, |op, ctx| {
 
     format!("{attributes} {func_name}({params}) {{\n{body}\n}}\n")
 });
+
+fn max_total_threads_never_declaring_a_single_simdgroup(cube_dim_total: u32) -> u32 {
+    const THREADS_PER_SIMDGROUP: u32 = 32;
+    const SMALLEST_BOUND_COMPILED_CORRECTLY: u32 = 2 * THREADS_PER_SIMDGROUP;
+    cube_dim_total.max(SMALLEST_BOUND_COMPILED_CORRECTLY)
+}
 
 fn gen_param(ctx: &Context, func: &FuncOp, i: usize, arg: Value) -> String {
     let mut segments = vec![];

--- a/crates/cubecl-runtime/src/tune/tuner.rs
+++ b/crates/cubecl-runtime/src/tune/tuner.rs
@@ -538,13 +538,13 @@ async fn resolve_bench(bench: PendingBench) -> AutotuneResult {
     // One unmeasured sample disqualifies the candidate, the way one failed
     // sample does. Dropping it and averaging the rest would let a candidate
     // whose window went untimed be judged on its remaining runs.
-    let Some(durations) = futures_util::future::join_all(
-        profiles.into_iter().map(ProfileDuration::resolve),
-    )
-    .await
-    .into_iter()
-    .map(|ticks| ticks.map(|ticks| ticks.duration()))
-    .collect::<Option<Vec<Duration>>>() else {
+    let Some(durations) =
+        futures_util::future::join_all(profiles.into_iter().map(ProfileDuration::resolve))
+            .await
+            .into_iter()
+            .map(|ticks| ticks.map(|ticks| ticks.duration()))
+            .collect::<Option<Vec<Duration>>>()
+    else {
         return AutotuneResult::error(AutotuneError::NotMeasured {
             name: name.to_string(),
         });


### PR DESCRIPTION
Cubek's default CMMA matmul kernel (SimpleCyclicCmma) is miscompiled by Apple's Metal compiler whenever cubecl emits [[max_total_threads_per_threadgroup(32)]], which is exactly one simdgroup. Rows 4 to 7 of some 8x8 output tiles come out corrupted, and the values are silently wrong, not only NaN. It shows up for small odd inner dimensions with an output width off the line size, which is what LU's rank-1 updates produce.

It should fix the currently all fail ci in burn with this fix in cubek: https://github.com/tracel-ai/cubek/pull/645/changes