### PR TITLE
ci: pin the miri job to nightly-2026-09-09

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,9 @@ jobs:
         rust: [nightly]
         include:
           - rust: nightly
-            toolchain: nightly
+            # parking_lot_core 0.9.12 fails later miri's c-variadic check on its futex syscall.
+            # Unpin once a parking_lot_core release passes `*u32` to `syscall(SYS_futex, ...)`.
+            toolchain: nightly-2026-09-09
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -179,5 +181,8 @@ jobs:
         uses: tracel-ai/github-actions/install-vulkan-sdk@v11
       # --------------------------------------------------------------------------------
       - name: Tests
-        run: xtask +n test --miri ub-only --ci
+        # Not `xtask +n`: it forces plain `nightly` and would ignore the matrix toolchain.
+        env:
+          RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
+        run: xtask test --miri ub-only --ci
 


### PR DESCRIPTION
## Summary

`linux-miri-tests (nightly)` fails on main and on every PR since nightly-2026-09-11, in `device::handle::tests_reentrant::test_concurrent_increment`:

```
error: Undefined Behavior: incorrect c-variadic argument type for `syscall(SYS_futex, ...)`:
expected argument #2 to have type `*mut u32` but got incompatible type `&core::sync::atomic::Atomic<i32>`
  --> parking_lot_core-0.9.12/src/thread_parker/linux.rs:112:13
```

This is not a cubecl bug. rust-lang/rust#161734 made miri type-check the variadic arguments of its shims. parking_lot_core 0.9.12 passes `&AtomicI32` to `syscall(SYS_futex, ...)` when parking, and `*const AtomicI32` when unparking. std had the same pattern and was fixed in that PR.

The check only fires when the reentrant mutex is contended and a thread actually parks, so whether a run hits it depends on miri's interleaving. nightly-2026-09-10 (`a36d05efa`) already contains the check and passed every run. nightly-2026-09-11 (`67eda617e`) fails every run. Locally on `67eda617e`, 7 of 64 miri seeds hit it on main. With parking_lot_core patched to pass `self.futex.as_ptr()` and `self.futex.cast::<i32>()`, 0 of 64 do.

## Change

- Pin the miri matrix toolchain to `nightly-2026-09-09`, the last nightly without the check. zed pinned the same one (zed-industries/zed#64013).
- Run `xtask test` with `RUSTUP_TOOLCHAIN` taken from the matrix instead of `xtask +n`. `+n` forces plain `nightly` and would ignore the pin. The job name stays `linux-miri-tests (nightly)`.

## Removing the pin

Once a parking_lot_core release passes `*u32` to the futex syscall, set the toolchain back to `nightly`. The `RUSTUP_TOOLCHAIN` step works unchanged with plain `nightly`. Nothing is filed upstream yet.

## Testing

Not run locally. This PR's own CI run of the miri job is the test of the pin.
