### PR TITLE
fix(llvm): keep amdgpu out of cubecl-llvm's default features

### DIFF
--- a/crates/cubecl-llvm/Cargo.toml
+++ b/crates/cubecl-llvm/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 
 [features]
-default = ["std", "cubecl-core/default", "cubecl-runtime/default", "amdgpu"]
+default = ["std", "cubecl-core/default", "cubecl-runtime/default"]
 
 pliron-dump = []
 std = ["cubecl-core/std", "cubecl-runtime/std"]


### PR DESCRIPTION
Default CPU builds on Apple Silicon fail to link:

```
Undefined symbols for architecture arm64:
  "_LLVMInitializeAMDGPUAsmPrinter", referenced from:
      cubecl_llvm::amdgpu::codegen::init_amdgpu ...
  "_LLVMInitializeAMDGPUTarget", ...
  "_LLVMInitializeAMDGPUTargetInfo", ...
  "_LLVMInitializeAMDGPUTargetMC", ...
ld: symbol(s) not found for architecture arm64
```

#1597 moved the AMDGPU code behind an `amdgpu` feature, but added that feature to cubecl-llvm's `default`. cubecl-cpu's own `default` enables `cubecl-llvm/default`, so the chain `cubecl/default -> cubecl-cpu/default -> cubecl-llvm/default -> amdgpu` keeps the AMDGPU path compiled in every default CPU build, on every OS. On macOS the bundled LLVM has no AMDGPU target, so the link fails. It was hit building cubek-reduce with `cubecl/cpu` on an M-series Mac, at cubecl `f3e3bd9e`, and `main` has the same feature table.

This drops `amdgpu` from cubecl-llvm's defaults. cubecl-hip already requests it explicitly and is the only crate using the AMDGPU API (`AmdGpuModule`), so HIP keeps it and the CPU backend stops compiling it.

## Checked

- `cargo tree -e features -i cubecl-llvm --target aarch64-apple-darwin`: cubecl-cpu and `cubecl --features cpu` now enable only `default` and `std` on cubecl-llvm; cubecl-hip still enables `amdgpu`.
- `cargo clippy -p cubecl-llvm -p cubecl-cpu --all-targets -- -D warnings` and `cargo check -p cubecl-hip` pass on Linux.

A default Linux CPU build also stops compiling the AMDGPU path. Anything that used cubecl-llvm's AMDGPU API through the defaults now has to enable `amdgpu`; in this repo that is only cubecl-hip, which already does.
